### PR TITLE
Flatten GA4 data attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Flatten GA4 data attributes ([PR #3649](https://github.com/alphagov/govuk_publishing_components/pull/3649))
 * Add GA4 'print intent' tracker ([PR #3652](https://github.com/alphagov/govuk_publishing_components/pull/3652))
 
 ## 35.19.0

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
@@ -95,6 +95,14 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       data.external = trackFunctions.isExternalLink(data.url) ? 'true' : 'false'
       data.index = this.setIndex(data.index, event.target)
 
+      // flatten the attributes in index into the main data
+      if (data.index) {
+        for (var prop in data.index) {
+          data[prop] = data.index[prop]
+        }
+        delete data.index
+      }
+
       if (data.type === 'smart answer' && data.action === 'change response') {
         data.section = this.PIIRemover.stripPIIWithOverride(data.section, true, true)
       }
@@ -117,7 +125,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     if (target.getAttribute('data-ga4-index')) {
       try {
         var indexLink = JSON.parse(target.getAttribute('data-ga4-index'))
-
         // Check whether the index object already exists on a parent element, as is the case with tracking accordion links.
         // If true, combine data-ga4-index with the index object. Otherwise, just return indexLink
         index = index ? window.GOVUK.extendObject(index, indexLink) : indexLink
@@ -126,7 +133,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         return
       }
     }
-
     return index
   }
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.js
@@ -118,7 +118,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         // following will be undefined if tracking percentages
         data.text = node.eventData.text
         data.section = node.eventData.text
-        data.index = node.eventData.index
+        data.index_section = node.eventData.index_section
+        data.index_section_count = node.eventData.index_section_count
         // following will be undefined if tracking headings
         data.percent_scrolled = node.eventData.percent_scrolled
 
@@ -165,10 +166,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
           eventData: {
             type: type,
             text: heading.textContent.replace(/\s+/g, ' ').trim(),
-            index: {
-              index_section: i + 1,
-              index_section_count: totalHeadings
-            }
+            index_section: i + 1,
+            index_section_count: totalHeadings
           }
         })
       }

--- a/app/assets/javascripts/govuk_publishing_components/components/accordion.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/accordion.js
@@ -62,7 +62,7 @@ window.GOVUK.Modules.GovukAccordion = window.GOVUKFrontend.Accordion;
     var isGa4Enabled = dataModule ? dataModule.indexOf('ga4-event-tracker') !== -1 : false
     if (isGa4Enabled) {
       var indexTotal = this.$module.querySelectorAll('.govuk-accordion__section').length
-      var showAllAttributesGa4 = { event_name: 'select_content', type: 'accordion', index: { index_section: 0, index_section_count: indexTotal } }
+      var showAllAttributesGa4 = { event_name: 'select_content', type: 'accordion', index_section: 0, index_section_count: indexTotal }
       showAll = this.$module.querySelector(this.showAllControls)
       showAll.setAttribute('data-ga4-event', JSON.stringify(showAllAttributesGa4))
     }

--- a/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
@@ -84,7 +84,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
     // if GA4 is enabled, set attributes on 'show all sections' for tracking using ga4-event-tracker
     if (this.$module.isGa4Enabled) {
-      var showAllAttributesGa4 = { event_name: 'select_content', type: 'step by step', index: { index_section: 0, index_section_count: this.$module.totalSteps } }
+      var showAllAttributesGa4 = { event_name: 'select_content', type: 'step by step', index_section: 0, index_section_count: this.$module.totalSteps }
       this.$module.showOrHideAllButton.setAttribute('data-ga4-event', JSON.stringify(showAllAttributesGa4))
     }
   }
@@ -196,10 +196,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
           event_name: 'select_content',
           type: 'step by step',
           text: titleText.trim(),
-          index: {
-            index_section: i + 1,
-            index_section_count: this.$module.totalSteps
-          },
+          index_section: i + 1,
+          index_section_count: this.$module.totalSteps,
           index_total: thisel.querySelectorAll('a').length
         }
 

--- a/app/views/govuk_publishing_components/components/_accordion.html.erb
+++ b/app/views/govuk_publishing_components/components/_accordion.html.erb
@@ -46,14 +46,12 @@
             event_name: "select_content",
             type: "accordion",
             text: heading_text,
-            index: {
-              index_section: index,
-              index_section_count: items.length,
-            },
+            index_section: index,
+            index_section_count: items.length,
           }.to_json
 
-          # These attributes have been created separately from the item[:data_attributes] 
-          # object in order to keep them from colliding with GA4 event tracking and UA 
+          # These attributes have been created separately from the item[:data_attributes]
+          # object in order to keep them from colliding with GA4 event tracking and UA
           # tracking attributes
           ga4_link_data_attributes = {}
           ga4_link_data_attributes[:module] = "ga4-link-tracker"
@@ -63,10 +61,8 @@
             event_name: "navigation",
             type: "accordion",
             section: heading_text,
-            index: {
-              index_section: index,
-              index_section_count: (items.length),
-            }
+            index_section: index,
+            index_section_count: (items.length),
           }.to_json
         end
 
@@ -94,9 +90,9 @@
           <%= tag.div(item[:summary][:text], id: "#{id}-summary-#{index}", class: summary_classes) if item[:summary].present? %>
         <% end %>
         <%= tag.div(
-          item[:content][:html], 
-          id: "#{id}-content-#{index}", 
-          class: "govuk-accordion__section-content", 
+          item[:content][:html],
+          id: "#{id}-content-#{index}",
+          class: "govuk-accordion__section-content",
           'aria-labelledby': "#{id}-heading-#{index}",
           data: ga4_link_data_attributes
         ) %>

--- a/app/views/govuk_publishing_components/components/_contents_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_contents_list.html.erb
@@ -44,9 +44,7 @@
           <% link_text = format_numbers ? cl_helper.wrap_numbers_with_spans(contents_item[:text]) : contents_item[:text]
             if ga4_tracking
               ga4_data[:event_name] = cl_helper.get_ga4_event_name(contents_item[:href]) if contents_item[:href]
-              ga4_data[:index] = {
-                "index_link": index_link,
-              }
+              ga4_data[:index_link] = index_link
             end
           %>
           <%= link_to_if !contents_item[:active], link_text, contents_item[:href],
@@ -69,9 +67,7 @@
                   <%
                     if ga4_tracking
                       ga4_data[:event_name] = cl_helper.get_ga4_event_name(nested_contents_item[:href]) if nested_contents_item[:href]
-                      ga4_data[:index] = {
-                        "index_link": index_link,
-                      }
+                      ga4_data[:index_link] = index_link
                     end
                   %>
                   <%= link_to_if !nested_contents_item[:active], nested_contents_item[:text], nested_contents_item[:href],

--- a/app/views/govuk_publishing_components/components/_intervention.html.erb
+++ b/app/views/govuk_publishing_components/components/_intervention.html.erb
@@ -34,7 +34,7 @@
 
   ga4_tracking ||= false
   suggestion_data_attributes[:module] = "#{suggestion_data_attributes[:module]} ga4-link-tracker".strip if ga4_tracking
-  suggestion_data_attributes[:ga4_link] = { event_name: "navigation", type: "intervention", section: suggestion_text, index: 1, index_total: 1 }.to_json if ga4_tracking
+  suggestion_data_attributes[:ga4_link] = { event_name: "navigation", type: "intervention", section: suggestion_text, index_link: 1, index_total: 1 }.to_json if ga4_tracking
   data_attributes[:ga4_intervention_banner] = "" if ga4_tracking # Added to the parent element for the GA4 pageview object to use
 
   suggestion_tag_options = {

--- a/app/views/govuk_publishing_components/components/_layout_footer.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_footer.html.erb
@@ -107,11 +107,9 @@
           data-ga4-link="<%= {
             "event_name": "navigation",
             "section": "Licence",
-            "index": {
-              "index_section": layout_footer_helper.ga4_ogl_link_index_section.to_s,
-              "index_link": "1",
-              "index_section_count": layout_footer_helper.ga4_index_section_count.to_s,
-            },
+            "index_section": layout_footer_helper.ga4_ogl_link_index_section.to_s,
+            "index_link": "1",
+            "index_section_count": layout_footer_helper.ga4_index_section_count.to_s,
             "text": "Open Government Licence v3.0",
             "index_total": "1",
             "type": "footer",
@@ -132,11 +130,9 @@
         data-ga4-link="<%= {
           "event_name": "navigation",
           "section": "Copyright",
-          "index": {
-            "index_section": layout_footer_helper.ga4_copyright_link_index_section.to_s,
-            "index_link": "1",
-            "index_section_count": layout_footer_helper.ga4_index_section_count.to_s,
-          },
+          "index_section": layout_footer_helper.ga4_copyright_link_index_section.to_s,
+          "index_link": "1",
+          "index_section_count": layout_footer_helper.ga4_index_section_count.to_s,
           "text": "© Crown copyright",
           "index_total": "1",
           "type": "footer",

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -96,11 +96,9 @@
               "external": "false",
               "text": "GOV.UK",
               "section": "Logo",
-              "index": {
-                "index_link": 1,
-                "index_section": 0,
-                "index_section_count": 2,
-              },
+              "index_link": 1,
+              "index_section": 0,
+              "index_section_count": 2,
               "index_total": 1
             }.to_json
           },
@@ -117,7 +115,7 @@
               },
               class: logotype_classes,
               height: "30",
-              width: "36",    
+              width: "36",
               focusable: "false",
               viewBox: "0 0 132 97",
               xmlns: "http://www.w3.org/2000/svg",
@@ -198,10 +196,8 @@
                   event_name: "select_content",
                   type: "header menu bar",
                   text: link[:label],
-                  index: {
-                    index_section: 1,
-                    index_section_count: 2,
-                  },
+                  index_section: 1,
+                  index_section_count: 2,
                   section: link[:label]
                 }
               },
@@ -232,10 +228,8 @@
                   "event_name": "select_content",
                   "type": "header menu bar",
                   "text": "Search",
-                  "index": {
-                    "index_section": 2,
-                    "index_section_count": 2,
-                  },
+                  "index_section": 2,
+                  "index_section_count": 2,
                   "section": "Search"
                   }.to_json
                 }"
@@ -320,11 +314,9 @@
                             ga4_link: {
                               "event_name": "navigation",
                               "type": "header menu bar",
-                              "index": {
-                                "index_section": column_index + 1,
-                                "index_link": index + 1,
-                                "index_section_count": 4,
-                              },
+                              "index_section": column_index + 1,
+                              "index_link": index + 1,
+                              "index_section_count": 4,
                               "index_total": index_total,
                               "section": column[:label],
                             }
@@ -395,11 +387,9 @@
                         ga4_link: {
                           "event_name": "navigation",
                           "type": "header menu bar",
-                          "index": {
-                            "index_section": 4,
-                            "index_link": index + 1,
-                            "index_section_count": 4,
-                          },
+                          "index_section": 4,
+                          "index_link": index + 1,
+                          "index_section_count": 4,
                           "index_total": index_total,
                           "section": popular_links_heading,
                         }

--- a/app/views/govuk_publishing_components/components/_share_links.html.erb
+++ b/app/views/govuk_publishing_components/components/_share_links.html.erb
@@ -54,9 +54,7 @@
               ga4_link_data = {
                 'event_name': 'navigation',
                 'type': 'share page',
-                'index': {
-                  'index_link': index + 1,
-                },
+                'index_link': index + 1,
                 'index_total': links.length,
                 'text': link[:icon],
               }
@@ -65,9 +63,7 @@
               ga4_link_data = {
                 'event_name': 'navigation',
                 'type': 'follow us',
-                'index': {
-                  'index_link': index + 1,
-                },
+                'index_link': index + 1,
                 'index_total': links.length
               }
             end

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav.html.erb
@@ -84,10 +84,8 @@
                 "ga4-link": {
                   "event_name": "navigation",
                   "type": "step by step",
-                  "index": {
-                    "index_section": step_index + 1,
-                    "index_section_count": steps.length
-                  },
+                  "index_section": step_index + 1,
+                  "index_section_count": steps.length,
                   "section": step[:title]
                 }.to_json
               }

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav_header.html.erb
@@ -26,6 +26,15 @@
     tracking_options ||= ({ dimension96: tracking_id }).to_json
   end
 
+  if ga4_tracking
+    ga4_data = {
+      event_name: "navigation",
+      type: "super breadcrumb",
+      index_link: "1",
+      index_total: "1",
+    }.to_json
+  end
+
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
   classes = %w[gem-c-step-nav-header]
   classes << shared_helper.get_margin_bottom if local_assigns[:margin_bottom]
@@ -44,7 +53,7 @@
         data-track-action="<%= tracking_action %>"
         data-track-label="<%= tracking_label %>"
         <% if ga4_tracking %>
-          data-ga4-link='{"event_name":"navigation", "type":"super breadcrumb", "index":{"index_link": "1"}, "index_total":"1"}'
+          data-ga4-link='<%= ga4_data %>'
         <% end %>
         <% if tracking_dimension_enabled %>
           data-track-dimension="<%= tracking_dimension %>"

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav_related.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav_related.html.erb
@@ -23,13 +23,11 @@
             data-track-dimension="<%= links[0][:text] %>"
             data-track-dimension-index="29"
             data-track-options='{"dimension96" : "<%= links[0][:tracking_id] %>" }'
-            <% if ga4_tracking 
+            <% if ga4_tracking
               ga4_attributes = {
                 event_name: "navigation",
                 type: "part of",
-                index:{
-                  "index_link": "1"
-                },
+                "index_link": "1",
                 index_total: "1",
                 section: pretitle,
               }.to_json
@@ -53,13 +51,11 @@
                 data-track-dimension="<%= link[:text] %>"
                 data-track-dimension-index="29"
                 data-track-options='{"dimension96" : "<%= link[:tracking_id] %>" }'
-                <% if ga4_tracking 
+                <% if ga4_tracking
                   ga4_attributes = {
                     event_name: "navigation",
                     type: "part of",
-                    index:{
-                      "index_link": (index + 1).to_s
-                    },
+                    index_link: (index + 1).to_s,
                     index_total: (links.length).to_s,
                     section: pretitle,
                   }.to_json

--- a/app/views/govuk_publishing_components/components/_tabs.html.erb
+++ b/app/views/govuk_publishing_components/components/_tabs.html.erb
@@ -34,10 +34,8 @@
               event_name: "select_content",
               type: "tabs",
               text: tab[:label],
-              index: {
-                index_section: index + 1,
-                index_section_count: tabs.length,
-              },
+              index_section: index + 1,
+              index_section_count: tabs.length,
             }
             ga4_attributes[:event_name] = "navigation" if as_links
             tab[:tab_data_attributes][:ga4_link] = ga4_attributes if as_links

--- a/app/views/govuk_publishing_components/components/contextual_sidebar/_ukraine_cta.html.erb
+++ b/app/views/govuk_publishing_components/components/contextual_sidebar/_ukraine_cta.html.erb
@@ -1,4 +1,4 @@
-<% 
+<%
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
   title = t("components.related_navigation.ukraine.title")
   lang = shared_helper.t_locale("components.related_navigation.ukraine.title")
@@ -15,11 +15,9 @@
           ga4_attributes = {
             event_name: "navigation",
             type: "related content",
-            index: {
-              index_section: "#{ga4_tracking_counts.index_section_count}",
-              index_link: "#{index + 1}",
-              index_section_count: "#{ga4_tracking_counts.index_section_count}",
-            },
+            index_section: "#{ga4_tracking_counts.index_section_count}",
+            index_link: "#{index + 1}",
+            index_section_count: "#{ga4_tracking_counts.index_section_count}",
             index_total: "#{index_total}",
             section: title,
           } if ga4_tracking

--- a/app/views/govuk_publishing_components/components/related_navigation/_section.html.erb
+++ b/app/views/govuk_publishing_components/components/related_navigation/_section.html.erb
@@ -24,7 +24,7 @@
   <% end %>
 
   <ul class="gem-c-related-navigation__link-list">
-    <% 
+    <%
       constructed_link_array = []
       section_link_limit = related_nav_helper.calculate_section_link_limit(links)
       index_total = links.length
@@ -35,11 +35,9 @@
         ga4_attributes = {
           event_name: "navigation",
           type: ga4_type,
-          index: {
-            index_section: "#{section_index}",
-            index_link: "#{index}",
-            index_section_count: "#{section_count}",
-          },
+          index_section: "#{section_index}",
+          index_link: "#{index}",
+          index_section_count: "#{section_count}",
           index_total: "#{index_total}",
           section: ga4_heading_text,
         } if ga4_tracking
@@ -70,7 +68,7 @@
 
     <% if links.length > section_link_limit %>
       <%
-        classes = "gem-c-related-navigation__link toggle-wrap"      
+        classes = "gem-c-related-navigation__link toggle-wrap"
         data_attributes_li = { module: "ga4-event-tracker" } if ga4_tracking
         data_attributes_link = {
           controls: "toggle_#{section_title}",
@@ -83,7 +81,7 @@
         <%= link_to("#", class: "gem-c-related-navigation__toggle", data: data_attributes_link) do %>
           <%= t("common.toggle_more",
             show: t('common.show'),
-            number: related_nav_helper.remaining_link_count(links)) %>        
+            number: related_nav_helper.remaining_link_count(links)) %>
         <% end %>
       <% end %>
 

--- a/docs/analytics-ga4/ga4-link-tracker.md
+++ b/docs/analytics-ga4/ga4-link-tracker.md
@@ -8,7 +8,7 @@ This script is intended for adding GA4 tracking to links. It depends upon the ma
 <a
   href="/link"
   data-module="ga4-link-tracker"
-  data-ga4-link='{ "event_name": "navigation", "type": "home page", "index": { "index_link": 1, "index_section": 1, "index_section_count": 3 }, "index_total": 1, "section": "name of section" }'>
+  data-ga4-link='{ "event_name": "navigation", "type": "home page", "index_link": 1, "index_section": 1, "index_section_count": 3, "index_total": 1, "section": "name of section" }'>
     Link
 </a>
 ```
@@ -23,12 +23,12 @@ Specific tracking can be applied to multiple elements within a container, by app
 <div data-module="ga4-link-tracker">
   <a
     href="/a-page"
-    data-ga4-link='{ "event_name": "navigation", "type": "browse", "index": { "index_link": 1, "index_section": 1, "index_section_count": 2 }, "index_total": "2", "section": "name of section" }'>
+    data-ga4-link='{ "event_name": "navigation", "type": "browse", "index_link": 1, "index_section": 1, "index_section_count": 2, "index_total": "2", "section": "name of section" }'>
     Link 1
   </a>
   <a
     href="/another-page"
-    data-ga4-link='{ "event_name": "navigation", "type": "browse", "index": { "index_link": 2, "index_section": 1, "index_section_count": 2 }, "index_total": "2", "section": "name of section" }'>
+    data-ga4-link='{ "event_name": "navigation", "type": "browse", "index_link": 2, "index_section": 1, "index_section_count": 2, "index_total": "2", "section": "name of section" }'>
     Link 2
   </a>
 </div>
@@ -44,7 +44,7 @@ The text of the link can be overridden by another value if passed in the data at
 <a
   href="/link"
   data-module="ga4-link-tracker"
-  data-ga4-link='{ "event_name": "navigation", "type": "home page", "index": { "index_link": 1, "index_section": 1, "index_section_count": 3 }, "index_total": 1, "section": "name of section", "text": "This text will be recorded in the GA event" }'>
+  data-ga4-link='{ "event_name": "navigation", "type": "home page", "index_link": 1, "index_section": 1, "index_section_count": 3, "index_total": 1, "section": "name of section", "text": "This text will be recorded in the GA event" }'>
     This text will not be recorded
 </a>
 ```

--- a/lib/govuk_publishing_components/presenters/breadcrumbs_helper.rb
+++ b/lib/govuk_publishing_components/presenters/breadcrumbs_helper.rb
@@ -61,9 +61,7 @@ module GovukPublishingComponents
           ga4_link: {
             event_name: "navigation",
             type: "breadcrumb",
-            index: {
-              index_link: index.to_s,
-            },
+            index_link: index.to_s,
             index_total: breadcrumbs_length.to_s,
           },
         }

--- a/lib/govuk_publishing_components/presenters/layout_footer_helper.rb
+++ b/lib/govuk_publishing_components/presenters/layout_footer_helper.rb
@@ -23,11 +23,9 @@ module GovukPublishingComponents
         {
           "event_name": "navigation",
           "type": "footer",
-          "index": {
-            "index_link": (index_link + 1).to_s,
-            "index_section": (index_section + 1).to_s,
-            "index_section_count": @ga4_index_section_count.to_s,
-          },
+          "index_link": (index_link + 1).to_s,
+          "index_section": (index_section + 1).to_s,
+          "index_section_count": @ga4_index_section_count.to_s,
           "index_total": index_total.to_s,
           "section": section,
         }

--- a/spec/components/accordion_spec.rb
+++ b/spec/components/accordion_spec.rb
@@ -214,8 +214,8 @@ describe "Accordion", type: :view do
 
     assert_select ".govuk-accordion[data-ga4-expandable]"
     assert_select '.govuk-accordion[data-module="govuk-accordion gem-accordion ga4-event-tracker"]'
-    assert_select '.govuk-accordion__section-heading[data-ga4-event=\'{"event_name":"select_content","type":"accordion","text":"Heading 1","index":{"index_section":1,"index_section_count":2}}\']'
-    assert_select '.govuk-accordion__section-heading[data-ga4-event=\'{"event_name":"select_content","type":"accordion","text":"Heading 2","index":{"index_section":2,"index_section_count":2}}\']'
+    assert_select '.govuk-accordion__section-heading[data-ga4-event=\'{"event_name":"select_content","type":"accordion","text":"Heading 1","index_section":1,"index_section_count":2}\']'
+    assert_select '.govuk-accordion__section-heading[data-ga4-event=\'{"event_name":"select_content","type":"accordion","text":"Heading 2","index_section":2,"index_section_count":2}\']'
   end
 
   it '`data-module="govuk-accordion"` attribute is present when no custom data attributes given' do

--- a/spec/components/breadcrumbs_spec.rb
+++ b/spec/components/breadcrumbs_spec.rb
@@ -73,9 +73,7 @@ describe "Breadcrumbs", type: :view do
     expected_tracking_options = {
       event_name: "navigation",
       type: "breadcrumb",
-      index: {
-        index_link: "1",
-      },
+      index_link: "1",
       index_total: "1",
     }
 

--- a/spec/components/contents_list_spec.rb
+++ b/spec/components/contents_list_spec.rb
@@ -142,7 +142,7 @@ describe "Contents list", type: :view do
 
     # Child link attributes
     expected_ga4_json[:index_total] = 7
-    expected_ga4_json[:index] = { index_link: 1 }
+    expected_ga4_json[:index_link] = 1
 
     contents_list_links = assert_select(".gem-c-contents-list__list-item a")
 
@@ -154,7 +154,7 @@ describe "Contents list", type: :view do
 
     contents_list_links.each_with_index do |link, index|
       expected_ga4_json[:event_name] = events[index]
-      expected_ga4_json[:index] = { index_link: index_links[index] }
+      expected_ga4_json[:index_link] = index_links[index]
       expect(link.attr("data-ga4-link").to_s).to eq expected_ga4_json.to_json
       expect(link).to have_text(texts[index])
     end

--- a/spec/components/contextual_footer_spec.rb
+++ b/spec/components/contextual_footer_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "Contextual footer", type: :view do
     render_component(content_item:, ga4_tracking: true)
 
     assert_select ".gem-c-related-navigation[data-module='gem-track-click ga4-link-tracker']"
-    assert_select ".gem-c-related-navigation__section-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"contextual footer\",\"index\":{\"index_section\":\"1\",\"index_link\":\"1\",\"index_section_count\":\"1\"},\"index_total\":\"2\",\"section\":\"Explore the topic\"}']", text: "Skating"
-    assert_select ".gem-c-related-navigation__section-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"contextual footer\",\"index\":{\"index_section\":\"1\",\"index_link\":\"2\",\"index_section_count\":\"1\"},\"index_total\":\"2\",\"section\":\"Explore the topic\"}']", text: "Paragliding"
+    assert_select ".gem-c-related-navigation__section-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"contextual footer\",\"index_section\":\"1\",\"index_link\":\"1\",\"index_section_count\":\"1\",\"index_total\":\"2\",\"section\":\"Explore the topic\"}']", text: "Skating"
+    assert_select ".gem-c-related-navigation__section-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"contextual footer\",\"index_section\":\"1\",\"index_link\":\"2\",\"index_section_count\":\"1\",\"index_total\":\"2\",\"section\":\"Explore the topic\"}']", text: "Paragliding"
   end
 end

--- a/spec/components/contextual_sidebar_spec.rb
+++ b/spec/components/contextual_sidebar_spec.rb
@@ -44,7 +44,7 @@ describe "Contextual sidebar", type: :view do
     )
     index_total = 4 # have to hard code this here but if ukraine links change this number may change, and test will fail
     assert_select ".gem-c-contextual-sidebar .gem-c-contextual-sidebar__cta--ukraine[data-module='gem-track-click ga4-link-tracker']"
-    assert_select ".gem-c-contextual-sidebar .gem-c-contextual-sidebar__cta--ukraine .govuk-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"related content\",\"index\":{\"index_section\":\"1\",\"index_link\":\"1\",\"index_section_count\":\"1\"},\"index_total\":\"#{index_total}\",\"section\":\"Invasion of Ukraine\"}']"
-    assert_select ".gem-c-contextual-sidebar .gem-c-contextual-sidebar__cta--ukraine .govuk-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"related content\",\"index\":{\"index_section\":\"1\",\"index_link\":\"2\",\"index_section_count\":\"1\"},\"index_total\":\"#{index_total}\",\"section\":\"Invasion of Ukraine\"}']"
+    assert_select ".gem-c-contextual-sidebar .gem-c-contextual-sidebar__cta--ukraine .govuk-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"related content\",\"index_section\":\"1\",\"index_link\":\"1\",\"index_section_count\":\"1\",\"index_total\":\"#{index_total}\",\"section\":\"Invasion of Ukraine\"}']"
+    assert_select ".gem-c-contextual-sidebar .gem-c-contextual-sidebar__cta--ukraine .govuk-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"related content\",\"index_section\":\"1\",\"index_link\":\"2\",\"index_section_count\":\"1\",\"index_total\":\"#{index_total}\",\"section\":\"Invasion of Ukraine\"}']"
   end
 end

--- a/spec/components/intervention_spec.rb
+++ b/spec/components/intervention_spec.rb
@@ -69,7 +69,7 @@ describe "Intervention", type: :view do
 
     assert_select ".gem-c-intervention[data-ga4-intervention-banner]"
     assert_select ".gem-c-intervention a:first-of-type[data-module='ga4-link-tracker']"
-    assert_select ".gem-c-intervention a:first-of-type[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"intervention\",\"section\":\"You might be interested in\",\"index\":1,\"index_total\":1}']"
+    assert_select ".gem-c-intervention a:first-of-type[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"intervention\",\"section\":\"You might be interested in\",\"index_link\":1,\"index_total\":1}']"
 
     assert_select ".js-dismiss-link[data-module=ga4-event-tracker]"
     assert_select ".js-dismiss-link[data-ga4-event='{\"event_name\":\"select_content\",\"type\":\"intervention\",\"section\":\"You might be interested in\",\"action\":\"closed\"}']"

--- a/spec/components/layout_footer_spec.rb
+++ b/spec/components/layout_footer_spec.rb
@@ -252,19 +252,19 @@ describe "Layout footer", type: :view do
     # Note that in these tests, the index_section_count will always be 2 higher than the amount
     # in the above render_component, due to the OGL and Crown Copyright link always being rendered by default.
     assert_select ".govuk-footer__link[href='/link1']" do |link|
-      expect(link.attr("data-ga4-link").to_s).to eq '{"event_name":"navigation","type":"footer","index":{"index_link":"1","index_section":"1","index_section_count":"4"},"index_total":"2","section":"Section 1"}'
+      expect(link.attr("data-ga4-link").to_s).to eq '{"event_name":"navigation","type":"footer","index_link":"1","index_section":"1","index_section_count":"4","index_total":"2","section":"Section 1"}'
     end
 
     assert_select ".govuk-footer__link[href='/link2']" do |link|
-      expect(link.attr("data-ga4-link").to_s).to eq '{"event_name":"navigation","type":"footer","index":{"index_link":"2","index_section":"1","index_section_count":"4"},"index_total":"2","section":"Section 1"}'
+      expect(link.attr("data-ga4-link").to_s).to eq '{"event_name":"navigation","type":"footer","index_link":"2","index_section":"1","index_section_count":"4","index_total":"2","section":"Section 1"}'
     end
 
     assert_select ".govuk-footer__link[href='/link3']" do |link|
-      expect(link.attr("data-ga4-link").to_s).to eq '{"event_name":"navigation","type":"footer","index":{"index_link":"1","index_section":"2","index_section_count":"4"},"index_total":"2","section":"Section 2"}'
+      expect(link.attr("data-ga4-link").to_s).to eq '{"event_name":"navigation","type":"footer","index_link":"1","index_section":"2","index_section_count":"4","index_total":"2","section":"Section 2"}'
     end
 
     assert_select ".govuk-footer__link[href='/link4']" do |link|
-      expect(link.attr("data-ga4-link").to_s).to eq '{"event_name":"navigation","type":"footer","index":{"index_link":"2","index_section":"2","index_section_count":"4"},"index_total":"2","section":"Section 2"}'
+      expect(link.attr("data-ga4-link").to_s).to eq '{"event_name":"navigation","type":"footer","index_link":"2","index_section":"2","index_section_count":"4","index_total":"2","section":"Section 2"}'
     end
   end
 
@@ -287,11 +287,11 @@ describe "Layout footer", type: :view do
     # Note that in these tests, the index_total and index_section_count will always be 2 higher than the amount
     # in the above render_component, due to the OGL and Crown Copyright link always being rendered by default.
     assert_select ".govuk-footer__link[href='/link1']" do |link|
-      expect(link.attr("data-ga4-link").to_s).to eq '{"event_name":"navigation","type":"footer","index":{"index_link":"1","index_section":"1","index_section_count":"3"},"index_total":"2","section":"Support links"}'
+      expect(link.attr("data-ga4-link").to_s).to eq '{"event_name":"navigation","type":"footer","index_link":"1","index_section":"1","index_section_count":"3","index_total":"2","section":"Support links"}'
     end
 
     assert_select ".govuk-footer__link[href='/link2']" do |link|
-      expect(link.attr("data-ga4-link").to_s).to eq '{"event_name":"navigation","type":"footer","index":{"index_link":"2","index_section":"1","index_section_count":"3"},"index_total":"2","section":"Support links"}'
+      expect(link.attr("data-ga4-link").to_s).to eq '{"event_name":"navigation","type":"footer","index_link":"2","index_section":"1","index_section_count":"3","index_total":"2","section":"Support links"}'
     end
   end
 
@@ -299,7 +299,7 @@ describe "Layout footer", type: :view do
     render_component(navigation: [])
     assert_select ".govuk-footer__licence-description" do |link_parent|
       expect(link_parent.attr("data-ga4-track-links-only").to_s).to eq ""
-      expect(link_parent.attr("data-ga4-link").to_s).to eq '{"event_name":"navigation","section":"Licence","index":{"index_section":"1","index_link":"1","index_section_count":"2"},"text":"Open Government Licence v3.0","index_total":"1","type":"footer"}'
+      expect(link_parent.attr("data-ga4-link").to_s).to eq '{"event_name":"navigation","section":"Licence","index_section":"1","index_link":"1","index_section_count":"2","text":"Open Government Licence v3.0","index_total":"1","type":"footer"}'
     end
   end
 
@@ -307,7 +307,7 @@ describe "Layout footer", type: :view do
     render_component(navigation: [])
     assert_select ".govuk-footer__meta-item[data-ga4-link]" do |link_parent|
       expect(link_parent.attr("data-ga4-track-links-only").to_s).to eq ""
-      expect(link_parent.attr("data-ga4-link").to_s).to eq '{"event_name":"navigation","section":"Copyright","index":{"index_section":"2","index_link":"1","index_section_count":"2"},"text":"© Crown copyright","index_total":"1","type":"footer"}'
+      expect(link_parent.attr("data-ga4-link").to_s).to eq '{"event_name":"navigation","section":"Copyright","index_section":"2","index_link":"1","index_section_count":"2","text":"© Crown copyright","index_total":"1","type":"footer"}'
     end
   end
 
@@ -367,40 +367,40 @@ describe "Layout footer", type: :view do
     # Navigation links
 
     assert_select ".govuk-footer__link[href='/link1']" do |link|
-      expect(link.attr("data-ga4-link").to_s).to eq '{"event_name":"navigation","type":"footer","index":{"index_link":"1","index_section":"1","index_section_count":"5"},"index_total":"2","section":"Section 1"}'
+      expect(link.attr("data-ga4-link").to_s).to eq '{"event_name":"navigation","type":"footer","index_link":"1","index_section":"1","index_section_count":"5","index_total":"2","section":"Section 1"}'
     end
 
     assert_select ".govuk-footer__link[href='/link2']" do |link|
-      expect(link.attr("data-ga4-link").to_s).to eq '{"event_name":"navigation","type":"footer","index":{"index_link":"2","index_section":"1","index_section_count":"5"},"index_total":"2","section":"Section 1"}'
+      expect(link.attr("data-ga4-link").to_s).to eq '{"event_name":"navigation","type":"footer","index_link":"2","index_section":"1","index_section_count":"5","index_total":"2","section":"Section 1"}'
     end
 
     assert_select ".govuk-footer__link[href='/link3']" do |link|
-      expect(link.attr("data-ga4-link").to_s).to eq '{"event_name":"navigation","type":"footer","index":{"index_link":"1","index_section":"2","index_section_count":"5"},"index_total":"2","section":"Section 2"}'
+      expect(link.attr("data-ga4-link").to_s).to eq '{"event_name":"navigation","type":"footer","index_link":"1","index_section":"2","index_section_count":"5","index_total":"2","section":"Section 2"}'
     end
 
     assert_select ".govuk-footer__link[href='/link4']" do |link|
-      expect(link.attr("data-ga4-link").to_s).to eq '{"event_name":"navigation","type":"footer","index":{"index_link":"2","index_section":"2","index_section_count":"5"},"index_total":"2","section":"Section 2"}'
+      expect(link.attr("data-ga4-link").to_s).to eq '{"event_name":"navigation","type":"footer","index_link":"2","index_section":"2","index_section_count":"5","index_total":"2","section":"Section 2"}'
     end
 
     # Meta links
     assert_select ".govuk-footer__link[href='/link5']" do |link|
-      expect(link.attr("data-ga4-link").to_s).to eq '{"event_name":"navigation","type":"footer","index":{"index_link":"1","index_section":"3","index_section_count":"5"},"index_total":"3","section":"Support links"}'
+      expect(link.attr("data-ga4-link").to_s).to eq '{"event_name":"navigation","type":"footer","index_link":"1","index_section":"3","index_section_count":"5","index_total":"3","section":"Support links"}'
     end
 
     assert_select ".govuk-footer__link[href='/link6']" do |link|
-      expect(link.attr("data-ga4-link").to_s).to eq '{"event_name":"navigation","type":"footer","index":{"index_link":"2","index_section":"3","index_section_count":"5"},"index_total":"3","section":"Support links"}'
+      expect(link.attr("data-ga4-link").to_s).to eq '{"event_name":"navigation","type":"footer","index_link":"2","index_section":"3","index_section_count":"5","index_total":"3","section":"Support links"}'
     end
 
     # OGL link
     assert_select ".govuk-footer__licence-description" do |link_parent|
       expect(link_parent.attr("data-ga4-track-links-only").to_s).to eq ""
-      expect(link_parent.attr("data-ga4-link").to_s).to eq '{"event_name":"navigation","section":"Licence","index":{"index_section":"4","index_link":"1","index_section_count":"5"},"text":"Open Government Licence v3.0","index_total":"1","type":"footer"}'
+      expect(link_parent.attr("data-ga4-link").to_s).to eq '{"event_name":"navigation","section":"Licence","index_section":"4","index_link":"1","index_section_count":"5","text":"Open Government Licence v3.0","index_total":"1","type":"footer"}'
     end
 
     # Crown Copyright link
     assert_select ".govuk-footer__meta-item[data-ga4-link]" do |link_parent|
       expect(link_parent.attr("data-ga4-track-links-only").to_s).to eq ""
-      expect(link_parent.attr("data-ga4-link").to_s).to eq '{"event_name":"navigation","section":"Copyright","index":{"index_section":"5","index_link":"1","index_section_count":"5"},"text":"© Crown copyright","index_total":"1","type":"footer"}'
+      expect(link_parent.attr("data-ga4-link").to_s).to eq '{"event_name":"navigation","section":"Copyright","index_section":"5","index_link":"1","index_section_count":"5","text":"© Crown copyright","index_total":"1","type":"footer"}'
     end
   end
 end

--- a/spec/components/layout_super_navigation_header_spec.rb
+++ b/spec/components/layout_super_navigation_header_spec.rb
@@ -166,12 +166,12 @@ describe "Super navigation header", type: :view do
 
     assert_select "header[data-module='gem-track-click ga4-event-tracker ga4-link-tracker']"
     assert_select "a[data-ga4-link]", count: 29
-    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","external":"false","text":"GOV.UK","section":"Logo","index":{"index_link":1,"index_section":0,"index_section_count":2},"index_total":1}\']'
-    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":{"index_section":1,"index_link":1,"index_section_count":4},"index_total":16,"section":"Services and information"}\']'
-    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":{"index_section":1,"index_link":16,"index_section_count":4},"index_total":16,"section":"Services and information"}\']'
-    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":{"index_section":2,"index_link":1,"index_section_count":4},"index_total":6,"section":"Government activity"}\']'
-    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":{"index_section":2,"index_link":6,"index_section_count":4},"index_total":6,"section":"Government activity"}\']'
-    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":{"index_section":4,"index_link":1,"index_section_count":4},"index_total":6,"section":"Popular on GOV.UK"}\']'
-    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":{"index_section":4,"index_link":5,"index_section_count":4},"index_total":6,"section":"Popular on GOV.UK"}\']'
+    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","external":"false","text":"GOV.UK","section":"Logo","index_link":1,"index_section":0,"index_section_count":2,"index_total":1}\']'
+    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index_section":1,"index_link":1,"index_section_count":4,"index_total":16,"section":"Services and information"}\']'
+    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index_section":1,"index_link":16,"index_section_count":4,"index_total":16,"section":"Services and information"}\']'
+    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index_section":2,"index_link":1,"index_section_count":4,"index_total":6,"section":"Government activity"}\']'
+    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index_section":2,"index_link":6,"index_section_count":4,"index_total":6,"section":"Government activity"}\']'
+    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index_section":4,"index_link":1,"index_section_count":4,"index_total":6,"section":"Popular on GOV.UK"}\']'
+    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index_section":4,"index_link":5,"index_section_count":4,"index_total":6,"section":"Popular on GOV.UK"}\']'
   end
 end

--- a/spec/components/related_navigation_spec.rb
+++ b/spec/components/related_navigation_spec.rb
@@ -247,11 +247,11 @@ describe "Related navigation", type: :view do
     render_component(content_item:, ga4_tracking: true)
 
     assert_select ".gem-c-related-navigation[data-module='gem-track-click ga4-link-tracker']"
-    assert_select ".gem-c-related-navigation__section-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"related content\",\"index\":{\"index_section\":\"1\",\"index_link\":\"1\",\"index_section_count\":\"3\"},\"index_total\":\"2\",\"section\":\"Related content\"}']", text: "Fishing"
-    assert_select ".gem-c-related-navigation__section-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"related content\",\"index\":{\"index_section\":\"1\",\"index_link\":\"2\",\"index_section_count\":\"3\"},\"index_total\":\"2\",\"section\":\"Related content\"}']", text: "Surfing"
+    assert_select ".gem-c-related-navigation__section-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"related content\",\"index_section\":\"1\",\"index_link\":\"1\",\"index_section_count\":\"3\",\"index_total\":\"2\",\"section\":\"Related content\"}']", text: "Fishing"
+    assert_select ".gem-c-related-navigation__section-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"related content\",\"index_section\":\"1\",\"index_link\":\"2\",\"index_section_count\":\"3\",\"index_total\":\"2\",\"section\":\"Related content\"}']", text: "Surfing"
 
-    assert_select ".gem-c-related-navigation__section-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"related content\",\"index\":{\"index_section\":\"2\",\"index_link\":\"1\",\"index_section_count\":\"3\"},\"index_total\":\"3\",\"section\":\"Explore the topic\"}']", text: "Skating"
-    assert_select ".gem-c-related-navigation__section-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"related content\",\"index\":{\"index_section\":\"2\",\"index_link\":\"2\",\"index_section_count\":\"3\"},\"index_total\":\"3\",\"section\":\"Explore the topic\"}']", text: "Paragliding"
+    assert_select ".gem-c-related-navigation__section-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"related content\",\"index_section\":\"2\",\"index_link\":\"1\",\"index_section_count\":\"3\",\"index_total\":\"3\",\"section\":\"Explore the topic\"}']", text: "Skating"
+    assert_select ".gem-c-related-navigation__section-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"related content\",\"index_section\":\"2\",\"index_link\":\"2\",\"index_section_count\":\"3\",\"index_total\":\"3\",\"section\":\"Explore the topic\"}']", text: "Paragliding"
 
     assert_select ".gem-c-related-navigation__section-link[href=\"/world/wales/news\"]", text: "Wales"
     assert_select ".gem-c-related-navigation__link.toggle-wrap[data-module='ga4-event-tracker']"

--- a/spec/components/share_links_spec.rb
+++ b/spec/components/share_links_spec.rb
@@ -82,7 +82,7 @@ describe "ShareLinks", type: :view do
     assert_select '.gem-c-share-links__link[data-track-category="social media"][data-track-action="facebook"]'
     assert_select '.gem-c-share-links__link[data-track-options=\'{"socialAction":"share","socialNetwork":"facebook","socialTarget":"/facebook"}\']'
 
-    assert_select '.gem-c-share-links__link[data-ga4-link="{\"event_name\":\"navigation\",\"type\":\"share page\",\"index\":{\"index_link\":1},\"index_total\":1,\"text\":\"facebook\"}"]'
+    assert_select '.gem-c-share-links__link[data-ga4-link="{\"event_name\":\"navigation\",\"type\":\"share page\",\"index_link\":1,\"index_total\":1,\"text\":\"facebook\"}"]'
   end
 
   it "adds social interactions tracking for following" do
@@ -90,7 +90,7 @@ describe "ShareLinks", type: :view do
     assert_select '.gem-c-share-links[data-module="gem-track-click ga4-link-tracker"]'
     assert_select '.gem-c-share-links__link[data-track-category="social media"][data-track-action="facebook"]'
 
-    assert_select '.gem-c-share-links__link[data-ga4-link="{\"event_name\":\"navigation\",\"type\":\"follow us\",\"index\":{\"index_link\":1},\"index_total\":1}"]'
+    assert_select '.gem-c-share-links__link[data-ga4-link="{\"event_name\":\"navigation\",\"type\":\"follow us\",\"index_link\":1,\"index_total\":1}"]'
   end
 
   it "adds branding correctly" do

--- a/spec/components/single_page_notification_button_spec.rb
+++ b/spec/components/single_page_notification_button_spec.rb
@@ -158,9 +158,7 @@ describe "Single page notification button", type: :view do
         ga4_link: {
           event_name: "navigation",
           type: "subscribe",
-          index: {
-            index_link: 1,
-          },
+          index_link: 1,
           index_total: 2,
           section: "Top",
         },
@@ -170,7 +168,7 @@ describe "Single page notification button", type: :view do
 
     assert_select "[data-module='gem-track-click ga4-link-tracker']"
     assert_select ".gem-c-single-page-notification-button__submit" do |button|
-      expect(button.attr("data-ga4-link").to_s).to eq '{"event_name":"navigation","type":"subscribe","index":{"index_link":1},"index_total":2,"section":"Top","url":"/email/subscriptions/single-page/new"}'
+      expect(button.attr("data-ga4-link").to_s).to eq '{"event_name":"navigation","type":"subscribe","index_link":1,"index_total":2,"section":"Top","url":"/email/subscriptions/single-page/new"}'
     end
   end
 

--- a/spec/components/step_by_step_nav_header_spec.rb
+++ b/spec/components/step_by_step_nav_header_spec.rb
@@ -86,6 +86,22 @@ describe "Step by step navigation header", type: :view do
     assert_select "#{link}[data-track-options='{\"dimension96\":\"tracking-id\"}']"
   end
 
+  it "adds GA4 tracking" do
+    render_component(
+      title: "This is my title",
+      path: "/notalink",
+      ga4_tracking: true,
+    )
+    expected = {
+      event_name: "navigation",
+      type: "super breadcrumb",
+      index_link: "1",
+      index_total: "1",
+    }.to_json
+    assert_select(".gem-c-step-nav-header[data-module='gem-track-click ga4-link-tracker']")
+    assert_select(".gem-c-step-nav-header__title[data-ga4-link='#{expected}']")
+  end
+
   it "adds a custom tracking without tracking id or custom dimensions" do
     render_component(
       title: "This is my title",

--- a/spec/components/step_by_step_nav_related_spec.rb
+++ b/spec/components/step_by_step_nav_related_spec.rb
@@ -120,7 +120,7 @@ describe "Step by step navigation related", type: :view do
     expected = {
       "event_name": "navigation",
       "type": "part of",
-      "index": { "index_link": "1" },
+      "index_link": "1",
       "index_total": "1",
       "section": "Some text",
     }
@@ -136,7 +136,7 @@ describe "Step by step navigation related", type: :view do
     expected = {
       "event_name": "navigation",
       "type": "related content",
-      "index": { "index_link": "1" },
+      "index_link": "1",
       "index_total": "1",
       "section": "Part of",
     }
@@ -153,7 +153,7 @@ describe "Step by step navigation related", type: :view do
     expected_one = {
       "event_name": "navigation",
       "type": "part of",
-      "index": { "index_link": "1" },
+      "index_link": "1",
       "index_total": "2",
       "section": "Some more text",
     }
@@ -161,7 +161,7 @@ describe "Step by step navigation related", type: :view do
     expected_two = {
       "event_name": "navigation",
       "type": "part of",
-      "index": { "index_link": "2" },
+      "index_link": "2",
       "index_total": "2",
       "section": "Some more text",
     }
@@ -179,7 +179,7 @@ describe "Step by step navigation related", type: :view do
     expected_one = {
       "event_name": "navigation",
       "type": "related content",
-      "index": { "index_link": "1" },
+      "index_link": "1",
       "index_total": "2",
       "section": "Part of",
     }
@@ -187,7 +187,7 @@ describe "Step by step navigation related", type: :view do
     expected_two = {
       "event_name": "navigation",
       "type": "related content",
-      "index": { "index_link": "2" },
+      "index_link": "2",
       "index_total": "2",
       "section": "Part of",
     }

--- a/spec/components/step_by_step_nav_spec.rb
+++ b/spec/components/step_by_step_nav_spec.rb
@@ -296,7 +296,8 @@ describe "step nav", type: :view do
     expected = {
       "event_name": "navigation",
       "type": "step by step",
-      "index": { "index_section": 1, "index_section_count": 2 },
+      "index_section": 1,
+      "index_section_count": 2,
       "section": "Step 1",
     }.to_json
 
@@ -309,7 +310,8 @@ describe "step nav", type: :view do
     expected = {
       "event_name": "navigation",
       "type": "step by step",
-      "index": { "index_section": 2, "index_section_count": 2 },
+      "index_section": 2,
+      "index_section_count": 2,
       "section": "Step 2",
     }.to_json
 
@@ -326,7 +328,8 @@ describe "step nav", type: :view do
     expected = {
       "event_name": "navigation",
       "type": "step by step",
-      "index": { "index_section": 1, "index_section_count": 5 },
+      "index_section": 1,
+      "index_section_count": 5,
       "section": "Step 1",
     }.to_json
 
@@ -339,7 +342,8 @@ describe "step nav", type: :view do
     expected = {
       "event_name": "navigation",
       "type": "step by step",
-      "index": { "index_section": 2, "index_section_count": 5 },
+      "index_section": 2,
+      "index_section_count": 5,
       "section": "Step 1 and",
     }.to_json
 
@@ -352,7 +356,8 @@ describe "step nav", type: :view do
     expected = {
       "event_name": "navigation",
       "type": "step by step",
-      "index": { "index_section": 3, "index_section_count": 5 },
+      "index_section": 3,
+      "index_section_count": 5,
       "section": "Step 2",
     }.to_json
 

--- a/spec/components/tabs_spec.rb
+++ b/spec/components/tabs_spec.rb
@@ -76,9 +76,9 @@ describe "Tabs", type: :view do
     )
 
     assert_select ".govuk-tabs[data-module='govuk-tabs ga4-event-tracker']"
-    assert_select ".govuk-tabs__tab[data-ga4-event='{\"event_name\":\"select_content\",\"type\":\"tabs\",\"text\":\"First section\",\"index\":{\"index_section\":1,\"index_section_count\":3}}']"
-    assert_select ".govuk-tabs__tab[data-ga4-event='{\"event_name\":\"select_content\",\"type\":\"tabs\",\"text\":\"Second section\",\"index\":{\"index_section\":2,\"index_section_count\":3}}']"
-    assert_select ".govuk-tabs__tab[data-ga4-event='{\"event_name\":\"select_content\",\"type\":\"tabs\",\"text\":\"Third section\",\"index\":{\"index_section\":3,\"index_section_count\":3}}']"
+    assert_select ".govuk-tabs__tab[data-ga4-event='{\"event_name\":\"select_content\",\"type\":\"tabs\",\"text\":\"First section\",\"index_section\":1,\"index_section_count\":3}']"
+    assert_select ".govuk-tabs__tab[data-ga4-event='{\"event_name\":\"select_content\",\"type\":\"tabs\",\"text\":\"Second section\",\"index_section\":2,\"index_section_count\":3}']"
+    assert_select ".govuk-tabs__tab[data-ga4-event='{\"event_name\":\"select_content\",\"type\":\"tabs\",\"text\":\"Third section\",\"index_section\":3,\"index_section_count\":3}']"
   end
 
   it "renders with GA4 tracking on tabs as links" do
@@ -103,8 +103,8 @@ describe "Tabs", type: :view do
     )
 
     assert_select ".govuk-tabs[data-module='ga4-link-tracker']"
-    assert_select ".govuk-tabs__tab[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"tabs\",\"text\":\"First section\",\"index\":{\"index_section\":1,\"index_section_count\":3}}']"
-    assert_select ".govuk-tabs__tab[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"tabs\",\"text\":\"Second section\",\"index\":{\"index_section\":2,\"index_section_count\":3}}']"
-    assert_select ".govuk-tabs__tab[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"tabs\",\"text\":\"Third section\",\"index\":{\"index_section\":3,\"index_section_count\":3}}']"
+    assert_select ".govuk-tabs__tab[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"tabs\",\"text\":\"First section\",\"index_section\":1,\"index_section_count\":3}']"
+    assert_select ".govuk-tabs__tab[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"tabs\",\"text\":\"Second section\",\"index_section\":2,\"index_section_count\":3}']"
+    assert_select ".govuk-tabs__tab[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"tabs\",\"text\":\"Third section\",\"index_section\":3,\"index_section_count\":3}']"
   end
 end

--- a/spec/javascripts/components/accordion-spec.js
+++ b/spec/javascripts/components/accordion-spec.js
@@ -107,10 +107,8 @@ describe('Accordion component', function () {
     var ga4Object = {
       event_name: 'select_content',
       type: 'accordion',
-      index: {
-        index_section: 0,
-        index_section_count: 3
-      }
+      index_section: 0,
+      index_section_count: 3
     }
     accordion.setAttribute('data-show-all-attributes', JSON.stringify(wrappingObject))
     accordion.setAttribute('data-module', accordion.getAttribute('data-module') + ' ga4-event-tracker')

--- a/spec/javascripts/components/step-by-step-nav-spec.js
+++ b/spec/javascripts/components/step-by-step-nav-spec.js
@@ -936,14 +936,14 @@ describe('A stepnav module', function () {
       var stepNav = element.childNodes[0]
       var showAllButton = stepNav.querySelector('button.js-step-controls-button')
 
-      expect(showAllButton.getAttribute('data-ga4-event')).toEqual('{"event_name":"select_content","type":"step by step","index":{"index_section":0,"index_section_count":3}}')
+      expect(showAllButton.getAttribute('data-ga4-event')).toEqual('{"event_name":"select_content","type":"step by step","index_section":0,"index_section_count":3}')
     })
 
     it('adds the data-ga4-event attribute to the JS generated step button', function () {
       var stepNav = element.childNodes[0]
       var stepButton = stepNav.querySelector('#topic-step-one .js-step-title button')
 
-      expect(stepButton.getAttribute('data-ga4-event')).toEqual('{"event_name":"select_content","type":"step by step","text":"This title\'s got quotation marks \\" in it.","index":{"index_section":1,"index_section_count":3},"index_total":1}')
+      expect(stepButton.getAttribute('data-ga4-event')).toEqual('{"event_name":"select_content","type":"step by step","text":"This title\'s got quotation marks \\" in it.","index_section":1,"index_section_count":3,"index_total":1}')
     })
   })
 })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-auto-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-auto-tracker.spec.js
@@ -105,11 +105,9 @@ describe('Google Analytics auto tracker', function () {
         event_name: 'select_content',
         type: 'tabs',
         not_a_schema_attribute: 'something',
-        index: {
-          index_section: 7,
-          index_link: undefined,
-          index_section_count: undefined
-        }
+        index_section: 7,
+        index_link: undefined,
+        index_section_count: undefined
       }
       element.setAttribute('data-ga4-auto', JSON.stringify(attributes))
       new GOVUK.Modules.Ga4AutoTracker(element).init()

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.spec.js
@@ -534,9 +534,7 @@ describe('Google Analytics event tracker', function () {
           type: 'header menu bar',
           text: button.textContent,
           section: button.textContent,
-          index: {
-            index_section: i + 1
-          },
+          index_section: i + 1,
           index_total: buttons.length
         }))
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
@@ -101,9 +101,7 @@ describe('GA4 link tracker', function () {
       attributes = {
         event_name: 'navigation',
         type: 'a link',
-        index: {
-          index_link: 1
-        }
+        index_link: 1
       }
       expected.event = 'event_data'
       expected.event_data.type = 'a link'

--- a/spec/lib/govuk_publishing_components/components/layout_footer_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/components/layout_footer_helper_spec.rb
@@ -56,11 +56,9 @@ RSpec.describe GovukPublishingComponents::Presenters::LayoutFooterHelper do
       expected = {
         "event_name": "navigation",
         "type": "footer",
-        "index": {
-          "index_link": "1",
-          "index_section": "1",
-          "index_section_count": "4",
-        },
+        "index_link": "1",
+        "index_section": "1",
+        "index_section_count": "4",
         "index_total": "5",
         "section": "Test",
       }


### PR DESCRIPTION
## What / why
In a [PR a while back](https://github.com/alphagov/govuk_publishing_components/pull/3436) we removed the need for attributes such as `index_link` to be nested beneath an `index` attribute, as the JS could now find each attribute name and insert it into a copy of the schema, where structure was defined.

This PR updates some of our code to make use of this functionality, by de-nesting nested attributes. Note that this change is internal to the gem and should not break anything - another PR will be raised later to remove the code that currently checks for nested attributes, once it is safe to do so.

## Visual Changes
None.

Trello card: https://trello.com/c/IseA05Fd/644-remove-nesting-of-ga4-attributes

