### PR TITLE
Version 35.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 35.18.0
 
 * Change GA4 type on contents lists ([PR #3647](https://github.com/alphagov/govuk_publishing_components/pull/3647))
 * Bump Ruby version and use floating patch version ([PR #3646](https://github.com/alphagov/govuk_publishing_components/pull/3646))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (35.17.0)
+    govuk_publishing_components (35.18.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "35.17.0".freeze
+  VERSION = "35.18.0".freeze
 end


### PR DESCRIPTION
* Change GA4 type on contents lists ([PR #3647](https://github.com/alphagov/govuk_publishing_components/pull/3647))
* Bump Ruby version and use floating patch version ([PR #3646](https://github.com/alphagov/govuk_publishing_components/pull/3646))
* Add homepage variant of navbar for new design of homepage ([PR #3566](https://github.com/alphagov/govuk_publishing_components/pull/3566))
