### PR TITLE
Add GA4 'print intent' tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add GA4 'print intent' tracker ([PR #3652](https://github.com/alphagov/govuk_publishing_components/pull/3652))
+
 ## 35.19.0
 
 * Improve attachment details styles ([PR #3668](https://github.com/alphagov/govuk_publishing_components/pull/3668))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4.js
@@ -3,6 +3,7 @@
 //= require ./analytics-ga4/ga4-schemas
 //= require ./analytics-ga4/pii-remover
 //= require ./analytics-ga4/ga4-page-views
+//= require ./analytics-ga4/ga4-print-intent-tracker
 //= require ./analytics-ga4/ga4-specialist-link-tracker
 //= require ./analytics-ga4/ga4-link-tracker
 //= require ./analytics-ga4/ga4-event-tracker

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-print-intent-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-print-intent-tracker.js
@@ -1,0 +1,24 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
+window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analyticsModules || {};
+
+(function (analyticsModules) {
+  'use strict'
+
+  var Ga4PrintIntentTracker = {
+    init: function () {
+      window.addEventListener('beforeprint', function () {
+        var data = {
+          event_name: 'print_page',
+          type: 'print page',
+          method: 'browser print'
+        }
+        var schema = new window.GOVUK.analyticsGa4.Schemas()
+        schema = schema.mergeProperties(data, 'event_data')
+        window.GOVUK.analyticsGa4.core.sendData(schema)
+      })
+    }
+  }
+
+  analyticsModules.Ga4PrintIntentTracker = Ga4PrintIntentTracker
+})(window.GOVUK.analyticsGa4.analyticsModules)

--- a/docs/analytics-ga4/ga4-all-trackers.md
+++ b/docs/analytics-ga4/ga4-all-trackers.md
@@ -27,6 +27,10 @@ There are several types of link tracking. To distinguish them and simplify the c
 - the [link tracker](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-link-tracker.md) handles link clicks with data attributes added to specific links, or to parent elements of groups of links
 - the [specialist link tracker](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-specialist-link-tracker.md)automatically tracks clicks on 'special' links, such as external links, download links and mailto links
 
+## Print intent tracker
+
+The [print intent tracker](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-print-intent-tracker.md) tracks if the page has been requested to be printed.
+
 ## Scroll tracker
 
 The [scroll tracker](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-scroll-tracker.md) tracks how much of a page has been viewed.

--- a/docs/analytics-ga4/ga4-print-intent-tracker.md
+++ b/docs/analytics-ga4/ga4-print-intent-tracker.md
@@ -1,0 +1,20 @@
+# Google Analytics 4 print intent tracker
+
+This script tracks when the user opens the print prompt in their browser, e.g. when pressing Ctrl/Cmd + P or going to File > Print.
+
+## How it works
+
+Assuming that consent has been given, the print intent tracker is launched automatically by `init-ga4.js`, as there is a function in that file which automatically runs the `init()` function on anything namespaced under `window.GOVUK.analyticsGa4.analyticsModules`.
+
+When initialised, a `beforeprint` event listener is added to the JavaScript `window`. If the `beforeprint` event is fired, the following dataLayer object is sent to GA4:
+
+```JSON
+{
+  "event": "event_data",
+  "event_data": {
+    "event_name": "print_intent",
+    "type": "print intent",
+    "method": "browser print"
+  }
+}
+```

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-print-intent-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-print-intent-tracker.spec.js
@@ -1,0 +1,29 @@
+/* eslint-env jasmine */
+
+describe('Google Analytics 4 print intent tracker', function () {
+  var GOVUK = window.GOVUK
+  var expected
+
+  beforeAll(function () {
+    window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
+    window.GOVUK.analyticsGa4.vars = window.GOVUK.analyticsGa4.vars || {}
+    window.GOVUK.analyticsGa4.vars.gem_version = 'aVersion'
+  })
+
+  beforeEach(function () {
+    window.dataLayer = []
+    expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
+    expected.event = 'event_data'
+    expected.event_data.event_name = 'print_page'
+    expected.event_data.type = 'print page'
+    expected.event_data.method = 'browser print'
+    expected.govuk_gem_version = 'aVersion'
+  })
+
+  it('triggers a GA4 event when the \'beforeprint\' event is fired', function () {
+    GOVUK.analyticsGa4.analyticsModules.Ga4PrintIntentTracker.init()
+    window.GOVUK.triggerEvent(window, 'beforeprint')
+
+    expect(window.dataLayer[0]).toEqual(expected)
+  })
+})


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Adds a new tracker called `ga4-print-intent-tracker`
- This runs on pageload, adding a `beforeprint` listener to the `window`
- The event listener fires if the user triggers a "Print page" via their browser (e.g. with `Ctrl/Cmd + P`, or by going to `File > Print`)

## Why
<!-- What are the reasons behind this change being made? -->
- This is tracked in UA https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics/print-intent.js . I'm not sure why the code is a lot more complicated, I guess the UA requirements were different. I didn't reuse this code as well because `mediaQueryList.addListener` is deprecated JS.
- https://trello.com/c/EpTcwew0/684-print-page-event-to-be-sent-with-ctrl-cmdp

## How to test
- Run `static` with a local version of `govuk_publishing_components` pointing to this branch
- Trigger a print page on static, and you should see the object in the data layer

## Visual Changes

None.