### PR TITLE
Replace '+' in GA4 search term values with an actual space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Replace '+' in GA4 search term values with an actual space ([PR #3653](https://github.com/alphagov/govuk_publishing_components/pull/3653))
+
 ## 35.18.0
 
 * Change GA4 type on contents lists ([PR #3647](https://github.com/alphagov/govuk_publishing_components/pull/3647))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
@@ -89,6 +89,8 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
       }
 
       searchTerm = searchTerm[0].replace('keywords=', '')
+      searchTerm = searchTerm.replace(/\++/g, ' ')
+      searchTerm = window.GOVUK.analyticsGa4.core.trackFunctions.removeLinesAndExtraSpaces(searchTerm)
       searchTerm = this.PIIRemover.stripPIIWithOverride(searchTerm, true, true)
       return searchTerm
     },

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
@@ -553,15 +553,23 @@ describe('Google Tag Manager page view tracking', function () {
     it('correctly sets the parameter using ?keywords= with PII values redacted', function () {
       spyOn(GOVUK.analyticsGa4.analyticsModules.PageViewTracker, 'getSearch').and.returnValue('?keywords=hello+world+email@example.com+SW12AA+1990-01-01&another=one')
       expected.page_view.query_string = 'keywords=hello+world+[email]+[postcode]+[date]&another=one'
-      expected.page_view.search_term = 'hello+world+[email]+[postcode]+[date]'
+      expected.page_view.search_term = 'hello world [email] [postcode] [date]'
       GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
       expect(window.dataLayer[0]).toEqual(expected)
     })
 
-    it('correctly sets the  parameter using &keywords= with PII values redacted', function () {
+    it('correctly sets the parameter using &keywords= with PII values redacted', function () {
       spyOn(GOVUK.analyticsGa4.analyticsModules.PageViewTracker, 'getSearch').and.returnValue('?test=true&keywords=hello+world+email@example.com+SW12AA+1990-01-01&another=one')
       expected.page_view.query_string = 'test=true&keywords=hello+world+[email]+[postcode]+[date]&another=one'
-      expected.page_view.search_term = 'hello+world+[email]+[postcode]+[date]'
+      expected.page_view.search_term = 'hello world [email] [postcode] [date]'
+      GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+
+    it('replaces plusses with spaces', function () {
+      spyOn(GOVUK.analyticsGa4.analyticsModules.PageViewTracker, 'getSearch').and.returnValue('?test=true&keywords=hello++++world+there+are+spaces++in+++a+lot++++of+++places')
+      expected.page_view.query_string = 'test=true&keywords=hello++++world+there+are+spaces++in+++a+lot++++of+++places'
+      expected.page_view.search_term = 'hello world there are spaces in a lot of places'
       GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
       expect(window.dataLayer[0]).toEqual(expected)
     })


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Search terms with spaces come through as 'hello+world' in URLs, and subsequently our `search_term` pageview parameter
- The PAs would rather have the actual spaces e.g. 'hello world'
- This PR fixes that using regex

## Why
<!-- What are the reasons behind this change being made? -->
https://trello.com/c/OCr10DWn/700-searchterm-parameter-includes-between-words

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.