### PR TITLE
Update logo spacing for new homepage design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 ## Unreleased
 
 * Replace '+' in GA4 search term values with an actual space ([PR #3653](https://github.com/alphagov/govuk_publishing_components/pull/3653))
+* Update image card two thirds variation #3661 ([PR #3661](https://github.com/alphagov/govuk_publishing_components/pull/3661))
+* Update logo spacing for new homepage design #3658 ([PR #3658](https://github.com/alphagov/govuk_publishing_components/pull/3658))
 
 ## 35.18.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -877,6 +877,13 @@ $after-button-padding-left: govuk-spacing(4);
   }
 }
 
+// Ensure the total space to the left of the logo for mobile screen sizes is 24px (margin is 15px)
+@include govuk-media-query($until: tablet) {
+  .gem-c-layout-super-navigation-header__header-logo--large-navbar {
+    padding-left: 9px;
+  }
+}
+
 @include govuk-media-query($from: desktop) {
   // can't use govuk-spacing here because the navbar height
   // isn't a multiple of 5 :(


### PR DESCRIPTION
## What
Ensure the total space to the left of the logo for mobile screen sizes is 24px (margin is 15px) for the new homepage design

## Why
For the new homepage design, the total space on the left and right of the content should be 24px for mobile.

[Trello card](https://trello.com/c/9j5GiXNP/2172-look-and-feel-homepage-update-left-and-right-spacing-on-mobile-s)

## Visual Changes

### Before
<img width="437" alt="homepage-nav-before" src="https://github.com/alphagov/govuk_publishing_components/assets/28779939/a36de675-2026-4019-b5ca-8a33c9d42be7">


### After
<img width="436" alt="homepage-nav-after" src="https://github.com/alphagov/govuk_publishing_components/assets/28779939/0de92209-b645-42cb-93d4-f86daab0c3c8">

