### PR TITLE
Implement One Login "cross service header"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Implement One Login "cross service header" ([PR #3659](https://github.com/alphagov/govuk_publishing_components/pull/3659))
+
 ## 35.22.0
 
 * Enable GA4 by default on components ([PR #3705](https://github.com/alphagov/govuk_publishing_components/pull/3705))

--- a/app/assets/config/govuk_publishing_components_manifest.js
+++ b/app/assets/config/govuk_publishing_components_manifest.js
@@ -30,6 +30,7 @@
 //= link govuk_publishing_components/components/_contextual-sidebar.css
 //= link govuk_publishing_components/components/_cookie-banner.css
 //= link govuk_publishing_components/components/_copy-to-clipboard.css
+//= link govuk_publishing_components/components/_cross-service-header.css
 //= link govuk_publishing_components/components/_date-input.css
 //= link govuk_publishing_components/components/_details.css
 //= link govuk_publishing_components/components/_devolved-nations.css

--- a/app/assets/javascripts/govuk_publishing_components/components/cross-service-header.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/cross-service-header.js
@@ -1,0 +1,78 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  /**
+  * A modified adaptation of the Design System header script
+  * To initialise the One Login header, run:
+  * new window.CrossServiceHeader(document.querySelector("[data-module='one-login-header']")).init();
+  */
+  function CrossServiceHeader ($module) {
+    this.$header = $module
+    this.$navigation = $module && $module.querySelectorAll('[data-one-login-header-nav]')
+    this.$numberOfNavs = this.$navigation && this.$navigation.length
+    if (this.$header) {
+      this.$header.classList.add('js-enabled')
+    }
+  }
+  /**
+  * Initialise header
+  *
+  * Check for the presence of the header, menu and menu button – if any are
+  * missing then there's nothing to do so return early.
+  */
+  CrossServiceHeader.prototype.init = function () {
+    if (!this.$header && !this.$numberOfNavs) {
+      return
+    }
+    /**
+    * The header can render with one or two navigation elements which collapse
+    * into dropdowns on the mobile variation. This initialises the dropdown
+    * functionality for all navs that have a menu button which has:
+    * 1. a class of .js-x-header-toggle
+    * 2. an aria-controls attribute which can be mapped to the ID of the element
+    * that should be hidden on mobile
+    */
+    for (var i = 0; i < this.$numberOfNavs; i++) {
+      var $nav = this.$navigation[i]
+      $nav.$menuButton = $nav.querySelector('.js-x-header-toggle')
+
+      $nav.$menu = $nav.$menuButton && $nav.querySelector(
+        '#' + $nav.$menuButton.getAttribute('aria-controls')
+      )
+      if (!$nav.$menuButton || !$nav.$menu) {
+        return
+      }
+      $nav.$menuOpenClass = $nav.$menu && $nav.$menu.dataset.openClass
+      $nav.$menuButtonOpenClass = $nav.$menuButton && $nav.$menuButton.dataset.openClass
+      $nav.$menuButtonOpenLabel = $nav.$menuButton && $nav.$menuButton.dataset.labelForShow
+      $nav.$menuButtonCloseLabel = $nav.$menuButton && $nav.$menuButton.dataset.labelForHide
+      $nav.$menuButtonOpenText = $nav.$menuButton && $nav.$menuButton.dataset.textForShow
+      $nav.$menuButtonCloseText = $nav.$menuButton && $nav.$menuButton.dataset.textForHide
+      $nav.isOpen = false
+
+      $nav.$menuButton.addEventListener('click', this.handleMenuButtonClick.bind($nav))
+    }
+  }
+
+  /**
+  * Handle menu button click
+  *
+  * When the menu button is clicked, change the visibility of the menu and then
+  * sync the accessibility state and menu button state
+  */
+  CrossServiceHeader.prototype.handleMenuButtonClick = function () {
+    this.isOpen = !this.isOpen
+    this.$menuOpenClass && this.$menu.classList.toggle(this.$menuOpenClass, this.isOpen)
+    this.$menuButtonOpenClass && this.$menuButton.classList.toggle(this.$menuButtonOpenClass, this.isOpen)
+    this.$menuButton.setAttribute('aria-expanded', this.isOpen)
+    if (this.$menuButtonCloseLabel && this.$menuButtonOpenLabel) {
+      this.$menuButton.setAttribute('aria-label', (this.isOpen ? this.$menuButtonCloseLabel : this.$menuButtonOpenLabel))
+    }
+    if (this.$menuButtonCloseText && this.$menuButtonOpenText) {
+      this.$menuButton.innerHTML = this.isOpen ? this.$menuButtonCloseText : this.$menuButtonOpenText
+    }
+  }
+
+  Modules.CrossServiceHeader = CrossServiceHeader
+})(window.GOVUK.Modules)

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -27,6 +27,7 @@ $govuk-new-link-styles: true;
 @import "components/contextual-sidebar";
 @import "components/cookie-banner";
 @import "components/copy-to-clipboard";
+@import "components/cross-service-header";
 @import "components/date-input";
 @import "components/details";
 @import "components/devolved-nations";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cross-service-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cross-service-header.scss
@@ -1,0 +1,430 @@
+@import "govuk_publishing_components/individual_component_support";
+
+// start mixins and variables
+$govuk-header-link-underline-thickness: 3px;
+
+@mixin toggle-button-focus($default-text-colour) {
+  color: $default-text-colour;
+  // apply focus style on :focus for browsers which support :focus but not :focus-visible
+  &:focus {
+    @include govuk-focused-text;
+
+    // overwrite previous styles for browsers which support :focus-visible
+    &:not(:focus-visible) {
+      outline: none;
+      color: $default-text-colour;
+      background: none;
+      box-shadow: none;
+    }
+
+    // apply focus style on :focus-visible for browsers which support :focus-visible
+    &-visible {
+      @include govuk-focused-text;
+    }
+  }
+}
+
+@mixin nav-style($nav-open-class) {
+  display: block;
+  // if JS is unavailable, the nav links are expanded and the toggle button is hidden
+  .gem-c-cross-service-header.js-enabled & {
+    display: none;
+
+    &#{$nav-open-class} {
+      display: block;
+    }
+
+    @include govuk-media-query($from: tablet) {
+      display: block;
+    }
+  }
+
+  @include govuk-media-query($until: tablet) {
+    width: 100%;
+  }
+}
+// end mixins and variables
+
+.gem-c-cross-service-header__button {
+  display: none;
+
+  .gem-c-cross-service-header.js-enabled & {
+    display: inline;
+    display: flex;
+
+    @include govuk-media-query($from: tablet) {
+      display: none;
+    }
+  }
+
+  @include govuk-font($size: 19, $weight: bold);
+  position: relative;
+  align-items: center;
+  cursor: pointer;
+  min-width: 240px;
+  min-width: max-content;
+  border: 0;
+  margin: 0;
+  padding: govuk-spacing(2) 0 govuk-spacing(1) govuk-spacing(4);
+  background: none;
+
+  &::before {
+    content: "";
+    position: absolute;
+    left: 0.15rem;
+    top: 50%;
+    box-sizing: border-box;
+    display: inline-block;
+    width: 0.6rem;
+    height: 0.6rem;
+    transform: translateY(-65%) rotate(135deg);
+    border-top: 0.15rem solid;
+    border-right: 0.15rem solid;
+  }
+
+  &.gem-c-cross-service-header__button--open {
+    &::before {
+      transform: translateY(-15%) rotate(-45deg);
+    }
+  }
+
+  &.gem-c-cross-service-header__button--service-header {
+    @include toggle-button-focus($govuk-link-colour);
+  }
+
+  &.gem-c-cross-service-header__button--one-login {
+    @include toggle-button-focus(govuk-colour("white"));
+  }
+}
+
+.gem-c-cross-service-header__button-icon {
+  margin-left: govuk-spacing(2);
+  font-size: 0;
+
+  &.gem-c-cross-service-header__button-icon--focus {
+    display: none;
+  }
+
+  // apply focus style on :focus for browsers which support :focus but not :focus-visible
+  .gem-c-cross-service-header__button:focus & {
+    &.gem-c-cross-service-header__button-icon--default {
+      display: none;
+    }
+
+    &.gem-c-cross-service-header__button-icon--focus {
+      display: inline;
+    }
+  }
+
+  // overwrite previous styles for browsers which support :focus-visible
+  .gem-c-cross-service-header__button:focus:not(:focus-visible) & {
+    &.gem-c-cross-service-header__button-icon--default {
+      display: inline;
+    }
+
+    &.gem-c-cross-service-header__button-icon--focus {
+      display: none;
+    }
+  }
+
+  // apply focus style on :focus-visible for browsers which support :focus-visible
+  .gem-c-cross-service-header__button:focus-visible & {
+    &.gem-c-cross-service-header__button-icon--default {
+      display: none;
+    }
+
+    &.gem-c-cross-service-header__button-icon--focus {
+      display: inline;
+    }
+  }
+}
+
+// start One Login header styles
+.gem-c-one-login-header {
+  @include govuk-font($size: 19);
+  color: govuk-colour("white");
+  background: govuk-colour("black");
+  border-bottom: govuk-spacing(2) solid $govuk-link-colour;
+  position: relative;
+}
+
+.gem-c-one-login-header__container {
+  display: flex;
+  position: relative;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.gem-c-one-login-header__logo {
+  min-width: max-content;
+  padding-top: govuk-spacing(2);
+  padding-bottom: govuk-spacing(2);
+  max-width: 33.33%;
+  @include govuk-media-query($from: desktop) {
+    width: 33.33%;
+    padding-right: govuk-spacing(3);
+  }
+}
+
+.gem-c-one-login-header__link,
+.gem-c-one-login-header__nav__link {
+  &:link,
+  &:visited {
+    @include govuk-typography-common;
+    @include govuk-link-style-inverse;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+      text-decoration-thickness: $govuk-header-link-underline-thickness;
+
+      @if $govuk-link-underline-offset {
+        text-underline-offset: $govuk-link-underline-offset;
+      }
+    }
+
+    &:focus {
+      @include govuk-focused-text;
+    }
+  }
+}
+
+.gem-c-one-login-header__logotype {
+  display: inline-block;
+
+  // Add a gap after the logo in case it's followed by a product name. This
+  // gets removed later if the logotype is a :last-child.
+  margin-right: govuk-spacing(1);
+
+  // Prevent readability backplate from obscuring underline in Windows High
+  // Contrast Mode
+  @media (forced-colors: active) {
+    forced-color-adjust: none;
+    color: linktext;
+  }
+
+  // Remove the gap after the logo if there's no product name to keep hover
+  // and focus states neat
+  &:last-child {
+    margin-right: 0;
+  }
+}
+
+.gem-c-one-login-header__logotype-crown {
+  position: relative;
+  top: -1px;
+  margin-right: 1px;
+  fill: currentcolor;
+  vertical-align: top;
+}
+
+.gem-c-one-login-header__logotype-crown-fallback-image {
+  width: 36px;
+  height: 32px;
+  border: 0;
+  vertical-align: bottom;
+}
+
+.gem-c-one-login-header__link--homepage {
+  // Font size needs to be set on the link so that the box sizing is correct
+  // in Firefox
+  @include govuk-font($size: false, $weight: bold);
+
+  display: inline-block;
+  margin-right: govuk-spacing(2);
+  font-size: 30px; // We don't have a mixin that produces 30px font size
+  line-height: 1;
+
+  @include govuk-media-query($from: tablet) {
+    display: inline;
+
+    &:focus {
+      // Replicate the focus box shadow but without the -2px y-offset of the first yellow shadow
+      // This is to stop the logo getting cut off by the box shadow when focused on above a product name
+      box-shadow: 0 0 $govuk-focus-colour;
+    }
+  }
+
+  &:link,
+  &:visited {
+    text-decoration: none;
+  }
+
+  &:hover,
+  &:active {
+    // Negate the added border
+    margin-bottom: $govuk-header-link-underline-thickness * -1;
+    // Omitting colour will use default value of currentColor – if we
+    // specified currentColor explicitly IE8 would ignore this rule.
+    border-bottom: $govuk-header-link-underline-thickness solid;
+  }
+
+  // Remove any borders that show when focused and hovered.
+  &:focus {
+    margin-bottom: 0;
+    border-bottom: 0;
+  }
+}
+
+.gem-c-one-login-header__nav {
+  @include nav-style(".gem-c-one-login-header__nav--open");
+  @include govuk-media-query($from: tablet) {
+    max-width: 66%;
+  }
+}
+
+.gem-c-one-login-header__nav__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+
+  @include govuk-media-query($from: tablet) {
+    padding: govuk-spacing(2) 0;
+    display: flex;
+    align-items: center;
+  }
+}
+
+.gem-c-one-login-header__nav__list-item {
+  display: inline-block;
+  padding: govuk-spacing(2) 0;
+
+  @include govuk-media-query($from: tablet) {
+    padding: govuk-spacing(2) 0 govuk-spacing(2) govuk-spacing(6);
+    border-left: 1px solid $govuk-border-colour;
+    align-self: stretch;
+
+    &:not(:last-child) {
+      margin-right: govuk-spacing(4);
+    }
+  }
+
+  @include govuk-media-query($until: tablet) {
+    width: 100%;
+
+    &:not(:last-child) {
+      border-bottom: 1px solid $govuk-border-colour;
+    }
+  }
+}
+
+.gem-c-one-login-header__nav__link {
+  font-weight: bold;
+
+  &.gem-c-one-login-header__nav__link--one-login {
+    @include govuk-media-query($from: tablet) {
+      display: flex;
+      justify-content: center;
+
+      // stylelint-disable max-nesting-depth
+      &:focus {
+        .gem-c-cross-service-header__button-icon {
+          display: none;
+        }
+
+        .gem-c-cross-service-header__button-icon--focus {
+          display: inline;
+        }
+      }
+    }
+
+    @include govuk-media-query($until: tablet) {
+      .gem-c-cross-service-header__button-icon {
+        display: none;
+      }
+    }
+  }
+}
+// end One Login header styles
+
+// start service navigation styles
+.gem-c-service-header {
+  background-color: govuk-colour("light-grey");
+  border-bottom: 1px solid govuk-colour("mid-grey");
+}
+
+.gem-c-service-header__container {
+  padding-top: govuk-spacing(1);
+
+  @include govuk-media-query ($until: tablet) {
+    margin-bottom: govuk-spacing(1);
+  }
+
+  @include govuk-media-query ($from: tablet) {
+    display: flex;
+    flex-wrap: wrap;
+  }
+}
+
+.gem-c-service-header__heading {
+  @include govuk-font($size: 24, $weight: bold);
+  color: $govuk-text-colour;
+  padding: govuk-spacing(3) 0;
+  margin: 0;
+  flex-grow: 1;
+
+  @include govuk-media-query($until: tablet) {
+    padding: govuk-spacing(1) 0;
+  }
+}
+
+.gem-c-service-header__nav {
+  @include nav-style(".gem-c-service-header__nav--open");
+}
+
+.gem-c-service-header__nav-list {
+  @include govuk-font($size: 19, $weight: bold);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+
+  @include govuk-media-query($from: tablet) {
+    @include govuk-font($size: 19, $weight: bold);
+  }
+}
+
+.gem-c-service-header__nav-list-item {
+  margin: govuk-spacing(3) 0 govuk-spacing(4);
+
+  &.gem-c-service-header__nav-list-item--active {
+    padding-left: govuk-spacing(3);
+    border-left: govuk-spacing(1) solid $govuk-link-colour;
+  }
+
+  @include govuk-media-query($from: tablet) {
+    display: inline-block;
+    margin: 0 govuk-spacing(6) 0 0;
+    border-bottom: govuk-spacing(1) solid transparent;
+
+    &:last-of-type {
+      margin: 0;
+    }
+
+    &.gem-c-service-header__nav-list-item--active {
+      border-left: 0;
+      padding-left: 0;
+      border-bottom: govuk-spacing(1) solid $govuk-link-colour;
+    }
+  }
+}
+
+.gem-c-service-header__nav-list-item-link {
+  @include govuk-link-common;
+  @include govuk-link-style-default;
+  @include govuk-link-style-no-visited-state;
+
+  &:not(:hover) {
+    text-decoration: none;
+  }
+
+  @include govuk-media-query($from: tablet) {
+    display: inline-block;
+    padding: govuk-spacing(3) 0 govuk-spacing(3);
+
+    &:focus {
+      box-shadow: 0 (-(govuk-spacing(1))) $govuk-focus-colour, 0 govuk-spacing(1) $govuk-focus-text-colour;
+    }
+  }
+}
+// end service navigation styles

--- a/app/views/govuk_publishing_components/components/_cross_service_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_cross_service_header.html.erb
@@ -1,0 +1,19 @@
+<%
+  add_gem_component_stylesheet("cross-service-header")
+
+  product_name ||= nil
+  one_login_navigation_items ||= []
+  service_navigation_items ||= []
+  service_navigation_aria_label ||= "Service menu"
+%>
+
+<header class="gem-c-cross-service-header" role="banner" data-module="cross-service-header">
+  <%= render "govuk_publishing_components/components/cross_service_header/one_login_header", {
+    one_login_navigation_items: one_login_navigation_items,
+  } %>
+  <%= render "govuk_publishing_components/components/cross_service_header/service_header", {
+    service_navigation_aria_label: service_navigation_aria_label,
+    service_navigation_items: service_navigation_items,
+    product_name: product_name,
+  } %>
+</header>

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -11,12 +11,15 @@
   blue_bar_background_colour = layout_helper.blue_bar_background_colours.include?(blue_bar_background_colour) ? blue_bar_background_colour : nil
   logo_link ||= "/"
   navigation_items ||= []
+  one_login_navigation_items ||= {}
+  service_navigation_items ||= []
   omit_feedback_form ||= false
   omit_footer_navigation ||= false
   omit_footer_border ||= false
   omit_header ||= false
   product_name ||= nil
   show_explore_header ||= false
+  show_cross_service_header ||= false
   draft_watermark ||= false
   show_search = local_assigns.include?(:show_search) ? local_assigns[:show_search] : true
   title ||= "GOV.UK - The best place to find government services and information"
@@ -113,6 +116,12 @@
             logo_link: logo_link,
           } %>
         <% end %>
+      <% elsif show_cross_service_header %>
+        <%= render "govuk_publishing_components/components/cross_service_header", {
+          one_login_navigation_items: one_login_navigation_items,
+          service_navigation_items: service_navigation_items,
+          product_name: product_name,
+        } %>
       <% else %>
         <%= render "govuk_publishing_components/components/layout_header", {
           search: show_search,

--- a/app/views/govuk_publishing_components/components/cross_service_header/_one_login_header.html.erb
+++ b/app/views/govuk_publishing_components/components/cross_service_header/_one_login_header.html.erb
@@ -1,0 +1,97 @@
+  <% one_login_home = one_login_navigation_items[:one_login_home] %>
+  <% one_login_sign_out = one_login_navigation_items[:one_login_sign_out] %>
+  
+  <div class="gem-c-one-login-header" data-one-login-header-nav>
+    <div class="gem-c-one-login-header__container govuk-width-container">
+      <div class="gem-c-one-login-header__logo">
+        <a href="https://www.gov.uk/" class="gem-c-one-login-header__link gem-c-one-login-header__link--homepage">
+          <span class="gem-c-one-login-header__logotype">
+            <!--[if gt IE 8]><!-->
+            <svg aria-hidden="true" focusable="false" class="gem-c-one-login-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 132 97" height="30" width="36">
+              <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
+            </svg>
+            <!--<![endif]-->
+            <span>
+              GOV.UK
+            </span>
+          </span>
+        </a>
+      </div>
+
+      <button type="button" 
+        aria-controls="one-login-header__nav" 
+        aria-label="Show GOV.UK One Login menu" 
+        data-open-class="gem-c-cross-service-header__button--open" 
+        data-label-for-show="Show GOV.UK One Login menu" 
+        data-label-for-hide="Hide GOV.UK One Login menu" 
+        aria-expanded="false" 
+        class="gem-c-cross-service-header__button gem-c-cross-service-header__button--one-login js-x-header-toggle">
+        <span class="gem-c-cross-service-header__button-content">One Login</span>
+
+        <!--[if gt IE 8]><!-->
+        <span class="gem-c-cross-service-header__button-icon gem-c-cross-service-header__button-icon--default">
+          <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
+            <circle cx="11" cy="11" r="11" fill="white"/>
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M3.29297 18.8487C4.23255 15.4753 7.32741 13 11.0004 13C14.6731 13 17.7678 15.4749 18.7076 18.848C17.8058 19.7338 16.752 20.4654 15.5889 21H11.0004H6.41097C5.24819 20.4655 4.19463 19.7342 3.29297 18.8487Z" fill="#1D70B8"/>
+            <circle cx="11" cy="7.75" r="3.75" fill="#1D70B8"/>
+            <circle cx="11" cy="11" r="10" stroke="white" stroke-width="2"/>
+          </svg>
+        </span>
+        <!--<![endif]-->
+
+        <!--[if gt IE 8]><!-->
+        <span class="gem-c-cross-service-header__button-icon gem-c-cross-service-header__button-icon--focus">
+          <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
+            <circle cx="11" cy="11" r="11" fill="black"/>
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M3.29297 18.8487C4.23255 15.4753 7.32741 13 11.0004 13C14.6731 13 17.7678 15.4749 18.7076 18.848C17.8058 19.7338 16.752 20.4654 15.5889 21H11.0004H6.41097C5.24819 20.4655 4.19463 19.7342 3.29297 18.8487Z" fill="white"/>
+            <circle cx="11" cy="7.75" r="3.75" fill="white"/>
+            <circle cx="11" cy="11" r="10" stroke="black" stroke-width="2"/>
+          </svg>
+        </span>
+        <!--<![endif]-->
+      </button>
+
+      <nav aria-label="GOV.UK One Login menu" class="gem-c-one-login-header__nav" data-open-class="gem-c-one-login-header__nav--open" id="one-login-header__nav">
+        <ul class="gem-c-one-login-header__nav__list">
+          <li class="gem-c-one-login-header__nav__list-item">
+            <%= link_to one_login_home[:href], class: "gem-c-one-login-header__nav__link gem-c-one-login-header__nav__link--one-login", data: one_login_home[:data] do %>
+              <span class="gem-c-one-login-header__nav__link-content">
+                GOV.UK One Login
+              </span>
+
+              <!--[if gt IE 8]><!-->
+              <span class="gem-c-cross-service-header__button-icon gem-c-cross-service-header__button-icon--default">
+                <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
+                  <circle cx="11" cy="11" r="11" fill="white"/>
+                  <path fill-rule="evenodd" clip-rule="evenodd" d="M3.29297 18.8487C4.23255 15.4753 7.32741 13 11.0004 13C14.6731 13 17.7678 15.4749 18.7076 18.848C17.8058 19.7338 16.752 20.4654 15.5889 21H11.0004H6.41097C5.24819 20.4655 4.19463 19.7342 3.29297 18.8487Z" fill="#1D70B8"/>
+                  <circle cx="11" cy="7.75" r="3.75" fill="#1D70B8"/>
+                  <circle cx="11" cy="11" r="10" stroke="white" stroke-width="2"/>
+                </svg>
+              </span>
+              <!--<![endif]-->
+
+              <!--[if gt IE 8]><!-->
+              <span class="gem-c-cross-service-header__button-icon gem-c-cross-service-header__button-icon--focus">
+                <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
+                  <circle cx="11" cy="11" r="11" fill="black"/>
+                  <path fill-rule="evenodd" clip-rule="evenodd" d="M3.29297 18.8487C4.23255 15.4753 7.32741 13 11.0004 13C14.6731 13 17.7678 15.4749 18.7076 18.848C17.8058 19.7338 16.752 20.4654 15.5889 21H11.0004H6.41097C5.24819 20.4655 4.19463 19.7342 3.29297 18.8487Z" fill="white"/>
+                  <circle cx="11" cy="7.75" r="3.75" fill="white"/>
+                  <circle cx="11" cy="11" r="10" stroke="black" stroke-width="2"/>
+                </svg>
+              </span>
+              <!--<![endif]-->
+            <% end %>
+          </li>
+          <li class="gem-c-one-login-header__nav__list-item">
+            <%= link_to(
+              one_login_sign_out[:text],
+              one_login_sign_out[:href],
+              class: 'gem-c-one-login-header__nav__link',
+              data: one_login_sign_out[:data],
+            ) %>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+  

--- a/app/views/govuk_publishing_components/components/cross_service_header/_service_header.html.erb
+++ b/app/views/govuk_publishing_components/components/cross_service_header/_service_header.html.erb
@@ -1,0 +1,49 @@
+<% service_navigation_aria_label ||= "Service menu" %>
+
+<% if product_name %>
+<div class="gem-c-service-header" data-one-login-header-nav>
+  <div class="govuk-width-container">
+    <div class="gem-c-service-header__container">
+      <!-- The name of your service goes here -->
+      <h2 class="gem-c-service-header__heading"><%= product_name %></h2>
+      <% if service_navigation_items.any? %>
+        <div>
+          <button type="button" 
+            aria-controls="service-header__nav" 
+            data-open-class="gem-c-cross-service-header__button--open" 
+            aria-label="Show service navigation menu" 
+            data-label-for-show="Show service navigation menu" 
+            data-label-for-hide="Hide service navigation menu" 
+            data-text-for-show="Menu" 
+            data-text-for-hide="Close" 
+            aria-expanded="false" 
+            class="gem-c-cross-service-header__button gem-c-cross-service-header__button--gem-c-service-header js-x-header-toggle">
+            <span class="gem-c-service-header__button-content">Menu</span>
+          </button>
+          <!-- Important! Label your navigation appropriately! When there are multiple navigation landmarks on a page, additional labelling is required to provide support for screen reader users -->
+          <nav aria-label="<%= service_navigation_aria_label %>">
+            <ul class="gem-c-service-header__nav-list gem-c-service-header__nav" id="service-header__nav" data-open-class="gem-c-service-header__nav--open">
+              <% service_navigation_items.each_with_index do |item, index| %>
+                <%
+                  li_classes = %w(gem-c-service-header__nav-list-item)
+                  li_classes << "gem-c-service-header__nav-list-item--active" if item[:active]
+                  aria_current = item[:active] ? "page" : nil
+                %>
+                <%= tag.li class: li_classes do %>
+                  <%= link_to(
+                    item[:text],
+                    item[:href],
+                    class: 'gem-c-service-header__nav-list-item-link',
+                    data: item[:data],
+                    aria: { current: aria_current }
+                  ) %>
+                <% end %>
+              <% end %>
+            </ul>
+          </nav>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/cross_service_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/cross_service_header.yml
@@ -1,0 +1,64 @@
+name: Cross service header
+description: | 
+  The One Login header contains two distinct navigation menus - one for GOV.UK One Login links and another for internal service navigation.
+body: |
+  The header contains two links:
+
+  * "GOV.UK One Login": this takes the user to their One Login ‘home’ area, where they can manage their credentials and see and access the services they've used - you don't need to update the url this points to
+  * "Sign out": you'll need to adapt this link so that it signs the user out of your service and signs them out of One Login - how you do this will depend on how you've implemented sign out functionality in your service
+shared_accessibility_criteria:
+  - link
+accessibility_criteria:
+accessibility_excluded_rules:
+  - landmark-banner-is-top-level
+  - duplicate-id-aria
+  - landmark-no-duplicate-banner
+  - landmark-unique
+examples:
+  default:
+    description:
+    data:
+      show_account_layout: true
+      show_cross_service_header: true
+      product_name: GOV.UK email subscriptions
+      one_login_navigation_items:
+        one_login_home:
+          href: "#"
+        one_login_sign_out:
+          text: Sign out
+  with_data_attributes:
+    data:
+      show_account_layout: true
+      show_cross_service_header: true
+      product_name: GOV.UK email subscriptions
+      one_login_navigation_items:
+        one_login_home:
+          href: "#"
+          data:
+            module: explicit-cross-domain-links
+        one_login_sign_out:
+          text: Sign out
+          data:
+            module: explicit-cross-domain-links
+  with_service_navigation_links:
+    description: The header has space to optionally add links to different parts of your service, just as the current 'service header' component from the Design System does. Follow the same patterns for internal service navigation links as you do with the [Design System service header](https://design-system.service.gov.uk/components/header/).
+    data:
+      show_account_layout: true
+      show_cross_service_header: true
+      product_name: GOV.UK email subscriptions
+      one_login_navigation_items:
+        one_login_home:
+          href: "#"
+          data:
+            module: explicit-cross-domain-links
+        one_login_sign_out:
+          text: Sign out
+          data:
+            module: explicit-cross-domain-links
+      service_navigation_items:
+        - text: Example link 1
+          href: "#"
+        - text: Example link 2
+          href: "#"
+        - text: Example link 3
+          href: "#"

--- a/lib/govuk_publishing_components/app_helpers/asset_helper.rb
+++ b/lib/govuk_publishing_components/app_helpers/asset_helper.rb
@@ -28,6 +28,7 @@ module GovukPublishingComponents
         govuk_publishing_components/components/_title.css
 
         govuk_publishing_components/components/_cookie-banner.css
+        govuk_publishing_components/components/_cross-service-header.css
         govuk_publishing_components/components/_feedback.css
         govuk_publishing_components/components/_layout-footer.css
         govuk_publishing_components/components/_layout-for-public.css

--- a/spec/component_guide/component_index_spec.rb
+++ b/spec/component_guide/component_index_spec.rb
@@ -52,6 +52,7 @@ describe "Component guide index" do
 @import 'govuk_publishing_components/components/button';
 @import 'govuk_publishing_components/components/contextual-sidebar';
 @import 'govuk_publishing_components/components/cookie-banner';
+@import 'govuk_publishing_components/components/cross-service-header';
 @import 'govuk_publishing_components/components/details';
 @import 'govuk_publishing_components/components/error-message';
 @import 'govuk_publishing_components/components/error-summary';
@@ -90,6 +91,7 @@ describe "Component guide index" do
 //= require govuk_publishing_components/components/accordion
 //= require govuk_publishing_components/components/button
 //= require govuk_publishing_components/components/cookie-banner
+//= require govuk_publishing_components/components/cross-service-header
 //= require govuk_publishing_components/components/details
 //= require govuk_publishing_components/components/error-summary
 //= require govuk_publishing_components/components/feedback

--- a/spec/components/cross_service_header_spec.rb
+++ b/spec/components/cross_service_header_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+describe "Cross service header", type: :view do
+  def component_name
+    "cross_service_header"
+  end
+
+  def one_login_navigation_items
+    {
+      one_login_home: {
+        href: "#",
+      },
+      one_login_sign_out: {
+        href: "#",
+        text: "Sign out",
+      },
+    }
+  end
+
+  def with_data_attributes
+    one_login_navigation_items.transform_values do |value|
+      value.merge({
+        data: {
+          module: "explicit-cross-domain-links",
+        },
+      })
+    end
+  end
+
+  it "renders the One Login service header" do
+    render_component({ show_account_layout: true,
+                       one_login_navigation_items:,
+                       product_name: "GOV.UK email subscriptions" })
+
+    assert_select ".gem-c-service-header__heading", text: "GOV.UK email subscriptions"
+    assert_select ".gem-c-cross-service-header__button-content", text: "One Login"
+    assert_select ".gem-c-one-login-header__nav__list-item:nth-child(1) [href]", text: "GOV.UK One Login"
+    assert_select ".gem-c-one-login-header__nav__list-item:nth-child(2) [href]", text: "Sign out"
+  end
+
+  it "renders the One Login service header with data attributes" do
+    render_component({ show_account_layout: true,
+                       one_login_navigation_items: with_data_attributes,
+                       product_name: "GOV.UK email subscriptions" })
+
+    assert_select ".gem-c-one-login-header__nav__list-item:nth-child(1) [data-module=\'explicit-cross-domain-links\']", text: "GOV.UK One Login"
+    assert_select ".gem-c-one-login-header__nav__list-item:nth-child(2) [data-module=\'explicit-cross-domain-links\']", text: "Sign out"
+  end
+
+  it "renders the One Login service header and service navigation" do
+    service_navigation_items = [
+      { text: "Example link 1", href: "#" },
+      { text: "Example link 2", href: "#" },
+      { text: "Example link 3", href: "#" },
+    ]
+    render_component({ show_account_layout: true,
+                       one_login_navigation_items:,
+                       product_name: "GOV.UK email subscriptions",
+                       service_navigation_items: })
+
+    assert_select ".gem-c-service-header nav"
+    assert_select ".gem-c-service-header__nav-list-item", count: 3
+  end
+end

--- a/spec/javascripts/components/cross-service-header.js
+++ b/spec/javascripts/components/cross-service-header.js
@@ -1,0 +1,307 @@
+/* eslint-env jasmine, jquery */
+/* global GOVUK */
+
+describe('The _layout_header_one_login', function () {
+  'use strict'
+
+  var container
+  var thisModule
+
+  beforeEach(function () {
+    container = document.createElement('div')
+    container.innerHTML =
+      '<header class="gem-c-cross-service-header" role="banner" data-module="cross-service-header">' +
+      '<div class="gem-c-one-login-header" data-one-login-header-nav>' +
+        '<div class="gem-c-one-login-header__container govuk-width-container">' +
+          '<div class="gem-c-one-login-header__logo">' +
+            '<a href="https://www.gov.uk/" class="gem-c-one-login-header__link gem-c-one-login-header__link--homepage">' +
+              '<span class="gem-c-one-login-header__logotype">' +
+                '<!--[if gt IE 8]>' + '<!-->' +
+                '<svg aria-hidden="true" focusable="false" class="gem-c-one-login-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 132 97" height="30" width="36">' +
+                  '<path fill="currentColor" fill-rule="evenodd"' +
+                    'd="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"' +
+                  '>' + '</path>' +
+                '</svg>' +
+                '<!--<![endif]-->' +
+                '<span>GOV.UK</span>' +
+              '</span>' +
+            '</a>' +
+          '</div>' +
+          '<button ' +
+            'type="button"' +
+            'aria-controls="one-login-header__nav"' +
+            'aria-label="Show GOV.UK One Login menu"' +
+            'data-open-class="gem-c-cross-service-header__button--open"' +
+            'data-label-for-show="Show GOV.UK One Login menu"' +
+            'data-label-for-hide="Hide GOV.UK One Login menu"' +
+            'aria-expanded="false"' +
+            'class="gem-c-cross-service-header__button gem-c-cross-service-header__button--one-login js-x-header-toggle"' +
+          '>' +
+            '<span class="gem-c-cross-service-header__button-content">One Login</span>' +
+            '<!--[if gt IE 8]>' + '<!-->' +
+            '<span class="gem-c-cross-service-header__button-icon gem-c-cross-service-header__button-icon--default">' +
+              '<svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">' +
+                '<circle cx="11" cy="11" r="11" fill="white" />' +
+                '<path fill-rule="evenodd" clip-rule="evenodd" d="M3.29297 18.8487C4.23255 15.4753 7.32741 13 11.0004 13C14.6731 13 17.7678 15.4749 18.7076 18.848C17.8058 19.7338 16.752 20.4654 15.5889 21H11.0004H6.41097C5.24819 20.4655 4.19463 19.7342 3.29297 18.8487Z" fill="#1D70B8" />' +
+                '<circle cx="11" cy="7.75" r="3.75" fill="#1D70B8" />' +
+                '<circle cx="11" cy="11" r="10" stroke="white" stroke-width="2" />' +
+              '</svg>' +
+            '</span>' +
+            '<!--<![endif]-->' +
+
+            '<!--[if gt IE 8]>' + '<!-->' +
+            '<span class="gem-c-cross-service-header__button-icon gem-c-cross-service-header__button-icon--focus">' +
+              '<svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">' +
+                '<circle cx="11" cy="11" r="11" fill="black" />' +
+                '<path fill-rule="evenodd" clip-rule="evenodd" d="M3.29297 18.8487C4.23255 15.4753 7.32741 13 11.0004 13C14.6731 13 17.7678 15.4749 18.7076 18.848C17.8058 19.7338 16.752 20.4654 15.5889 21H11.0004H6.41097C5.24819 20.4655 4.19463 19.7342 3.29297 18.8487Z" fill="white" />' +
+                '<circle cx="11" cy="7.75" r="3.75" fill="white" />' +
+                '<circle cx="11" cy="11" r="10" stroke="black" stroke-width="2" />' +
+              '</svg>' +
+            '</span>' +
+            '<!--<![endif]-->' +
+          '</button>' +
+          '<nav aria-label="GOV.UK One Login menu" class="gem-c-one-login-header__nav" data-open-class="gem-c-one-login-header__nav--open" id="one-login-header__nav">' +
+            '<ul class="gem-c-one-login-header__nav__list">' +
+              '<li class="gem-c-one-login-header__nav__list-item">' +
+                '<a class="gem-c-one-login-header__nav__link gem-c-one-login-header__nav__link--one-login" data-module="explicit-cross-domain-links" href="#">' +
+                  '<span class="gem-c-one-login-header__nav__link-content">GOV.UK One Login</span>' +
+                  '<!--[if gt IE 8]>' + '<!-->' +
+                  '<span class="gem-c-cross-service-header__button-icon gem-c-cross-service-header__button-icon--default">' +
+                    '<svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">' +
+                      '<circle cx="11" cy="11" r="11" fill="white" />' +
+                      '<path fill-rule="evenodd" clip-rule="evenodd" d="M3.29297 18.8487C4.23255 15.4753 7.32741 13 11.0004 13C14.6731 13 17.7678 15.4749 18.7076 18.848C17.8058 19.7338 16.752 20.4654 15.5889 21H11.0004H6.41097C5.24819 20.4655 4.19463 19.7342 3.29297 18.8487Z" fill="#1D70B8" />' +
+                      '<circle cx="11" cy="7.75" r="3.75" fill="#1D70B8" />' +
+                      '<circle cx="11" cy="11" r="10" stroke="white" stroke-width="2" />' +
+                    '</svg>' +
+                  '</span>' +
+                  '<!--<![endif]-->' +
+                  '<!--[if gt IE 8]>' + '<!-->' +
+                  '<span class="gem-c-cross-service-header__button-icon gem-c-cross-service-header__button-icon--focus">' +
+                    '<svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">' +
+                      '<circle cx="11" cy="11" r="11" fill="black" />' +
+                      '<path fill-rule="evenodd" clip-rule="evenodd" d="M3.29297 18.8487C4.23255 15.4753 7.32741 13 11.0004 13C14.6731 13 17.7678 15.4749 18.7076 18.848C17.8058 19.7338 16.752 20.4654 15.5889 21H11.0004H6.41097C5.24819 20.4655 4.19463 19.7342 3.29297 18.8487Z" fill="white" />' +
+                      '<circle cx="11" cy="7.75" r="3.75" fill="white" />' +
+                      '<circle cx="11" cy="11" r="10" stroke="black" stroke-width="2" />' +
+                    '</svg>' +
+                  '</span>' +
+                  '<!--<![endif]-->' +
+                '</a>' +
+              '</li>' +
+              '<li class="gem-c-one-login-header__nav__list-item">' +
+                '<a class="gem-c-one-login-header__nav__link" data-module="explicit-cross-domain-links" href="#">Sign out</a>' +
+              '</li>' +
+            '</ul>' +
+          '</nav>' +
+        '</div>' +
+      '</div>' +
+      '<div class="gem-c-service-header" data-one-login-header-nav>' +
+        '<div class="govuk-width-container">' +
+          '<div class="gem-c-service-header__container">' +
+            '<h2 class="gem-c-service-header__heading">GOV.UK email subscriptions</h2>' +
+            '<div>' +
+              '<button ' +
+                'type="button"' +
+                'aria-controls="service-header__nav"' +
+                'data-open-class="gem-c-cross-service-header__button--open"' +
+                'aria-label="Show service navigation menu"' +
+                'data-label-for-show="Show service navigation menu"' +
+                'data-label-for-hide="Hide service navigation menu"' +
+                'data-text-for-show="Menu"' +
+                'data-text-for-hide="Close"' +
+                'aria-expanded="false"' +
+                'class="gem-c-cross-service-header__button gem-c-cross-service-header__button--service-header js-x-header-toggle">' +
+                '<span class="gem-c-service-header__button-content">Menu</span>' +
+              '</button>' +
+              '<nav aria-label="Service menu">' +
+                '<ul class="gem-c-service-header__nav-list gem-c-service-header__nav" id="service-header__nav" data-open-class="gem-c-service-header__nav--open">' +
+                  '<li class="gem-c-service-header__nav-list-item">' +
+                    '<a class="gem-c-service-header__nav-list-item-link" href="#">Example link 1</a>' +
+                  '</li>' +
+                  '<li class="gem-c-service-header__nav-list-item">' +
+                    '<a class="gem-c-service-header__nav-list-item-link" href="#">Example link 2</a>' +
+                  '</li>' +
+                  '<li class="gem-c-service-header__nav-list-item">' +
+                    '<a class="gem-c-service-header__nav-list-item-link" href="#">Example link 3</a>' +
+                  '</li>' +
+                '</ul>' +
+              '</nav>' +
+            '</div>' +
+          '</div>' +
+        '</div>' +
+      '</div>' +
+    '</header>'
+
+    document.body.appendChild(container)
+
+    var $element = document.querySelector('[data-module="cross-service-header"]')
+    thisModule = new GOVUK.Modules.CrossServiceHeader($element)
+
+    spyOn(GOVUK.analytics, 'trackEvent')
+  })
+
+  afterEach(function () {
+    if (GOVUK.analytics.trackEvent.calls) {
+      GOVUK.analytics.trackEvent.calls.reset()
+    }
+
+    document.body.removeChild(container)
+  })
+
+  describe('One Login header', function () {
+    var $button
+
+    beforeEach(function () {
+      thisModule.init()
+      $button = document.querySelector('.gem-c-cross-service-header__button--one-login.js-x-header-toggle')
+    })
+
+    describe('has the correct ARIA attributes', function () {
+      it('has `aria-controls` set to "one-login-header__nav"', function () {
+        expect($button).toHaveAttr('aria-controls', 'one-login-header__nav')
+      })
+
+      it('has `aria-label` set to "Show GOV.UK One Login menu"', function () {
+        expect($button).toHaveAttr('aria-label', 'Show GOV.UK One Login menu')
+      })
+
+      it('has `aria-expanded` set to false', function () {
+        expect($button).toHaveAttr('aria-expanded', 'false')
+      })
+    })
+
+    describe('updates correctly when clicked once', function () {
+      var $button, $menu
+
+      beforeEach(function () {
+        $button = document.querySelector('.gem-c-cross-service-header__button--one-login.js-x-header-toggle')
+        $menu = document.querySelector('#one-login-header__nav')
+
+        $button.click()
+      })
+
+      it('opens the menu', function () {
+        expect($menu).not.toHaveAttr('hidden')
+      })
+
+      it('updates the button’s `aria-expanded` attribute to true', function () {
+        expect($button).toHaveAttr('aria-expanded', 'true')
+      })
+
+      it('updates the button’s `aria-label`', function () {
+        var hideLabel = $button.getAttribute('data-label-for-hide')
+        expect($button).toHaveAttr('aria-label', hideLabel)
+      })
+    })
+
+    describe('updates correctly when clicked twice', function () {
+      var $button, $menu
+
+      beforeEach(function () {
+        $button = document.querySelector('.gem-c-cross-service-header__button--one-login.js-x-header-toggle')
+        $menu = document.querySelector('#one-login-header__nav')
+
+        $button.click()
+      })
+
+      it('opens and then closes the menu', function () {
+        expect($menu).toHaveClass('gem-c-one-login-header__nav--open')
+        $button.click()
+        expect($menu).not.toHaveClass('gem-c-one-login-header__nav--open')
+      })
+
+      it('sets the button’s `aria-expanded` attribute to true, then false', function () {
+        expect($button).toHaveAttr('aria-expanded', 'true')
+        $button.click()
+        expect($button).toHaveAttr('aria-expanded', 'false')
+      })
+
+      it('sets the button’s `aria-label` attribute to "Hide navigation menu", then "Show navigation menu"', function () {
+        expect($button).toHaveAttr('aria-label', 'Hide GOV.UK One Login menu')
+        $button.click()
+        expect($button).toHaveAttr('aria-label', 'Show GOV.UK One Login menu')
+      })
+    })
+  })
+
+  describe('Service navigation menu', function () {
+    var $button
+
+    beforeEach(function () {
+      thisModule.init()
+      $button = document.querySelector('.gem-c-cross-service-header__button--service-header.js-x-header-toggle')
+    })
+
+    describe('has the correct ARIA attributes', function () {
+      it('has `aria-controls` set to "service-header__nav"', function () {
+        expect($button).toHaveAttr('aria-controls', 'service-header__nav')
+      })
+
+      it('has `aria-label` set to "Show service navigation menu"', function () {
+        expect($button).toHaveAttr('aria-label', 'Show service navigation menu')
+      })
+
+      it('has `aria-expanded` set to false', function () {
+        expect($button).toHaveAttr('aria-expanded', 'false')
+      })
+    })
+
+    describe('updates correctly when clicked once', function () {
+      var $button, $menu
+
+      beforeEach(function () {
+        $button = document.querySelector('.gem-c-cross-service-header__button--service-header.js-x-header-toggle')
+        $menu = document.querySelector('#service-header__nav')
+
+        $button.click()
+      })
+
+      it('opens the menu', function () {
+        expect($menu).not.toHaveAttr('hidden')
+      })
+
+      it('updates the button’s `aria-expanded` attribute to true', function () {
+        expect($button).toHaveAttr('aria-expanded', 'true')
+      })
+
+      it('updates the button’s `aria-label`', function () {
+        var hideLabel = $button.getAttribute('data-label-for-hide')
+        expect($button).toHaveAttr('aria-label', hideLabel)
+      })
+    })
+
+    describe('updates correctly when clicked twice', function () {
+      var $button, $menu
+
+      beforeEach(function () {
+        $button = document.querySelector('.gem-c-cross-service-header__button--service-header.js-x-header-toggle')
+        $menu = document.querySelector('#service-header__nav')
+
+        $button.click()
+      })
+
+      it('opens and then closes the menu', function () {
+        expect($menu).toHaveClass('gem-c-service-header__nav--open')
+        $button.click()
+        expect($menu).not.toHaveClass('gem-c-service-header__nav--open')
+      })
+
+      it('sets the button’s text to "Menu", then "Close"', function () {
+        expect($button.textContent).toBe('Close')
+        $button.click()
+        expect($button.textContent).toBe('Menu')
+      })
+
+      it('sets the button’s `aria-expanded` attribute to true, then false', function () {
+        expect($button).toHaveAttr('aria-expanded', 'true')
+        $button.click()
+        expect($button).toHaveAttr('aria-expanded', 'false')
+      })
+
+      it('sets the button’s `aria-label` attribute to "Hide service navigation menu", then "Show service navigation menu"', function () {
+        expect($button).toHaveAttr('aria-label', 'Hide service navigation menu')
+        $button.click()
+        expect($button).toHaveAttr('aria-label', 'Show service navigation menu')
+      })
+    })
+  })
+})

--- a/spec/lib/govuk_publishing_components/app_helpers/asset_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/app_helpers/asset_helper_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe GovukPublishingComponents::AppHelpers::AssetHelper do
     end
 
     it "detect the total number of stylesheet paths" do
-      expect(get_component_css_paths.count).to eql(74)
+      expect(get_component_css_paths.count).to eql(75)
     end
 
     it "initialize empty asset helper" do


### PR DESCRIPTION
## What

https://trello.com/c/9o9pvE3a/2146-implement-one-login-cross-service-header-on-the-email-subscriptions-service

## Why

> - To help us here in One Login improve the component
> - To provide email subscriptions service users with the navigation improvements we’re already confident about following our testing

## Visual changes
See: https://components-gem-pr-3659.herokuapp.com/component-guide/cross_service_header

## Anything else
- I've added the naming convention of '**cross service header**' for both component and file names, aligning them with the JavaScript module name. Additionally, CSS classes use `gem-c-cross-service-header`, `gem-c-one-login-header`, and `gem-c-service-header`, maintaining concise and clear naming.
- See spike notes [here](https://docs.google.com/document/d/1PZMk0DA86QQLdJLKAAEH6Fwa75sxvEcs3RcXdMTbbQE/edit?pli=1) which details why it's not currently possible to replace the **layout header** component (and hence the need to add new properties such as `show_cross_service_header` and `one_login_navigation_items`.

Also, see:
- https://github.com/alphagov/email-alert-frontend/pull/1634
- https://github.com/alphagov/static/pull/3170