### PR TITLE
Update image card two thirds variation

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/image_card.yml
+++ b/app/views/govuk_publishing_components/components/docs/image_card.yml
@@ -206,11 +206,11 @@ examples:
         <%= component %>
       </div>
   two_thirds_column:
-    description: This variant is used for the featured section on the homepage.
+    description: This variant is used for the featured section on the homepage, the aspect ratio used is 1:1
     data:
       two_thirds: true
       href: "/still-not-a-page"
-      image_src: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/91397/s712_SG_Swear_in_1_.jpg"
+      image_src: "https://www.gov.uk/assets/static/govuk-apple-touch-icon-180x180-026deaa34fa328ae5f1f519a37dbd15e6555c5086e1ba83986cd0827a7209902.png"
       image_alt: "some meaningful alt text please"
       heading_text: "Something has happened nearby possibly"
       description: "Following a news report that something has happened, further details are emerging of the thing that has happened and what that means for you."

--- a/lib/govuk_publishing_components/presenters/image_card_helper.rb
+++ b/lib/govuk_publishing_components/presenters/image_card_helper.rb
@@ -63,6 +63,10 @@ module GovukPublishingComponents
       def image
         classes = %w[gem-c-image-card__image-wrapper]
         classes << "gem-c-image-card__image-wrapper--one-third" if @two_thirds
+        height = 200
+        width = 300
+        height = 90 if @two_thirds
+        width = 90 if @two_thirds
 
         if @image_src
           content_tag(:figure, class: classes) do
@@ -73,8 +77,8 @@ module GovukPublishingComponents
               loading: @image_loading,
               sizes: @sizes,
               srcset: @srcset,
-              height: 200,
-              width: 300,
+              height:,
+              width:,
             )
           end
         end

--- a/spec/components/image_card_spec.rb
+++ b/spec/components/image_card_spec.rb
@@ -108,11 +108,13 @@ describe "ImageCard", type: :view do
     assert_select ".gem-c-image-card.gem-c-image-card--large"
   end
 
-  it "renders two thirds variant" do
+  it "renders two thirds variant with correct image width and height attributes" do
     render_component(href: "#", image_src: "/moo.jpg", image_alt: "some meaningful alt text", heading_text: "test", two_thirds: true)
     assert_select ".gem-c-image-card.gem-c-image-card--two-thirds"
     assert_select ".gem-c-image-card__text-wrapper.gem-c-image-card__text-wrapper--two-thirds"
     assert_select ".gem-c-image-card__image-wrapper.gem-c-image-card__image-wrapper--one-third"
+    assert_select ".gem-c-image-card__image[width='90']"
+    assert_select ".gem-c-image-card__image[height='90']"
   end
 
   it "applies tracking attributes" do
@@ -145,6 +147,12 @@ describe "ImageCard", type: :view do
   it "checks image loading attribute is 'auto' when value 'image_loading' is not specified" do
     render_component(href: "#", image_src: "/moo.jpg", image_alt: "some meaningful alt text")
     assert_select ".gem-c-image-card__image[loading='auto']"
+  end
+
+  it "applies correct default width and height attributes to the image" do
+    render_component(href: "#", image_src: "/moo.jpg", image_alt: "some meaningful alt text")
+    assert_select ".gem-c-image-card__image[width='300']"
+    assert_select ".gem-c-image-card__image[height='200']"
   end
 
   it "applies the sizes attribute to image if specified" do


### PR DESCRIPTION
## What
- Set the correct width and height attributes when using the new two_thirds variation of the image-card component. The aspect ratio for the featured image size to be used on the new homepage design is 1:1 when using the new two_thirds variation of the image card component
- Add related tests to ensure that the correct width and height attributes are set
- Update documentation for the two_thirds image card variation

## Why

Required for the new homepage design

[Trello card](https://trello.com/c/OM7sZgaY/2169-look-and-feel-homepage-update-image-card-component-for-featured-section-m)
<!-- What are the reasons behind this change being made? -->
