### PR TITLE
Limit GA4 ecommerce arrays to 200 items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Replace '+' in GA4 search term values with an actual space ([PR #3653](https://github.com/alphagov/govuk_publishing_components/pull/3653))
 * Update image card two thirds variation #3661 ([PR #3661](https://github.com/alphagov/govuk_publishing_components/pull/3661))
 * Update logo spacing for new homepage design #3658 ([PR #3658](https://github.com/alphagov/govuk_publishing_components/pull/3658))
+* Limit GA4 ecommerce arrays to 200 items ([PR #3662](https://github.com/alphagov/govuk_publishing_components/pull/3662))
 
 ## 35.18.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -335,6 +335,11 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
           }
         } else {
           for (var i = 0; i < items.length; i++) {
+            // GA4 limits us to 200 items, so we should limit the array to this size.
+            if (i === 200) {
+              break
+            }
+
             var item = items[i]
             var path = item.getAttribute('data-ga4-ecommerce-path')
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
@@ -582,6 +582,37 @@ describe('GA4 core', function () {
 
         expect(builtEcommerceObject).toEqual(expectedEcommerceObject)
       })
+
+      it('the ecommerce items array is limited to 200 items', function () {
+        var innerHTML = ''
+        var ecommerceItems = []
+
+        // Adds 500 search results to the DOM, but only adds 200 to our expected ecommerce object array
+        for (var i = 0; i < 500; i++) {
+          innerHTML = innerHTML + '<a data-ga4-ecommerce-path="https://www.gov.uk/the-warm-home-discount-scheme" href="https://www.gov.uk/the-warm-home-discount-scheme" data-ecommerce-index="' + (i + 1) + '">Check if you’re eligible for the Warm Home Discount scheme</a>'
+
+          if (i < 200) {
+            ecommerceItems.push({
+              item_id: 'https://www.gov.uk/the-warm-home-discount-scheme',
+              item_list_name: 'Smart answer results',
+              index: i + 1
+            })
+          }
+        }
+
+        resultsCount.innerHTML = '500 results'
+        results.innerHTML = innerHTML
+        expectedEcommerceObject.search_results.results = 500
+        expectedEcommerceObject.search_results.ecommerce.items = ecommerceItems
+
+        var builtEcommerceObject = GOVUK.analyticsGa4.core.ecommerceHelperFunctions.populateEcommerceSchema({
+          element: resultsParentEl,
+          resultsId: 'result-count'
+        })
+
+        expect(builtEcommerceObject).toEqual(expectedEcommerceObject)
+        expect(builtEcommerceObject.search_results.ecommerce.items.length).toEqual(200)
+      })
     })
   })
 })


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Limits the amount of items in the GA4 ecommerce items array to a maximum of 200 items

## Why
<!-- What are the reasons behind this change being made? -->
- There are a couple search finders that contain more than 200 search results on one page, for example https://www.gov.uk/world/organisations and https://www.gov.uk/government/groups
- The dataLayer push for these was fine, but the PAs were having issues with the data when it was in their dashboard
- We think this is due to GA4 limiting how big an array sent to it can be
- Therefore we are limiting the array to the GA4 limit in their documentation

https://trello.com/c/wLz7uULw/679-fix-world-organisations-finder-ecommerce-tracking
https://trello.com/c/jHYCtOA8/678-fix-groups-finder-ecommerce-tracking
## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
