### PR TITLE
Allow GA4 Form text values to be undefined instead of 'No answer given'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Update image card two thirds variation #3661 ([PR #3661](https://github.com/alphagov/govuk_publishing_components/pull/3661))
 * Update logo spacing for new homepage design #3658 ([PR #3658](https://github.com/alphagov/govuk_publishing_components/pull/3658))
 * Limit GA4 ecommerce arrays to 200 items ([PR #3662](https://github.com/alphagov/govuk_publishing_components/pull/3662))
+* Allow GA4 Form text values to be undefined instead of 'No answer given' ([PR #3663](https://github.com/alphagov/govuk_publishing_components/pull/3663))
 
 ## 35.18.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
@@ -9,6 +9,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.trackingTrigger = 'data-ga4-form' // elements with this attribute get tracked
     this.includeTextInputValues = this.module.hasAttribute('data-ga4-form-include-text')
     this.redacted = false
+    this.useFallbackValue = this.module.hasAttribute('data-ga4-form-no-answer-undefined') ? undefined : 'No answer given'
   }
 
   Ga4FormTracker.prototype.init = function () {
@@ -43,7 +44,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
       var formInputs = this.getFormInputs()
       var formData = this.getInputValues(formInputs)
-      data.text = data.text || (this.combineGivenAnswers(formData) || 'No answer given')
+      data.text = data.text || this.combineGivenAnswers(formData) || this.useFallbackValue
 
       if (data.action === 'search') {
         data.text = data.text.toLowerCase()

--- a/docs/analytics-ga4/ga4-form-tracker.md
+++ b/docs/analytics-ga4/ga4-form-tracker.md
@@ -36,3 +36,5 @@ In the example above, the following would be pushed to the dataLayer. Note that 
   }
 }
 ```
+
+When a form is submitted with an empty input value, the tracker will set the `text` value in the dataLayer to `"No answer given"`. If you require empty input to be sent as `undefined` instead, add the `data-ga4-form-no-answer-undefined` attribute to the form.

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
@@ -224,6 +224,44 @@ describe('Google Analytics form tracking', function () {
     })
   })
 
+  describe('when tracking a form with undefined instead of no answer given', function () {
+    beforeEach(function () {
+      var attributes = {
+        event_name: 'form_response',
+        type: 'smart answer',
+        section: 'What is the title of this question?',
+        action: 'Continue',
+        tool_name: 'What is the title of this smart answer?'
+      }
+      element.setAttribute('data-ga4-form', JSON.stringify(attributes))
+      element.setAttribute('data-ga4-form-no-answer-undefined', '')
+      expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
+      expected.event = 'event_data'
+      expected.event_data.event_name = 'form_response'
+      expected.event_data.type = 'smart answer'
+      expected.event_data.section = 'What is the title of this question?'
+      expected.event_data.action = 'Continue'
+      expected.event_data.tool_name = 'What is the title of this smart answer?'
+      expected.govuk_gem_version = 'aVersion'
+      var tracker = new GOVUK.Modules.Ga4FormTracker(element)
+      tracker.init()
+    })
+
+    it('allows the fallback value when the text is empty to be undefined', function () {
+      var attributes = {
+        event_name: 'form_response',
+        type: 'smart answer',
+        section: 'What is the title of this question?',
+        action: 'Continue',
+        tool_name: 'What is the title of this smart answer?'
+      }
+      element.setAttribute('data-ga4-form', JSON.stringify(attributes))
+      window.GOVUK.triggerEvent(element, 'submit')
+      expected.event_data.text = undefined
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+  })
+
   describe('when tracking a form with text redaction disabled', function () {
     beforeEach(function () {
       var attributes = {


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Adds detection of a data attribute on forms called `data-ga4-form-undefined-if-text-is-empty` 
- When this is present on a form, and the submitted text by the user on the form is empty, it will push `undefined` to GA4 instead of `No answer given`
- Let me know if `data-ga4-form-undefined-if-text-is-empty` is too long of a name

## Why
<!-- What are the reasons behind this change being made? -->
https://trello.com/c/WtvEWiS3/592-placeholder-replace-no-answer-given-with-undefined-on-homepage-search-event

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
