### PR TITLE
Add viewport size to GA4 page view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add viewport size to GA4 page view ([PR #3665](https://github.com/alphagov/govuk_publishing_components/pull/3665))
 * Replace '+' in GA4 search term values with an actual space ([PR #3653](https://github.com/alphagov/govuk_publishing_components/pull/3653))
 * Update image card two thirds variation #3661 ([PR #3661](https://github.com/alphagov/govuk_publishing_components/pull/3661))
 * Update logo spacing for new homepage design #3658 ([PR #3658](https://github.com/alphagov/govuk_publishing_components/pull/3658))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
@@ -20,6 +20,7 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
             referrer: this.getReferrer(referrer),
             title: this.getTitle(),
             status_code: this.getStatusCode(),
+            viewport_size: this.getViewPort(),
 
             ab_test: this.getMetaContent('ab-test'),
             document_type: this.getMetaContent('format'),
@@ -129,6 +130,12 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
       } else {
         return '200'
       }
+    },
+
+    getViewPort: function () {
+      var vw = Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0)
+      var vh = Math.max(document.documentElement.clientHeight || 0, window.innerHeight || 0)
+      return vw + 'x' + vh
     },
 
     getMetaContent: function (name) {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
@@ -20,6 +20,7 @@ describe('Google Tag Manager page view tracking', function () {
         referrer: document.referrer,
         title: 'This here page',
         status_code: '200',
+        viewport_size: GOVUK.analyticsGa4.analyticsModules.PageViewTracker.getViewPort(),
 
         ab_test: undefined,
         document_type: undefined,


### PR DESCRIPTION
## What
Adds browser viewport width and height to the GA4 page view.

Uses a fairly clean approach that appears to be reasonably backwards compatible for browsers.

In the tests I'm using the function I'm testing to get the viewport size, which seems a bit redundant but otherwise I think we'd need to be setting the viewport size in the test, which could get complicated and messy. Although now I write this that sounds useful. Perhaps something to consider while reviewing. EDIT: done some digging, this indeed looks difficult and messy. Maybe best avoided.

## Why
Part of the GA4 migration.

## Visual Changes
None.

Trello card: https://trello.com/c/9J21E5KI/698-viewport-size-custom-dimension
