### PR TITLE
Fix GA4 contents list events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Fix GA4 contents list events ([PR #3667](https://github.com/alphagov/govuk_publishing_components/pull/3667))
 * Add viewport size to GA4 page view ([PR #3665](https://github.com/alphagov/govuk_publishing_components/pull/3665))
 * Replace '+' in GA4 search term values with an actual space ([PR #3653](https://github.com/alphagov/govuk_publishing_components/pull/3653))
 * Update image card two thirds variation #3661 ([PR #3661](https://github.com/alphagov/govuk_publishing_components/pull/3661))

--- a/app/views/govuk_publishing_components/components/_contents_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_contents_list.html.erb
@@ -16,7 +16,8 @@
   ga4_data = {
     event_name: "navigation",
     section: t("components.contents_list.contents", locale: :en) || "",
-    index_total: cl_helper.get_index_total
+    type: "contents list",
+    index_total: cl_helper.get_index_total,
   } if ga4_tracking
   local_assigns[:aria] ||= {}
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
@@ -42,10 +43,10 @@
         <li class="<%= cl_helper.list_item_classes(contents_item, false) %>" <%= "aria-current=true" if contents_item[:active] %>>
           <% link_text = format_numbers ? cl_helper.wrap_numbers_with_spans(contents_item[:text]) : contents_item[:text]
             if ga4_tracking
+              ga4_data[:event_name] = cl_helper.get_ga4_event_name(contents_item[:href]) if contents_item[:href]
               ga4_data[:index] = {
                 "index_link": index_link,
               }
-              ga4_data[:type] = cl_helper.get_ga4_type(contents_item[:href]) if contents_item[:href]
             end
           %>
           <%= link_to_if !contents_item[:active], link_text, contents_item[:href],
@@ -67,10 +68,10 @@
                 <li class="<%= cl_helper.list_item_classes(nested_contents_item, true) %>" <%= "aria-current=true" if nested_contents_item[:active] %>>
                   <%
                     if ga4_tracking
+                      ga4_data[:event_name] = cl_helper.get_ga4_event_name(nested_contents_item[:href]) if nested_contents_item[:href]
                       ga4_data[:index] = {
                         "index_link": index_link,
                       }
-                      ga4_data[:type] = cl_helper.get_ga4_type(nested_contents_item[:href]) if nested_contents_item[:href]
                     end
                   %>
                   <%= link_to_if !nested_contents_item[:active], nested_contents_item[:text], nested_contents_item[:href],

--- a/lib/govuk_publishing_components/presenters/contents_list_helper.rb
+++ b/lib/govuk_publishing_components/presenters/contents_list_helper.rb
@@ -48,10 +48,10 @@ module GovukPublishingComponents
         total
       end
 
-      def get_ga4_type(link)
-        return "select content" if link.start_with?("#")
+      def get_ga4_event_name(link)
+        return "select_content" if link.start_with?("#")
 
-        "contents list"
+        "navigation"
       end
 
     private

--- a/spec/components/contents_list_spec.rb
+++ b/spec/components/contents_list_spec.rb
@@ -132,6 +132,7 @@ describe "Contents list", type: :view do
     expected_ga4_json = {
       event_name: "navigation",
       section: "Contents",
+      type: "contents list",
     }
 
     # Parent element attributes
@@ -149,10 +150,10 @@ describe "Contents list", type: :view do
     # should still be respected. Therefore the final link should still have an index of 7 even though there's only 6 <a> tags.
     index_links = [1, 2, 3, 4, 5, 7]
     texts = ["1. One", "2. Two", "3. Three", "Nested one", "Nested two", "4. Four"]
-    types = ["contents list", "select content", "contents list", "contents list", "contents list", "select content"]
+    events = %w[navigation select_content navigation navigation navigation select_content]
 
     contents_list_links.each_with_index do |link, index|
-      expected_ga4_json[:type] = types[index]
+      expected_ga4_json[:event_name] = events[index]
       expected_ga4_json[:index] = { index_link: index_links[index] }
       expect(link.attr("data-ga4-link").to_s).to eq expected_ga4_json.to_json
       expect(link).to have_text(texts[index])

--- a/spec/lib/govuk_publishing_components/components/contents_list_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/components/contents_list_helper_spec.rb
@@ -97,10 +97,10 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentsListHelper do
       expect(cl.get_index_total).to eql(4)
     end
 
-    it "returns the required GA4 type" do
+    it "returns the required GA4 event name" do
       cl = GovukPublishingComponents::Presenters::ContentsListHelper.new({})
-      expect(cl.get_ga4_type("#anchor")).to eql("select content")
-      expect(cl.get_ga4_type("https://www.gov.uk")).to eql("contents list")
+      expect(cl.get_ga4_event_name("#anchor")).to eql("select_content")
+      expect(cl.get_ga4_event_name("https://www.gov.uk")).to eql("navigation")
     end
   end
 


### PR DESCRIPTION
## What
Set the GA4 attributes for contents list events to be the correct values. Hopefully. This time.

## Why
I got them wrong. I don't know how.

## Visual Changes
None.

Trello card: https://trello.com/c/pWP26ZKI/691-add-contents-list-selectcontent-events-to-taxon-pages
