### PR TITLE
Improve attachment details styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Improve attachment details styles ([PR #3668](https://github.com/alphagov/govuk_publishing_components/pull/3668))
 * Fix GA4 contents list events ([PR #3667](https://github.com/alphagov/govuk_publishing_components/pull/3667))
 * Add viewport size to GA4 page view ([PR #3665](https://github.com/alphagov/govuk_publishing_components/pull/3665))
 * Replace '+' in GA4 search term values with an actual space ([PR #3653](https://github.com/alphagov/govuk_publishing_components/pull/3653))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
@@ -14,8 +14,8 @@ $thumbnail-icon-border-colour: govuk-colour("mid-grey", $legacy: "grey-3");
   @include govuk-clearfix;
   position: relative;
 
-  .govuk-details__summary {
-    @include govuk-font($size: 14);
+  .govuk-details {
+    margin: govuk-spacing(3) 0;
   }
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
@@ -12,6 +12,7 @@
   // Scope attachment and attachment-link component styles to gem-c-govspeak
   @import "../attachment-link";
   @import "../attachment";
+  @import "../details";
 
   // This block is duplicated from Whitehall as a transitional step, see the
   // commit message for 2d893c10ee3f2cab27162b9aba38b12379a71d07 before making

--- a/app/views/govuk_publishing_components/components/_govspeak.html.erb
+++ b/app/views/govuk_publishing_components/components/_govspeak.html.erb
@@ -1,5 +1,6 @@
 <%
   add_gem_component_stylesheet("govspeak")
+
   inverse ||= false
   direction_class = "direction-#{direction}" if local_assigns.include?(:direction)
   disable_youtube_expansions = local_assigns.fetch(:disable_youtube_expansions) if local_assigns.include?(:disable_youtube_expansions)


### PR DESCRIPTION
## What
Fix some styling issues with the details component where it appears inside the attachment component.

- where the details component is included in the attachment component inside govspeak it was not being styled, because the details stylesheet was not being included
- also increases font size of this component in this context, and fixes a spacing issue


## Why
Improve accessibility and visual appearance.

## Visual Changes
The problem can be seen on [pages like this](https://www.gov.uk/government/groups/secretary-of-state-for-transports-honorary-medical-advisory-panel-on-driving-and-psychiatric-disorders) rendered using govspeak inside `government-frontend`. The details component lacks focus and other styles. In addition, the details component had been shrunk so that it was smaller than its contents.

Spacing has also been added to the top of the details component in this context as the paragraph above has a 'last of type' zero bottom margin. This lack of a gap was less noticeable with the former smaller font size.

Before | After
------- | ------
![Screenshot 2023-10-17 at 14 09 46](https://github.com/alphagov/govuk_publishing_components/assets/861310/03b896da-79a7-4dbc-bdc7-3e81732806d9) | ![Screenshot 2023-10-17 at 14 11 01](https://github.com/alphagov/govuk_publishing_components/assets/861310/a1210cc3-7eac-4b85-b319-a762556bf501)
