### PR TITLE
Update the styling of image-card two thirds variation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Add GA4 'print intent' tracker ([PR #3652](https://github.com/alphagov/govuk_publishing_components/pull/3652))
 * Update LUX to version 312 ([PR #3672](https://github.com/alphagov/govuk_publishing_components/pull/3672))
 * Grab data-ga4-ecommerce-content-id in GA4 ecommerce tracking ([PR #3676](https://github.com/alphagov/govuk_publishing_components/pull/3676))
+* Update the styling of image-card two thirds variation ([PR #3671](https://github.com/alphagov/govuk_publishing_components/pull/3671))
 
 ## 35.19.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -41,13 +41,6 @@
   }
 }
 
-@include govuk-media-query($from: tablet) {
-  .gem-c-image-card.gem-c-image-card--two-thirds {
-    margin: 0 (- govuk-spacing(3)) govuk-spacing(6) (- govuk-spacing(3));
-    display: block;
-  }
-}
-
 @include govuk-media-query($from: mobile, $until: tablet) {
   .gem-c-image-card {
     margin: 0 (- govuk-spacing(3)) govuk-spacing(6) (- govuk-spacing(3));
@@ -77,7 +70,6 @@
 
   .gem-c-image-card__text-wrapper.gem-c-image-card__text-wrapper--two-thirds {
     @include govuk-grid-column($width: two-thirds, $float: right, $at: tablet);
-    padding-left: 0;
   }
 }
 
@@ -89,6 +81,37 @@
   border-left: none;
   border-right: none;
   border-bottom: none;
+}
+
+.gem-c-image-card.gem-c-image-card--two-thirds {
+  // Change default flex-direction from column-reverse
+  // so that the image and text appear in the same row,
+  // with the image to the left
+  flex-direction: row-reverse;
+  -ms-flex-direction: row-reverse;
+  // Wrap flex items onto a new line and ensure
+  // that items are aligned correctly
+  flex-wrap: wrap-reverse;
+  -ms-flex-wrap: wrap-reverse;
+  justify-content: flex-end;
+  align-items: flex-end;
+}
+
+.gem-c-image-card__image-wrapper.gem-c-image-card__image-wrapper--one-third {
+  // The first two values set flex-grow and flex-basis to 0
+  // This ensures that the flex item does not grow or shrink
+  // The the last value, sets flex-basis to 95px
+  // padding-left is set to 15px and the image used is 80px wide
+  flex: 0 0 95px;
+  padding-right: 0;
+}
+
+.gem-c-image-card__text-wrapper.gem-c-image-card__text-wrapper--two-thirds {
+  // The first two values set flex-grow and flex-basis to 1
+  // This allows the flex item contain the image card text to grow or shrink
+  // The last value, sets flex-basis to 70%
+  // If the width of the flex-item shrinks below 70%, it will wrap onto a new line
+  flex: 1 1 70%;
 }
 
 .gem-c-image-card__title {

--- a/app/views/govuk_publishing_components/components/docs/image_card.yml
+++ b/app/views/govuk_publishing_components/components/docs/image_card.yml
@@ -205,8 +205,8 @@ examples:
       <div class="govuk-!-width-full">
         <%= component %>
       </div>
-  two_thirds_column:
-    description: This variant is used for the featured section on the homepage, the aspect ratio used is 1:1
+  two_thirds:
+    description: This variant is used for the featured section on the homepage. The aspect ratio used is 1:1 and the width of the image is constrained to 80px wide.
     data:
       two_thirds: true
       href: "/still-not-a-page"


### PR DESCRIPTION
## What
Update the styling of the image-card component (two thirds variation), the changes include:

- Remove the `display: block` rule, using the default value set of `display: flex` instead
- Use flex to align the card image and card text in the same row
- Wrap the image card text onto a new line if the width would go below 70%
- Ensure the card image and card text align as intended

## Why
As part of the changes for the new homepage design and to help ensure that the image card text does not appear too squashed at smaller Desktop screen sizes.

[Trello card](https://trello.com/c/LbnpQxg3/2136-iterate-featured-section-images-m)

## Visual Changes
For larger desktop screen sizes, there is no change to the layout of the featured section, it will remain as shown in the screenshot below:

<img width="391" alt="desktop-new-featured-section" src="https://github.com/alphagov/govuk_publishing_components/assets/28779939/f3062ecd-26a8-4e2e-b2ac-76a86d241c30">

### Featured section new homepage before - 768px
<img width="334" alt="desktop-769-before" src="https://github.com/alphagov/govuk_publishing_components/assets/28779939/5154c88d-f982-430c-a19d-0e594152e834">

### Featured section new homepage after - 768px
<img width="321" alt="desktop-769-after" src="https://github.com/alphagov/govuk_publishing_components/assets/28779939/b63a7296-24c6-4b60-9416-9e43012f8a21">

### IE11 support
When testing in browser stack, IE11 will render the card image above the card text as shown below:

<img width="449" alt="IE11-layout" src="https://github.com/alphagov/govuk_publishing_components/assets/28779939/ab452b41-a299-4917-bc59-052260487a4c">