### PR TITLE
Use custom SVG for search 'cancel' icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Flatten GA4 data attributes ([PR #3649](https://github.com/alphagov/govuk_publishing_components/pull/3649))
+* Use custom SVG for search 'cancel' icon ([PR #3673](https://github.com/alphagov/govuk_publishing_components/pull/3673))
 * Add GA4 'print intent' tracker ([PR #3652](https://github.com/alphagov/govuk_publishing_components/pull/3652))
 * Update LUX to version 312 ([PR #3672](https://github.com/alphagov/govuk_publishing_components/pull/3672))
 * Grab data-ga4-ecommerce-content-id in GA4 ecommerce tracking ([PR #3676](https://github.com/alphagov/govuk_publishing_components/pull/3676))

--- a/app/assets/images/govuk_publishing_components/icon-close.svg
+++ b/app/assets/images/govuk_publishing_components/icon-close.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none"><path fill="#0B0C0C" d="M2 15.435 15.435 2l2.121 2.121L4.121 17.556z"/><path fill="#0B0C0C" d="M15.436 17.557 2 4.122l2.12-2.121 13.436 13.435z"/></svg>

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -91,6 +91,19 @@ $large-input-size: 50px;
   &:focus {
     @include gem-c-search-input-focus;
   }
+
+  // Note: this is a non-standard CSS feature and will not do anything in Firefox. https://bugzilla.mozilla.org/show_bug.cgi?id=1417753
+  &::-webkit-search-cancel-button {
+    -webkit-appearance: none;
+    background-image: image-url("govuk_publishing_components/icon-close.svg");
+    background-position: center;
+    background-repeat: no-repeat;
+    cursor: pointer;
+    height: 20px;
+    margin-left: 0;
+    margin-right: 0;
+    width: 20px;
+  }
 }
 
 @mixin icon-positioning($container-size) {


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Replaces the default search 'cancel' button with our own custom SVG provided by one of our designers. The default browser icon does not scale well when zoomed in, so we are using our own SVG for this icon which scales when zoomed in.
- I have run the SVG through a minifier to reduce it's filesize.
- I have made it bigger than the default icon, as a bigger hitbox is better for accessibility, especially on mobile. But let me know if it's too big.
- This doesn't apply to Firefox as Firefox doesn't support search cancel buttons. I have been asked by our GOVUK Lead FE Dev to raise an issue in this repo that we're using this non standard CSS, just so we're kept aware of it once it's merged.
- Visual changes have been approved by the designer 

## Why
<!-- What are the reasons behind this change being made? -->
- The default cancel button used by browsers does not scale well when zoomed in
- Closes #3086

## Testing
- Chrome on Desktop & Mobile ✅ 
- Edge ✅ 
- IE 11 ✅ 
- Safari on Mac & iPhone ✅ 
- Samsung Browser ✅ 
- Firefox ❌ - It doesn't support `::-webkit-search-cancel-button` so there are never any cancel buttons present on Firefox. [See the MDN page for ::webkit-search-cancel-button](https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-search-cancel-button)

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

### Before

<img width="563" alt="image" src="https://github.com/alphagov/govuk_publishing_components/assets/8880610/af165fbe-5f06-452f-9db5-0dcddc59af21">

<img width="725" alt="image" src="https://github.com/alphagov/govuk_publishing_components/assets/8880610/7dc8112c-1198-4130-834a-294a665c46cf">



### After

<img width="563" alt="image" src="https://github.com/alphagov/govuk_publishing_components/assets/8880610/af78628e-2f04-4382-88e9-e5dcd0a150b8">

<img width="725" alt="image" src="https://github.com/alphagov/govuk_publishing_components/assets/8880610/a9cf892f-0ea6-4a87-8c6d-81dca4a13852">



