### PR TITLE
Grab data-ga4-ecommerce-content-id in GA4 ecommerce tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Flatten GA4 data attributes ([PR #3649](https://github.com/alphagov/govuk_publishing_components/pull/3649))
 * Add GA4 'print intent' tracker ([PR #3652](https://github.com/alphagov/govuk_publishing_components/pull/3652))
 * Update LUX to version 312 ([PR #3672](https://github.com/alphagov/govuk_publishing_components/pull/3672))
+* Grab data-ga4-ecommerce-content-id in GA4 ecommerce tracking ([PR #3676](https://github.com/alphagov/govuk_publishing_components/pull/3676))
 
 ## 35.19.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -325,6 +325,7 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
           var target = data.event.target
           ecommerceSchema.search_results.ecommerce.items.push({
             item_id: target.getAttribute('data-ga4-ecommerce-path'),
+            item_content_id: target.getAttribute('data-ga4-ecommerce-content-id') || undefined,
             item_name: target.textContent,
             item_list_name: listTitle,
             index: window.GOVUK.analyticsGa4.core.ecommerceHelperFunctions.getIndex(target, startPosition)
@@ -351,6 +352,7 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
 
             ecommerceSchema.search_results.ecommerce.items.push({
               item_id: path,
+              item_content_id: item.getAttribute('data-ga4-ecommerce-content-id') || undefined,
               item_list_name: listTitle,
               index: window.GOVUK.analyticsGa4.core.ecommerceHelperFunctions.getIndex(item, startPosition)
             })

--- a/docs/analytics-ga4/ga4-ecommerce-tracker.md
+++ b/docs/analytics-ga4/ga4-ecommerce-tracker.md
@@ -114,6 +114,7 @@ If a user clicks on a search result, the following object will be pushed to the 
                 {
                     "index": 1,
                     "item_id": "/vehicle-tax",
+                    "item_content_id": "fa748fae-3de4-4266-ae85-0797ada3f40c",
                     "item_list_name": "Search",
                     "item_name": "Tax your vehicle"
                 }

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
@@ -534,26 +534,31 @@ describe('GA4 core', function () {
               items: [
                 {
                   item_id: 'https://www.gov.uk/the-warm-home-discount-scheme',
+                  item_content_id: undefined,
                   item_list_name: 'Smart answer results',
                   index: 1
                 },
                 {
                   item_id: '/apply-council-tax-reduction',
+                  item_content_id: undefined,
                   item_list_name: 'Smart answer results',
                   index: 2
                 },
                 {
                   item_id: '/budgeting-help-benefits',
+                  item_content_id: undefined,
                   item_list_name: 'Smart answer results',
                   index: 3
                 },
                 {
                   item_id: 'https://www.nhs.uk/nhs-services/help-with-health-costs',
+                  item_content_id: undefined,
                   item_list_name: 'Smart answer results',
                   index: 4
                 },
                 {
                   item_id: 'https://www.gov.uk/support-for-mortgage-interest',
+                  item_content_id: undefined,
                   item_list_name: 'Smart answer results',
                   index: 5
                 }
@@ -594,6 +599,7 @@ describe('GA4 core', function () {
           if (i < 200) {
             ecommerceItems.push({
               item_id: 'https://www.gov.uk/the-warm-home-discount-scheme',
+              item_content_id: undefined,
               item_list_name: 'Smart answer results',
               index: i + 1
             })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-ecommerce-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-ecommerce-tracker.spec.js
@@ -28,15 +28,15 @@ describe('Google Analytics ecommerce tracking', function () {
 
     searchResults = document.createElement('div')
     searchResults.innerHTML =
-      '<a data-ga4-ecommerce-path="/coronavirus" data-ecommerce-row="1" data-ecommerce-index="1" href="/coronavirus">Coronavirus (COVID-19): guidance and support</a>' +
+      '<a data-ga4-ecommerce-path="/coronavirus" data-ecommerce-row="1" data-ecommerce-index="1" data-ga4-ecommerce-content-id="test0" href="/coronavirus">Coronavirus (COVID-19): guidance and support</a>' +
 
-      '<a data-ga4-ecommerce-path="/guidance/travel-abroad-from-england-during-coronavirus-covid-19" data-ecommerce-row="1" data-ecommerce-index="2" href="/guidance/travel-abroad">Travel abroad</a>' +
+      '<a data-ga4-ecommerce-path="/guidance/travel-abroad-from-england-during-coronavirus-covid-19" data-ga4-ecommerce-content-id="test1" data-ecommerce-row="1" data-ecommerce-index="2" href="/guidance/travel-abroad">Travel abroad</a>' +
 
-      '<a data-ga4-ecommerce-path="/guidance/people-with-symptoms-of-a-respiratory-infection-including-covid-19" data-ecommerce-row="1" data-ecommerce-index="3" href="/guidance/people">People</a>' +
+      '<a data-ga4-ecommerce-path="/guidance/people-with-symptoms-of-a-respiratory-infection-including-covid-19" data-ga4-ecommerce-content-id="test2" data-ecommerce-row="1" data-ecommerce-index="3" href="/guidance/people">People</a>' +
 
-      '<a data-ga4-ecommerce-path="/foreign-travel-advice" onclick="event.preventDefault()" data-ecommerce-row="1" data-ecommerce-index="4" href="/foreign-travel-advice">Foreign travel advice</a>' +
+      '<a data-ga4-ecommerce-path="/foreign-travel-advice" onclick="event.preventDefault()" data-ecommerce-row="1" data-ga4-ecommerce-content-id="test3" data-ecommerce-index="4" href="/foreign-travel-advice">Foreign travel advice</a>' +
 
-      '<a data-ga4-ecommerce-path="/guidance/living-safely-with-respiratory-infections-including-covid-19" data-ecommerce-row="1" data-ecommerce-index="5" href="/guidance/living-safely">Living safely</a>'
+      '<a data-ga4-ecommerce-path="/guidance/living-safely-with-respiratory-infections-including-covid-19" data-ga4-ecommerce-content-id="test4" data-ecommerce-row="1" data-ecommerce-index="5" href="/guidance/living-safely">Living safely</a>'
 
     onPageLoadExpected = {
       event: 'search_results',
@@ -50,26 +50,31 @@ describe('Google Analytics ecommerce tracking', function () {
           items: [
             {
               item_id: '/coronavirus',
+              item_content_id: 'test0',
               item_list_name: 'test-list-title',
               index: 1
             },
             {
               item_id: '/guidance/travel-abroad-from-england-during-coronavirus-covid-19',
+              item_content_id: 'test1',
               item_list_name: 'test-list-title',
               index: 2
             },
             {
               item_id: '/guidance/people-with-symptoms-of-a-respiratory-infection-including-covid-19',
+              item_content_id: 'test2',
               item_list_name: 'test-list-title',
               index: 3
             },
             {
               item_id: '/foreign-travel-advice',
+              item_content_id: 'test3',
               item_list_name: 'test-list-title',
               index: 4
             },
             {
               item_id: '/guidance/living-safely-with-respiratory-infections-including-covid-19',
+              item_content_id: 'test4',
               item_list_name: 'test-list-title',
               index: 5
             }
@@ -141,6 +146,15 @@ describe('Google Analytics ecommerce tracking', function () {
       var searchResults = window.dataLayer[1].search_results.ecommerce.items
       for (var i = 0; i < searchResults.length; i++) {
         expect(searchResults[i].item_id).toBe(onPageLoadExpected.search_results.ecommerce.items[i].item_id)
+      }
+    })
+
+    it('should get the item content id for each search result', function () {
+      GOVUK.analyticsGa4.Ga4EcommerceTracker.init()
+
+      var searchResults = window.dataLayer[1].search_results.ecommerce.items
+      for (var i = 0; i < searchResults.length; i++) {
+        expect(searchResults[i].item_content_id).toBe(onPageLoadExpected.search_results.ecommerce.items[i].item_content_id)
       }
     })
 
@@ -240,6 +254,7 @@ describe('Google Analytics ecommerce tracking', function () {
             items: [
               {
                 item_id: '/foreign-travel-advice',
+                item_content_id: 'test3',
                 item_name: 'Foreign travel advice',
                 item_list_name: 'test-list-title',
                 index: 4

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-smart-answer-results-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-smart-answer-results-tracker.spec.js
@@ -46,26 +46,31 @@ describe('GA4 smart answer results tracking', function () {
           items: [
             {
               item_id: 'https://www.gov.uk/the-warm-home-discount-scheme',
+              item_content_id: undefined,
               item_list_name: 'Smart answer results',
               index: 1
             },
             {
               item_id: '/apply-council-tax-reduction',
+              item_content_id: undefined,
               item_list_name: 'Smart answer results',
               index: 2
             },
             {
               item_id: '/budgeting-help-benefits',
+              item_content_id: undefined,
               item_list_name: 'Smart answer results',
               index: 3
             },
             {
               item_id: 'https://www.nhs.uk/nhs-services/help-with-health-costs',
+              item_content_id: undefined,
               item_list_name: 'Smart answer results',
               index: 4
             },
             {
               item_id: 'https://www.gov.uk/support-for-mortgage-interest',
+              item_content_id: undefined,
               item_list_name: 'Smart answer results',
               index: 5
             }
@@ -172,6 +177,7 @@ describe('GA4 smart answer results tracking', function () {
             items: [
               {
                 item_id: '/budgeting-help-benefits',
+                item_content_id: undefined,
                 item_name: 'Check if you’re eligible for a Budgeting Loan',
                 item_list_name: 'Smart answer results',
                 index: 3


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Allows the GA4 ecommerce tracker to grab a data attribute called `data-ga4-ecommerce-content-id` and push it to the dataLayer.  We want to track the content id of results, as the URLs get cut off by GA4s 100 character limit.
- We are using this for finders only, so any of the tests referring to smart answers have the value set to `undefined`

## Why
<!-- What are the reasons behind this change being made? -->
- High priority bug fix https://trello.com/c/7Snj5Lx1/710-search-enhancement-add-content-id-to-searchresults-ecommerce-items-because-link-paths-are-truncated-to-100-characters
- Related to https://github.com/alphagov/finder-frontend/pull/3192 but either PR can be merged in any order, as nothing should crash if one is merged and the other isn't
## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.