### PR TITLE
Adjust the size of large navbar super navigation header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Adjustments to the navbar for the homepage ([PR #3666](https://github.com/alphagov/govuk_publishing_components/pull/3666))
+* Adjust the size of large navbar super navigation header ([PR #3677](https://github.com/alphagov/govuk_publishing_components/pull/3677))
 
 ## 35.20.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -8,7 +8,7 @@ $search-width-or-height: $black-bar-height;
 $pseudo-underline-height: 3px;
 $button-pipe-colour: darken(govuk-colour("mid-grey"), 20%);
 
-$large-navbar-height: 86px;
+$large-navbar-height: 72px;
 
 $pale-blue-colour: #d2e2f1;
 
@@ -918,12 +918,12 @@ $after-button-padding-left: govuk-spacing(4);
   }
 
   .gem-c-layout-super-navigation-header__logotype-crown--large-navbar {
-    height: 36px;
-    width: 49px;
+    height: 32px;
+    width: 44px;
   }
 
   .gem-c-header__link--large-navbar:focus {
-    box-shadow: 0 -4px 0 18px $govuk-focus-colour;
+    box-shadow: 0 -6px 0 12px $govuk-focus-colour;
     border-bottom: $govuk-focus-width solid govuk-colour("black");
     padding-bottom: 10px;
   }
@@ -933,9 +933,9 @@ $after-button-padding-left: govuk-spacing(4);
   }
 
   .gem-c-layout-super-navigation-header__header-logo--large-navbar {
-    height: 35px;
-    padding-bottom: govuk-spacing(5);
-    padding-top: govuk-spacing(5);
+    height: 32px;
+    padding-bottom: govuk-spacing(4);
+    padding-top: govuk-spacing(4);
   }
 
   .gem-c-layout-super-navigation-header__search-toggle-button--large-navbar {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -846,6 +846,19 @@ $after-button-padding-left: govuk-spacing(4);
   }
 }
 
+.gem-c-layout-super-navigation-header__navigation-top-toggle-button--large-navbar {
+  .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
+    padding-left: 26px;
+    padding-right: 26px;
+  }
+}
+
+.gem-c-layout-super-navigation-header__search-toggle-button--large-navbar {
+  padding-left: 24px;
+  padding-right: 24px;
+  width: 68px;
+}
+
 .gem-c-layout-super-navigation-header__navigation-dropdown-menu--large-navbar .gem-c-layout-super-navigation-header__navigation-second-item-description {
   font-size: 19px;
   font-size: govuk-px-to-rem(19px);


### PR DESCRIPTION
## What
- Decrease the large navbar height from 86px to 72px
- Decrease the crown logo size
- Adjust related height and padding values to ensure the header logo is contained and aligned correctly

## Why
As part of the new homepage design changes.

[Trello card](https://trello.com/c/9IrSqRv5/2187-tweaks-to-apply-to-the-menu-bar-on-desktop-m-l)

## Visual Changes

### Before - Crown logo size
<img width="339" alt="Screenshot 2023-10-23 at 09 07 23" src="https://github.com/alphagov/govuk_publishing_components/assets/28779939/a51586bd-a58d-466b-98d5-06964fcc90a9">

### After - Crown Logo size
<img width="333" alt="Screenshot 2023-10-23 at 09 07 39" src="https://github.com/alphagov/govuk_publishing_components/assets/28779939/bf4b9d7e-1ca3-4f96-a7ab-069ba5ad2eb3">


### Before - focus state
<img width="996" alt="Screenshot 2023-10-23 at 09 04 15" src="https://github.com/alphagov/govuk_publishing_components/assets/28779939/4ec0d91a-ee34-40cf-808f-780784d064a0">

### After - focus state
<img width="1016" alt="Screenshot 2023-10-23 at 09 04 45" src="https://github.com/alphagov/govuk_publishing_components/assets/28779939/61195ce4-fb21-4474-96a2-885b3d9b8b3a">


### Before - nav menu toggle button sizes
<img width="470" alt="Screenshot 2023-10-24 at 14 27 25" src="https://github.com/alphagov/govuk_publishing_components/assets/28779939/f28c9930-e853-4970-9ee8-4cca43317f99">

### After - nav menu toggle button sizes
<img width="469" alt="Screenshot 2023-10-24 at 14 27 04" src="https://github.com/alphagov/govuk_publishing_components/assets/28779939/6b1a1ba8-b92a-49e0-aafd-1888679160b8">

