### PR TITLE
Version 35.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 35.20.0
 
 * Flatten GA4 data attributes ([PR #3649](https://github.com/alphagov/govuk_publishing_components/pull/3649))
 * Use custom SVG for search 'cancel' icon ([PR #3673](https://github.com/alphagov/govuk_publishing_components/pull/3673))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (35.19.0)
+    govuk_publishing_components (35.20.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "35.19.0".freeze
+  VERSION = "35.20.0".freeze
 end


### PR DESCRIPTION
## 35.20.0

* Flatten GA4 data attributes ([PR #3649](https://github.com/alphagov/govuk_publishing_components/pull/3649))
* Use custom SVG for search 'cancel' icon ([PR #3673](https://github.com/alphagov/govuk_publishing_components/pull/3673))
* Add GA4 'print intent' tracker ([PR #3652](https://github.com/alphagov/govuk_publishing_components/pull/3652))
* Update LUX to version 312 ([PR #3672](https://github.com/alphagov/govuk_publishing_components/pull/3672))
* Grab data-ga4-ecommerce-content-id in GA4 ecommerce tracking ([PR #3676](https://github.com/alphagov/govuk_publishing_components/pull/3676))
* Update the styling of image-card two thirds variation ([PR #3671](https://github.com/alphagov/govuk_publishing_components/pull/3671))
