### PR TITLE
Prevent GA4 data sending during Smokey tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add metadata inverse no padding option ([PR #3689](https://github.com/alphagov/govuk_publishing_components/pull/3689))
+* Prevent GA4 data sending during Smokey tests ([PR #3680](https://github.com/alphagov/govuk_publishing_components/pull/3680))
 
 ## 35.20.1
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -30,7 +30,16 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
       firstScript.parentNode.insertBefore(newScript, firstScript)
     },
 
+    getUserAgent: function () {
+      return navigator.userAgent
+    },
+
     sendData: function (data) {
+      // Prevent any GA4 data being sent during Smokey tests
+      if (this.getUserAgent() === 'Smokey Test / Ruby') {
+        return
+      }
+
       data.govuk_gem_version = this.getGemVersion()
       // set this in the console as a debugging aid
       if (window.GOVUK.analyticsGa4.showDebug) {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
@@ -68,6 +68,15 @@ describe('GA4 core', function () {
     })
   })
 
+  it('does not push data to the dataLayer if it is a Smokey test', function () {
+    spyOn(GOVUK.analyticsGa4.core, 'getUserAgent').and.returnValue('Smokey Test / Ruby')
+    var data = {
+      hello: 'I must be going'
+    }
+    GOVUK.analyticsGa4.core.sendData(data)
+    expect(window.dataLayer).toEqual([])
+  })
+
   describe('link tracking functions', function () {
     describe('find tracking attributes on elements', function () {
       var element


### PR DESCRIPTION
This prevents the GA4 dashboards being polluted with Smokey test data

## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Our GA4 dashboards are being polluted with test data coming from Smokey
- It seems that smokey sets it's user agent to `Smokey Test / Ruby`. As we can grab user agents in JS, we can use this to prevent data being sent if `Smokey Test / Ruby` is the user agent. See https://github.com/alphagov/smokey/blob/32678764d2dfdf18615b2e24d30c615b6cfec644/features/support/env.rb#L33 and https://github.com/alphagov/smokey/blob/32678764d2dfdf18615b2e24d30c615b6cfec644/features/support/http_requests.rb#L77
- I am preventing Smokey data from being sent to GA4 in the `sendData` function. I considered just disabling analytics entirely if it was a Smokey test, but I thought this was a bad idea. Mainly because then we couldn't write new Smokey tests which check our GA4 code is actually working. By doing it this way, in the future we could modify `sendData` so that if the user is a smokey test, it pushes to a different array such as `window.smokeyLayer` so that we can have smokey tests that check our dataLayer is working without actually pushing any data to GA4.


## Why
<!-- What are the reasons behind this change being made? -->
- https://trello.com/c/TnMU9ZPm/709-investigate-how-to-filter-smokey-tests

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
