### PR TITLE
Add data-ga4-form-no-answer-undefined to header search form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Adjustments to the navbar for the homepage ([PR #3666](https://github.com/alphagov/govuk_publishing_components/pull/3666))
 * Adjust the size of large navbar super navigation header ([PR #3677](https://github.com/alphagov/govuk_publishing_components/pull/3677))
 * Add visually hidden text to the navbar ([PR #3684](https://github.com/alphagov/govuk_publishing_components/pull/3684))
+* Add data-ga4-form-no-answer-undefined to header search form ([PR #3682](https://github.com/alphagov/govuk_publishing_components/pull/3682))
 
 ## 35.20.0
 

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -359,6 +359,7 @@
                 data-module="ga4-form-tracker"
                 data-ga4-form='{ "event_name": "search", "type": "header menu bar", "section": "Search GOV.UK", "action": "search", "url": "/search/all" }'
                 data-ga4-form-include-text
+                data-ga4-form-no-answer-undefined
                 action="/search"
                 method="get"
                 role="search"


### PR DESCRIPTION
## What
Adds `data-ga4-form-no-answer-undefined` to the header search form. When this attribute exists, it will send `text: undefined` when the form is empty, instead of `text: "No answer given"`.

## Why

https://trello.com/c/WtvEWiS3/592-placeholder-replace-no-answer-given-with-undefined-on-homepage-search-event