### PR TITLE
Add visually hidden text to navbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Adjustments to the navbar for the homepage ([PR #3666](https://github.com/alphagov/govuk_publishing_components/pull/3666))
 * Adjust the size of large navbar super navigation header ([PR #3677](https://github.com/alphagov/govuk_publishing_components/pull/3677))
+* Add visually hidden text to the navbar ([PR #3684](https://github.com/alphagov/govuk_publishing_components/pull/3684))
 
 ## 35.20.0
 

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -111,6 +111,11 @@
             label: logo_link_title,
           }
         } do %>
+          <% if hide_logo_text %>
+            <span class="govuk-visually-hidden">
+              <%= logo_text %>
+            </span>
+          <% end %>
           <span class="govuk-header__logotype">
             <!--[if gt IE 8]><!-->
             <%= content_tag(:svg, {

--- a/spec/components/layout_super_navigation_header_spec.rb
+++ b/spec/components/layout_super_navigation_header_spec.rb
@@ -103,12 +103,13 @@ describe "Super navigation header", type: :view do
     assert_select "a.govuk-header__link--homepage[href='https://www.example.com/']", count: 1
   end
 
-  it "hides logo text" do
+  it "hides logo text and renders visually hidden span" do
     render_component({
       hide_logo_text: true,
     })
 
-    assert_select "a.govuk-header__link--homepage[href='https://www.gov.uk/']", ""
+    assert_select "a.govuk-header__link--homepage[href='https://www.gov.uk/']", "GOV.UK"
+    assert_select "a.govuk-header__link--homepage .govuk-visually-hidden"
   end
 
   it "hides left border of button" do


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

Add visually hidden span to the navbar crown logo link if we are hiding the logo text. Add test to make sure the visually hidden text is being added.

## Why
<!-- What are the reasons behind this change being made? -->

If users change the styles of the navbar, then there is still fallback text for this link.

[Relevant Trello Card](https://trello.com/c/V1oeVTKL/2206-look-and-feel-accessibility-fix-alternative-text-for-govuk-logo-is-okay-with-aria-label-but-would-be-better-with-visually-hidden)