### PR TITLE
Stop search icon from moving up and down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Adjust the size of large navbar super navigation header ([PR #3677](https://github.com/alphagov/govuk_publishing_components/pull/3677))
 * Add visually hidden text to the navbar ([PR #3684](https://github.com/alphagov/govuk_publishing_components/pull/3684))
 * Add data-ga4-form-no-answer-undefined to header search form ([PR #3682](https://github.com/alphagov/govuk_publishing_components/pull/3682))
+* Stop search icon from moving up and down ([PR #3685](https://github.com/alphagov/govuk_publishing_components/pull/3685))
 
 ## 35.20.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -630,6 +630,12 @@ $after-button-padding-left: govuk-spacing(4);
     color: govuk-colour("white");
   }
 
+  &:focus-visible {
+    &.gem-c-layout-super-navigation-header__search-toggle-button--blue-background {
+      border-bottom: $pseudo-underline-height solid govuk-colour("black");
+    }
+  }
+
   @include govuk-media-query($from: "desktop") {
     border: 0;
     margin: 0;
@@ -655,14 +661,20 @@ $after-button-padding-left: govuk-spacing(4);
       // stylelint-disable max-nesting-depth
       @include focus-not-focus-visible {
         border-bottom: $pseudo-underline-height solid $govuk-brand-colour;
+
+        &:hover {
+          border-bottom: $pseudo-underline-height solid govuk-colour("white");
+        }
       }
       // stylelint-enable max-nesting-depth
     }
 
     &:focus-visible {
       &.gem-c-layout-super-navigation-header__search-toggle-button--blue-background {
+        color: govuk-colour("black");
+
         &:hover {
-          border-bottom: $pseudo-underline-height solid $govuk-focus-colour;
+          border-bottom: $pseudo-underline-height solid govuk-colour("black");
           color: govuk-colour("black");
         }
       }
@@ -681,6 +693,11 @@ $after-button-padding-left: govuk-spacing(4);
       &:hover {
         border-bottom: $pseudo-underline-height solid govuk-colour("light-grey");
         color: govuk-colour("white");
+      }
+
+      &:focus-visible {
+        border-bottom: $pseudo-underline-height solid govuk-colour("black");
+        color: govuk-colour("black");
       }
     }
 
@@ -704,6 +721,10 @@ $after-button-padding-left: govuk-spacing(4);
       border-bottom-color: govuk-colour("light-grey");
       color: govuk-colour("light-grey");
       outline: 1px solid govuk-colour("light-grey"); // overlap the border of the nav menu so it won't appear when menu open
+
+      &:hover {
+        border-bottom: $pseudo-underline-height solid govuk-colour("light-grey");
+      }
     }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -654,7 +654,7 @@ $after-button-padding-left: govuk-spacing(4);
 
       // stylelint-disable max-nesting-depth
       @include focus-not-focus-visible {
-        border-bottom: none;
+        border-bottom: $pseudo-underline-height solid $govuk-brand-colour;
       }
       // stylelint-enable max-nesting-depth
     }
@@ -953,10 +953,7 @@ $after-button-padding-left: govuk-spacing(4);
 
   .gem-c-layout-super-navigation-header__search-toggle-button--large-navbar {
     height: $large-navbar-height;
-  }
-
-  // to stop the search icon moving on hover
-  .gem-c-layout-super-navigation-header__search-toggle-button--large-navbar:hover {
+    // to stop the search icon moving on hover
     padding-bottom: 12px;
   }
 


### PR DESCRIPTION
## What
When interacting with the search toggle button in the main nav menu, the search icon would move up and down depending on the state.

This approach ensures that the bottom border is always 3px and blends into the background of the blue navbar.

## Why
<!-- What are the reasons behind this change being made? -->

## Visual Changes

### Before - hover state
https://github.com/alphagov/govuk_publishing_components/assets/28779939/76ac249c-bd1a-4802-a3f8-c37299ddddc2

### After - hover state
https://github.com/alphagov/govuk_publishing_components/assets/28779939/529b0895-1c47-4818-9fe8-5506c97858e2

### Before - focus state
https://github.com/alphagov/govuk_publishing_components/assets/28779939/6f1f17fe-6288-4c3e-91a4-58381050dedd

### After - focus state
https://github.com/alphagov/govuk_publishing_components/assets/28779939/74e84631-accc-48d2-955f-ffee8769e9bc
