### PR TITLE
Version 35.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 35.20.1
 
 * Adjustments to the navbar for the homepage ([PR #3666](https://github.com/alphagov/govuk_publishing_components/pull/3666))
 * Adjust the size of large navbar super navigation header ([PR #3677](https://github.com/alphagov/govuk_publishing_components/pull/3677))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (35.20.0)
+    govuk_publishing_components (35.20.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "35.20.0".freeze
+  VERSION = "35.20.1".freeze
 end


### PR DESCRIPTION
## 35.20.1

* Adjustments to the navbar for the homepage ([PR #3666](https://github.com/alphagov/govuk_publishing_components/pull/3666))
* Adjust the size of large navbar super navigation header ([PR #3677](https://github.com/alphagov/govuk_publishing_components/pull/3677))
* Add visually hidden text to the navbar ([PR #3684](https://github.com/alphagov/govuk_publishing_components/pull/3684))
* Add data-ga4-form-no-answer-undefined to header search form ([PR #3682](https://github.com/alphagov/govuk_publishing_components/pull/3682))
* Stop search icon from moving up and down ([PR #3685](https://github.com/alphagov/govuk_publishing_components/pull/3685))
