### PR TITLE
Fix issue with padding on navbar description

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -880,6 +880,10 @@ $after-button-padding-left: govuk-spacing(4);
   width: 68px;
 }
 
+.gem-c-layout-super-navigation-header__navigation-second-item-description {
+  margin-top: govuk-spacing(1);
+}
+
 .gem-c-layout-super-navigation-header__navigation-dropdown-menu--large-navbar .gem-c-layout-super-navigation-header__navigation-second-item-description {
   font-size: 19px;
   font-size: govuk-px-to-rem(19px);


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

Revert margin on second item description in the navbar to 5px.

## Why

Was accidentally increased in changes to the large navbar.

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

### Before

![Screenshot 2023-10-26 at 15 03 08](https://github.com/alphagov/govuk_publishing_components/assets/3727504/2be12cf6-03dc-44bb-8cff-65e0de2c77de)

### After

![Screenshot 2023-10-26 at 15 02 45](https://github.com/alphagov/govuk_publishing_components/assets/3727504/cdac6710-9898-4c87-9edb-037ad4861c4e)

