### PR TITLE
Fix bug when forms with data-ga4-form-no-answer-undefined are submitted

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
@@ -46,7 +46,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       var formData = this.getInputValues(formInputs)
       data.text = data.text || this.combineGivenAnswers(formData) || this.useFallbackValue
 
-      if (data.action === 'search') {
+      if (data.action === 'search' && data.text) {
         data.text = data.text.toLowerCase()
         data.text = window.GOVUK.analyticsGa4.core.trackFunctions.removeLinesAndExtraSpaces(data.text)
       }


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
When data-ga4-form-no-answer-undefined exists, it sets the text to undefined. However straight after that, it was trying to call .toLowerCase(), so the GA4 JS crashes on submit of these search forms.

## Why
<!-- What are the reasons behind this change being made? -->
Not sure how I missed this, apologies. I must have just used the jasmine test (which passed) to prove this as working.
