### PR TITLE
Fix visual bug with contents list manually numbered headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix visual bug with contents list manually numbered headings ([PR #3694](https://github.com/alphagov/govuk_publishing_components/pull/3694))
+
 ## 35.21.0
 
 * Add metadata inverse no padding option ([PR #3689](https://github.com/alphagov/govuk_publishing_components/pull/3689))

--- a/lib/govuk_publishing_components/presenters/contents_list_helper.rb
+++ b/lib/govuk_publishing_components/presenters/contents_list_helper.rb
@@ -24,13 +24,13 @@ module GovukPublishingComponents
 
       def wrap_numbers_with_spans(content_item_link)
         content_item_text = strip_tags(content_item_link) # just the text of the link
-
+        content_item_text_stripped = content_item_text.strip # strip trailing spaces for the regex. Keep original content_item_text for the string replacement.
         # Must start with a number
         # Number must be between 1 and 999 (ie not 2014)
         # Must be followed by a space
         # May contain a period `1.`
         # May be a decimal `1.2`
-        number = /^\d{1,3}(\.?|\.\d{1,2})(?=\s)/.match(content_item_text)
+        number = /^\d{1,3}(\.?|\.\d{1,2})(?=\s)/.match(content_item_text_stripped)
 
         if number
           words = content_item_text.sub(number.to_s, "").strip # remove the number from the text

--- a/spec/lib/govuk_publishing_components/components/contents_list_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/components/contents_list_helper_spec.rb
@@ -11,6 +11,12 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentsListHelper do
       assert_split_number_and_text("100. Thing", "100.", "Thing")
     end
 
+    it "accounts for trailing spaces in the heading" do
+      assert_split_number_and_text(" 1. Thing", "1.", "Thing")
+      assert_split_number_and_text(" 10. Thing ", "10.", "Thing")
+      assert_split_number_and_text("100. Thing ", "100.", "Thing")
+    end
+
     it "keeps a space between number and text for screen reader pronunciation" do
       cl = GovukPublishingComponents::Presenters::ContentsListHelper.new({})
       # 1.Thing can be pronounced "1 dot Thing"


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- In `whitehall`, a user can choose to manually number headings in their markdown, e.g. `## 1. Heading`.
- Our contents lists have some code which is meant to take these manually numbered headings, and generate a formatted contents list from them.
- However, when they format a heading like `## 1. Heading`, the space between `##` and `1.` was kept in the heading string. This caused some regex not to fire, which is used to format contents lists with heading numbers. This is because the regex expects the heading to start with a number, and not a space character.
- This caused a visual bug where contents lists were not formatted properly, since the regex was treating them as not being numbered, due to the space character causing the regex not to match against anything.
- I've fixed that in this PR by using a `.strip` version of the heading text for the regex check.
- The regex hasn't been modified to match spaces, as you don't want the space matched as part of the number. Otherwise, the space gets included when the `<span>` for it in the contents list is created.

## Why
<!-- What are the reasons behind this change being made? -->
- A bug came through on 2nd Line about this. I directed them to write their headings without a trailing space e.g. `##1. Heading` but we should fix this here, as our guidance says to include the space, e.g. `## 1. Heading`

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

### Before
![image](https://github.com/alphagov/govuk_publishing_components/assets/8880610/64524924-748e-4437-8dc5-935f2a94b978)


### After
![image](https://github.com/alphagov/govuk_publishing_components/assets/8880610/2cc8d61c-f541-4a67-8704-2e485329ad6f)

