### PR TITLE
Version 35.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 35.21.1
 
+* Replace UA ecommerce tracking attributes with GA4 specific ones ([PR #3688](https://github.com/alphagov/govuk_publishing_components/pull/3688))
 * Fix visual bug with contents list manually numbered headings ([PR #3694](https://github.com/alphagov/govuk_publishing_components/pull/3694))
 
 ## 35.21.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (35.21.0)
+    govuk_publishing_components (35.21.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "35.21.0".freeze
+  VERSION = "35.21.1".freeze
 end


### PR DESCRIPTION
## 35.21.1

* Replace UA ecommerce tracking attributes with GA4 specific ones ([PR #3688](https://github.com/alphagov/govuk_publishing_components/pull/3688))
* Fix visual bug with contents list manually numbered headings ([PR #3694](https://github.com/alphagov/govuk_publishing_components/pull/3694))
