### PR TITLE
GA4 debug mode sort attributes

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -43,6 +43,7 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
       data.govuk_gem_version = this.getGemVersion()
       // set this in the console as a debugging aid
       if (window.GOVUK.analyticsGa4.showDebug) {
+        data.event_data = this.sortEventData(data.event_data)
         console.info(JSON.stringify(data, null, ' '))
       }
       window.dataLayer.push(data)
@@ -50,6 +51,20 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
 
     getGemVersion: function () {
       return window.GOVUK.analyticsGa4.vars.gem_version || 'not found'
+    },
+
+    sortEventData: function (eventData) {
+      if (!Object.keys) { // check for IE9 and below
+        return eventData
+      }
+
+      var keys = Object.keys(eventData)
+      keys.sort()
+      var newEventData = {}
+      for (var i = 0; i < keys.length; i++) {
+        newEventData[keys[i]] = eventData[keys[i]]
+      }
+      return newEventData
     },
 
     trackFunctions: {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
@@ -77,6 +77,22 @@ describe('GA4 core', function () {
     expect(window.dataLayer).toEqual([])
   })
 
+  it('sorts event data alphabetically for debug mode', function () {
+    var data = {
+      c: 'c_data',
+      b: 'b_data',
+      a: {},
+      q: 'q_data'
+    }
+    var expected = {
+      a: {},
+      b: 'b_data',
+      c: 'c_data',
+      q: 'q_data'
+    }
+    expect(GOVUK.analyticsGa4.core.sortEventData(data)).toEqual(expected)
+  })
+
   describe('link tracking functions', function () {
     describe('find tracking attributes on elements', function () {
       var element


### PR DESCRIPTION
## What
We have a debug mode for GA4, activated by typing `window.GOVUK.analyticsGa4.showDebug = true` in the browser console. This outputs any data pushed to the dataLayer for GA4 while on the current page.

Currently the data is shown exactly as it is created. This change sorts the attributes in the `event_data` object alphabetically.

## Why
To make the data more readable for those using it and to make this output consistent with the implementation record, which helps when checking changes.

## Visual Changes

Before | After
------ | ------
![Screenshot 2023-11-06 at 13 35 09](https://github.com/alphagov/govuk_publishing_components/assets/861310/57aa772a-9345-4bd7-a9db-246887d9f922) | ![Screenshot 2023-11-06 at 13 35 16](https://github.com/alphagov/govuk_publishing_components/assets/861310/6314cf31-973a-4b6c-8b38-9b40ea6a0ef1)
