### PR TITLE
Enable GA4 by default on components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Enable GA4 by default on components ([PR #3705](https://github.com/alphagov/govuk_publishing_components/pull/3705))
 * Change GA4 video tracking duration handling ([PR #3717](https://github.com/alphagov/govuk_publishing_components/pull/3717))
 
 ## 35.21.4

--- a/app/views/govuk_publishing_components/components/_accordion.html.erb
+++ b/app/views/govuk_publishing_components/components/_accordion.html.erb
@@ -10,7 +10,7 @@
   anchor_navigation ||= false
   track_show_all_clicks ||= false
   track_sections ||= false
-  ga4_tracking ||= false
+  disable_ga4 ||= false
   data_attributes_show_all ||= nil
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
@@ -19,8 +19,8 @@
   component_helper.add_class(shared_helper.get_margin_bottom)
 
   component_helper.add_data_attribute({ module: "govuk-accordion gem-accordion" })
-  component_helper.add_data_attribute({ module: "ga4-event-tracker" }) if ga4_tracking
-  component_helper.add_data_attribute({ ga4_expandable: "" }) if ga4_tracking
+  component_helper.add_data_attribute({ module: "ga4-event-tracker" }) unless disable_ga4
+  component_helper.add_data_attribute({ ga4_expandable: "" }) unless disable_ga4
   component_helper.add_data_attribute({ anchor_navigation: anchor_navigation }) if anchor_navigation
   component_helper.add_data_attribute({ track_show_all_clicks: track_show_all_clicks }) if track_show_all_clicks
   component_helper.add_data_attribute({ track_sections: track_sections }) if track_sections
@@ -39,7 +39,7 @@
         item[:data_attributes] ||= nil
         ga4_link_data_attributes ||= nil
 
-        if ga4_tracking
+        unless disable_ga4
           heading_text = Nokogiri::HTML(item[:heading][:text]).text
           item[:data_attributes] ||= {}
           item[:data_attributes][:ga4_event] = {

--- a/app/views/govuk_publishing_components/components/_contents_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_contents_list.html.erb
@@ -12,18 +12,18 @@
   link_classes << brand_helper.color_class
   link_classes << "govuk-link--no-underline" unless underline_links
 
-  ga4_tracking ||= false
+  disable_ga4 ||= false
   ga4_data = {
     event_name: "navigation",
     section: t("components.contents_list.contents", locale: :en) || "",
     type: "contents list",
     index_total: cl_helper.get_index_total,
-  } if ga4_tracking
+  } unless disable_ga4
   local_assigns[:aria] ||= {}
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-contents-list #{brand_helper.brand_class}")
   component_helper.add_data_attribute({ module: "gem-track-click" })
-  component_helper.add_data_attribute({ module: "ga4-link-tracker" }) if ga4_tracking
+  component_helper.add_data_attribute({ module: "ga4-link-tracker" }) unless disable_ga4
   component_helper.add_aria_attribute({ label: t("components.contents_list.contents") }) unless local_assigns[:aria][:label]
   component_helper.add_role("navigation")
 -%>
@@ -38,11 +38,11 @@
     <% end %>
 
     <ol class="gem-c-contents-list__list">
-      <% index_link = 1 if ga4_tracking %>
+      <% index_link = 1 unless disable_ga4 %>
       <% contents.each.with_index(1) do |contents_item, position| %>
         <li class="<%= cl_helper.list_item_classes(contents_item, false) %>" <%= "aria-current=true" if contents_item[:active] %>>
           <% link_text = format_numbers ? cl_helper.wrap_numbers_with_spans(contents_item[:text]) : contents_item[:text]
-            if ga4_tracking
+            unless disable_ga4
               ga4_data[:event_name] = cl_helper.get_ga4_event_name(contents_item[:href]) if contents_item[:href]
               ga4_data[:index_link] = index_link
             end
@@ -56,16 +56,16 @@
               track_options: {
                 dimension29: contents_item[:text]
               },
-              ga4_link: (ga4_tracking ? ga4_data.to_json : nil)
+              ga4_link: (!disable_ga4 ? ga4_data.to_json : nil)
             }
           %>
-          <% index_link += 1 if ga4_tracking %>
+          <% index_link += 1 unless disable_ga4 %>
           <% if contents_item[:items] && contents_item[:items].any? %>
             <ol class="gem-c-contents-list__nested-list">
               <% contents_item[:items].each.with_index(1) do |nested_contents_item, nested_position| %>
                 <li class="<%= cl_helper.list_item_classes(nested_contents_item, true) %>" <%= "aria-current=true" if nested_contents_item[:active] %>>
                   <%
-                    if ga4_tracking
+                    unless disable_ga4
                       ga4_data[:event_name] = cl_helper.get_ga4_event_name(nested_contents_item[:href]) if nested_contents_item[:href]
                       ga4_data[:index_link] = index_link
                     end
@@ -79,11 +79,11 @@
                       track_options: {
                         dimension29: nested_contents_item[:text]
                       },
-                      ga4_link: (ga4_tracking ? ga4_data.to_json : nil)
+                      ga4_link: (!disable_ga4 ? ga4_data.to_json : nil)
                     }
                   %>
                 </li>
-                <% index_link += 1 if ga4_tracking %>
+                <% index_link += 1 unless disable_ga4 %>
               <% end %>
             </ol>
           <% end %>

--- a/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
@@ -1,9 +1,9 @@
-<% 
-  ga4_tracking ||= false
+<%
+  disable_ga4 ||= false
   prioritise_taxon_breadcrumbs ||= false
-  breadcrumb_selector = GovukPublishingComponents::Presenters::BreadcrumbSelector.new(content_item, request, prioritise_taxon_breadcrumbs, ga4_tracking)
+  breadcrumb_selector = GovukPublishingComponents::Presenters::BreadcrumbSelector.new(content_item, request, prioritise_taxon_breadcrumbs, disable_ga4)
   inverse ||= false
-  collapse_on_mobile ||= true unless local_assigns[:collapse_on_mobile].eql?(false) 
+  collapse_on_mobile ||= true unless local_assigns[:collapse_on_mobile].eql?(false)
 %>
 
 <div class="gem-c-contextual-breadcrumbs">

--- a/app/views/govuk_publishing_components/components/_contextual_footer.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_footer.html.erb
@@ -1,12 +1,12 @@
 <% navigation = GovukPublishingComponents::Presenters::ContextualNavigation.new(content_item, request) %>
-<% ga4_tracking ||= false %>
+<% disable_ga4 ||= false %>
 
 <% unless navigation.content_tagged_to_current_step_by_step? %>
   <div class="gem-c-contextual-footer">
     <%# Rendering related navigation because no step by step list %>
     <%= render 'govuk_publishing_components/components/related_navigation',
                content_item: content_item,
-               ga4_tracking: ga4_tracking,
+               disable_ga4: disable_ga4,
                context: :footer %>
   </div>
 <% end %>

--- a/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
@@ -1,8 +1,8 @@
 <%
   add_gem_component_stylesheet("contextual-sidebar")
 
-  ga4_tracking ||= false
-  request.query_parameters[:ga4_tracking] = ga4_tracking
+  disable_ga4 ||= false
+  request.query_parameters[:disable_ga4] = disable_ga4
   navigation = GovukPublishingComponents::Presenters::ContextualNavigation.new(content_item, request)
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
   show_ukraine_cta = navigation.show_ukraine_cta?
@@ -13,7 +13,7 @@
 <div class="gem-c-contextual-sidebar">
   <% if navigation.content_tagged_to_a_reasonable_number_of_step_by_steps? %>
     <%# Rendering step by step related items because there are a few but not too many of them %>
-    <%= render 'govuk_publishing_components/components/step_by_step_nav_related', links: navigation.step_nav_helper.related_links, ga4_tracking: ga4_tracking %>
+    <%= render 'govuk_publishing_components/components/step_by_step_nav_related', links: navigation.step_nav_helper.related_links, disable_ga4: disable_ga4 %>
   <% end %>
 
   <% if navigation.content_tagged_to_current_step_by_step? %>
@@ -21,7 +21,7 @@
     <%= render 'govuk_publishing_components/components/step_by_step_nav', navigation.step_nav_helper.sidebar %>
   <% else %>
     <%# Rendering related navigation sidebar because no step by step list %>
-    <%= render 'govuk_publishing_components/components/related_navigation', content_item: content_item, context: :sidebar, ga4_tracking: ga4_tracking, ga4_tracking_counts: ga4_tracking_counts %>
+    <%= render 'govuk_publishing_components/components/related_navigation', content_item: content_item, context: :sidebar, disable_ga4: disable_ga4, ga4_tracking_counts: ga4_tracking_counts %>
   <% end %>
 
   <% if navigation.content_tagged_to_other_step_by_steps? %>
@@ -30,11 +30,11 @@
       pretitle: t("components.contextual_sidebar.pretitle"),
       links: navigation.step_nav_helper.also_part_of_step_nav,
       always_display_as_list: true,
-      ga4_tracking: ga4_tracking
+      disable_ga4: disable_ga4
     } %>
   <% end %>
 
   <% if show_ukraine_cta %>
-    <%= render 'govuk_publishing_components/components/contextual_sidebar/ukraine_cta', content_item: content_item, ga4_tracking: ga4_tracking, ga4_tracking_counts: ga4_tracking_counts %>
+    <%= render 'govuk_publishing_components/components/contextual_sidebar/ukraine_cta', content_item: content_item, disable_ga4: disable_ga4, ga4_tracking_counts: ga4_tracking_counts %>
   <% end %>
 </div>

--- a/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
@@ -31,7 +31,7 @@
   css_classes = %w(gem-c-cookie-banner govuk-clearfix govuk-cookie-banner js-banner-wrapper)
   css_classes << "gem-c-cookie-banner--services" if services_cookies
 
-  ga4_tracking ||= false
+  disable_ga4 ||= false
 %>
 
 <div id="<%= id %>" class="<%= css_classes.join(' ') %>" data-module="cookie-banner" data-nosnippet role="region" aria-label="<%= title %>">
@@ -42,7 +42,7 @@
         <div tabindex="-1" class="govuk-cookie-banner__content gem-c-cookie-banner__confirmation">
           <span class="gem-c-cookie-banner__content"><%= text %></span>
           <p class="gem-c-cookie-banner__confirmation-message--accepted govuk-body" hidden
-          <% if ga4_tracking %>
+          <% unless disable_ga4 %>
             data-ga4-cookie-banner <%# GA4 pageview JS looks for data-ga4-cookie-banner %>
             data-module="ga4-link-tracker"
             data-ga4-track-links-only
@@ -96,14 +96,14 @@
     <div hidden class="js-hide-button govuk-button-group">
       <%
         button_data_module = "gem-track-click"
-        button_data_module << " ga4-event-tracker" if ga4_tracking
+        button_data_module << " ga4-event-tracker" unless disable_ga4
 
         ga4_event = {
           event_name: "select_content",
           type: "cookie banner",
           action: "closed",
           section: t("components.cookie_banner.confirmation_message.accepted", locale: :en)
-        }.to_json if ga4_tracking
+        }.to_json unless disable_ga4
       %>
       <button
         class="gem-c-cookie-banner__hide-button govuk-button"
@@ -111,7 +111,7 @@
         data-module="<%= button_data_module %>"
         data-track-category="cookieBanner"
         data-track-action="Hide cookie banner"
-        <% if ga4_tracking %> data-ga4-event="<%= ga4_event %>" <% end %>>
+        <% unless disable_ga4 %> data-ga4-event="<%= ga4_event %>" <% end %>>
           <%= t("components.cookie_banner.hide") %>
         </button>
     </div>

--- a/app/views/govuk_publishing_components/components/_devolved_nations.html.erb
+++ b/app/views/govuk_publishing_components/components/_devolved_nations.html.erb
@@ -6,10 +6,10 @@
 
   applies_to ||= t("components.devolved_nations.applies_to")
   heading_level ||= 2
-  ga4_tracking ||= false
+  disable_ga4 ||= false
   data_attributes = {}
 
-  if ga4_tracking
+  unless disable_ga4
     data_attributes[:ga4_devolved_nations_banner] = devolved_nations_helper.ga4_applicable_nations_title_text(true)
     data_attributes[:module] = "ga4-link-tracker"
     data_attributes[:ga4_track_links_only] = ""

--- a/app/views/govuk_publishing_components/components/_emergency_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_emergency_banner.html.erb
@@ -7,7 +7,7 @@
   link_text ||= "More information"
   campaign_class ||= nil
   homepage ||= false
-  ga4_tracking ||= false
+  disable_ga4 ||= false
 
   emergency_banner_helper = GovukPublishingComponents::Presenters::EmergencyBannerHelper.new()
 
@@ -29,12 +29,11 @@
   description_classes = %w[gem-c-emergency-banner__description]
   description_classes << "gem-c-emergency-banner__description--homepage" if homepage
 
-
   data_attributes = {
     "nosnippet": true,
   }
 
-  if ga4_tracking
+  unless disable_ga4
     data_attributes[:ga4_emergency_banner] = ""
     data_attributes[:module] = "ga4-link-tracker"
     data_attributes[:ga4_track_links_only] = ""
@@ -46,7 +45,6 @@
     }.to_json
   end
 %>
-
 <%= content_tag('section', class: banner_classes, "aria-labelledby": "emergency-banner-heading", data: data_attributes) do %>
   <div class="govuk-width-container">
     <div class="govuk-grid-row">

--- a/app/views/govuk_publishing_components/components/_intervention.html.erb
+++ b/app/views/govuk_publishing_components/components/_intervention.html.erb
@@ -32,10 +32,10 @@
   intervention_helper = GovukPublishingComponents::Presenters::InterventionHelper.new(options)
   dismiss_href = intervention_helper.dismiss_link
 
-  ga4_tracking ||= false
-  suggestion_data_attributes[:module] = "#{suggestion_data_attributes[:module]} ga4-link-tracker".strip if ga4_tracking
-  suggestion_data_attributes[:ga4_link] = { event_name: "navigation", type: "intervention", section: suggestion_text, index_link: 1, index_total: 1 }.to_json if ga4_tracking
-  data_attributes[:ga4_intervention_banner] = "" if ga4_tracking # Added to the parent element for the GA4 pageview object to use
+  disable_ga4 ||= false
+  suggestion_data_attributes[:module] = "#{suggestion_data_attributes[:module]} ga4-link-tracker".strip unless disable_ga4
+  suggestion_data_attributes[:ga4_link] = { event_name: "navigation", type: "intervention", section: suggestion_text, index_link: 1, index_total: 1 }.to_json unless disable_ga4
+  data_attributes[:ga4_intervention_banner] = "" unless disable_ga4 # Added to the parent element for the GA4 pageview object to use
 
   suggestion_tag_options = {
     class: "govuk-link",
@@ -59,8 +59,8 @@
   }
   section_options.merge!({ hidden: true }) if hide
 
-  dismiss_link_data_attributes[:module] = "#{dismiss_link_data_attributes[:module]} ga4-event-tracker".strip if ga4_tracking
-  dismiss_link_data_attributes[:ga4_event] = { event_name: "select_content", type: "intervention", section: suggestion_text, action: 'closed' }.to_json if ga4_tracking
+  dismiss_link_data_attributes[:module] = "#{dismiss_link_data_attributes[:module]} ga4-event-tracker".strip unless disable_ga4
+  dismiss_link_data_attributes[:ga4_event] = { event_name: "select_content", type: "intervention", section: suggestion_text, action: 'closed' }.to_json unless disable_ga4
 %>
 <% if intervention_helper.show? %>
   <%= tag.section **section_options do %>

--- a/app/views/govuk_publishing_components/components/_metadata.html.erb
+++ b/app/views/govuk_publishing_components/components/_metadata.html.erb
@@ -26,13 +26,13 @@
 
   classes << shared_helper.get_margin_bottom if local_assigns[:margin_bottom]
 
-  ga4_tracking ||= false
+  disable_ga4 ||= false
   ga4_object = {
     event_name: "navigation",
     type: "content history",
     section: "Top",
     action: "opened"
-  }.to_json
+  }.to_json unless disable_ga4
 %>
 <%= content_tag :div, class: classes, data: { module: "gem-toggle metadata" } do %>
   <dl class="gem-c-metadata__list" data-module="gem-track-click">
@@ -66,7 +66,7 @@
                     data-track-category="content-history"
                     data-track-action="see-all-updates-link-clicked"
                     data-track-label="history"
-                    <% if ga4_tracking %>
+                    <% unless disable_ga4 %>
                       data-module="ga4-link-tracker"
                       data-ga4-link="<%= ga4_object %>"
                     <% end%>>
@@ -84,7 +84,7 @@
         <% if definition.any? %>
           <dt class="gem-c-metadata__term"><%= title %>:</dt>
           <dd class="gem-c-metadata__definition"
-              <% if ga4_tracking %>
+              <% unless disable_ga4 %>
                 data-module="ga4-link-tracker"
                 data-ga4-track-links-only
                 data-ga4-link="<%= ga4_object %>"

--- a/app/views/govuk_publishing_components/components/_phase_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_phase_banner.html.erb
@@ -5,7 +5,7 @@ app_name ||= nil
 phase ||= nil
 message ||= nil
 inverse ||= false
-ga4_tracking ||= false
+disable_ga4 ||= false
 
 unless message.present?
   if phase == "beta"
@@ -20,7 +20,7 @@ container_css_classes << "gem-c-phase-banner--inverse" if inverse
 
 data_attributes = {}
 
-if ga4_tracking
+unless disable_ga4
   data_attributes[:ga4_phase_banner] = phase
   data_attributes[:module] = "ga4-link-tracker"
   data_attributes[:ga4_track_links_only] = ""

--- a/app/views/govuk_publishing_components/components/_previous_and_next_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_previous_and_next_navigation.html.erb
@@ -1,6 +1,6 @@
 <%
   add_gem_component_stylesheet("previous-and-next-navigation")
-  ga4_tracking ||= false
+  disable_ga4 ||= false
 
   if local_assigns.include?(:next_page) || local_assigns.include?(:previous_page)
 %>
@@ -8,7 +8,7 @@
     class="govuk-pagination govuk-pagination--block"
     role="navigation"
     aria-label="<%= t("components.previous_and_next_navigation.pagination") %>"
-    <% if ga4_tracking %>
+    <% unless disable_ga4 %>
       data-module="ga4-link-tracker"
     <% end %>
   >
@@ -27,7 +27,7 @@
           data-track-label="<%= previous_page[:url] %>"
           data-track-dimension="previous"
           data-track-dimension-index="29"
-          <% if ga4_tracking %>
+          <% unless disable_ga4 %>
             data-ga4-link = "<%= {
               event_name: "navigation",
               type: "previous and next",
@@ -63,7 +63,7 @@
           data-track-label="<%= next_page[:url] %>"
           data-track-dimension="next"
           data-track-dimension-index="29"
-          <% if ga4_tracking %>
+          <% unless disable_ga4 %>
             data-ga4-link = "<%= {
               event_name: "navigation",
               type: "previous and next",

--- a/app/views/govuk_publishing_components/components/_related_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_related_navigation.html.erb
@@ -1,11 +1,11 @@
 <%
   related_nav_helper = GovukPublishingComponents::Presenters::RelatedNavigationHelper.new(local_assigns)
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
-  ga4_tracking ||= false
+  disable_ga4 ||= false
   ga4_type = local_assigns[:context] == :footer ? "contextual footer" : "related content"
   data = {}
   data[:module] = "gem-track-click"
-  data[:module] << " ga4-link-tracker" if ga4_tracking
+  data[:module] << " ga4-link-tracker" unless disable_ga4
   ga4_tracking_counts ||= OpenStruct.new(index_section_count: 0)
   ga4_tracking_counts.index_section_count += related_nav_helper.index_section_count
 
@@ -43,7 +43,7 @@
         section_index: section_index,
         section_count: ga4_tracking_counts.index_section_count,
         random: random,
-        ga4_tracking: ga4_tracking,
+        disable_ga4: disable_ga4,
         ga4_type: ga4_type %>
     <% end %>
   <% end %>

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav.html.erb
@@ -18,12 +18,12 @@
 
   step_nav_helper = GovukPublishingComponents::Presenters::StepByStepNavHelper.new
 
-  ga4_tracking ||= false
+  disable_ga4 ||= false
 %>
 <% if steps %>
   <div
-    data-module="gemstepnav<% if ga4_tracking %> ga4-event-tracker<% end %>"
-    <%= "data-ga4-expandable" if ga4_tracking %>
+    data-module="gemstepnav<% unless disable_ga4 %> ga4-event-tracker<% end %>"
+    <%= "data-ga4-expandable" unless disable_ga4 %>
     class="gem-c-step-nav js-hidden <% if small %>govuk-!-display-none-print<% end %> <% unless small %>gem-c-step-nav--large<% end %>"
     <%= "data-remember" if remember_last_step %>
     <%= "data-id=#{tracking_id}" if tracking_id %>
@@ -76,7 +76,7 @@
           <%
             ga4_link_data = {}
 
-            if ga4_tracking
+            unless disable_ga4
               ga4_link_data = {
                 "module": "ga4-link-tracker",
                 "ga4-track-links-only": "",
@@ -99,7 +99,7 @@
               options[:step_title] = step[:title]
               options[:step_index] = step_index
               options[:link_index] = 0
-              options[:ga4_tracking] = ga4_tracking
+              options[:disable_ga4] = disable_ga4
             %>
             <% step[:contents].each do |element| %>
               <%= step_nav_helper.render_step_nav_element(element, options) %>

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav_header.html.erb
@@ -3,7 +3,7 @@
 
   title ||= false
   path ||= false
-  ga4_tracking ||= false
+  disable_ga4 ||= false
   breadcrumbs = [
     { title: "Home", url: "/" },
     { title: title, url: path }
@@ -12,7 +12,7 @@
 
   data = {}
   data[:module] = "gem-track-click"
-  data[:module] << " ga4-link-tracker" if ga4_tracking
+  data[:module] << " ga4-link-tracker" unless disable_ga4
 
   tracking_id ||= false
   tracking_category ||= "stepNavHeaderClicked"
@@ -26,7 +26,7 @@
     tracking_options ||= ({ dimension96: tracking_id }).to_json
   end
 
-  if ga4_tracking
+  unless disable_ga4
     ga4_data = {
       event_name: "navigation",
       type: "super breadcrumb",
@@ -52,7 +52,7 @@
         data-track-category="<%= tracking_category %>"
         data-track-action="<%= tracking_action %>"
         data-track-label="<%= tracking_label %>"
-        <% if ga4_tracking %>
+        <% unless disable_ga4 %>
           data-ga4-link='<%= ga4_data %>'
         <% end %>
         <% if tracking_dimension_enabled %>

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav_related.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav_related.html.erb
@@ -1,6 +1,6 @@
 <%
   add_gem_component_stylesheet("step-by-step-nav-related")
-  ga4_tracking ||= false
+  disable_ga4 ||= false
   links ||= []
   pretitle ||= t("components.step_by_step_nav_related.part_of")
   always_display_as_list ||= false
@@ -8,7 +8,7 @@
   classes << "gem-c-step-nav-related--singular" if links.length == 1
   data = {}
   data[:module] = "gem-track-click"
-  data[:module] << " ga4-link-tracker" if ga4_tracking
+  data[:module] << " ga4-link-tracker" unless disable_ga4
 %>
 <% if links.any? %>
   <%= tag.div(class: classes, data: data) do %>
@@ -23,7 +23,7 @@
             data-track-dimension="<%= links[0][:text] %>"
             data-track-dimension-index="29"
             data-track-options='{"dimension96" : "<%= links[0][:tracking_id] %>" }'
-            <% if ga4_tracking
+            <% unless disable_ga4
               ga4_attributes = {
                 event_name: "navigation",
                 type: "part of",
@@ -51,7 +51,7 @@
                 data-track-dimension="<%= link[:text] %>"
                 data-track-dimension-index="29"
                 data-track-options='{"dimension96" : "<%= link[:tracking_id] %>" }'
-                <% if ga4_tracking
+                <% unless disable_ga4
                   ga4_attributes = {
                     event_name: "navigation",
                     type: "part of",

--- a/app/views/govuk_publishing_components/components/_tabs.html.erb
+++ b/app/views/govuk_publishing_components/components/_tabs.html.erb
@@ -8,13 +8,13 @@
   panel_css_classes = panel_css_classes.join(" ")
 
   as_links ||= false
-  ga4_tracking ||= false
+  disable_ga4 ||= false
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("govuk-tabs gem-c-tabs")
   component_helper.add_data_attribute({ module: "govuk-tabs" }) unless as_links
 
-  if ga4_tracking
+  unless disable_ga4
     component_helper.add_data_attribute({ module: "ga4-event-tracker" }) unless as_links
     component_helper.add_data_attribute({ module: "ga4-link-tracker" }) if as_links
   end
@@ -29,7 +29,7 @@
       <li class="govuk-tabs__list-item <%= "govuk-tabs__list-item--selected" if tab[:active] %>">
         <%
           tab[:tab_data_attributes] ||= {}
-          if ga4_tracking
+          unless disable_ga4
             ga4_attributes = {
               event_name: "select_content",
               type: "tabs",
@@ -65,10 +65,10 @@
   <% end %>
 <% end %>
 <% if tabs.count == 1 %>
-    <section id="<%= tabs[0][:id] %>">
-      <% if tabs[0][:title] %>
-        <h2 class="govuk-heading-l"><%= tabs[0][:title] %></h2>
-      <% end %>
-      <%= tabs[0][:content] %>
-    </section>
+  <section id="<%= tabs[0][:id] %>">
+    <% if tabs[0][:title] %>
+      <h2 class="govuk-heading-l"><%= tabs[0][:title] %></h2>
+    <% end %>
+    <%= tabs[0][:content] %>
+  </section>
 <% end %>

--- a/app/views/govuk_publishing_components/components/contextual_sidebar/_ukraine_cta.html.erb
+++ b/app/views/govuk_publishing_components/components/contextual_sidebar/_ukraine_cta.html.erb
@@ -3,7 +3,7 @@
   title = t("components.related_navigation.ukraine.title")
   lang = shared_helper.t_locale("components.related_navigation.ukraine.title")
   data_module = "gem-track-click"
-  data_module << " ga4-link-tracker" if ga4_tracking
+  data_module << " ga4-link-tracker" unless disable_ga4
 %>
 <%= tag.div class: "gem-c-contextual-sidebar__cta gem-c-contextual-sidebar__cta--ukraine", data: { module: data_module } do %>
   <%= tag.h2 title, class: "gem-c-contextual-sidebar__heading govuk-heading-s" %>
@@ -20,7 +20,7 @@
             index_section_count: "#{ga4_tracking_counts.index_section_count}",
             index_total: "#{index_total}",
             section: title,
-          } if ga4_tracking
+          } unless disable_ga4
         %>
         <%= link_to link[:label],
           link[:href],

--- a/app/views/govuk_publishing_components/components/docs/accordion.yml
+++ b/app/views/govuk_publishing_components/components/docs/accordion.yml
@@ -34,7 +34,7 @@ accessibility_criteria: |
 
   * be fully expanded
   * not be marked as expandable
-uses_component_wrapper_helper: true  
+uses_component_wrapper_helper: true
 shared_accessibility_criteria:
   - link
 examples:
@@ -182,11 +182,11 @@ examples:
                     <a class="govuk-link" href="#">Retiring your service</a>
                   </li>
               </ul>'
-  with_ga4_tracking:
+  without_ga4_tracking:
     description: |
-      Allows you to add GA4 tracking to an accordion. This will add a data module and data-attributes with JSONs to the accordion. See the [ga4-event-tracker documentation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-event-tracker.md) for more information.
+      Disables GA4 tracking on the accordion. Tracking is enabled by default. This adds a data module and data-attributes with JSONs to the accordion. See the [ga4-event-tracker documentation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-event-tracker.md) for more information.
     data:
-      ga4_tracking: true
+      disable_ga4: true
       items:
         - heading:
             text: Writing well for the web

--- a/app/views/govuk_publishing_components/components/docs/contents_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/contents_list.yml
@@ -192,10 +192,10 @@ examples:
             text: 2. Numbers not parsed
           - href: "#third-thing"
             text: 3. Numbers are just text
-  with_ga4_tracking:
-    description: Enables the GA4 link tracker on the list.
+  without_ga4_tracking:
+    description: Disables GA4 link tracking on the list. Tracking is enabled by default.
     data:
-      ga4_tracking: true
+      disable_ga4: true
       contents:
         - href: "https://www.gov.uk"
           text: 1. First thing

--- a/app/views/govuk_publishing_components/components/docs/contextual_breadcrumbs.yml
+++ b/app/views/govuk_publishing_components/components/docs/contextual_breadcrumbs.yml
@@ -32,13 +32,12 @@ examples:
       inverse: true
     context:
       dark_background: true
-  with_ga4_tracking:
+  without_ga4_tracking:
     description: |
-      Adds GA4 tracking to the step by step nav header component when it is rendered as a breadcrumb. See the 
+      Disables GA4 tracking. Tracking is enabled by default. This includes GA4 tracking on the step by step nav header component when it is rendered as a breadcrumb. See the
       [ga4-link-tracker documentation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-link-tracker.md) for more information.
-      Note: tracking on regular breadcrumbs is enabled by default and does not require activating.
     data:
-      ga4_tracking: true
+      disable_ga4: true
       content_item:
         title: "A content item"
         links:

--- a/app/views/govuk_publishing_components/components/docs/contextual_footer.yml
+++ b/app/views/govuk_publishing_components/components/docs/contextual_footer.yml
@@ -69,10 +69,10 @@ examples:
           ordered_related_items:
             - title: "Find an apprenticeship"
               base_path: "/apply-apprenticeship"
-  with_ga4_tracking:
-    description: Adds Google Analytics 4 tracking to the Related Navigation component, if it is visible.
+  without_ga4_tracking:
+    description: Disables GA4 tracking on the component. Tracking is enabled by default.
     data:
-      ga4_tracking: true
+      disable_ga4: true
       content_item:
         title: "A content item"
         links:

--- a/app/views/govuk_publishing_components/components/docs/contextual_sidebar.yml
+++ b/app/views/govuk_publishing_components/components/docs/contextual_sidebar.yml
@@ -103,10 +103,10 @@ examples:
               title: "Russian invasion of Ukraine: UK government response"
               base_path: "/government/topical-events/russian-invasion-of-ukraine-uk-government-response"
               locale: "en"
-  with_ga4_tracking_on_related_navigation:
-    description: Adds Google Analytics 4 tracking to components within the sidebar. Currently only the Related Navigation component, Step by Step navigation component and Ukraine CTA accept this option.
+  without_ga4_tracking_on_related_navigation:
+    description: Disables GA4 tracking on components within the sidebar. Tracking is enabled by default. Currently only the Related Navigation component, Step by Step navigation component and Ukraine CTA have tracking.
     data:
-      ga4_tracking: true
+      disable_ga4: true
       content_item:
         title: "UK forces arrive to reinforce NATO’s eastern flank"
         content_id: "a342fd46-d801-4c1e-9d8f-f41fba6da563"
@@ -129,10 +129,10 @@ examples:
               title: "Russian invasion of Ukraine: UK government response"
               base_path: "/government/topical-events/russian-invasion-of-ukraine-uk-government-response"
               locale: "en"
-  with_ga4_tracking_on_step_by_step:
-    description: Adds Google Analytics 4 tracking to components within the sidebar. Currently only the Related Navigation component, Step by Step navigation component and Ukraine CTA accept this option.
+  without_ga4_tracking_on_step_by_step:
+    description: Disables GA4 tracking on components within the sidebar. Tracking is enabled by default. Currently only the Related Navigation component, Step by Step navigation component and Ukraine CTA accept this option.
     data:
-      ga4_tracking: true
+      disable_ga4: true
       content_item:
         title: "A content item"
         links:
@@ -157,10 +157,10 @@ examples:
                       - text: Arrange the funeral
                         href: "/after-a-death/arrange-the-funeral"
                     optional: false
-  with_ga4_tracking_on_part_of_step_by_step_heading(s):
-    description: Adds Google Analytics 4 tracking to the "Part of" step by step heading(s) in the sidebar. Currently only the Related Navigation component, Step by Step navigation component and Ukraine CTA accept this option.
+  without_ga4_tracking_on_part_of_step_by_step_heading(s):
+    description: Disables GA4 tracking on the "Part of" step by step heading(s) in the sidebar. Tracking is enabled by default. Currently only the Related Navigation component, Step by Step navigation component and Ukraine CTA accept this option.
     data:
-      ga4_tracking: true
+      disable_ga4: true
       content_item:
         links:
           part_of_step_navs:

--- a/app/views/govuk_publishing_components/components/docs/cookie_banner.yml
+++ b/app/views/govuk_publishing_components/components/docs/cookie_banner.yml
@@ -49,8 +49,8 @@ examples:
         cookie_preferences:
           text: How we use cookies
           href: "/cookies"
-  with_ga4_tracking:
+  without_ga4_tracking:
     description: |
-      Enables GA4 tracking on the banner. This includes link tracking on the "You have accepted cookies" section, and allows the pageview event that is sent when GA4 initialises to record the presence of the cookie acceptance message.
+      Disables GA4 tracking on the banner. Tracking is enabled by default. This includes link tracking on the "You have accepted cookies" section, and allows the pageview event that is sent when GA4 initialises to record the presence of the cookie acceptance message.
     data:
-      ga4_tracking: true
+      disable_ga4: true

--- a/app/views/govuk_publishing_components/components/docs/devolved_nations.yml
+++ b/app/views/govuk_publishing_components/components/docs/devolved_nations.yml
@@ -19,14 +19,14 @@ examples:
       national_applicability:
         england:
           applicable: true
-  applies_to_two_nations:  
+  applies_to_two_nations:
     data:
       national_applicability:
         england:
           applicable: true
         wales:
           applicable: true
-  applies_to_three_nations:  
+  applies_to_three_nations:
     data:
       national_applicability:
         england:
@@ -89,9 +89,9 @@ examples:
       national_applicability:
         england:
           applicable: true
-  with_ga4_tracking:
+  without_ga4_tracking:
     description: |
-      Enables GA4 tracking on the banner. This includes link tracking on the component itself, and allows pageviews to record the presence of the banner on page load.
+      Disables GA4 tracking on the banner. Tracking is enabled by default. This includes link tracking on the component itself, and allows pageviews to record the presence of the banner on page load.
     data:
       national_applicability:
         england:

--- a/app/views/govuk_publishing_components/components/docs/emergency_banner.yml
+++ b/app/views/govuk_publishing_components/components/docs/emergency_banner.yml
@@ -45,13 +45,13 @@ examples:
       short_description: "1491 to 1547"
       link: "https://www.gov.uk/"
       homepage: true
-  with_ga4_tracking:
+  without_ga4_tracking:
     description: |
-      Enables GA4 tracking on the banner. This includes link tracking on the component itself, and allows pageviews to record the presence of the banner on page load.
+      Disables GA4 tracking on the banner. Tracking is enabled by default. This includes link tracking on the component itself, and allows pageviews to record the presence of the banner on page load.
     data:
       campaign_class: "notable-death"
       heading: "His Royal Highness Henry VIII"
       short_description: "1491 to 1547"
       link: "https://www.gov.uk/"
       homepage: true
-      ga4_tracking: true
+      disable_ga4: true

--- a/app/views/govuk_publishing_components/components/docs/intervention.yml
+++ b/app/views/govuk_publishing_components/components/docs/intervention.yml
@@ -6,9 +6,9 @@ body: |
   that would be useful to them. This component would be used to add this personalised content and would
   indicate to the user that this is not normally part of the page, but has been added for them specifically.
 
-  The dismiss link works without Javascript by pointing to the current URL with the "hide-intervention" 
-  query string parameter set to "true". It's progressively enhanced and sets a cookie to remember that 
-  the user has dismissed the banner before. The cookie requires a "name" parameter, the value of which 
+  The dismiss link works without Javascript by pointing to the current URL with the "hide-intervention"
+  query string parameter set to "true". It's progressively enhanced and sets a cookie to remember that
+  the user has dismissed the banner before. The cookie requires a "name" parameter, the value of which
   is stored in the cookie to distinguish which campaign banner the user has dismissed.
 
 accessibility_criteria: |
@@ -33,8 +33,8 @@ examples:
       suggestion_link_url: /travel-abroad
 
   with_dismiss_link:
-    description: | 
-      Name is required in order to set a cookie. The name value should be distinct to the campaign for the banner, 
+    description: |
+      Name is required in order to set a cookie. The name value should be distinct to the campaign for the banner,
       so that other banners using this component are not hidden by accident.
     data:
       suggestion_text: You should renew your permit every 6 months.
@@ -89,11 +89,11 @@ examples:
         track-label: hide the intervention
       dismiss_link_data_attributes:
         track-category: example
-  with_ga4_tracking:
+  without_ga4_tracking:
     description: |
-      Enables GA4 tracking on the banner. This includes link tracking on the component itself, event tracking on the 'Hide' link, and allows pageviews to record the presence of the banner on page load.
+      Disables GA4 tracking on the banner. Tracking is enabled by default. This includes link tracking on the component itself, event tracking on the 'Hide' link, and allows pageviews to record the presence of the banner on page load.
     data:
-      ga4_tracking: true
+      disable_ga4: true
       suggestion_text: Based on your browsing you might be interested in
       suggestion_link_text: "Travel abroad: step by step"
       suggestion_link_url: /travel-abroad

--- a/app/views/govuk_publishing_components/components/docs/metadata.yml
+++ b/app/views/govuk_publishing_components/components/docs/metadata.yml
@@ -386,10 +386,10 @@ examples:
       first_published: 14 June 2014
       last_updated: 10 September 2015
       margin_bottom: 2
-  with_ga4_tracking:
+  without_ga4_tracking:
     description: |
-      Enables the GA4 link tracker on the 'See all updates' link.
+      Disables the GA4 link tracker on the 'See all updates' link. Tracking is enabled by default.
     data:
       last_updated: 10 September 2015
       see_updates_link: true
-      ga4_tracking: true
+      disable_ga4: true

--- a/app/views/govuk_publishing_components/components/docs/phase_banner.yml
+++ b/app/views/govuk_publishing_components/components/docs/phase_banner.yml
@@ -32,11 +32,11 @@ examples:
       app_name: Skittles Maker
       phase: beta
       inverse: true
-  with_ga4_tracking:
+  without_ga4_tracking:
     description: |
-      Enables GA4 tracking on the banner. This includes link tracking on the component itself, and allows pageviews to record the presence of the banner on page load.
+      Disables GA4 tracking on the banner. Tracking is enabled by default. This includes link tracking on the component itself, and allows pageviews to record the presence of the banner on page load.
     data:
       app_name: Skittles Maker
       phase: beta
       inverse: true
-      ga4_tracking: true
+      disable_ga4: true

--- a/app/views/govuk_publishing_components/components/docs/previous_and_next_navigation.yml
+++ b/app/views/govuk_publishing_components/components/docs/previous_and_next_navigation.yml
@@ -64,10 +64,10 @@ examples:
         url: next-page
         title: Next
         label: 'Driver CPC part 1 test: theory'
-  with_ga4_tracking:
-    description: Enables the GA4 link tracker on the links.
+  without_ga4_tracking:
+    description: Disables the GA4 link tracker on the links. Tracking is enabled by default.
     data:
-      ga4_tracking: true
+      disable_ga4: true
       previous_page:
         url: previous-page
         title: Previous

--- a/app/views/govuk_publishing_components/components/docs/related_navigation.yml
+++ b/app/views/govuk_publishing_components/components/docs/related_navigation.yml
@@ -306,10 +306,10 @@ examples:
               title: "Student loans: terms and conditions 2017 to 2018 (PDF, 136KB)"
             - title: The Student Room repaying your student loan
               url: https://www.thestudentroom.co.uk/content.php?r=5967-Repaying-your-student-loan
-  with_ga4_tracking:
-    description: Adds Google Analytics 4 tracking to the component, using the [GA4 link tracker](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-link-tracker.md).
+  without_ga4_tracking:
+    description: Disables GA4 tracking on the banner. Tracking is enabled by default and uses the [GA4 link tracker](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-link-tracker.md).
     data:
-      ga4_tracking: true
+      disable_ga4: true
       content_item:
         links:
           ordered_related_items:
@@ -352,4 +352,3 @@ examples:
               base_path: /world/chile/news
             - title: China
               base_path: /world/China/news
- 

--- a/app/views/govuk_publishing_components/components/docs/step_by_step_nav.yml
+++ b/app/views/govuk_publishing_components/components/docs/step_by_step_nav.yml
@@ -72,17 +72,13 @@ examples:
           ]
         }
       ]
-  with_google_analytics_4_tracking:
+  without_google_analytics_4_tracking:
     description: |
-      The ga4_tracking boolean allows you to add Google Analytics 4 (GA4) tracking to your component.
-      Setting this to true will add the `ga4-event-tracker` module to your component. The JavaScript will then add a `data-ga4-event` attribute and `data-ga4-expandable` attribute to the "Show all steps" button, and each clickable Step heading.
-      GA4 will then track these elements when they are expanded or collapsed.
-      `data-ga4-event` contains a JSON with event data relevant to our tracking. `data-ga4-expandable` enables the value of `aria-expanded` to be captured.
-      See the [ga4-event-tracker](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-event-tracker.md) docs for more information.
-      Links are also tracked with the [ga4-link-tracker](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-link-tracker.md).
-      Therefore the `ga4-link-tracker` data module also exists on these step by step components. Any links will contain a data attribute of `ga4-link`, which contains the relevant tracking data as a JSON.
+      Disables GA4 tracking on the component. Tracking is enabled by default. This includes the [ga4-event-tracker](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-event-tracker.md) module as well as `data-ga4-event` and `data-ga4-expandable` attributes on the "Show all steps" button, and each clickable Step heading. `data-ga4-event` contains JSON with event data relevant to tracking. `data-ga4-expandable` enables the value of `aria-expanded` to be captured.
+
+      Links within steps are tracked with the [ga4-link-tracker](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-link-tracker.md). Links are given a data attribute of `ga4-link`, which contains the relevant tracking data as JSON.
     data:
-      ga4_tracking: true
+      disable_ga4: true
       steps: [
         {
           title: "Do something",
@@ -128,7 +124,7 @@ examples:
       ]
   with_unique_tracking:
     description: |
-      In order to identify the step by step navigation the component is part of, we need to track a unique ID of the navigation in Google Analytics. This ID should be the same across all pages that are linked from and are part of that navigation. Its value is included in any tracking events, specifically in dimension96. It refers to the ID of the step nav page.
+      In order to identify the step by step navigation the component is part of, we need to track a unique ID of the navigation in Universal Analytics. This ID should be the same across all pages that are linked from and are part of that navigation. Its value is included in any tracking events, specifically in dimension96. It refers to the ID of the step nav page.
 
       This includes show/hide all, show/hide step and any link clicks.
     data:
@@ -531,7 +527,7 @@ examples:
 
           No change. Active step by step will be expanded.
 
-      4. Content item is part of multiple primary step by steps and a single secondary step by step 
+      4. Content item is part of multiple primary step by steps and a single secondary step by step
 
           No change. Show "Part of" step by steps list. Secondary step by step won't be shown.
 

--- a/app/views/govuk_publishing_components/components/docs/step_by_step_nav_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/step_by_step_nav_header.yml
@@ -51,9 +51,9 @@ examples:
       tracking_action: "customTrackingAction"
       tracking_label: "customTrackingLabel"
       tracking_dimension_enabled: false
-  with_ga4_tracking:
-    description: The ga4_tracking boolean allows you to add Google Analytics 4 (GA4) tracking to your component. Setting this to true will add the `ga4-link-tracker` module to your component. The JavaScript will then add a `data-ga4-link` attribute which contains a JSON object with data relevant to our tracking. See the [ga4-link-tracker docs](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-link-tracker.md) for more information.
+  without_ga4_tracking:
+    description: Disables GA4 tracking on the header. Tracking is enabled by default. This includes the `ga4-link-tracker` module and `data-ga4-link` attributes. See the [ga4-link-tracker docs](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-link-tracker.md) for more information.
     data:
-      ga4_tracking: true
+      disable_ga4: true
       title: 'Learn to drive a motorbike: step by step'
       path: /learn-to-drive-a-motorbike

--- a/app/views/govuk_publishing_components/components/docs/step_by_step_nav_related.yml
+++ b/app/views/govuk_publishing_components/components/docs/step_by_step_nav_related.yml
@@ -64,7 +64,7 @@ examples:
       ]
   always_display_as_a_list:
     description: |
-      when this component is rendered alongside an expanded step by step, we want it to render as a heading. 
+      when this component is rendered alongside an expanded step by step, we want it to render as a heading.
       However, in some cases the component will not be followed by a step by step, for example [Book Driving Test](https://www.gov.uk/book-driving-test).
       In these cases, the heading is not followed by any content, so it should be rendered as a list instead.
     data:
@@ -76,10 +76,10 @@ examples:
           text: 'Learn to drive a motorbike: step by step'
         }
       ]
-  with_ga4_tracking:
-    description: The ga4_tracking boolean allows you to add Google Analytics 4 (GA4) tracking to your component. Setting this to true will add the `ga4-link-tracker` module to your component. The JavaScript will then add a `data-ga4-link` attribute which contains a JSON object with data relevant to our tracking. See the [ga4-link-tracker docs](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-link-tracker.md) for more information.
+  without_ga4_tracking:
+    description: Disables GA4 tracking on the component. Tracking is enabled by default. This includes the `ga4-link-tracker` module and `data-ga4-link` attributes. See the [ga4-link-tracker docs](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-link-tracker.md) for more information.
     data:
-      ga4_tracking: true
+      disable_ga4: true
       pretitle: 'Example pretitle'
       links: [
         {

--- a/app/views/govuk_publishing_components/components/docs/tabs.yml
+++ b/app/views/govuk_publishing_components/components/docs/tabs.yml
@@ -95,10 +95,10 @@ examples:
             tracking: GTM-123AB
           content: |
             <p class="govuk-body-m">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam congue elementum commodo. Vestibulum elit turpis, efficitur quis posuere vitae, commodo vitae augue. Donec ut pharetra ligula. Phasellus ac mauris eu felis bibendum dapibus rutrum sed quam. Pellentesque posuere ante id consequat pretium.</p>
-  with_ga4_tracking_on_tabs:
-    description: Enables GA4 tracking by adding the event tracker and required data attributes to the tabs. See the [ga4-event-tracker documentation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-event-tracker.md) for more information.
+  without_ga4_tracking_on_tabs:
+    description: Disables GA4 tracking on tabs. Tracking is enabled by default. This includes the event tracker and required data attributes. See the [ga4-event-tracker documentation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-event-tracker.md) for more information.
     data:
-      ga4_tracking: true
+      disable_ga4: true
       tabs:
         - id: "tab-with-ga4-tracking-1"
           label: "First section"
@@ -110,8 +110,8 @@ examples:
           title: "Second section"
           content: |
             <p class="govuk-body-m">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam congue elementum commodo. Vestibulum elit turpis, efficitur quis posuere vitae, commodo vitae augue. Donec ut pharetra ligula. Phasellus ac mauris eu felis bibendum dapibus rutrum sed quam. Pellentesque posuere ante id consequat pretium.</p>
-  with_ga4_tracking_on_tabs_as_links:
-    description: Enables GA4 tracking by adding the link tracker and required data attributes to the tabs. See the [ga4-link-tracker documentation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-link-tracker.md) for more information.
+  without_ga4_tracking_on_tabs_as_links:
+    description: Disables GA4 tracking on tabs as links. Tracking is enabled by default.
     data:
       as_links: true
       ga4_tracking: true

--- a/app/views/govuk_publishing_components/components/related_navigation/_section.html.erb
+++ b/app/views/govuk_publishing_components/components/related_navigation/_section.html.erb
@@ -40,7 +40,7 @@
           index_section_count: "#{section_count}",
           index_total: "#{index_total}",
           section: ga4_heading_text,
-        } if ga4_tracking
+        } unless disable_ga4
         link_element = link_to(
           link[:text],
           link[:path],
@@ -69,13 +69,13 @@
     <% if links.length > section_link_limit %>
       <%
         classes = "gem-c-related-navigation__link toggle-wrap"
-        data_attributes_li = { module: "ga4-event-tracker" } if ga4_tracking
+        data_attributes_li = { module: "ga4-event-tracker" } unless disable_ga4
         data_attributes_link = {
           controls: "toggle_#{section_title}",
           expanded: "false",
           toggled_text: t("common.toggle_less")
         }
-        data_attributes_link[:ga4_event] = { "event_name": "select_content", "type": "related content" } if ga4_tracking
+        data_attributes_link[:ga4_event] = { "event_name": "select_content", "type": "related content" } unless disable_ga4
       %>
       <%= tag.li(class: classes, data: data_attributes_li) do %>
         <%= link_to("#", class: "gem-c-related-navigation__toggle", data: data_attributes_link) do %>

--- a/docs/analytics-ga4/ga4-all-trackers.md
+++ b/docs/analytics-ga4/ga4-all-trackers.md
@@ -2,7 +2,7 @@
 
 For tracking different kinds of data on GOV.UK we have built several different trackers. Each type of tracking is handled by a separate script, but some code is shared between them as they often do similar things.
 
-Most of the trackers work by adding a `data-module` attribute to an element along with additional data attributes to provide specific tracking information. Some components have this already built into their code, which is usually activated using a `ga4_tracking: true` option.
+Most of the trackers work by adding a `data-module` attribute to an element along with additional data attributes to provide specific tracking information. Some components have this already built into their code by default. These components should also include a `disable_ga4` option as a failsafe.
 
 ## Auto tracking
 

--- a/lib/govuk_publishing_components/presenters/breadcrumb_selector.rb
+++ b/lib/govuk_publishing_components/presenters/breadcrumb_selector.rb
@@ -3,11 +3,11 @@ module GovukPublishingComponents
     class BreadcrumbSelector
       attr_reader :content_item, :request, :prioritise_taxon_breadcrumbs
 
-      def initialize(content_item, request, prioritise_taxon_breadcrumbs, ga4_tracking)
+      def initialize(content_item, request, prioritise_taxon_breadcrumbs, disable_ga4)
         @content_item = content_item
         @request = request
         @prioritise_taxon_breadcrumbs = prioritise_taxon_breadcrumbs
-        @ga4_tracking = ga4_tracking
+        @disable_ga4 = disable_ga4
       end
 
       def breadcrumbs
@@ -38,7 +38,7 @@ module GovukPublishingComponents
         elsif navigation.content_tagged_to_current_step_by_step?
           {
             step_by_step: true,
-            breadcrumbs: navigation.step_nav_helper.header(@ga4_tracking),
+            breadcrumbs: navigation.step_nav_helper.header(@disable_ga4),
           }
         elsif navigation.content_is_tagged_to_a_live_taxon? && prioritise_taxon_breadcrumbs
           {

--- a/spec/components/accordion_spec.rb
+++ b/spec/components/accordion_spec.rb
@@ -194,10 +194,9 @@ describe "Accordion", type: :view do
     assert_select ".govuk-accordion[data-show-all-attributes='{\"module\":\"example\",\"track_action\":\"click\"}']"
   end
 
-  it "ga4 data attributes are present when required" do
+  it "ga4 data attributes are present by default" do
     test_data = {
       id: "test-for-data-attributes",
-      ga4_tracking: true,
       items: [
         {
           heading: { text: "Heading 1" },
@@ -218,6 +217,30 @@ describe "Accordion", type: :view do
     assert_select '.govuk-accordion__section-heading[data-ga4-event=\'{"event_name":"select_content","type":"accordion","text":"Heading 2","index_section":2,"index_section_count":2}\']'
   end
 
+  it "ga4 can be disabled" do
+    test_data = {
+      id: "test-for-data-attributes",
+      disable_ga4: true,
+      items: [
+        {
+          heading: { text: "Heading 1" },
+          content: { html: "<p>Content 1.</p>" },
+        },
+        {
+          heading: { text: "Heading 2" },
+          content: { html: "<p>Content 2.</p>" },
+        },
+      ],
+    }
+
+    render_component(test_data)
+
+    assert_select ".govuk-accordion[data-ga4-expandable]", false
+    assert_select '.govuk-accordion[data-module="govuk-accordion gem-accordion"]'
+    assert_select '.govuk-accordion[data-module="govuk-accordion gem-accordion ga4-event-tracker"]', false
+    assert_select ".govuk-accordion__section-heading[data-ga4-event]", false
+  end
+
   it '`data-module="govuk-accordion"` attribute is present when no custom data attributes given' do
     test_data = {
       id: "test-for-module-data-attributes",
@@ -233,7 +256,7 @@ describe "Accordion", type: :view do
       ],
     }
     render_component(test_data)
-    assert_select "[data-module='govuk-accordion gem-accordion']", count: 1
+    assert_select "[data-module='govuk-accordion gem-accordion ga4-event-tracker']", count: 1
   end
 
   it '`data-module="govuk-accordion"` attribute is present when custom data attributes given' do
@@ -260,7 +283,7 @@ describe "Accordion", type: :view do
       ],
     }
     render_component(test_data)
-    assert_select "[data-module='govuk-accordion gem-accordion']", count: 1
+    assert_select "[data-module='govuk-accordion gem-accordion ga4-event-tracker']", count: 1
     assert_select "[data-gtm]", count: 2
     assert_select "[data-gtm='this-is-gtm']", count: 1
     assert_select "[data-gtm='this-is-a-second-gtm']", count: 1
@@ -281,7 +304,7 @@ describe "Accordion", type: :view do
       ],
     }
     render_component(test_data)
-    assert_select "[data-module='gem-track-click govuk-accordion gem-accordion']", count: 1
+    assert_select "[data-module='gem-track-click govuk-accordion gem-accordion ga4-event-tracker']", count: 1
   end
 
   it "section has class added when expanded flag is present" do

--- a/spec/components/contents_list_spec.rb
+++ b/spec/components/contents_list_spec.rb
@@ -84,7 +84,7 @@ describe "Contents list", type: :view do
   it "renders data attributes for tracking" do
     render_component(contents: nested_contents_list)
 
-    assert_select ".gem-c-contents-list[data-module='gem-track-click']"
+    assert_select ".gem-c-contents-list[data-module='gem-track-click ga4-link-tracker']"
 
     assert_tracking_link("category", "contentsClicked", 6)
     assert_tracking_link("action", "content_item 1")
@@ -126,8 +126,8 @@ describe "Contents list", type: :view do
     assert_select ".gem-c-contents-list[aria-label=\"All pages in this guide\"]"
   end
 
-  it "ga4 tracking is added when ga4_tracking is true" do
-    render_component(contents: nested_contents_list, ga4_tracking: true)
+  it "GA4 tracking is added by default" do
+    render_component(contents: nested_contents_list)
 
     expected_ga4_json = {
       event_name: "navigation",
@@ -158,6 +158,16 @@ describe "Contents list", type: :view do
       expect(link.attr("data-ga4-link").to_s).to eq expected_ga4_json.to_json
       expect(link).to have_text(texts[index])
     end
+  end
+
+  it "GA4 tracking can be disabled" do
+    render_component(contents: nested_contents_list, disable_ga4: true)
+
+    assert_select ".gem-c-contents-list" do |contents_list|
+      expect(contents_list.attr("data-module").to_s).to eq "gem-track-click"
+    end
+
+    assert_select ".gem-c-contents-list__list-item a[data-ga4-link]", false
   end
 
   it "applies branding correctly" do

--- a/spec/components/contextual_footer_spec.rb
+++ b/spec/components/contextual_footer_spec.rb
@@ -45,10 +45,34 @@ RSpec.describe "Contextual footer", type: :view do
       ],
     }
 
-    render_component(content_item:, ga4_tracking: true)
+    render_component(content_item:)
 
     assert_select ".gem-c-related-navigation[data-module='gem-track-click ga4-link-tracker']"
     assert_select ".gem-c-related-navigation__section-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"contextual footer\",\"index_section\":\"1\",\"index_link\":\"1\",\"index_section_count\":\"1\",\"index_total\":\"2\",\"section\":\"Explore the topic\"}']", text: "Skating"
     assert_select ".gem-c-related-navigation__section-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"contextual footer\",\"index_section\":\"1\",\"index_link\":\"2\",\"index_section_count\":\"1\",\"index_total\":\"2\",\"section\":\"Explore the topic\"}']", text: "Paragliding"
+  end
+
+  it "allows GA4 to be disabled" do
+    content_item = {}
+    content_item["links"] = {
+      "topics" => [
+        {
+          "base_path" => "/skating",
+          "title" => "Skating",
+          "document_type" => "topic",
+        },
+        {
+          "base_path" => "/paragliding",
+          "title" => "Paragliding",
+          "document_type" => "topic",
+        },
+      ],
+    }
+
+    render_component(content_item:, disable_ga4: true)
+
+    assert_select ".gem-c-related-navigation[data-module='gem-track-click']"
+    assert_select ".gem-c-related-navigation[data-module='gem-track-click ga4-link-tracker']", false
+    assert_select ".gem-c-related-navigation__section-link[data-ga4-link]", false
   end
 end

--- a/spec/components/contextual_sidebar_spec.rb
+++ b/spec/components/contextual_sidebar_spec.rb
@@ -39,12 +39,36 @@ describe "Contextual sidebar", type: :view do
     content_item = content_item.deep_merge!(should_show_ukraine)
 
     render_component(
-      ga4_tracking: true,
       content_item:,
     )
     index_total = 4 # have to hard code this here but if ukraine links change this number may change, and test will fail
     assert_select ".gem-c-contextual-sidebar .gem-c-contextual-sidebar__cta--ukraine[data-module='gem-track-click ga4-link-tracker']"
     assert_select ".gem-c-contextual-sidebar .gem-c-contextual-sidebar__cta--ukraine .govuk-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"related content\",\"index_section\":\"1\",\"index_link\":\"1\",\"index_section_count\":\"1\",\"index_total\":\"#{index_total}\",\"section\":\"Invasion of Ukraine\"}']"
     assert_select ".gem-c-contextual-sidebar .gem-c-contextual-sidebar__cta--ukraine .govuk-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"related content\",\"index_section\":\"1\",\"index_link\":\"2\",\"index_section_count\":\"1\",\"index_total\":\"#{index_total}\",\"section\":\"Invasion of Ukraine\"}']"
+  end
+
+  it "allows GA4 tracking to be disabled" do
+    should_show_ukraine = {
+      links: {
+        topical_events: [
+          {
+            content_id: "bfa79635-ffda-4b5d-8266-a9cd3a03649c",
+            title: "Russian invasion of Ukraine: UK government response",
+            base_path: "/government/topical-events/russian-invasion-of-ukraine-uk-government-response",
+            locale: "en",
+          },
+        ],
+      },
+    }.deep_stringify_keys!
+    content_item = GovukSchemas::Example.find("document_collection", example_name: "document_collection")
+    content_item = content_item.deep_merge!(should_show_ukraine)
+
+    render_component(
+      content_item:,
+      disable_ga4: true,
+    )
+    assert_select ".gem-c-contextual-sidebar .gem-c-contextual-sidebar__cta--ukraine[data-module='gem-track-click']"
+    assert_select ".gem-c-contextual-sidebar .gem-c-contextual-sidebar__cta--ukraine[data-module='gem-track-click ga4-link-tracker']", false
+    assert_select ".gem-c-contextual-sidebar .gem-c-contextual-sidebar__cta--ukraine .govuk-link[data-ga4-link]", false
   end
 end

--- a/spec/components/cookie_banner_spec.rb
+++ b/spec/components/cookie_banner_spec.rb
@@ -47,7 +47,7 @@ describe "Cookie banner", type: :view do
     render_component({})
 
     assert_select ".govuk-button-group .gem-c-cookie-banner__hide-button", text: "Hide this message"
-    assert_select '.gem-c-cookie-banner__hide-button[data-module=gem-track-click][data-track-category=cookieBanner][data-track-action="Hide cookie banner"]'
+    assert_select '.gem-c-cookie-banner__hide-button[data-module="gem-track-click ga4-event-tracker"][data-track-category=cookieBanner][data-track-action="Hide cookie banner"]'
   end
 
   it "renders with custom content" do
@@ -111,8 +111,8 @@ describe "Cookie banner", type: :view do
     assert_select ".govuk-button-group .govuk-link[href='/cookies']", text: "How we use cookies"
   end
 
-  it "renders with GA4 attributes when ga4_tracking is true" do
-    render_component({ ga4_tracking: true })
+  it "renders with GA4 attributes" do
+    render_component({})
     assert_select ".gem-c-cookie-banner__confirmation-message--accepted[data-ga4-cookie-banner]"
     assert_select ".gem-c-cookie-banner__confirmation-message--accepted[data-module=ga4-link-tracker]"
     assert_select ".gem-c-cookie-banner__confirmation-message--accepted[data-ga4-track-links-only]"
@@ -123,8 +123,8 @@ describe "Cookie banner", type: :view do
     assert_select ".gem-c-cookie-banner__hide-button[data-ga4-event='{\"event_name\":\"select_content\",\"type\":\"cookie banner\",\"action\":\"closed\",\"section\":\"You have accepted additional cookies\"}']"
   end
 
-  it "renders without GA4 attributes when ga4_tracking is false" do
-    render_component({ ga4_tracking: false })
+  it "renders without GA4 attributes when disable_ga4 is true" do
+    render_component({ disable_ga4: true })
     assert_select ".gem-c-cookie-banner__confirmation-message--accepted[data-ga4-cookie-banner]", false
     assert_select ".gem-c-cookie-banner__confirmation-message--accepted[data-module]", false
     assert_select ".gem-c-cookie-banner__confirmation-message--accepted[data-ga4-track-links-only]", false

--- a/spec/components/devolved_nations_spec.rb
+++ b/spec/components/devolved_nations_spec.rb
@@ -177,7 +177,6 @@ describe "Devolved Nations", type: :view do
           alternative_url: "/publication-wales",
         },
       },
-      ga4_tracking: true,
     )
     assert_select ".gem-c-devolved-nations[data-ga4-devolved-nations-banner='England, Scotland, Wales']"
     assert_select ".gem-c-devolved-nations[data-module=ga4-link-tracker]"
@@ -193,7 +192,7 @@ describe "Devolved Nations", type: :view do
           applicable: true,
         },
       },
-      ga4_tracking: false,
+      disable_ga4: true,
     )
 
     assert_select ".gem-c-devolved-nations[data-ga4-devolved-nations-banner]", false

--- a/spec/components/emergency_banner_spec.rb
+++ b/spec/components/emergency_banner_spec.rb
@@ -13,7 +13,7 @@ describe "Emergency Banner", type: :view do
       link: options[:link],
       link_text: options[:link_text],
       homepage: options[:homepage],
-      ga4_tracking: options[:ga4_tracking],
+      disable_ga4: options[:disable_ga4],
     }
   end
 
@@ -80,7 +80,7 @@ describe "Emergency Banner", type: :view do
   end
 
   it "renders banner with ga4 attributes" do
-    render_component(emergency_banner_attributes({ campaign_class: "notable-death", ga4_tracking: true }))
+    render_component(emergency_banner_attributes({ campaign_class: "notable-death" }))
     assert_select ".gem-c-emergency-banner[data-ga4-emergency-banner]"
     assert_select ".gem-c-emergency-banner[data-module=ga4-link-tracker]"
     assert_select ".gem-c-emergency-banner[data-ga4-track-links-only]"
@@ -89,7 +89,7 @@ describe "Emergency Banner", type: :view do
   end
 
   it "renders banner without ga4 attributes" do
-    render_component(emergency_banner_attributes({ campaign_class: "notable-death", ga4_tracking: false }))
+    render_component(emergency_banner_attributes({ campaign_class: "notable-death", disable_ga4: true }))
     assert_select ".gem-c-emergency-banner[data-ga4-emergency-banner]", false
     assert_select ".gem-c-emergency-banner[data-module=ga4-link-tracker]", false
     assert_select ".gem-c-emergency-banner[data-ga4-track-links-only]", false

--- a/spec/components/intervention_spec.rb
+++ b/spec/components/intervention_spec.rb
@@ -75,7 +75,7 @@ describe "Intervention", type: :view do
     assert_select ".js-dismiss-link[data-ga4-event='{\"event_name\":\"select_content\",\"type\":\"intervention\",\"section\":\"You might be interested in\",\"action\":\"closed\"}']"
   end
 
-  it "ensures data modules are combined correctly when GA4 tracking is true" do
+  it "ensures data modules are combined correctly for GA4 tracking" do
     render_component(
       name: "test-campaign",
       suggestion_text: "You might be interested in",
@@ -88,21 +88,20 @@ describe "Intervention", type: :view do
       dismiss_link_data_attributes: {
         module: "hello-world",
       },
-      ga4_tracking: true,
     )
 
     assert_select ".gem-c-intervention a:first-of-type[data-module='hello-world ga4-link-tracker']"
     assert_select ".js-dismiss-link[data-module='hello-world ga4-event-tracker']"
   end
 
-  it "renders the component without GA4 tracking when ga4_tracking is false" do
+  it "renders the component without GA4 tracking when disable_ga4 is true" do
     render_component(
       name: "test-campaign",
       suggestion_text: "You might be interested in",
       suggestion_link_text: "Travel abroad",
       suggestion_link_url: "/travel-abroad",
       dismiss_text: "Hide this suggestion",
-      ga4_tracking: false,
+      disable_ga4: true,
     )
 
     assert_select ".gem-c-intervention[data-ga4-intervention-banner]", false

--- a/spec/components/metadata_spec.rb
+++ b/spec/components/metadata_spec.rb
@@ -213,8 +213,8 @@ describe "Metadata", type: :view do
     assert_select '.gem-c-metadata.govuk-\!-margin-bottom-2'
   end
 
-  it "adds GA4 tracking to the 'see all updates' link when GA4 tracking is true" do
-    render_component(last_updated: "Hello World", see_updates_link: true, ga4_tracking: true, other: { "Updated" => "13 April 2023, <a href=\"/hmrc-internal-manuals/self-assessment-claims-manual/updates\">see all updates</a>" })
+  it "adds GA4 tracking to the 'see all updates' link" do
+    render_component(last_updated: "Hello World", see_updates_link: true, other: { "Updated" => "13 April 2023, <a href=\"/hmrc-internal-manuals/self-assessment-claims-manual/updates\">see all updates</a>" })
 
     expected_ga4_json = {
       "event_name": "navigation",
@@ -233,6 +233,14 @@ describe "Metadata", type: :view do
       expect(alternate_see_all_updates_container.attr("data-ga4-track-links-only").to_s).to eq ""
       expect(alternate_see_all_updates_container.attr("data-ga4-link").to_s).to eq expected_ga4_json
     end
+  end
+
+  it "allows GA4 tracking to be disabled" do
+    render_component(last_updated: "Hello World", see_updates_link: true, disable_ga4: true, other: { "Updated" => "13 April 2023, <a href=\"/hmrc-internal-manuals/self-assessment-claims-manual/updates\">see all updates</a>" })
+
+    assert_select ".js-see-all-updates-link[data-module='ga4-link-tracker']", false
+    assert_select ".gem-c-metadata__definition:nth-of-type(2)[data-module='ga4-link-tracker']", false
+    assert_select ".gem-c-metadata__definition:nth-of-type(2)[data-ga4-track-links-only]", false
   end
 
   def assert_truncation(length, limit)

--- a/spec/components/phase_banner_spec.rb
+++ b/spec/components/phase_banner_spec.rb
@@ -42,7 +42,7 @@ describe "Phase banner", type: :view do
   end
 
   it "renders banner with ga4 attributes" do
-    render_component(phase: "beta", ga4_tracking: true)
+    render_component(phase: "beta")
     assert_select ".gem-c-phase-banner[data-ga4-phase-banner=beta]"
     assert_select ".gem-c-phase-banner[data-module=ga4-link-tracker]"
     assert_select ".gem-c-phase-banner[data-ga4-track-links-only]"
@@ -51,7 +51,7 @@ describe "Phase banner", type: :view do
   end
 
   it "renders banner without ga4 attributes" do
-    render_component(phase: "beta", ga4_tracking: false)
+    render_component(phase: "beta", disable_ga4: true)
     assert_select ".gem-c-phase-banner[data-ga4-phase-banner]", false
     assert_select ".gem-c-phase-banner[data-module=ga4-link-tracker]", false
     assert_select ".gem-c-phase-banner[data-ga4-track-links-only]", false

--- a/spec/components/previous_and_next_navigation_spec.rb
+++ b/spec/components/previous_and_next_navigation_spec.rb
@@ -68,7 +68,7 @@ describe "Previous and next navigation", type: :view do
     assert_select ".govuk-pagination__next .govuk-pagination__link .govuk-visually-hidden", false
   end
 
-  it "adds GA4 tracking when ga4_tracking is true" do
+  it "includes GA4 tracking" do
     render_component(
       previous_page: {
         url: "previous-page",
@@ -78,7 +78,6 @@ describe "Previous and next navigation", type: :view do
         url: "next-page",
         title: "Next page",
       },
-      ga4_tracking: true,
     )
 
     assert_select ".govuk-pagination" do |pagination|
@@ -106,6 +105,24 @@ describe "Previous and next navigation", type: :view do
     assert_select ".govuk-pagination__next a" do |pagination_link|
       expect(pagination_link.attr("data-ga4-link").to_s).to eq expected_ga4_json
     end
+  end
+
+  it "allows GA4 tracking to be disabled" do
+    render_component(
+      disable_ga4: true,
+      previous_page: {
+        url: "previous-page",
+        title: "Previous page",
+      },
+      next_page: {
+        url: "next-page",
+        title: "Next page",
+      },
+    )
+
+    assert_select ".govuk-pagination[data-module='ga4-link-tracker']", false
+    assert_select ".govuk-pagination__prev a[data-ga4-link]", false
+    assert_select ".govuk-pagination__next a[data-ga4-link]", false
   end
 
   def assert_link(link)

--- a/spec/components/related_navigation_spec.rb
+++ b/spec/components/related_navigation_spec.rb
@@ -167,7 +167,7 @@ describe "Related navigation", type: :view do
 
     assert_select ".gem-c-related-navigation__section-link[href=\"/world/wales/news\"]", text: "Wales"
     assert_select ".gem-c-related-navigation__link.toggle-wrap", text: "Show 2 more"
-    assert_select ".gem-c-related-navigation__link.toggle-wrap[data-module='ga4-event-tracker']", false
+    assert_select ".gem-c-related-navigation__link.toggle-wrap[data-module='ga4-event-tracker']"
     assert_select "#toggle_world_locations .gem-c-related-navigation__section-link[href=\"/world/mauritius/news\"]", text: "Mauritius"
     assert_select "#toggle_world_locations .gem-c-related-navigation__section-link[href=\"/world/brazil/news\"]", text: "Brazil"
   end
@@ -202,7 +202,7 @@ describe "Related navigation", type: :view do
     )
     render_component(content_item:)
 
-    assert_select ".gem-c-related-navigation[data-module='gem-track-click']"
+    assert_select ".gem-c-related-navigation[data-module='gem-track-click ga4-link-tracker']"
     assert_select ".gem-c-related-navigation__section-link[data-track-category='relatedLinkClicked']"
     assert_select ".gem-c-related-navigation__section-link[data-track-action='1.1 Explore the topic']"
     assert_select ".gem-c-related-navigation__section-link[data-track-label='/apprenticeships']"
@@ -244,7 +244,7 @@ describe "Related navigation", type: :view do
       content_item["links"]["world_locations"] << { "title" => country }
     end
 
-    render_component(content_item:, ga4_tracking: true)
+    render_component(content_item:)
 
     assert_select ".gem-c-related-navigation[data-module='gem-track-click ga4-link-tracker']"
     assert_select ".gem-c-related-navigation__section-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"related content\",\"index_section\":\"1\",\"index_link\":\"1\",\"index_section_count\":\"3\",\"index_total\":\"2\",\"section\":\"Related content\"}']", text: "Fishing"
@@ -256,6 +256,51 @@ describe "Related navigation", type: :view do
     assert_select ".gem-c-related-navigation__section-link[href=\"/world/wales/news\"]", text: "Wales"
     assert_select ".gem-c-related-navigation__link.toggle-wrap[data-module='ga4-event-tracker']"
     assert_select ".gem-c-related-navigation__toggle[data-ga4-event='{\"event_name\":\"select_content\",\"type\":\"related content\"}']", text: "Show 2 more"
+  end
+
+  it "allows GA4 to be disabled" do
+    content_item = {}
+    content_item["links"] = {
+      "ordered_related_items" => [
+        {
+          "base_path" => "/fishing",
+          "title" => "Fishing",
+        },
+        {
+          "base_path" => "/surfing",
+          "title" => "Surfing",
+        },
+      ],
+      "topics" => [
+        {
+          "base_path" => "/skating",
+          "title" => "Skating",
+          "document_type" => "topic",
+        },
+        {
+          "base_path" => "/paragliding",
+          "title" => "Paragliding",
+          "document_type" => "topic",
+        },
+        {
+          "base_path" => "/knitting",
+          "title" => "Knitting",
+          "document_type" => "topic",
+        },
+      ],
+      "world_locations" => [],
+    }
+    %w[USA Wales Fiji Iceland Sweden Mauritius Brazil].each do |country|
+      content_item["links"]["world_locations"] << { "title" => country }
+    end
+
+    render_component(content_item:, disable_ga4: true)
+
+    assert_select ".gem-c-related-navigation[data-module='gem-track-click']"
+    assert_select ".gem-c-related-navigation__section-link[data-ga4-link]", false
+
+    assert_select ".gem-c-related-navigation__link.toggle-wrap[data-module='ga4-event-tracker']", false
+    assert_select ".gem-c-related-navigation__toggle[data-ga4-event]", false
   end
 
   it "uses lang when locale is set" do

--- a/spec/components/step_by_step_nav_header_spec.rb
+++ b/spec/components/step_by_step_nav_header_spec.rb
@@ -86,11 +86,10 @@ describe "Step by step navigation header", type: :view do
     assert_select "#{link}[data-track-options='{\"dimension96\":\"tracking-id\"}']"
   end
 
-  it "adds GA4 tracking" do
+  it "includes GA4 tracking" do
     render_component(
       title: "This is my title",
       path: "/notalink",
-      ga4_tracking: true,
     )
     expected = {
       event_name: "navigation",
@@ -100,6 +99,17 @@ describe "Step by step navigation header", type: :view do
     }.to_json
     assert_select(".gem-c-step-nav-header[data-module='gem-track-click ga4-link-tracker']")
     assert_select(".gem-c-step-nav-header__title[data-ga4-link='#{expected}']")
+  end
+
+  it "allows GA4 tracking to be disabled" do
+    render_component(
+      title: "This is my title",
+      path: "/notalink",
+      disable_ga4: true,
+    )
+    assert_select(".gem-c-step-nav-header[data-module='gem-track-click']")
+    assert_select(".gem-c-step-nav-header[data-module='gem-track-click ga4-link-tracker']", false)
+    assert_select(".gem-c-step-nav-header__title[data-ga4-link]", false)
   end
 
   it "adds a custom tracking without tracking id or custom dimensions" do

--- a/spec/components/step_by_step_nav_related_spec.rb
+++ b/spec/components/step_by_step_nav_related_spec.rb
@@ -112,8 +112,8 @@ describe "Step by step navigation related", type: :view do
     assert_select ".gem-c-step-nav-related .gem-c-step-nav-related__links .govuk-link[href='/link1']", text: "Link 1"
   end
 
-  it "adds GA4 data attributes when ga4_tracking is true" do
-    render_component(pretitle: "Some text", links: one_link, ga4_tracking: true)
+  it "adds GA4 data attributes" do
+    render_component(pretitle: "Some text", links: one_link)
 
     this_link = ".gem-c-step-nav-related .gem-c-step-nav-related__heading .govuk-link"
 
@@ -128,8 +128,8 @@ describe "Step by step navigation related", type: :view do
     assert_select "#{this_link}[data-ga4-link='#{expected.to_json}']"
   end
 
-  it "does not add GA4 data attributes when ga4_tracking is false" do
-    render_component(links: one_link, ga4_tracking: false)
+  it "does not add GA4 data attributes when disable_ga4 is true" do
+    render_component(links: one_link, disable_ga4: true)
 
     this_link = ".gem-c-step-nav-related .gem-c-step-nav-related__heading .govuk-link"
 

--- a/spec/components/step_by_step_nav_spec.rb
+++ b/spec/components/step_by_step_nav_spec.rb
@@ -255,10 +255,17 @@ describe "step nav", type: :view do
   end
 
   it "adds ga4 attributes" do
-    render_component(steps: stepnav, ga4_tracking: true)
+    render_component(steps: stepnav)
 
     assert_select ".gem-c-step-nav[data-ga4-expandable]"
     assert_select ".gem-c-step-nav[data-module='gemstepnav ga4-event-tracker']"
+  end
+
+  it "allows GA4 to be disabled" do
+    render_component(steps: stepnav, disable_ga4: true)
+
+    assert_select ".gem-c-step-nav[data-ga4-expandable]", false
+    assert_select ".gem-c-step-nav[data-module='gemstepnav ga4-event-tracker']", false
   end
 
   it "adds ga4 link attributes when there is one section per step" do
@@ -291,7 +298,7 @@ describe "step nav", type: :view do
           },
         ],
       },
-    ], ga4_tracking: true)
+    ])
 
     expected = {
       "event_name": "navigation",
@@ -323,7 +330,7 @@ describe "step nav", type: :view do
   end
 
   it "adds ga4 link attributes when there are variable sections per step" do
-    render_component(steps: stepnav, ga4_tracking: true)
+    render_component(steps: stepnav)
 
     expected = {
       "event_name": "navigation",

--- a/spec/components/tabs_spec.rb
+++ b/spec/components/tabs_spec.rb
@@ -24,7 +24,7 @@ describe "Tabs", type: :view do
         },
       ],
     )
-    assert_select ".govuk-tabs[data-module='govuk-tabs']"
+    assert_select ".govuk-tabs[data-module='govuk-tabs ga4-event-tracker']"
     assert_select ".govuk-tabs__tab", 2
     assert_select ".govuk-tabs__panel", 2
     assert_select "#tab1"
@@ -45,8 +45,7 @@ describe "Tabs", type: :view do
         },
       ],
     )
-
-    assert_select ".govuk-tabs"
+    assert_select ".govuk-tabs[data-module='ga4-link-tracker']"
     assert_select ".govuk-tabs__tab", 2
     assert_select ".govuk-tabs__list-item", 2
     assert_select "a.govuk-tabs__tab[href='/page1']"
@@ -55,7 +54,6 @@ describe "Tabs", type: :view do
 
   it "renders with GA4 tracking on tabs" do
     render_component(
-      ga4_tracking: true,
       tabs: [
         {
           id: "tab1",
@@ -81,9 +79,29 @@ describe "Tabs", type: :view do
     assert_select ".govuk-tabs__tab[data-ga4-event='{\"event_name\":\"select_content\",\"type\":\"tabs\",\"text\":\"Third section\",\"index_section\":3,\"index_section_count\":3}']"
   end
 
+  it "renders without GA4 tracking on tabs" do
+    render_component(
+      disable_ga4: true,
+      tabs: [
+        {
+          id: "tab1",
+          label: "First section",
+          content: "<p>Fusce at dictum tellus, ac accumsan est. Nulla vitae turpis in nulla gravida tincidunt.</p>",
+        },
+        {
+          id: "tab2",
+          label: "Second section",
+          content: "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>",
+        },
+      ],
+    )
+
+    assert_select ".govuk-tabs[data-module='govuk-tabs ga4-event-tracker']", false
+    assert_select ".govuk-tabs__tab[data-ga4-event]", false
+  end
+
   it "renders with GA4 tracking on tabs as links" do
     render_component(
-      ga4_tracking: true,
       as_links: true,
       tabs: [
         {
@@ -106,5 +124,26 @@ describe "Tabs", type: :view do
     assert_select ".govuk-tabs__tab[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"tabs\",\"text\":\"First section\",\"index_section\":1,\"index_section_count\":3}']"
     assert_select ".govuk-tabs__tab[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"tabs\",\"text\":\"Second section\",\"index_section\":2,\"index_section_count\":3}']"
     assert_select ".govuk-tabs__tab[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"tabs\",\"text\":\"Third section\",\"index_section\":3,\"index_section_count\":3}']"
+  end
+
+  it "renders without GA4 tracking on tabs as links" do
+    render_component(
+      as_links: true,
+      disable_ga4: true,
+      tabs: [
+        {
+          href: "tab1",
+          label: "First section",
+          active: true,
+        },
+        {
+          href: "tab2",
+          label: "Second section",
+        },
+      ],
+    )
+
+    assert_select ".govuk-tabs[data-module='ga4-link-tracker']", false
+    assert_select ".govuk-tabs__tab[data-ga4-link]", false
   end
 end


### PR DESCRIPTION
## What
Switch the `ga4_tracking` flag to enable tracking on some components for a `disable_ga4` flag, and enable tracking by default on these components.

## Why
Until now our strategy for GA4 tracking on components was to include a `ga4_tracking` flag to enable tracking only on specific component instances. Now that most of the tracking is in place we need to ensure that if components are added to pages in future, tracking is included. 

However we also need to account for some instances where tracking may not be required on these components, so we replace this option with a `disable_ga4` flag.

## Visual Changes
None.

Trello card: https://trello.com/c/Xwp7dgJN/294-tracking-auditing-tracking-by-default
