### PR TITLE
GA4 auto tracker add PII redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* GA4 auto tracker add PII redaction ([PR #3707](https://github.com/alphagov/govuk_publishing_components/pull/3707))
+
 ## 35.21.2
 
 * Revert nav menu font changes ([PR #3696](https://github.com/alphagov/govuk_publishing_components/pull/3696))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-auto-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-auto-tracker.js
@@ -7,6 +7,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   function Ga4AutoTracker (module) {
     this.module = module
     this.trackingTrigger = 'data-ga4-auto'
+    this.PIIRemover = new window.GOVUK.analyticsGa4.PIIRemover()
   }
 
   Ga4AutoTracker.prototype.init = function () {
@@ -35,6 +36,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         return
       }
 
+      data.text = this.PIIRemover.stripPIIWithOverride(data.text, true, true)
       var schemas = new window.GOVUK.analyticsGa4.Schemas()
       var schema = schemas.mergeProperties(data, 'event_data')
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-auto-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-auto-tracker.spec.js
@@ -121,4 +121,27 @@ describe('Google Analytics auto tracker', function () {
       expect(window.dataLayer[0].not_a_schema_attribute).toEqual(undefined)
     })
   })
+
+  describe('PII removal', function () {
+    beforeEach(function () {
+      expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
+      expected.event = 'event_data'
+      expected.event_data.event_name = 'select_content'
+      expected.event_data.type = 'tabs'
+      expected.event_data.text = '/[date]/[postcode]/[email]'
+      expected.govuk_gem_version = 'aVersion'
+
+      var attributes = {
+        event_name: 'select_content',
+        type: 'tabs',
+        text: '/2022-02-02/SW10AA/email@example.com'
+      }
+      element.setAttribute('data-ga4-auto', JSON.stringify(attributes))
+      new GOVUK.Modules.Ga4AutoTracker(element).init()
+    })
+
+    it('redacts dates, postcodes and emails from text', function () {
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+  })
 })


### PR DESCRIPTION
## What
Add PII redaction to the GA4 auto tracker.

## Why
We need PII redaction on this value.

## Visual Changes
None.

Trello card: https://trello.com/c/2kvItAoh/729-fix-postcode-lookup-pii-collection-on-contact-electoral-registration-office
