### PR TITLE
Improve PII date removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Allow GA4 to be disabled via query string parameters ([PR #3731](https://github.com/alphagov/govuk_publishing_components/pull/3731))
 * Consolidate GA4 schema calls ([PR #3725](https://github.com/alphagov/govuk_publishing_components/pull/3725))
 * Make data-ga4-set-indexes ignore links with no href ([PR #3723](https://github.com/alphagov/govuk_publishing_components/pull/3723))
+* Improve PII date removal ([PR #3709](https://github.com/alphagov/govuk_publishing_components/pull/3709))
 
 ## 35.23.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.js
@@ -4,8 +4,22 @@
   var GOVUK = global.GOVUK || {}
   var EMAIL_PATTERN = /[^\s=/?&#+]+(?:@|%40)[^\s=/?&+]+/g
   var POSTCODE_PATTERN = /\b[A-PR-UWYZ][A-HJ-Z]?[0-9][0-9A-HJKMNPR-Y]?(?:[\s+]|%20)*[0-9](?!refund)[ABD-HJLNPQ-Z]{2,3}\b/gi
-  var DATE_PATTERN_NUMERIC = /\d{4}(-?)\d{2}(-?)\d{2}/g
-  var DATE_PATTERN_STRING = /\d{1,2}\s(January|February|March|April|May|June|July|August|September|October|November|December)\s\d{4}/g
+
+  // e.g. 01/01/1990 or 01-01-1990 or 1-1-1990 or 1/1/1990 or 01\01\1990 or 1\1\1990
+  var DATE_PATTERN_NUMERIC_1 = /\d{1,2}([-\/\\])\d{1,2}([-\/\\])\d{4}/g // eslint-disable-line no-useless-escape
+
+  // e.g. 1990/01/01 or 1990-01-01 or 1990-1-1 or 1990/1/1 or 1990\1\1 or 1990\01\01
+  var DATE_PATTERN_NUMERIC_2 = /\d{4}([-\/\\])\d{1,2}([-\/\\])\d{1,2}/g // eslint-disable-line no-useless-escape
+
+  // e.g. 12345678 (This originated from the UA PII Remover)
+  var DATE_PATTERN_NUMERIC_3 = /[0-9]{8}/g
+
+  // e.g. 1(st) (of) Jan(uary) 1990 (or 90 or '90) - where the bracketed characters are optional parts that can be matched
+  var DATE_PATTERN_STRING_1 = /\d{1,2}(?:st|nd|rd|th)?\s(?:of\s)?(Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:t)?(?:ember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\s(?:')?(\d{4}|\d{2})/gi
+
+  // e.g. Jan(uary) 1(st) 1990 (or 90 or '90) - where the bracketed characters are optional parts that can be matched
+  var DATE_PATTERN_STRING_2 = /(Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:t)?(?:ember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\s\d{1,2}?(?:st|nd|rd|th)?\s(?:')?(\d{4}|\d{2})/gi
+
   var ESCAPE_REGEX_PATTERN = /[|\\{}()[\]^$+*?.]/g
 
   // specific URL parameters to be redacted from accounts URLs
@@ -86,8 +100,12 @@
     stripped = this.stripQueryStringParameters(stripped)
 
     if (this.stripDatePII === true) {
-      stripped = stripped.replace(DATE_PATTERN_NUMERIC, '[date]')
-      stripped = stripped.replace(DATE_PATTERN_STRING, '[date]')
+      var DATE_REDACTION_STRING = '[date]'
+      stripped = stripped.replace(DATE_PATTERN_NUMERIC_1, DATE_REDACTION_STRING)
+      stripped = stripped.replace(DATE_PATTERN_NUMERIC_2, DATE_REDACTION_STRING)
+      stripped = stripped.replace(DATE_PATTERN_NUMERIC_3, DATE_REDACTION_STRING)
+      stripped = stripped.replace(DATE_PATTERN_STRING_1, DATE_REDACTION_STRING)
+      stripped = stripped.replace(DATE_PATTERN_STRING_2, DATE_REDACTION_STRING)
     }
     if (this.stripPostcodePII === true) {
       stripped = stripped.replace(POSTCODE_PATTERN, '[postcode]')

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.spec.js
@@ -218,6 +218,58 @@ describe('GOVUK.analyticsGa4.PIIRemover', function () {
     expect(string).toEqual('hello+world+[email]+SW12AA+1990-01-01')
   })
 
+  it('can strip a wide range of dates', function () {
+    var dates = [
+      '01/01/1990', '01-01-1990', '1-1-1990', '1/1/1990', '01\\01\\1990', '1\\1\\1990',
+      '1990/01/01', '1990-01-01', '1990-1-1', '1990/1/1', '1990\\1\\1', '1990\\01\\01',
+      '19900101'
+    ]
+
+    // Use a for loop to create all the possible string date combinations
+    var months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December',
+      'Jan', 'Feb', 'Mar', 'Apr', 'Jun', 'Jul', 'Aug', 'Sep', 'Sept', 'Oct', 'Nov', 'Dec']
+
+    for (var i = 0; i < months.length; i++) {
+      var month = months[i]
+      var monthVariations = [month, month.toLowerCase(), month.toUpperCase()] // Test multiple character case types e.g. 'January', 'JANUARY, 'january'
+
+      for (var j = 0; j < monthVariations; j++) {
+        var monthVariation = monthVariations[j]
+        dates.push('1st of ' + monthVariation + ' 1990')
+        dates.push('1st ' + monthVariation + ' 1990')
+        dates.push('1 ' + monthVariation + ' 1990')
+        dates.push('1 of ' + monthVariation + ' 1990')
+        dates.push('2nd of ' + monthVariation + ' 1990')
+        dates.push('2nd ' + monthVariation + ' 1990')
+        dates.push('3rd of ' + monthVariation + ' 1990')
+        dates.push('3rd ' + monthVariation + ' 1990')
+        dates.push('4th of ' + monthVariation + ' 1990')
+        dates.push('4th ' + monthVariation + ' 1990')
+        dates.push('10th of ' + monthVariation + ' 1990')
+        dates.push('10th ' + monthVariation + ' 1990')
+        dates.push('10 of ' + monthVariation + ' 1990')
+        dates.push('25th of ' + monthVariation + ' 90')
+        dates.push('25th of ' + monthVariation + " '90")
+
+        dates.push(monthVariation + ' 1st 1990')
+        dates.push(monthVariation + ' 2nd 1990')
+        dates.push(monthVariation + ' 3rd 1990')
+        dates.push(monthVariation + ' 4th 1990')
+        dates.push(monthVariation + ' 10th 1990')
+        dates.push(monthVariation + ' 1 1990')
+        dates.push(monthVariation + ' 10 1990')
+        dates.push(monthVariation + ' 10 90')
+        dates.push(monthVariation + " 10 '90")
+      }
+    }
+
+    for (i = 0; i < dates.length; i++) {
+      var date = dates[i]
+      var string = pii.stripPIIWithOverride(date, true, true)
+      expect(string).toEqual('[date]')
+    }
+  })
+
   function resetHead () {
     $('head').find('meta[name="govuk:static-analytics:strip-postcodes"]').remove()
     $('head').find('meta[name="govuk:static-analytics:strip-dates"]').remove()


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- There is some regex to remove dates from GA4 data in our PII remover
- This was taken from the UA PII remover
- The date regex was not very comprehensive, it only matched:
    - Dates exactly like '1 January 1990'
    - Dates exactly like '1990-01-01'
    - 8 numbers in a row (i'm assuming to catch things like 01012000 - and I believe this is causing false positives for PAs)
- The new regex can match:
    - 01/01/1990
    - 01-01-1990
    - 1-1-1990
    - 1/1/1990
    - 01\01\1990
    - 1\1\1990
    - 1990/01/01
    - 1990-01-01
    - 1990-1-1
    - 1990/1/1
    - 1990\1\1
    - 1990\01\01
    - Dates like: 1st of January 1990 (or 90 or '90),  25th of May 2005 (or 05 or '05)
    - Dates like: 1st January 1990 (or 90 or '90), 25th October 2005 (or 05 or '05)
    - Dates like: 1 January 1990 (or 90 or '90), 25 October 2005 (or 05 or '05)
    - Dates like: 1 Jan 1990 (or 90 or '90), 25 Oct 2005 (or 05 or '05)
    - Dates like: 1st Jan 1990 (or 90 or '90), 25th Oct 2005 (or 05 or '05)
    - Dates like: 1st of Jan 1990 (or 90 or '90), 25th of Oct 2005 (or 05 or '05)
    - 8 numbers in a row, e.g. 25122023

- We are going to keep the old '8 numbers in a row' pattern, but there is discussion that this that may have been too strict of a pattern, and begs the question of why 6 numbers in a row wasn't matched for dates like `251223` (25th December 2023.) This will be discussed with the PAs.

## Why
<!-- What are the reasons behind this change being made? -->
- We should reduce PII to the best of our ability - of course there are ways this can slip through, for example if someone wrote `I was born on the twenty fifth of January, on a cold Friday, in 1968` it's not going to be redacted
- https://trello.com/c/l8PbQXOZ/565-improve-pii-date-removal
- Note there are three separate numeric regexes, as trying to combine them into one leads to false positives (and extra complexity reading the regex)

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
