### PR TITLE
Metadata component inverse option remove background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Metadata component inverse option remove background ([PR #3711](https://github.com/alphagov/govuk_publishing_components/pull/3711))
+
 ## 35.21.3
 
 * GA4 auto tracker add PII redaction ([PR #3707](https://github.com/alphagov/govuk_publishing_components/pull/3707))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_metadata.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_metadata.scss
@@ -23,7 +23,6 @@
 }
 
 .gem-c-metadata--inverse {
-  background-color: govuk-colour("blue");
   color: govuk-colour("white");
 
   a {

--- a/app/views/govuk_publishing_components/components/docs/metadata.yml
+++ b/app/views/govuk_publishing_components/components/docs/metadata.yml
@@ -355,6 +355,8 @@ examples:
       see_updates_link: true
       other:
         Applies to: England, Scotland, and Wales (see detailed guidance for <a href="http://www.dardni.gov.uk/news-dard-pa022-a-13-new-procedure-for" rel="external">Northern Ireland</a>)
+    context:
+      dark_background: true
   on_a_dark_background_without_padding:
     description: By default the inverse option includes extra spacing around the component. This option removes this padding. Note that both the `inverse` and `inverse_compress` options must be supplied.
     data:
@@ -375,6 +377,8 @@ examples:
       see_updates_link: true
       other:
         Applies to: England, Scotland, and Wales (see detailed guidance for <a href="http://www.dardni.gov.uk/news-dard-pa022-a-13-new-procedure-for" rel="external">Northern Ireland</a>)
+    context:
+      dark_background: true
   with_custom_margin_bottom:
     description: |
       The component accepts a number for margin bottom from `0` to `9` (`0px` to `60px`) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to the `margin-bottom` values defined in the [responsive-bottom-margin mixin](https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/stylesheets/govuk_publishing_components/components/mixins/_margins.scss#L1)


### PR DESCRIPTION
## What
- the metadata component has an inverse option, which includes a background colour of dark blue
- it isn't always used on a dark blue background, for example here it is used against a green background and therefore looks wrong: [Air Passenger Duty](https://www.gov.uk/hmrc-internal-manuals/air-passenger-duty/updates)
- removing the background to prevent this problem

## Why
I made a [change recently](https://github.com/alphagov/government-frontend/pull/2975/commits/a846908d0cb471f284dbf9f3b186b898bb583e06) to make `government-frontend` comply with our [component principles](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/component_principles.md#a-component-is-isolated-when) better. This involved removing some style overrides on the metadata component. The focus of that work was on the padding around the element, but it turns out that it was also removing the background on the component for some pages where it appears on a green background.

The problem here is that for an inverse option a component shouldn't have a background colour set at all, otherwise we'd end up with either multiple inverse options with different background colours (hard to maintain and anticipate) or style overrides within applications (breaking our component principles). Instead we set no background on the component and use the `context` `dark_background: true` option in the component guide to simulate being on a dark background.

## Visual Changes
Weirdly this change does involve a visual change as for some reason the `dark_background` option in the component guide includes its own padding - so now the inverse option in the guide appears doubly padded. However this is only a difference in the guide.

Before | After
------ | ------
![Screenshot 2023-11-13 at 11 13 31](https://github.com/alphagov/govuk_publishing_components/assets/861310/49556757-1e27-4754-a443-10a2428cb584) | ![Screenshot 2023-11-13 at 11 13 42](https://github.com/alphagov/govuk_publishing_components/assets/861310/d7e5c9cc-c46f-401b-92c6-49d39a606ed4)

Testing it locally in `government-frontend` and it looks to have fixed the problem.

Before | After
------ | ------
![Screenshot 2023-11-13 at 11 18 30](https://github.com/alphagov/govuk_publishing_components/assets/861310/ea095b2a-1508-462f-993d-eda151f61e9c) | ![Screenshot 2023-11-13 at 11 18 39](https://github.com/alphagov/govuk_publishing_components/assets/861310/08efa0bc-db00-44ba-a922-f88abce288fa)

For completeness, I've also checked every other place where the metadata component is used, to make sure where it is on a dark background that it still appears correctly.


collections (2)

- [app/views/subtopics/_subtopic.html.erb](https://github.com/alphagov/collections/blob/main/app/views/subtopics/_subtopic.html.erb#L10) - not inverse
- [app/views/topical_events/show.html.erb](https://github.com/alphagov/collections/blob/main/app/views/topical_events/show.html.erb#L52) - not inverse

collections-publisher (2)

- [app/views/coronavirus/pages/show.html.erb](https://github.com/alphagov/collections-publisher/blob/main/app/views/coronavirus/pages/show.html.erb#L30) - not inverse
- [app/views/step_by_step_pages/show.html.erb](https://github.com/alphagov/collections-publisher/blob/main/app/views/step_by_step_pages/show.html.erb#L88) - not inverse

finder-frontend (1)

- [app/views/finders/_show_header.html.erb](https://github.com/alphagov/finder-frontend/blob/main/app/views/finders/_show_header.html.erb#L61) - uses inverse, checked and is fine (see below for details)

government-frontend (5)

- [app/views/content_items/manuals/_header.html.erb](https://github.com/alphagov/government-frontend/blob/main/app/views/content_items/manuals/_header.html.erb#L29) - this is the page this fix is for, checked and is fine
- [app/views/content_items/service_manual_guide.html.erb](https://github.com/alphagov/government-frontend/blob/main/app/views/content_items/service_manual_guide.html.erb#L46) - two instances, neither inverse
- [app/views/shared/_publisher_metadata_with_logo.html.erb](https://github.com/alphagov/government-frontend/blob/main/app/views/shared/_publisher_metadata_with_logo.html.erb#L8) - not sure which page this renders on, but have checked options and not inverse
- [app/views/shared/_travel_advice_first_part.html.erb](https://github.com/alphagov/government-frontend/blob/main/app/views/shared/_travel_advice_first_part.html.erb#L1) - not inverse

travel-advice-publisher (1)

- [app/views/admin/editions/_country_summary.html.erb](https://github.com/alphagov/travel-advice-publisher/blob/main/app/views/admin/editions/_country_summary.html.erb#L5) - not inverse

### Finder-frontend
Writing this down in case anyone finds it useful. Finders have an 'inverse' option on them, which [happens on some finders](https://github.com/alphagov/finder-frontend/blob/main/app/views/finders/show.html.erb#L15-L25), but I've yet to find a live example of this. You can test it by changing the two lines I've linked to above to `if true` and looking at any finder. It looks a bit broken (which is why I suspect it isn't in use) but at least the metadata component appears correctly still. This was previously explored in [this change](https://github.com/alphagov/finder-frontend/pull/3193).

![Screenshot 2023-11-13 at 11 33 23](https://github.com/alphagov/govuk_publishing_components/assets/861310/ac94b06a-a8ad-45b8-87a3-588005efe776)
