### PR TITLE
Version 35.21.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 35.21.4
 
 * Metadata component inverse option remove background ([PR #3711](https://github.com/alphagov/govuk_publishing_components/pull/3711))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (35.21.3)
+    govuk_publishing_components (35.21.4)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "35.21.3".freeze
+  VERSION = "35.21.4".freeze
 end


### PR DESCRIPTION
## 35.21.4

* Metadata component inverse option remove background ([PR #3711](https://github.com/alphagov/govuk_publishing_components/pull/3711))
