### PR TITLE
Add checking what components use govuk-frontend to components audit

### DIFF
--- a/app/models/govuk_publishing_components/audit_comparer.rb
+++ b/app/models/govuk_publishing_components/audit_comparer.rb
@@ -277,6 +277,7 @@ module GovukPublishingComponents
 
         results << {
           name: component_name,
+          govuk_frontend: component[:uses_govuk_frontend],
           count: locations.length,
           locations:,
         }

--- a/app/models/govuk_publishing_components/audit_components.rb
+++ b/app/models/govuk_publishing_components/audit_components.rb
@@ -118,6 +118,11 @@ module GovukPublishingComponents
         else
           @component_numbers[type.to_sym] += 1
           details["#{type}_exists".to_sym] = true
+
+          if type == "javascript" && uses_govuk_frontend?(file)
+            details[:uses_govuk_frontend] = true
+          end
+
           details["#{type}_lines".to_sym] = count_lines_in(file)
           details["#{type}_link".to_sym] = get_asset_link(type, component)
         end
@@ -128,6 +133,10 @@ module GovukPublishingComponents
 
     def count_lines_in(file)
       File.read(file).each_line.count
+    end
+
+    def uses_govuk_frontend?(file)
+      File.read(file).match(/require govuk\/components/)
     end
 
     def clean_files(files, replace)

--- a/app/views/govuk_publishing_components/audit/_items_in_applications.html.erb
+++ b/app/views/govuk_publishing_components/audit/_items_in_applications.html.erb
@@ -6,6 +6,9 @@
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">
               <%= item[:name] %> (<%= pluralize(item[:count], 'use') %>)
+              <% if item[:govuk_frontend] %>
+                <span class="govuk-tag">ES6 JS</span>
+              <% end %>
             </dt>
             <dd class="govuk-summary-list__value">
               <% item[:locations].each do |application| %>


### PR DESCRIPTION
## What

Adds checking to see what components use govuk-frontend to the components audit.

## Why

Implemented this to double check that I wasn't missing out any component JS when making changes to applications to support govuk-frontend v5. Thought it could be useful if this was a standard feature in the auditing, so I have opened this PR.

## Visual Changes

### Before

![Screenshot 2023-11-14 at 14 50 07](https://github.com/alphagov/govuk_publishing_components/assets/3727504/799e106c-9b49-4dfa-ac98-a13002e57d19)

### After

![Screenshot 2023-11-14 at 14 49 55](https://github.com/alphagov/govuk_publishing_components/assets/3727504/09afa0cf-80c9-4e72-be9d-5343b0a6f9d8)


