### PR TITLE
Change GA4 video tracking duration handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Change GA4 video tracking duration handling ([PR #3717](https://github.com/alphagov/govuk_publishing_components/pull/3717))
+
 ## 35.21.4
 
 * Metadata component inverse option remove background ([PR #3711](https://github.com/alphagov/govuk_publishing_components/pull/3711))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-video-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-video-tracker.js
@@ -13,7 +13,7 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
     configureVideo: function (event) {
       var player = event.target
       var videoId = player.id
-      var duration = player.getDuration()
+      var duration = Math.ceil(player.getDuration())
       var percentages = [25, 50, 75]
 
       for (var i = 0; i < percentages.length; i++) {
@@ -23,6 +23,10 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
         // interval is once a second, so end point must be at least one second beyond begin point
         this.handlers['video-' + videoId + '-' + percent + '-percent-end'] = position + 2
       }
+      // store all these values otherwise we have to get them for every event
+      this.handlers['video-' + videoId + '-duration'] = duration // store initially, as number returned from API varies
+      this.handlers['video-' + videoId + '-title'] = player.videoTitle
+      this.handlers['video-' + videoId + '-url'] = this.cleanVideoUrl(player.getVideoUrl())
     },
 
     trackVideo: function (event, state) {
@@ -68,13 +72,13 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
 
     sendData: function (player, event, position) {
       var data = {}
+      data.action = event
       data.event_name = 'video_' + event
       data.type = 'video'
-      data.url = this.cleanVideoUrl(player.getVideoUrl())
-      data.text = player.videoTitle
-      data.action = event
+      data.url = this.handlers['video-' + player.id + '-url']
+      data.text = this.handlers['video-' + player.id + '-title']
       data.video_current_time = Math.round(player.getCurrentTime())
-      data.video_duration = Math.ceil(player.getDuration()) // number returned from the API varies, so round up
+      data.video_duration = this.handlers['video-' + player.id + '-duration']
       data.video_percent = position
 
       var schemas = new window.GOVUK.analyticsGa4.Schemas()

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-video-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-video-tracker.spec.js
@@ -12,6 +12,7 @@ describe('Google Analytics video tracker', function () {
     event = {
       target: {
         id: 1,
+        videoTitle: 'An example video',
         getCurrentTime: function () {
           return 0
         },
@@ -32,7 +33,10 @@ describe('Google Analytics video tracker', function () {
       'video-1-50-percent-begin': 250,
       'video-1-50-percent-end': 252,
       'video-1-75-percent-begin': 375,
-      'video-1-75-percent-end': 377
+      'video-1-75-percent-end': 377,
+      'video-1-duration': 500,
+      'video-1-title': 'An example video',
+      'video-1-url': 'https://www.youtube.com/watch?v=abcdef'
     }
     videoTracker.configureVideo(event)
     expect(videoTracker.handlers).toEqual(expectedHandlers)
@@ -44,6 +48,7 @@ describe('Google Analytics video tracker', function () {
       expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
       expected.event = 'event_data'
       expected.event_data.type = 'video'
+      expected.event_data.text = 'An example video'
       expected.event_data.url = 'https://www.youtube.com/watch?v=abcdef'
       expected.event_data.video_duration = 500
       expected.govuk_gem_version = 'aVersion'
@@ -74,10 +79,10 @@ describe('Google Analytics video tracker', function () {
 
   describe('cleans urls', function () {
     beforeEach(function () {
-      videoTracker.configureVideo(event)
       expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
       expected.event = 'event_data'
       expected.event_data.type = 'video'
+      expected.event_data.text = 'An example video'
       expected.event_data.url = 'https://www.youtube.com/watch?v=abcdef'
       expected.event_data.video_duration = 500
       expected.govuk_gem_version = 'aVersion'
@@ -91,24 +96,29 @@ describe('Google Analytics video tracker', function () {
       event.target.getVideoUrl = function () {
         return 'https://www.youtube.com/watch?t=26&v=abcdef'
       }
+      videoTracker.configureVideo(event)
       videoTracker.trackVideo(event, 'VideoUnstarted')
       expect(window.dataLayer[0]).toEqual(expected)
     })
 
-    it('with a time not as the first parameter', function () {
+    it('with a time as the second parameter', function () {
       event.target.getVideoUrl = function () {
         return 'https://www.youtube.com/watch?v=abcdef&t=03434'
       }
+      videoTracker.configureVideo(event)
       expected.event_data.url = 'https://www.youtube.com/watch?v=abcdef'
       videoTracker.trackVideo(event, 'VideoUnstarted')
       expect(window.dataLayer[0]).toEqual(expected)
+    })
 
+    it('with another random parameter', function () {
       event.target.getVideoUrl = function () {
         return 'https://www.youtube.com/watch?v=abcdef&t=03434&test=test'
       }
+      videoTracker.configureVideo(event)
       expected.event_data.url = 'https://www.youtube.com/watch?v=abcdef&test=test'
       videoTracker.trackVideo(event, 'VideoUnstarted')
-      expect(window.dataLayer[1]).toEqual(expected)
+      expect(window.dataLayer[0]).toEqual(expected)
     })
   })
 
@@ -149,6 +159,7 @@ describe('Google Analytics video tracker', function () {
       expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
       expected.event = 'event_data'
       expected.event_data.type = 'video'
+      expected.event_data.text = 'An example video'
       expected.event_data.url = 'https://www.youtube.com/watch?v=abcdef'
       expected.event_data.video_duration = 500
       expected.event_data.event_name = 'video_progress'
@@ -219,11 +230,12 @@ describe('Google Analytics video tracker', function () {
     var event2 = {
       target: {
         id: 2,
+        videoTitle: 'Another example video',
         getCurrentTime: function () {
           return 0
         },
         getVideoUrl: function () {
-          return 'https://www.youtube.com/watch?t=26&v=abcdef'
+          return 'https://www.youtube.com/watch?t=26&v=xyz'
         },
         getDuration: function () {
           return 1000
@@ -252,12 +264,18 @@ describe('Google Analytics video tracker', function () {
         'video-1-50-percent-end': 252,
         'video-1-75-percent-begin': 375,
         'video-1-75-percent-end': 377,
+        'video-1-duration': 500,
+        'video-1-title': 'An example video',
+        'video-1-url': 'https://www.youtube.com/watch?v=abcdef',
         'video-2-25-percent-begin': 250,
         'video-2-25-percent-end': 252,
         'video-2-50-percent-begin': 500,
         'video-2-50-percent-end': 502,
         'video-2-75-percent-begin': 750,
-        'video-2-75-percent-end': 752
+        'video-2-75-percent-end': 752,
+        'video-2-duration': 1000,
+        'video-2-title': 'Another example video',
+        'video-2-url': 'https://www.youtube.com/watch?v=xyz'
       }
       expect(videoTracker.handlers).toEqual(expectedHandlers)
     })


### PR DESCRIPTION
## What / why
- for some reason we're getting differing numbers back from the YouTube API when requesting video durations
- solution is to just ask for it once, then store it along with the percentage positions calculated when videos are loading
- in terms of efficiency, it's also therefore sensible to get and store the video title and URL at the start as well, instead of requesting them each time an event fires during playback

## Visual Changes
None.

Trello card: https://trello.com/c/Zj359UYH/727-fix-video-duration-rounding-issue
