### PR TITLE
Add alt/option click tracking to GA4 link tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Implement One Login "cross service header" ([PR #3659](https://github.com/alphagov/govuk_publishing_components/pull/3659))
+* Add alt/option click tracking to GA4 link tracker ([PR #3720](https://github.com/alphagov/govuk_publishing_components/pull/3720))
 
 ## 35.22.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -135,6 +135,8 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
               return 'command/win click'
             } else if (event.shiftKey) {
               return 'shift click'
+            } else if (event.altKey) {
+              return 'alt/option click'
             } else {
               return 'primary click'
             }

--- a/docs/analytics-ga4/ga4-specialist-link-tracker.md
+++ b/docs/analytics-ga4/ga4-specialist-link-tracker.md
@@ -111,3 +111,4 @@ For `method`:
 - Meta key clicks are `command/win click`
 - Shift key clicks are `shift click`
 - Control clicks are `ctrl click`
+- Alt clicks are `alt/option click`

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
@@ -209,6 +209,92 @@ describe('GA4 link tracker', function () {
     })
   })
 
+  describe('different types of clicks', function () {
+    beforeEach(function () {
+      attributes = {
+        event_name: 'navigation',
+        type: 'a link',
+        index_link: 1
+      }
+      expected.event = 'event_data'
+      expected.event_data.type = 'a link'
+      expected.event_data.external = 'false'
+      expected.event_data.index = {
+        index_link: 1,
+        index_section: undefined,
+        index_section_count: undefined
+      }
+      var link = '#aNormalLink'
+      element = document.createElement('a')
+      element.setAttribute('data-ga4-link', JSON.stringify(attributes))
+      element.setAttribute('href', link)
+      var linkText = 'A normal link'
+      element.textContent = linkText
+      expected.event_data.text = linkText
+      expected.event_data.url = link
+      expected.event_data.link_path_parts['1'] = link
+    })
+
+    it('tracks primary clicks on a single link', function () {
+      expected.event_data.method = 'primary click'
+      initModule(element, true)
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+
+    it('tracks ctrl clicks on a single link', function () {
+      expected.event_data.method = 'ctrl click'
+      initModule(element, false)
+      var clickEvent = new window.CustomEvent('click', { cancelable: true, bubbles: true })
+      clickEvent.ctrlKey = true
+      element.dispatchEvent(clickEvent)
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+
+    it('tracks shift clicks on a single link', function () {
+      expected.event_data.method = 'shift click'
+      initModule(element, false)
+      var clickEvent = new window.CustomEvent('click', { cancelable: true, bubbles: true })
+      clickEvent.shiftKey = true
+      element.dispatchEvent(clickEvent)
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+
+    it('tracks alt/option clicks on a single link', function () {
+      expected.event_data.method = 'alt/option click'
+      initModule(element, false)
+      var clickEvent = new window.CustomEvent('click', { cancelable: true, bubbles: true })
+      clickEvent.altKey = true
+      element.dispatchEvent(clickEvent)
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+
+    it('tracks command/win clicks on a single link', function () {
+      expected.event_data.method = 'command/win click'
+      initModule(element, false)
+      var clickEvent = new window.CustomEvent('click', { cancelable: true, bubbles: true })
+      clickEvent.metaKey = true
+      element.dispatchEvent(clickEvent)
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+
+    it('tracks middle mouse clicks on a single link', function () {
+      expected.event_data.method = 'middle click'
+      initModule(element, false)
+      var clickEvent = new window.CustomEvent('mousedown', { cancelable: true, bubbles: true })
+      clickEvent.button = 1
+      element.dispatchEvent(clickEvent)
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+
+    it('tracks right clicks on a single link', function () {
+      expected.event_data.method = 'secondary click'
+      initModule(element, false)
+      var clickEvent = new window.CustomEvent('contextmenu', { cancelable: true, bubbles: true })
+      element.dispatchEvent(clickEvent)
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+  })
+
   describe('when the track links only feature is enabled', function () {
     beforeEach(function () {
       attributes = {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.spec.js
@@ -280,6 +280,25 @@ describe('A specialist link tracker', function () {
       }
     })
 
+    it('detects alt/option click events on external links', function () {
+      var linksToTest = document.querySelectorAll('.fully-structured-external-links a')
+
+      for (var i = 0; i < linksToTest.length; i++) {
+        window.dataLayer = []
+        var link = linksToTest[i]
+        var clickEvent = new window.CustomEvent('click', { cancelable: true, bubbles: true })
+        clickEvent.altKey = true
+        link.dispatchEvent(clickEvent)
+        expected.event_data.link_domain = link.getAttribute('link_domain')
+        expected.event_data.url = link.getAttribute('href')
+        expected.event_data.text = link.innerText.trim()
+        expected.event_data.method = 'alt/option click'
+        var linkPath = link.getAttribute('path')
+        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
+        expect(window.dataLayer[0]).toEqual(expected)
+      }
+    })
+
     it('ignores links that are already being tracked by the other link tracker', function () {
       links.querySelector('.alreadytracked').click()
       expect(window.dataLayer).toEqual([])


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- When the `alt` or `option` key were held down while a link was clicked, it was being tracked as a `primary click`.
- This PR changes that, so that the click is tracked as an `alt/option` click.

## Why
<!-- What are the reasons behind this change being made? -->
https://trello.com/c/36r3mAUe/734-option-clicks-currently-coming-through-with-method-primary-click-switch-to-option-click

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.