### PR TITLE
Version 35.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 35.23.0
 
 * Implement One Login "cross service header" ([PR #3659](https://github.com/alphagov/govuk_publishing_components/pull/3659))
 * Add alt/option click tracking to GA4 link tracker ([PR #3720](https://github.com/alphagov/govuk_publishing_components/pull/3720))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (35.22.0)
+    govuk_publishing_components (35.23.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "35.22.0".freeze
+  VERSION = "35.23.0".freeze
 end


### PR DESCRIPTION
* Implement One Login "cross service header" ([PR #3659](https://github.com/alphagov/govuk_publishing_components/pull/3659))
* Add alt/option click tracking to GA4 link tracker ([PR #3720](https://github.com/alphagov/govuk_publishing_components/pull/3720))