### PR TITLE
Make data-ga4-set-indexes ignore links with no href

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Make data-ga4-set-indexes ignore links with no href ([PR #3723](https://github.com/alphagov/govuk_publishing_components/pull/3723))
+
 ## 35.23.0
 
 * Implement One Login "cross service header" ([PR #3659](https://github.com/alphagov/govuk_publishing_components/pull/3659))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -261,8 +261,8 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
         var totalLinks = 0
         for (var i = 0; i < links.length; i++) {
           var link = links[i]
-          // Only index links that are not search results or do not have a data-ga4-do-not-index attribute
-          if (link.getAttribute('data-ga4-ecommerce-path') || link.getAttribute('data-ga4-do-not-index') !== null) {
+          // Ignore links that don't have a href, have a data-ga4-do-not-index attribute on them, or are search result links.
+          if (!link.getAttribute('href') || link.getAttribute('data-ga4-ecommerce-path') || link.getAttribute('data-ga4-do-not-index') !== null) {
             continue
           }
           totalLinks++

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
@@ -362,6 +362,37 @@ describe('GA4 core', function () {
         data = JSON.parse(module.getAttribute('data-ga4-link'))
         expect(data.index_total).toEqual(9000)
       })
+
+      it('ignores links without a href', function () {
+        module = document.createElement('div')
+        module.setAttribute('data-ga4-link', '{"someData": "blah"}')
+        module.innerHTML = '<a id="example1" href="www.example1.com">Example link 1</a>' +
+        '<a id="example2" href="www.example2.com">Example link 2</a>' +
+        '<a id="example3" href="">Example link 3</a>' +
+        '<a id="example4" href="www.example4.com">Example link 4</a>' +
+        '<a id="example5">Example link 5</a>'
+
+        window.dataLayer = []
+        document.body.appendChild(module)
+        GOVUK.analyticsGa4.core.trackFunctions.setIndexes(module)
+        var links = module.querySelectorAll('a')
+
+        // Manually track the indexes as there are two links which won't have an index, so we can't use the loop's i variable to check the indexes are correct.
+        var index = 0
+
+        for (var i = 0; i < links.length; i++) {
+          var linkIndexAttribute = links[i].getAttribute('data-ga4-index')
+
+          // The links with no href should have no data-ga4-index attribute
+          if (i === 2 || i === 4) {
+            expect(linkIndexAttribute).toEqual(null)
+          } else {
+          // Increment the index as the following link should have the data-ga4-index-attribute
+            index++
+            expect(linkIndexAttribute).toEqual('{"index_link": ' + (index) + '}')
+          }
+        }
+      })
     })
 
     describe('when the data-ga4-set-indexes attribute exists on a module that contains search results or links with a data-ga4-do-not-index attribute', function () {


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
Make data-ga4-set-indexes ignore links with no href

## Why
<!-- What are the reasons behind this change being made? -->
- Prevents future issues if invalid links are introduced into the HTML
- https://trello.com/c/UlhiLIok/732-update-index-code-to-count-links-if-they-also-have-href-or-text-values

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.