### PR TITLE
Consolidate GA4 schema calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Consolidate GA4 schema calls ([PR #3725](https://github.com/alphagov/govuk_publishing_components/pull/3725))
 * Make data-ga4-set-indexes ignore links with no href ([PR #3723](https://github.com/alphagov/govuk_publishing_components/pull/3723))
 
 ## 35.23.0

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-auto-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-auto-tracker.js
@@ -35,12 +35,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         console.error('GA4 configuration error: ' + e.message, window.location)
         return
       }
-
       data.text = this.PIIRemover.stripPIIWithOverride(data.text, true, true)
-      var schemas = new window.GOVUK.analyticsGa4.Schemas()
-      var schema = schemas.mergeProperties(data, 'event_data')
-
-      window.GOVUK.analyticsGa4.core.sendData(schema)
+      window.GOVUK.analyticsGa4.core.applySchemaAndSendData(data, 'event_data')
     }
   }
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -49,6 +49,12 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
       window.dataLayer.push(data)
     },
 
+    applySchemaAndSendData: function (data, name) {
+      var schemas = new window.GOVUK.analyticsGa4.Schemas()
+      var schema = schemas.mergeProperties(data, name)
+      this.sendData(schema)
+    },
+
     getGemVersion: function () {
       return window.GOVUK.analyticsGa4.vars.gem_version || 'not found'
     },

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.js
@@ -43,9 +43,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       var text = data.text || event.target.textContent
       data.text = window.GOVUK.analyticsGa4.core.trackFunctions.removeLinesAndExtraSpaces(text)
 
-      var schemas = new window.GOVUK.analyticsGa4.Schemas()
-      var schema = schemas.mergeProperties(data, 'event_data')
-
       /* Ensure it only tracks aria-expanded in an element with data-ga4-expandable on it. */
       if (target.closest('[data-ga4-expandable]')) {
         var ariaExpanded = this.getClosestAttribute(target, 'aria-expanded')
@@ -59,12 +56,12 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       var detailsElement = target.closest('details')
 
       if (ariaExpanded) {
-        schema.event_data.text = data.text || target.innerText
-        schema.event_data.action = (ariaExpanded === 'false') ? 'opened' : 'closed'
+        data.text = data.text || target.innerText
+        data.action = (ariaExpanded === 'false') ? 'opened' : 'closed'
       } else if (detailsElement) {
-        schema.event_data.text = data.text || detailsElement.textContent
+        data.text = data.text || detailsElement.textContent
         var openAttribute = detailsElement.getAttribute('open')
-        schema.event_data.action = (openAttribute == null) ? 'opened' : 'closed'
+        data.action = (openAttribute == null) ? 'opened' : 'closed'
       }
 
       /* If a tab was clicked, grab the href of the clicked tab (usually an anchor # link) */
@@ -74,12 +71,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         if (aTag) {
           var href = aTag.getAttribute('href')
           if (href) {
-            schema.event_data.url = window.GOVUK.analyticsGa4.core.trackFunctions.appendPathToAnchorLinks(href)
+            data.url = window.GOVUK.analyticsGa4.core.trackFunctions.appendPathToAnchorLinks(href)
           }
         }
       }
-
-      window.GOVUK.analyticsGa4.core.sendData(schema)
+      window.GOVUK.analyticsGa4.core.applySchemaAndSendData(data, 'event_data')
     }
   }
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
@@ -50,10 +50,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         data.text = data.text.toLowerCase()
         data.text = window.GOVUK.analyticsGa4.core.trackFunctions.removeLinesAndExtraSpaces(data.text)
       }
-
-      var schemas = new window.GOVUK.analyticsGa4.Schemas()
-      var schema = schemas.mergeProperties(data, 'event_data')
-      window.GOVUK.analyticsGa4.core.sendData(schema)
+      window.GOVUK.analyticsGa4.core.applySchemaAndSendData(data, 'event_data')
     }
   }
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
@@ -106,10 +106,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       if (data.type === 'smart answer' && data.action === 'change response') {
         data.section = this.PIIRemover.stripPIIWithOverride(data.section, true, true)
       }
-
-      var schemas = new window.GOVUK.analyticsGa4.Schemas()
-      var schema = schemas.mergeProperties(data, 'event_data')
-      window.GOVUK.analyticsGa4.core.sendData(schema)
+      window.GOVUK.analyticsGa4.core.applySchemaAndSendData(data, 'event_data')
     }
   }
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-print-intent-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-print-intent-tracker.js
@@ -13,9 +13,7 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
           type: 'print page',
           method: 'browser print'
         }
-        var schema = new window.GOVUK.analyticsGa4.Schemas()
-        schema = schema.mergeProperties(data, 'event_data')
-        window.GOVUK.analyticsGa4.core.sendData(schema)
+        window.GOVUK.analyticsGa4.core.applySchemaAndSendData(data, 'event_data')
       })
     }
   }

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.js
@@ -123,9 +123,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         // following will be undefined if tracking headings
         data.percent_scrolled = node.eventData.percent_scrolled
 
-        var schemas = new window.GOVUK.analyticsGa4.Schemas()
-        var schema = schemas.mergeProperties(data, 'event_data')
-        window.GOVUK.analyticsGa4.core.sendData(schema)
+        window.GOVUK.analyticsGa4.core.applySchemaAndSendData(data, 'event_data')
       }
     }
   }

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.js
@@ -81,10 +81,7 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
           data.text = 'image'
         }
         data.method = window.GOVUK.analyticsGa4.core.trackFunctions.getClickType(event)
-
-        var schemas = new window.GOVUK.analyticsGa4.Schemas()
-        var schema = schemas.mergeProperties(data, 'event_data')
-        window.GOVUK.analyticsGa4.core.sendData(schema)
+        window.GOVUK.analyticsGa4.core.applySchemaAndSendData(data, 'event_data')
       }
     },
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-video-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-video-tracker.js
@@ -81,10 +81,7 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
       data.video_duration = this.handlers['video-' + player.id + '-duration']
       data.video_percent = position
 
-      var schemas = new window.GOVUK.analyticsGa4.Schemas()
-      var schema = schemas.mergeProperties(data, 'event_data')
-
-      window.GOVUK.analyticsGa4.core.sendData(schema)
+      window.GOVUK.analyticsGa4.core.applySchemaAndSendData(data, 'event_data')
     },
 
     cleanVideoUrl: function (url) {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
@@ -378,7 +378,6 @@ describe('GA4 core', function () {
       })
 
       it('ignores links without a href', function () {
-        module = document.createElement('div')
         module.setAttribute('data-ga4-link', '{"someData": "blah"}')
         module.innerHTML = '<a id="example1" href="www.example1.com">Example link 1</a>' +
         '<a id="example2" href="www.example2.com">Example link 2</a>' +
@@ -386,8 +385,6 @@ describe('GA4 core', function () {
         '<a id="example4" href="www.example4.com">Example link 4</a>' +
         '<a id="example5">Example link 5</a>'
 
-        window.dataLayer = []
-        document.body.appendChild(module)
         GOVUK.analyticsGa4.core.trackFunctions.setIndexes(module)
         var links = module.querySelectorAll('a')
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
@@ -15,6 +15,7 @@ describe('GA4 core', function () {
     window.GOVUK.analyticsGa4.vars.id = undefined
     window.GOVUK.analyticsGa4.vars.auth = undefined
     window.GOVUK.analyticsGa4.vars.preview = undefined
+    spyOn(GOVUK.analyticsGa4.core, 'getGemVersion').and.returnValue('aVersion')
   })
 
   afterEach(function () {
@@ -60,7 +61,6 @@ describe('GA4 core', function () {
     var data = {
       hello: 'I must be going'
     }
-    spyOn(GOVUK.analyticsGa4.core, 'getGemVersion').and.returnValue('aVersion')
     GOVUK.analyticsGa4.core.sendData(data)
     expect(window.dataLayer[0]).toEqual({
       hello: 'I must be going',
@@ -91,6 +91,20 @@ describe('GA4 core', function () {
       q: 'q_data'
     }
     expect(GOVUK.analyticsGa4.core.sortEventData(data)).toEqual(expected)
+  })
+
+  it('uses the schema to control data sent to the dataLayer', function () {
+    var data = {
+      index_link: 3,
+      not_a_property: '1'
+    }
+    var schemas = new window.GOVUK.analyticsGa4.Schemas()
+    var expected = schemas.mergeProperties(data, 'test')
+    expected.govuk_gem_version = 'aVersion'
+    expected.event_data.index.index_link = 3
+
+    GOVUK.analyticsGa4.core.applySchemaAndSendData(data, 'test')
+    expect(window.dataLayer[0]).toEqual(expected)
   })
 
   describe('link tracking functions', function () {


### PR DESCRIPTION
## What

- creates new function in core code 'applySchemaAndSendData', which de-duplicates calls to the schema generation code in trackers
- leaves existing sendData function in place as not always used in this way

## Why
Optimising code.

## Visual Changes
None.

Trello card: https://trello.com/c/sI76EaNX/655-investigate-shortening-calls-to-schema-code
