### PR TITLE
Update GA4 docs

### DIFF
--- a/docs/analytics-ga4/analytics.md
+++ b/docs/analytics-ga4/analytics.md
@@ -78,6 +78,14 @@ While our aim is to keep the majority of the analytics code in `govuk_publishing
 
 - [finder-frontend](https://github.com/alphagov/finder-frontend/tree/main/docs/analytics-ga4)
 
+### Code in components
+
+Often tracking will need to be built into components, either using an [existing tracker](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-all-trackers.md) or some custom code, or a combination of both.
+
+Where component tracking needs additional data to be passed (for example `index` or `section` values to show where the component is on a page) this should be built into the component and the data required documented in the component guide.
+
+Where component tracking can be entirely self contained (i.e. nothing needs to be passed) tracking should be enabled by default, but a `disable_ga4` option should be included and documented to allow the tracking to be disabled if required. See the [tabs component](https://github.com/alphagov/govuk_publishing_components/blob/main/app/views/govuk_publishing_components/components/_tabs.html.erb#L11) for an example.
+
 ## Data schemas
 
 All of the data sent to GTM is based on a common schema.

--- a/docs/analytics-ga4/ga4-event-tracker.md
+++ b/docs/analytics-ga4/ga4-event-tracker.md
@@ -44,30 +44,12 @@ The value for `text` will be determined based on the text of the element, or a v
 
 ## Advanced use
 
-In some scenarios we use components that cannot be modified directly (i.e. unable to place the `data-ga4-event` attribute on the element as shown in the 'Basic use' section). In these cases, we attach the necessary data attributes for tracking by passing an argument containing our data attributes to the render method.
+Sometimes it isn't possible to use the event tracker as shown above as the requirements are more complicated. For example when tracking dynamic elements like the 'Show/hide all sections' links on accordions. In this situation tracking has to be built into the component itself.
 
-Many components already accept data attributes in this way (see the [component guide](https://components.publishing.service.gov.uk/component-guide) for examples) but some, like the accordion, are more complicated.
+This is because the element being tracked is created and updated dynamically using JavaScript, and the state of the element and the data to be recorded changes on interaction (i.e. whether it was opened or closed).
 
-### Overview
+This is further complicated as the JavaScript that creates this element is imported from `govuk-frontend` and therefore can't be modified directly. In order to get attributes onto this link, we have to do the following.
 
-To track clicks on the 'Show/hide all sections' accordion link, use the `ga4_tracking` option as shown.
-
-```erb
-<div data-module="ga4-event-tracker">
-  <%= render 'govuk_publishing_components/components/accordion', {
-    ga4_tracking: true,
-    items: []
-  } %>
-</div>
-```
-
-### Detailed guide
-
-In some situations we want to track dynamic elements like the 'Show/hide all sections' links on accordions. This is complicated by the element being created and updated dynamically using JavaScript and the need to track the state of the element when clicked (to record whether it was opened or closed).
-
-It is also complicated by the fact that the JavaScript that creates this element is imported from `govuk-frontend` and therefore can't be modified directly. In order to get attributes onto this link, we have to do the following.
-
-- Enable tracking for an accordion using the `ga4_tracking` option
 - the 'Show/hide all' link is created by `govuk-frontend` JavaScript
 - the accordion JavaScript checks for `ga4-event-tracker`
   - it adds `data-ga4-event` with the relevant GTM JSON to the 'Show/hide all' link

--- a/docs/analytics-ga4/ga4-link-tracker.md
+++ b/docs/analytics-ga4/ga4-link-tracker.md
@@ -98,14 +98,3 @@ To apply tracking to links within a specific element within part of a page, use 
   </div>
 </div>
 ```
-
-## Using the link tracker on components
-
-If a component needs the link tracker adding to it (rather than a single component instance being wrapped in it) make sure that it is possible to disable this tracking, in the event that this default tracking would collide with other tracking. Implement a `disable_ga4` option as shown below. See existing components for examples.
-
-```erb
-<%= render 'govuk_publishing_components/components/contextual_breadcrumbs', {
-  disable_ga4: true,
-  items: []
-} %>
-```

--- a/docs/analytics-ga4/ga4-link-tracker.md
+++ b/docs/analytics-ga4/ga4-link-tracker.md
@@ -101,11 +101,11 @@ To apply tracking to links within a specific element within part of a page, use 
 
 ## Using the link tracker on components
 
-Where possible, we should make link tracking optional for components in order to provide flexibility where different types of tracking might overlap. When adding the link tracker for links within a component (e.g. contextual breadcrumbs), implement a `ga4_tracking` option as shown:
+If a component needs the link tracker adding to it (rather than a single component instance being wrapped in it) make sure that it is possible to disable this tracking, in the event that this default tracking would collide with other tracking. Implement a `disable_ga4` option as shown below. See existing components for examples.
 
 ```erb
 <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', {
-  ga4_tracking: true,
+  disable_ga4: true,
   items: []
 } %>
 ```


### PR DESCRIPTION
## What
Updating some of our GA4 docs.

## Why
We changed our tracking from disabled by default to enabled by default on most components and I didn't update these docs.

Also adds some documentation around how to add tracking to components.

## Visual Changes
None.

Trello card: https://trello.com/c/Xwp7dgJN/294-tracking-auditing-tracking-by-default
