### PR TITLE
Fix GA4 debug

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -43,7 +43,13 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
       data.govuk_gem_version = this.getGemVersion()
       // set this in the console as a debugging aid
       if (window.GOVUK.analyticsGa4.showDebug) {
-        data.event_data = this.sortEventData(data.event_data)
+        if (data.event_data) {
+          data.event_data = this.sortEventData(data.event_data)
+        } else if (data.page_view) {
+          data.page_view = this.sortEventData(data.page_view)
+        } else if (data.search_results) {
+          data.search_results = this.sortEventData(data.search_results)
+        }
         console.info(JSON.stringify(data, null, ' '))
       }
       window.dataLayer.push(data)


### PR DESCRIPTION
## What / why
- we have a debugging aid built into our GA4 JS, activated by pasting `window.GOVUK.analyticsGa4.showDebug = true` into the console, which shows any events fired on the current page
- it works fine except on search results e.g. /search/news-and-communications
- because it previously assumed that the data object contained `event_data`, but for search results it might be `page_view` or `search_results` instead

## Visual Changes
None.
