### PR TITLE
[DO NOT MERGE] Add a test for the component wrapper's presence

### DIFF
--- a/docs/component-wrapper-helper.md
+++ b/docs/component-wrapper-helper.md
@@ -6,7 +6,7 @@ The component wrapper helper is designed to provide a standard way to wrap compo
 
 The helper can be added to a component by including the helper and replacing the component parent element as shown. Note that a `div` tag is only used as an example.
 
-```
+```Ruby
 <% component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns) %>
 
 <%= tag.div(**component_helper.all_attributes) do %>
@@ -16,8 +16,23 @@ The helper can be added to a component by including the helper and replacing the
 
 You must also add the following line to the component documentation YAML file, in order that these extra options are shown when viewing the component in the component guide.
 
-```
+```Ruby
 uses_component_wrapper_helper: true
+```
+
+Since the wrapper provides functionality and tests for various attributes, any existing tests that would now be duplicate can be removed (for example, if there is already a test for passing `data_attributes` to the parent element of the component).
+
+To test that the wrapper is installed and continues to be installed as expected, the following test can be added to the component. The minimum data required to make the component render will need to be added to `test_data`.
+
+```Ruby
+it "has the component wrapper installed correctly" do
+  test_data = {
+    component_wrapper_test: true,
+  }
+
+  render_component(test_data)
+  assert_select ".gem-c-nameofcomponent[data-componentwrappertest='component wrapper installed']"
+end
 ```
 
 ## Passing options
@@ -37,7 +52,7 @@ The helper checks that any passed `id` attribute is valid, specifically that it 
 
 The `data_attributes` and `aria` options must be Ruby hashes of the form that would normally be passed to the `tag` method. For example:
 
-```
+```Ruby
 <%= render "govuk_publishing_components/components/example", {
   data_attributes: {
     module: "example-module",
@@ -57,7 +72,7 @@ Classes can be passed to components. To prevent breaking [component isolation](h
 
 Any passed classes should be prefixed with `js-`. To allow for extending this option, classes prefixed with `gem-c-` or `govuk-` are also permitted, but should only be used within the component and not passed to it.
 
-```
+```Ruby
 <%= render "govuk_publishing_components/components/example", {
   classes: "js-example"
 } %>
@@ -78,7 +93,7 @@ The helper includes additional methods to make this possible.
 
 This is an example component template using some of these methods.
 
-```
+```Ruby
 <%
   helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   helper.add_class("gem-c-my-component")
@@ -92,7 +107,7 @@ This is an example component template using some of these methods.
 
 This is an example call to this component.
 
-```
+```Ruby
 <%= render "govuk_publishing_components/components/example", {
   classes: "js-hook",
   data_attributes: {
@@ -104,7 +119,7 @@ This is an example call to this component.
 
 This would be the result.
 
-```
+```Ruby
 <div class="gem-c-my-component js-hook" data-module="gem-track-click another-module" data-example="example">
   component content
 </div>

--- a/lib/govuk_publishing_components/presenters/component_wrapper_helper.rb
+++ b/lib/govuk_publishing_components/presenters/component_wrapper_helper.rb
@@ -22,6 +22,11 @@ module GovukPublishingComponents
         attributes[:role] = @options[:role] unless @options[:role].blank?
         attributes[:lang] = @options[:lang] unless @options[:lang].blank?
 
+        if @options[:component_wrapper_test]
+          attributes[:data] = {} if attributes[:data].blank?
+          attributes[:data][:componentwrappertest] = "component wrapper installed"
+        end
+
         attributes
       end
 

--- a/spec/components/accordion_spec.rb
+++ b/spec/components/accordion_spec.rb
@@ -307,6 +307,22 @@ describe "Accordion", type: :view do
     assert_select "[data-module='gem-track-click govuk-accordion gem-accordion ga4-event-tracker']", count: 1
   end
 
+  it "has the component wrapper installed correctly" do
+    test_data = {
+      id: "test-for-heading-and-content",
+      component_wrapper_test: true,
+      items: [
+        {
+          heading: { text: "Heading 1" },
+          content: { html: "<p>Content 1.</p>" },
+        },
+      ],
+    }
+
+    render_component(test_data)
+    assert_select ".gem-c-accordion[data-componentwrappertest='component wrapper installed']"
+  end
+
   it "section has class added when expanded flag is present" do
     test_data = {
       id: "test-for-expanded-layout",

--- a/spec/components/action_link_spec.rb
+++ b/spec/components/action_link_spec.rb
@@ -9,6 +9,15 @@ describe "Action link", type: :view do
     assert_empty render_component(href: "/coronavirus")
   end
 
+  it "has the component wrapper installed correctly" do
+    render_component(
+      text: "Get more info",
+      href: "/coronavirus",
+      component_wrapper_test: true,
+    )
+    assert_select ".gem-c-action-link[data-componentwrappertest='component wrapper installed']"
+  end
+
   it "applies default margin to the component" do
     render_component(
       text: "Get more info",

--- a/spec/components/breadcrumbs_spec.rb
+++ b/spec/components/breadcrumbs_spec.rb
@@ -20,6 +20,11 @@ describe "Breadcrumbs", type: :view do
     assert_link_with_text_in(".govuk-breadcrumbs__list-item:first-child", "/section", "Section")
   end
 
+  it "has the component wrapper installed correctly" do
+    render_component(breadcrumbs: [{ title: "Section", url: "/section" }], component_wrapper_test: true)
+    assert_select ".gem-c-breadcrumbs[data-componentwrappertest='component wrapper installed']"
+  end
+
   it "renders schema data" do
     breadcrumbs = [
       { title: "Section 1", url: "/section-1" },

--- a/spec/lib/govuk_publishing_components/components/component_wrapper_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/components/component_wrapper_helper_spec.rb
@@ -27,6 +27,35 @@ RSpec.describe GovukPublishingComponents::Presenters::ComponentWrapperHelper do
       expect(component_helper.all_attributes).to eql(expected)
     end
 
+    it "has an option to allow components to test it is installed and working correctly" do
+      args = {
+        component_wrapper_test: true,
+      }
+      component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(args)
+      expected = {
+        data: {
+          componentwrappertest: "component wrapper installed",
+        },
+      }
+      expect(component_helper.all_attributes).to eql(expected)
+
+      # check that the test doesn't conflict with passed data attributes
+      args = {
+        component_wrapper_test: true,
+        data_attributes: {
+          module: "module",
+        },
+      }
+      component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(args)
+      expected = {
+        data: {
+          module: "module",
+          componentwrappertest: "component wrapper installed",
+        },
+      }
+      expect(component_helper.all_attributes).to eql(expected)
+    end
+
     it "accepts valid class names" do
       component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(classes: "gem-c-component govuk-component brand--thing brand__thing")
       expected = {


### PR DESCRIPTION
## What / why

- one of the aims of the component wrapper is to reduce duplicate code by providing a central place where various attributes are added to components
- this should reduce the number of tests we have e.g. once the wrapper is installed, no need to test that data attributes can be passed to that component
- but still need some confidence that the wrapper is installed correctly, so adding this option
- now components can have a single test to check that the wrapper is installed and working as expected (see the documentation change for details)

TODO: finish adding to remaining components that use the wrapper.

## Visual Changes
None.
