### PR TITLE
Let applications use the component wrapper helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Let applications use the component wrapper helper ([PR #3736](https://github.com/alphagov/govuk_publishing_components/pull/3736))
 * [BREAKING] Change action link component options ([PR #3729](https://github.com/alphagov/govuk_publishing_components/pull/3729))
 * Remove attribute nesting handling from GA4 schemas ([PR #3718](https://github.com/alphagov/govuk_publishing_components/pull/3718))
 * Allow GA4 to be disabled via query string parameters ([PR #3731](https://github.com/alphagov/govuk_publishing_components/pull/3731))

--- a/docs/component-wrapper-helper.md
+++ b/docs/component-wrapper-helper.md
@@ -55,7 +55,7 @@ The helper checks that passed aria attributes are valid, based on a hard coded l
 
 Classes can be passed to components. To prevent breaking [component isolation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/component_principles.md#a-component-is-isolated-when), passed classes should only be used for JavaScript hooks and not styling. All component styling should be included only in the component itself.
 
-Any passed classes should be prefixed with `js-`. To allow for extending this option, classes prefixed with `gem-c-` or `govuk-` are also permitted, but should only be used within the component and not passed to it.
+Any passed classes should be prefixed with `js-`. To allow for extending this option, classes prefixed with `gem-c-`, `app-c-` or `govuk-` are also permitted, but should only be used within the component and not passed to it.
 
 ```
 <%= render "govuk_publishing_components/components/example", {

--- a/lib/govuk_publishing_components/presenters/component_wrapper_helper.rb
+++ b/lib/govuk_publishing_components/presenters/component_wrapper_helper.rb
@@ -76,7 +76,7 @@ module GovukPublishingComponents
         return if classes.blank?
 
         class_array = classes.split(" ")
-        unless class_array.all? { |c| c.start_with?("js-", "gem-c-", "govuk-", "brand--", "brand__") }
+        unless class_array.all? { |c| c.start_with?("js-", "gem-c-", "govuk-", "app-c-", "brand--", "brand__") }
           raise(ArgumentError, "Classes (#{classes}) must be prefixed with `js-`")
         end
       end

--- a/spec/lib/govuk_publishing_components/components/component_wrapper_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/components/component_wrapper_helper_spec.rb
@@ -28,9 +28,9 @@ RSpec.describe GovukPublishingComponents::Presenters::ComponentWrapperHelper do
     end
 
     it "accepts valid class names" do
-      component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(classes: "gem-c-component govuk-component brand--thing brand__thing")
+      component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(classes: "gem-c-component govuk-component app-c-component brand--thing brand__thing")
       expected = {
-        class: "gem-c-component govuk-component brand--thing brand__thing",
+        class: "gem-c-component govuk-component app-c-component brand--thing brand__thing",
       }
       expect(component_helper.all_attributes).to eql(expected)
     end


### PR DESCRIPTION
## What
- applications can't use the component wrapper helper in their components, because it doesn't allow classes that start with our convention for application components, `.app-c-componentname`
- extend the component wrapper to allow classes beginning with `app-c-` so that applications can use it

## Why
I want to use it in `finder-frontend` as part of some changes to tidy up our analytics code.

## Visual Changes
None.
