### PR TITLE
Version 36.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 36.0.0
 
 * Let applications use the component wrapper helper ([PR #3736](https://github.com/alphagov/govuk_publishing_components/pull/3736))
 * [BREAKING] Change action link component options ([PR #3729](https://github.com/alphagov/govuk_publishing_components/pull/3729))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (35.23.0)
+    govuk_publishing_components (36.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "35.23.0".freeze
+  VERSION = "36.0.0".freeze
 end


### PR DESCRIPTION
## 36.0.0

* Let applications use the component wrapper helper ([PR #3736](https://github.com/alphagov/govuk_publishing_components/pull/3736))
* [BREAKING] Change action link component options ([PR #3729](https://github.com/alphagov/govuk_publishing_components/pull/3729))
* Remove attribute nesting handling from GA4 schemas ([PR #3718](https://github.com/alphagov/govuk_publishing_components/pull/3718))
* Allow GA4 to be disabled via query string parameters ([PR #3731](https://github.com/alphagov/govuk_publishing_components/pull/3731))
* Consolidate GA4 schema calls ([PR #3725](https://github.com/alphagov/govuk_publishing_components/pull/3725))
* Make data-ga4-set-indexes ignore links with no href ([PR #3723](https://github.com/alphagov/govuk_publishing_components/pull/3723))
* Improve PII date removal ([PR #3709](https://github.com/alphagov/govuk_publishing_components/pull/3709))
* Decommission GA4 link_path_parts and splitting of taxonomy_all and taxonomy_all_ids ([PR #3730](https://github.com/alphagov/govuk_publishing_components/pull/3730))
* Create new political meta tags for GA4 ([PR #3706](https://github.com/alphagov/govuk_publishing_components/pull/3706))
