### PR TITLE
 Prevent government_frontend test failure if meta tag key doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Prevent government_frontend test failure if meta tag key doesn't exist ([PR #3741](https://github.com/alphagov/govuk_publishing_components/pull/3741))
+
 ## 36.0.1
 
 * Use component wrapper on option select ([PR #3738](https://github.com/alphagov/govuk_publishing_components/pull/3738))

--- a/lib/govuk_publishing_components/presenters/meta_tags.rb
+++ b/lib/govuk_publishing_components/presenters/meta_tags.rb
@@ -92,13 +92,12 @@ module GovukPublishingComponents
       def add_ga4_political_tags(meta_tags)
         government = content_item.dig(:links, :government, 0)
 
-        # political: true/false is in a different place to current: true/false, which is why we have 'details' and 'government[:details]'
+        # political: true/false is in a different place to current: true/false, which is why we have 'details' and 'government.dig(:details)'
         if government && details[:political]
-          meta_tags["govuk:ga4-political-status"] = government[:details][:current] ? "political" : "historic"
-
-          government_title = government[:title]
-          if government_title && !government[:details][:current]
-            meta_tags["govuk:ga4-publishing-government"] = government_title
+          current_government = government.dig(:details, :current)
+          unless current_government
+            meta_tags["govuk:ga4-political-status"] = "historic"
+            meta_tags["govuk:ga4-publishing-government"] = government[:title] if government[:title]
           end
         end
 

--- a/spec/components/meta_tags_spec.rb
+++ b/spec/components/meta_tags_spec.rb
@@ -440,10 +440,10 @@ describe "Meta tags", type: :view do
   end
 
   it "doesn't render govuk:ga4-browse-topic if the dig doesn't return anything" do
-    content_item = {
-      "links": nil,
-    }
-    render_component(content_item: example_document_for("transaction", "transaction").merge(content_item))
+    content_item = example_document_for("html_publication", "published_with_history_mode")
+    content_item.delete("links")
+
+    render_component(content_item:)
     assert_no_meta_tag("govuk:ga4-browse-topic")
   end
 
@@ -454,46 +454,57 @@ describe "Meta tags", type: :view do
   end
 
   it "doesn't render GA4 political tags if the government object doesn't exist in the content item" do
-    content_item = {
-      "links": {
-        "government": nil,
-      },
-    }
-    render_component(content_item: example_document_for("html_publication", "published_with_history_mode").merge(content_item))
+    content_item = example_document_for("html_publication", "published_with_history_mode")
+    content_item["links"].delete("government")
+
+    render_component(content_item:)
     assert_no_meta_tag("govuk:ga4-publishing-government")
     assert_no_meta_tag("govuk:ga4-political-status")
   end
 
+  it "doesn't crash generating GA4 political tags if details/current does not exist" do
+    content_item = example_document_for("html_publication", "published_with_history_mode")
+    content_item["links"]["government"][0].delete("details")
+
+    render_component(content_item:)
+    assert_meta_tag("govuk:ga4-publishing-government", "2010 to 2015 Conservative and Liberal Democrat coalition government")
+    assert_meta_tag("govuk:ga4-political-status", "historic")
+  end
+
   it "doesn't render GA4 political tags if the government object exists in the content item, but political is false" do
-    content_item = {
-      "political": false,
-      "links": {
-        "government": {
+    content_item = example_document_for("html_publication", "published_with_history_mode")
+    content_item["details"]["political"] = false
+    content_item["links"] = {
+      "government": [
+        {
           "details": {
             "current": false,
           },
           "title": "2005 to 2010 Labour government",
         },
-      },
+      ],
     }
-    render_component(content_item: example_document_for("html_publication", "published_with_history_mode").merge(content_item))
+
+    render_component(content_item:)
     assert_no_meta_tag("govuk:ga4-publishing-government")
     assert_no_meta_tag("govuk:ga4-political-status")
   end
 
   it "doesn't render GA4 political tags if the government object exists in the content item, but it refers to the current government" do
-    content_item = {
-      "political": true,
-      "links": {
-        "government": {
+    content_item = example_document_for("html_publication", "published_with_history_mode")
+    content_item["details"]["political"] = true
+    content_item["links"] = {
+      "government": [
+        {
           "details": {
             "current": true,
           },
           "title": "2015 Conservative government",
         },
-      },
+      ],
     }
-    render_component(content_item: example_document_for("html_publication", "published_with_history_mode").merge(content_item))
+
+    render_component(content_item:)
     assert_no_meta_tag("govuk:ga4-publishing-government")
     assert_no_meta_tag("govuk:ga4-political-status")
   end


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- To generate a new meta tag for GA4, we were diving into a nested value within the content_item JSON: `government[:details][:current]`
- `government_frontend` tests generate random but valid schemas to test against. Therefore, the test schema sometimes would contain the `government` object, but the `government` object wouldn't contain `[:details][:current]` and therefore crash.
- The error in `government_frontend` is: 
```Ruby
Minitest::UnexpectedError:         ActionView::Template::Error: undefined method `[]' for nil:NilClass
            app/views/layouts/application.html.erb:63` 

``` 
- and `application.html.erb:63` was the call to render `meta_tags.html.erb.` in `government-frontend`. I used puts statements within `meta_tags.rb` in this repo  to determine which line in our GA4 meta tag code was crashing during the `government-frontend` test.
- This PR should fix the issue. It uses `.dig` in Ruby instead, which will return `nil` instead of crashing if the key doesn't exist.
-  I tested `government_frontend` against this local branch, and forced the test to give me the same erroring content schema each time (instead of giving random ones) and the `government-frontend` test passes now. I also tested it multiple times against random schemas and have not experienced any test failures.
- I also modified the meta tag code slightly as I noticed the tests for it were passing but were false-positives. This was because I was using `.merge` to try and remove values in the existing content item, but this was actually not working reliably. Therefore it was better to use `.delete` when removing values, and to just override keys that needed changing. This surfaced some issues with the meta tag code which are now fixed, and the code is simpler as a result.

## Why
<!-- What are the reasons behind this change being made? -->
- The current code caused flaky tests in `government-frontend`, because the tests check randomly generated but valid content schemas (that are different to ones on production), so some schemas didn't have the right data we needed and therefore the tests would fail when encountering that version of a schema.
- https://github.com/alphagov/government-frontend/pull/3000
- https://github.com/alphagov/government-frontend/pull/3001

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
