### PR TITLE
Standardise search term formatting across GA4 trackers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Standardise search term formatting across GA4 trackers ([PR #3746](https://github.com/alphagov/govuk_publishing_components/pull/3746))
+
 ## 36.0.2
 
 * Prevent government_frontend test failure if meta tag key doesn't exist ([PR #3741](https://github.com/alphagov/govuk_publishing_components/pull/3741))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -275,6 +275,19 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
           return url
         }
         return this.getPathname() + url
+      },
+
+      standardiseSearchTerm: function (searchTerm) {
+        if (!searchTerm) {
+          return undefined // Prevents conversion of undefined to a string by this function.
+        }
+
+        var PIIRemover = new window.GOVUK.analyticsGa4.PIIRemover()
+        searchTerm = searchTerm.replace(/\++|(%2B)+/gm, ' ') // Turn + characters or unicode + characters (%2B) into a space.
+        searchTerm = window.GOVUK.analyticsGa4.core.trackFunctions.removeLinesAndExtraSpaces(searchTerm)
+        searchTerm = PIIRemover.stripPIIWithOverride(searchTerm, true, true)
+        searchTerm = searchTerm.toLowerCase()
+        return searchTerm
       }
     },
 
@@ -313,12 +326,11 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
         var isSearchResult = element.getAttribute('data-ga4-search-query')
 
         var ecommerceSchema = new window.GOVUK.analyticsGa4.Schemas().ecommerceSchema()
-        var PIIRemover = new window.GOVUK.analyticsGa4.PIIRemover()
         var DEFAULT_LIST_TITLE = 'Smart answer results'
 
         if (isSearchResult) {
           // Limiting to 100 characters to avoid noise from extra long search queries and to stop the size of the payload going over 8k limit.
-          var searchQuery = PIIRemover.stripPII(element.getAttribute('data-ga4-search-query')).substring(0, 100).toLowerCase()
+          var searchQuery = window.GOVUK.analyticsGa4.core.trackFunctions.standardiseSearchTerm(element.getAttribute('data-ga4-search-query')).substring(0, 100)
           var variant = element.getAttribute('data-ga4-ecommerce-variant')
           DEFAULT_LIST_TITLE = 'Site search results'
         }

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
@@ -47,8 +47,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       data.text = data.text || this.combineGivenAnswers(formData) || this.useFallbackValue
 
       if (data.action === 'search' && data.text) {
-        data.text = data.text.toLowerCase()
-        data.text = window.GOVUK.analyticsGa4.core.trackFunctions.removeLinesAndExtraSpaces(data.text)
+        data.text = window.GOVUK.analyticsGa4.core.trackFunctions.standardiseSearchTerm(data.text)
       }
       window.GOVUK.analyticsGa4.core.applySchemaAndSendData(data, 'event_data')
     }

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
@@ -86,9 +86,8 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
       }
 
       searchTerm = searchTerm[0].replace('keywords=', '')
-      searchTerm = searchTerm.replace(/\++/g, ' ')
-      searchTerm = window.GOVUK.analyticsGa4.core.trackFunctions.removeLinesAndExtraSpaces(searchTerm)
-      searchTerm = this.PIIRemover.stripPIIWithOverride(searchTerm, true, true)
+      searchTerm = window.GOVUK.analyticsGa4.core.trackFunctions.standardiseSearchTerm(searchTerm)
+
       return searchTerm
     },
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
@@ -285,6 +285,14 @@ describe('GA4 core', function () {
       expect(domains).toContain('gov.uk')
     })
 
+    it('standardises search terms for consistency across trackers', function () {
+      var searchTerm = 'NO UPPERCASE, NO %2B plus + signs, NO PII email@example.com SW1A 2AA 1st Jan 1990 and    NO    extra    spaces \n \r      '
+      var expected = 'no uppercase, no plus signs, no pii [email] [postcode] [date] and no extra spaces'
+
+      searchTerm = GOVUK.analyticsGa4.core.trackFunctions.standardiseSearchTerm(searchTerm)
+      expect(searchTerm).toEqual(expected)
+    })
+
     describe('when the data-ga4-set-indexes attribute exists on the module', function () {
       var module
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-ecommerce-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-ecommerce-tracker.spec.js
@@ -103,35 +103,50 @@ describe('Google Analytics 4 ecommerce tracking', function () {
     })
 
     it('should get the search query', function () {
-      onPageLoadExpected.search_results.term = 'coronavirus'
+      var expected = 'coronavirus'
       searchResultsParentEl.setAttribute('data-ga4-search-query', 'coronavirus')
       GOVUK.analyticsGa4.Ga4EcommerceTracker.init()
 
-      expect(window.dataLayer[1].search_results.term).toBe(onPageLoadExpected.search_results.term)
+      expect(window.dataLayer[1].search_results.term).toBe(expected)
     })
 
     it('should remove PII from search query', function () {
-      onPageLoadExpected.search_results.term = '[email]'
+      var expected = '[email]'
       searchResultsParentEl.setAttribute('data-ga4-search-query', 'email@example.com')
       GOVUK.analyticsGa4.Ga4EcommerceTracker.init()
 
-      expect(window.dataLayer[1].search_results.term).toBe(onPageLoadExpected.search_results.term)
+      expect(window.dataLayer[1].search_results.term).toBe(expected)
+    })
+
+    it('should replace plusses with spaces, and remove extra lines/spaces from search query', function () {
+      var expected = 'i have a lot of spaces'
+      searchResultsParentEl.setAttribute('data-ga4-search-query', '%2Bi++have+\n+\r+a+lot+of+   spaces')
+      GOVUK.analyticsGa4.Ga4EcommerceTracker.init()
+
+      expect(window.dataLayer[1].search_results.term).toBe(expected)
+    })
+
+    it('should set the search query to lowercase', function () {
+      var expected = 'i am lowercase'
+      searchResultsParentEl.setAttribute('data-ga4-search-query', 'I AM LOWERCASE')
+      GOVUK.analyticsGa4.Ga4EcommerceTracker.init()
+
+      expect(window.dataLayer[1].search_results.term).toBe(expected)
     })
 
     it('should get the variant', function () {
-      onPageLoadExpected.search_results.sort = 'Relevance'
+      var expected = 'Relevance'
       searchResultsParentEl.setAttribute('data-ga4-ecommerce-variant', 'Relevance')
       GOVUK.analyticsGa4.Ga4EcommerceTracker.init()
 
-      expect(window.dataLayer[1].search_results.sort).toBe(onPageLoadExpected.search_results.sort)
+      expect(window.dataLayer[1].search_results.sort).toBe(expected)
     })
 
     it('should set the variant to undefined when the data-ga4-ecommerce-variant does not exist', function () {
-      onPageLoadExpected.search_results.sort = undefined
       searchResultsParentEl.removeAttribute('data-ga4-ecommerce-variant')
       GOVUK.analyticsGa4.Ga4EcommerceTracker.init()
 
-      expect(window.dataLayer[1].search_results.sort).toBe(onPageLoadExpected.search_results.sort)
+      expect(window.dataLayer[1].search_results.sort).toBe(undefined)
     })
 
     it('should get the number of search results i.e. 12345 search results in this test case', function () {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
@@ -358,12 +358,22 @@ describe('Google Analytics form tracking', function () {
       expect(window.dataLayer[0]).toEqual(expected)
     })
 
-    it('removes extra spaces', function () {
+    it('converts plusses to spaces, and then removes extra lines and spaces', function () {
       element.innerHTML =
         '<label for="text">Search</label>' +
-        '<input type="text" id="text" name="text" value="  there  should     be    no  extra  spaces     "/>'
+        '<input type="text" id="text" name="text" value="  there+%2B++  \n \r should     be    no  extra  spaces     "/>'
 
       expected.event_data.text = 'there should be no extra spaces'
+      window.GOVUK.triggerEvent(element, 'submit')
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+
+    it('redacts PII', function () {
+      element.innerHTML =
+        '<label for="text">Search</label>' +
+        '<input type="text" id="text" name="text" value="email@example.com SW1A 2AA Jan 1st 1990"/>'
+
+      expected.event_data.text = '[email] [postcode] [date]'
       window.GOVUK.triggerEvent(element, 'submit')
       expect(window.dataLayer[0]).toEqual(expected)
     })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
@@ -537,10 +537,18 @@ describe('Google Tag Manager page view tracking', function () {
       expect(window.dataLayer[0]).toEqual(expected)
     })
 
-    it('replaces plusses with spaces', function () {
-      spyOn(GOVUK.analyticsGa4.core.trackFunctions, 'getSearch').and.returnValue('?test=true&keywords=hello++++world+there+are+spaces++in+++a+lot++++of+++places')
-      expected.page_view.query_string = 'test=true&keywords=hello++++world+there+are+spaces++in+++a+lot++++of+++places'
+    it('replaces plusses with spaces, and removes extra lines and spaces', function () {
+      spyOn(GOVUK.analyticsGa4.core.trackFunctions, 'getSearch').and.returnValue('?test=true&keywords=hello++%2B+world+there+are+spaces++in+++a+lot++++of++\n++places')
+      expected.page_view.query_string = 'test=true&keywords=hello++%2B+world+there+are+spaces++in+++a+lot++++of++\n++places'
       expected.page_view.search_term = 'hello world there are spaces in a lot of places'
+      GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+
+    it('sets the search term to lowercase', function () {
+      spyOn(GOVUK.analyticsGa4.core.trackFunctions, 'getSearch').and.returnValue('?test=true&keywords=I+AM+LOWERCASE')
+      expected.page_view.query_string = 'test=true&keywords=I+AM+LOWERCASE'
+      expected.page_view.search_term = 'i am lowercase'
       GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
       expect(window.dataLayer[0]).toEqual(expected)
     })


### PR DESCRIPTION
## What
- Search terms were being cleaned up in different ways by different trackers (These were the pageview tracker, the form tracker, and the ecommerce tracker)
- I have fixed this by creating a function which all trackers that utilise the search term now use. This function will cleanup/format the search term instead of the individual trackers.
- I then added extra tests where relevant to the trackers to ensure that they handled search terms in the same way.

## Why
<!-- What are the reasons behind this change being made? -->
- The PAs require the search term to be consistent across trackers so they can cross reference data/follow user journeys.
- Trello card: ['search_term' page_view parameter is coming through with capitals - should be lowercased](https://trello.com/c/Xuzx1cYM/738-searchterm-pageview-parameter-is-coming-through-with-capitals-should-be-lowercased)
- Trello card: [Ensure clean-up regex is the same across all search_term fields](https://trello.com/c/ntC48CCa/739-ensure-clean-up-regex-is-the-same-across-all-searchterm-fields)

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
