### PR TITLE
Prevent crash when link tracker runs on a non-link element

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
@@ -85,7 +85,13 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       if (!data.text && (element.querySelector('img') || element.querySelector('svg') || element.tagName === 'IMG' || element.closest('svg'))) {
         data.text = 'image'
       }
-      var url = data.url || this.findLink(event.target).getAttribute('href')
+      try {
+        var url = data.url || this.findLink(event.target).getAttribute('href')
+      } catch (e) {
+        // no href found, so abort
+        return
+      }
+
       data.url = trackFunctions.removeCrossDomainParams(url)
       data.url = trackFunctions.applyRedactionIfRequired(this.PIIRemover, element, data.url)
       data.url = trackFunctions.appendPathToAnchorLinks(data.url)

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
@@ -589,4 +589,22 @@ describe('GA4 link tracker', function () {
       expect(window.dataLayer[0].event_data.url).toEqual('/hello-world#link1')
     })
   })
+
+  describe('clicking an element that is not a link', function () {
+    beforeEach(function () {
+      spyOn(GOVUK.analyticsGa4.core.trackFunctions, 'getPathname').and.returnValue('/hello-world')
+    })
+
+    it('does not crash', function () {
+      element = document.createElement('div')
+      element.setAttribute('data-ga4-link', '{"event_name": "navigation"}')
+      element.innerHTML = '<span class="not-a-link">I am not a link</span>'
+
+      initModule(element, true)
+      var link = element.querySelector('.not-a-link')
+
+      link.click()
+      expect(window.dataLayer).toEqual([])
+    })
+  })
 })


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- If the link tracker exists without `data-ga4-track-links-only`, it will assume every child element inside of it is an `<a>` tag with a href.
- However, sometimes we do not use `data-ga4-track-links-only`, so certain elements (e.g. SVG icons or paragraph text) are being run through our `trackClick` function in the link tracker. Since these elements do not have hrefs, the link tracking crashes when these elements are clicked.
- Examples include the SVG icons on the action links on the homepage, and the "Open Government License" paragraph text in the footer. Clicking either of these produces an error in the console.
- To fix this, we put a guard in that will `return` our `trackClick` function if there is no `href` on the link, or no `url` in the link tracker JSON.

## Why
<!-- What are the reasons behind this change being made? -->
- Prevents a JS error in the console

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
