### PR TITLE
Add ZIP file support to attachment component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Standardise search term formatting across GA4 trackers ([PR #3746](https://github.com/alphagov/govuk_publishing_components/pull/3746))
+* Add ZIP file support to attachment component ([PR #3751](https://github.com/alphagov/govuk_publishing_components/pull/3751))
 
 ## 36.0.2
 

--- a/lib/govuk_publishing_components/presenters/attachment_helper.rb
+++ b/lib/govuk_publishing_components/presenters/attachment_helper.rb
@@ -105,6 +105,7 @@ module GovukPublishingComponents
           { content_type: "application/vnd.openxmlformats-officedocument.presentationml.presentation", name: "MS PowerPoint Presentation" }.freeze, # pptx
           { content_type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", name: "MS Excel Spreadsheet", spreadsheet: true }.freeze, # xlsx
           { content_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document", name: "MS Word Document", document: true }.freeze, # docx
+          { content_type: "application/zip", abbr: "ZIP", name: "Zip archive" }.freeze,
           { content_type: "application/xml", abbr: "XML", name: "XML Document" }.freeze,
           { content_type: "image/gif", abbr: "GIF", name: "Graphics Interchange Format" }.freeze,
           { content_type: "image/jpeg", name: "JPEG" }.freeze,


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
Add ZIP file support to attachment component

## Why
<!-- What are the reasons behind this change being made? -->
Missed during the migration in `whitehall` to use our attachment component

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

I've added an example to the components guide for the PR (which is why Percy is failing,) but will remove it before merging
