### PR TITLE
Move image-card overrides from frontend app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 * Standardise search term formatting across GA4 trackers ([PR #3746](https://github.com/alphagov/govuk_publishing_components/pull/3746))
 * Add ZIP file support to attachment component ([PR #3751](https://github.com/alphagov/govuk_publishing_components/pull/3751))
+* Move image-card overrides from frontend app ([PR #3752](https://github.com/alphagov/govuk_publishing_components/pull/3752))
 
 ## 36.0.2
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -97,6 +97,33 @@
   align-items: flex-end;
 }
 
+.gem-c-image-card--two-thirds {
+  .gem-c-image-card__image {
+    border-top: none;
+  }
+
+  // TODO: Temporary fixes to ensure the layout
+  // renders correctly on screen sizes less than 320px wide
+  @include govuk-media-query($until: "mobile") {
+    padding: 0 govuk-spacing(3);
+  }
+
+  .gem-c-image-card__image-wrapper {
+    @include govuk-media-query($until: "mobile") {
+      margin-bottom: govuk-spacing(2);
+    }
+  }
+
+  // Ensures the font-size is 19px on all screen sizes
+  .gem-c-image-card__title-link--large-font-size-mobile,
+  .gem-c-image-card__description--large-font-size-mobile {
+    @include govuk-media-query($until: "tablet") {
+      font-size: 19px;
+      font-size: govuk-px-to-rem(19);
+    }
+  }
+}
+
 .gem-c-image-card__image-wrapper.gem-c-image-card__image-wrapper--one-third {
   // The first two values set flex-grow and flex-basis to 0
   // This ensures that the flex item does not grow or shrink

--- a/app/views/govuk_publishing_components/components/_image_card.html.erb
+++ b/app/views/govuk_publishing_components/components/_image_card.html.erb
@@ -27,6 +27,7 @@
     govuk-link
   ]
   heading_link_classes << brand_helper.color_class
+  heading_link_classes << "gem-c-image-card__title-link--large-font-size-mobile" if card_helper.large_mobile_font_size?
   extra_link_classes = %w[
     gem-c-image-card__list-item-link
     govuk-link

--- a/app/views/govuk_publishing_components/components/docs/image_card.yml
+++ b/app/views/govuk_publishing_components/components/docs/image_card.yml
@@ -206,7 +206,10 @@ examples:
         <%= component %>
       </div>
   two_thirds:
-    description: This variant is used for the featured section on the homepage. The aspect ratio used is 1:1 and the width of the image is constrained to 80px wide.
+    description: |
+      This variant is used for the featured section on the homepage. The aspect ratio used is 1:1 and the width of the image is constrained to 80px wide.
+
+      Setting `large_font_size_mobile` to `true` will ensure that the font size for the title and description will be 19px on all screen sizes.
     data:
       two_thirds: true
       href: "/still-not-a-page"
@@ -214,6 +217,7 @@ examples:
       image_alt: "some meaningful alt text please"
       heading_text: "Something has happened nearby possibly"
       description: "Following a news report that something has happened, further details are emerging of the thing that has happened and what that means for you."
+      large_font_size_mobile: true
     embed: |
       <div class="govuk-!-width-full">
         <%= component %>

--- a/lib/govuk_publishing_components/presenters/image_card_helper.rb
+++ b/lib/govuk_publishing_components/presenters/image_card_helper.rb
@@ -4,7 +4,7 @@ module GovukPublishingComponents
       include ActionView::Helpers
       include ActionView::Context
 
-      attr_reader :href_data_attributes, :extra_details, :extra_details_no_indent, :heading_text, :metadata, :lang, :image_loading, :youtube_video_id, :image_src, :two_thirds
+      attr_reader :href_data_attributes, :extra_details, :extra_details_no_indent, :heading_text, :metadata, :lang, :image_loading, :youtube_video_id, :image_src, :two_thirds, :large_font_size_mobile
 
       def initialize(local_assigns, brand_helper)
         @href = local_assigns[:href]
@@ -21,6 +21,7 @@ module GovukPublishingComponents
         @description = local_assigns[:description]
         @large = local_assigns[:large]
         @two_thirds = local_assigns[:two_thirds] || false
+        @large_font_size_mobile = local_assigns[:large_font_size_mobile] || false
         @heading_text = local_assigns[:heading_text]
         @extra_details_no_indent = local_assigns[:extra_details_no_indent]
         @metadata = local_assigns[:metadata]
@@ -41,6 +42,13 @@ module GovukPublishingComponents
         # the small variant, large will be always
         # true if a youtube_video_id is supplied
         @youtube_video_id || @large
+      end
+
+      def large_mobile_font_size?
+        # allow the font-size to be 19px on mobile
+        # for the two-thirds varation of the
+        # image card component
+        @two_thirds && @large_font_size_mobile
       end
 
       def is_tracking?
@@ -104,6 +112,8 @@ module GovukPublishingComponents
       end
 
       def description
+        return content_tag(:div, @description, class: "gem-c-image-card__description gem-c-image-card__description--large-font-size-mobile") if @description && large_mobile_font_size?
+
         content_tag(:div, @description, class: "gem-c-image-card__description") if @description
       end
 

--- a/spec/components/image_card_spec.rb
+++ b/spec/components/image_card_spec.rb
@@ -117,6 +117,12 @@ describe "ImageCard", type: :view do
     assert_select ".gem-c-image-card__image[height='90']"
   end
 
+  it "renders two thirds variant with large title and description text font size for mobile" do
+    render_component(href: "#", image_src: "/moo.jpg", image_alt: "some meaningful alt text", heading_text: "heading", description: "description", two_thirds: true, large_font_size_mobile: true)
+    assert_select ".gem-c-image-card--two-thirds .gem-c-image-card__title-link--large-font-size-mobile", text: "heading"
+    assert_select ".gem-c-image-card--two-thirds .gem-c-image-card__description--large-font-size-mobile", text: "description"
+  end
+
   it "applies tracking attributes" do
     render_component(href: "#", href_data_attributes: { track_category: "cat" }, heading_text: "test")
     assert_select ".gem-c-image-card[data-module='gem-track-click ga4-link-tracker']"


### PR DESCRIPTION
## What
- Move the style overrides for the two thirds image card variation used in the frontend app to the gem
- Add new local assign and method to check if `large_mobile_font_size` can be used. When set to true, the font size for the title and description will be 19px on all screen sizes.
- Add test for using large mobile font size on the two thirds image card variation
- Update image card documentation

## Why
Overrides to the publishing components is not best practice, it should be avoided as it makes the component harder to maintain, behaviour / rendering will be different than expected when following the component guide, it could break if the component is updated in the gem.

[Trello card](https://trello.com/c/jZu4Jnsc/2280-homepage-live-test-5-layout-follow-up-card-iterate-the-image-card-component-in-publishing-components-s)

## Visual Changes
One of the overrides used in the frontend app was to remove the top border from the image used in the image card. Now this change is included in the gem instead, the change is showing in the Percy visual regression test.

## Further info
This component will likely need further refactoring either in the publishing components gem, or move to the `frontend` rendering app as an individual component. I have created a new Trello card to capture this so it can be worked on further - https://trello.com/c/N8J5AuZl/772-refactor-or-move-the-image-card-two-thirds-component-to-the-frontend-app