### PR TITLE
Fix error in video tracker

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
@@ -116,7 +116,7 @@
             // https://github.com/alphagov/govuk_publishing_components/pull/908#discussion_r302913995
             var videoTitle = options.title
             event.target.getIframe().title = videoTitle + ' (video)'
-            if (window.GOVUK.analyticsGa4.analyticsModules.VideoTracker) {
+            if (window.GOVUK.analyticsGa4.analyticsModules && window.GOVUK.analyticsGa4.analyticsModules.VideoTracker) {
               window.GOVUK.analyticsGa4.analyticsModules.VideoTracker.configureVideo(event)
             }
           },


### PR DESCRIPTION
## What
- where the analytics code is not run (such as the component guide) the image card video variant was experiencing a JS error
- this shouldn't happen in the wild but it shouldn't happen in our dev environments either
- added a simple check to ensure the code fails silently if analytics is not initialised

## Why
Error was `Uncaught TypeError: Cannot read properties of undefined (reading 'VideoTracker')`

## Visual Changes
None.
