### PR TITLE
Fix rendering of the image card YouTube variation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix rendering of the image card YouTube variation #3757 ([PR #3757](https://github.com/alphagov/govuk_publishing_components/pull/3757))
+
 ## 36.1.0
 
 * Add heading option to file input component ([PR #3755](https://github.com/alphagov/govuk_publishing_components/pull/3755))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -259,56 +259,6 @@
   }
 }
 
-// The following two rules are used to 'trick' the
-// Youtube embed into using the desktop styles. Without
-// this, the Youtube embed will use mobile styles in
-// desktop viewports. The Youtube mobile styles are more
-// challenging to use with a keyboard as they are designed
-// for a touch screen interface. There is seemingly no way
-// to make an iframe request the desktop version of a site
-// and there is no parameter in the Youtube embed that would
-// force the desktop styles. Hence this workaround.
-
-// In the first rule, we are adding an arbitrarly large
-// enough px to the width of the Youtube iframe so that
-// it will use the desktop styling. Unfortunately, this width
-// would result in the Youtube embed overlapping into the
-// text content. To stop this happening, we scale the size of
-// the embed down.
-
-.gem-c-image-card__youtube-video-embed iframe {
-  @include govuk-media-query($from: tablet) {
-    transform: scale(.7);
-    width: calc(100% + 45px);
-  }
-  z-index: 1;
-}
-
-// In the second rule, we scale the container of the embed
-// up by the amount that we scaled the Youtube embed down.
-// This results in the embed being the correct size and the
-// desktop styles being used.
-
-.gem-c-image-card__youtube-video-embed {
-  @include govuk-media-query($from: tablet) {
-    transform: scale(1.3);
-  }
-  margin: 0;
-  padding-bottom: 68%;
-}
-
-// This rule is to reposition the embed to the correct
-// place in the image card. As the embed has been scaled
-// down and then scaled up again, it is misaligned and
-// here we correct that misalignment.
-
-.gem-c-image-card__youtube-video-embed.gem-c-govspeak__youtube-video iframe {
-  @include govuk-media-query($from: tablet) {
-    left: -22px;
-    top: -10px;
-  }
-}
-
 .gem-c-image-card__youtube-thumbnail-image-container {
   position: relative;
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -259,6 +259,22 @@
   }
 }
 
+// Ensure the YouTube video has a fluid width
+// https://alistapart.com/article/creating-intrinsic-ratios-for-video/
+.gem-c-image-card__youtube-video-embed {
+  position: relative;
+  padding-bottom: 56.25%; /* 16:9 */
+  height: 0;
+}
+
+.gem-c-image-card__youtube-video-embed iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
 .gem-c-image-card__youtube-thumbnail-image-container {
   position: relative;
 


### PR DESCRIPTION
## What
- Remove the scaling trick for the YouTube embedded video, this was [originally added to improve the keyboard navigation](https://github.com/alphagov/govuk_publishing_components/pull/3156) when tabbing to the controls on Desktop, however this no longer appears to be an issue after further testing
- Ensure the embedded YouTube video width is fluid and contained to its parent container

## Why
Fixes rendering issues with the YouTube image card variation of the image card component where the text overlaps with the image and the padding bottom added too much space to the bottom of the component as shown in the screenshots below.

Fixes: https://github.com/alphagov/govuk_publishing_components/issues/3675

## Visual Changes

### Before
<img width="975" alt="image-card-youtube-video-after" src="https://github.com/alphagov/govuk_publishing_components/assets/28779939/e2bc7cbe-87fb-40c8-9dc3-158da219cff7">

### After
<img width="986" alt="image-card-youtube-video-before" src="https://github.com/alphagov/govuk_publishing_components/assets/28779939/f6f05bab-7727-46c8-a9ed-194665c84ba9">