### PR TITLE
Version 36.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 36.1.0
+
+* Add heading option to file input component ([PR #3755](https://github.com/alphagov/govuk_publishing_components/pull/3755))
+
 ## 36.0.3
 
 * Standardise search term formatting across GA4 trackers ([PR #3746](https://github.com/alphagov/govuk_publishing_components/pull/3746))
 * Add ZIP file support to attachment component ([PR #3751](https://github.com/alphagov/govuk_publishing_components/pull/3751))
-* Add heading option to file input component ([PR #3755](https://github.com/alphagov/govuk_publishing_components/pull/3755))
 
 ## 36.0.2
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (36.0.3)
+    govuk_publishing_components (36.1.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "36.0.3".freeze
+  VERSION = "36.1.0".freeze
 end


### PR DESCRIPTION
## 36.1.0

* Add heading option to file input component ([PR #3755](https://github.com/alphagov/govuk_publishing_components/pull/3755))