### PR TITLE
Add GA4 copy event tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add GA4 copy event tracker ([PR #3761](https://github.com/alphagov/govuk_publishing_components/pull/3761))
+
 ## 37.0.0
 
 * [BREAKING] Data attributes for option select button ([PR #3750](https://github.com/alphagov/govuk_publishing_components/pull/3750))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4.js
@@ -4,6 +4,7 @@
 //= require ./analytics-ga4/pii-remover
 //= require ./analytics-ga4/ga4-page-views
 //= require ./analytics-ga4/ga4-print-intent-tracker
+//= require ./analytics-ga4/ga4-copy-tracker
 //= require ./analytics-ga4/ga4-specialist-link-tracker
 //= require ./analytics-ga4/ga4-link-tracker
 //= require ./analytics-ga4/ga4-event-tracker

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-copy-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-copy-tracker.js
@@ -1,0 +1,55 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
+window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analyticsModules || {};
+
+(function (analyticsModules) {
+  'use strict'
+
+  var Ga4CopyTracker = {
+    init: function () {
+      window.addEventListener('copy', this.trackCopy.bind(this))
+    },
+
+    trackCopy: function (event) {
+      try {
+        var text = this.getSelectedText()
+        if (!text) {
+          return // do nothing if no text has been selected
+        }
+        var target = event.target.tagName
+        if (target === 'INPUT' || target === 'TEXTAREA') {
+          return // do nothing if text is being copied from an input
+        }
+
+        var PIIRemover = new window.GOVUK.analyticsGa4.PIIRemover()
+        text = window.GOVUK.analyticsGa4.core.trackFunctions.removeLinesAndExtraSpaces(text)
+        text = PIIRemover.stripPIIWithOverride(text, true, true)
+        var length = text.length
+        text = text.substring(0, 30)
+
+        var data = {
+          event_name: 'copy',
+          type: 'copy',
+          action: 'copy',
+          method: 'browser copy',
+          text: text,
+          length: length
+        }
+        window.GOVUK.analyticsGa4.core.applySchemaAndSendData(data, 'event_data')
+      } catch (e) {
+        console.warn('GA4 copy tracker error: ' + e.message, window.location)
+      }
+    },
+
+    getSelectedText: function () {
+      if (window.getSelection) {
+        return window.getSelection().toString()
+      } else if (document.selection) {
+        return document.selection.createRange().text
+      }
+      return false
+    }
+  }
+
+  analyticsModules.Ga4CopyTracker = Ga4CopyTracker
+})(window.GOVUK.analyticsGa4.analyticsModules)

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.js
@@ -30,7 +30,7 @@
         tool_name: this.undefined,
         percent_scrolled: this.undefined,
         video_current_time: this.undefined,
-        video_duration: this.undefined,
+        length: this.undefined,
         video_percent: this.undefined
       }
     }

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-video-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-video-tracker.js
@@ -78,7 +78,7 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
       data.url = this.handlers['video-' + player.id + '-url']
       data.text = this.handlers['video-' + player.id + '-title']
       data.video_current_time = Math.round(player.getCurrentTime())
-      data.video_duration = this.handlers['video-' + player.id + '-duration']
+      data.length = this.handlers['video-' + player.id + '-duration']
       data.video_percent = position
 
       window.GOVUK.analyticsGa4.core.applySchemaAndSendData(data, 'event_data')

--- a/docs/analytics-ga4/ga4-schemas.md
+++ b/docs/analytics-ga4/ga4-schemas.md
@@ -40,7 +40,7 @@ The event tracker will read this attribute and pass it to the schemas, where it 
     tool_name: undefined,
     percent_scrolled: undefined,
     video_current_time: undefined,
-    video_duration: undefined,
+    length: undefined,
     video_percent: undefined
   }
 }

--- a/docs/analytics-ga4/ga4-video-tracker.md
+++ b/docs/analytics-ga4/ga4-video-tracker.md
@@ -18,7 +18,7 @@ These events only fire once for each video on any given page. Below is an exampl
     'text': 'My first Self Assessment tax return',
     'action': 'start',
     'video_current_time': 0,
-    'video_duration': 152,
+    'length': 152,
     'video_percent': 0
   }
 }

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-copy-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-copy-tracker.spec.js
@@ -1,0 +1,94 @@
+/* eslint-env jasmine */
+
+describe('Google Analytics 4 copy tracker', function () {
+  var GOVUK = window.GOVUK
+  var expected
+
+  beforeAll(function () {
+    window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
+    window.GOVUK.analyticsGa4.vars = window.GOVUK.analyticsGa4.vars || {}
+    window.GOVUK.analyticsGa4.vars.gem_version = 'aVersion'
+    GOVUK.analyticsGa4.analyticsModules.Ga4CopyTracker.init()
+  })
+
+  beforeEach(function () {
+    window.dataLayer = []
+    expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
+    expected.event = 'event_data'
+    expected.event_data.event_name = 'copy'
+    expected.event_data.type = 'copy'
+    expected.event_data.action = 'copy'
+    expected.event_data.method = 'browser copy'
+    expected.govuk_gem_version = 'aVersion'
+  })
+
+  it('triggers a GA4 event when the copy event is fired', function () {
+    var text = 'This is some text'
+    expected.event_data.text = text
+    expected.event_data.length = 17
+    spyOn(window, 'getSelection').and.returnValue(text)
+
+    window.GOVUK.triggerEvent(window, 'copy')
+    expect(window.dataLayer[0]).toEqual(expected)
+  })
+
+  it('does not send data unless text has been selected', function () {
+    spyOn(window, 'getSelection').and.returnValue('')
+
+    window.GOVUK.triggerEvent(window, 'copy')
+    expect(window.dataLayer.length).toEqual(0)
+  })
+
+  it('does not send data if copying from an input element', function () {
+    var html = '<p id="p_tag">hello</p>' +
+      '<input type="text" id="input_tag"/>' +
+      '<textarea id="textarea_tag"></textarea>'
+    var element = document.createElement('div')
+    element.innerHTML = html
+    document.body.appendChild(element)
+    spyOn(window, 'getSelection').and.returnValue('no thankyou')
+
+    window.GOVUK.triggerEvent(document.getElementById('input_tag'), 'copy')
+    expect(window.dataLayer.length).toEqual(0)
+
+    window.GOVUK.triggerEvent(document.getElementById('textarea_tag'), 'copy')
+    expect(window.dataLayer.length).toEqual(0)
+
+    window.GOVUK.triggerEvent(document.getElementById('p_tag'), 'copy')
+    // in testing the copy listener is created multiple times, can't be precise here
+    // so we test that at least one copy event has occurred
+    expect(window.dataLayer.length).toBeGreaterThan(0)
+
+    document.body.removeChild(element)
+  })
+
+  it('cleans line breaks and other characters from copied text', function () {
+    var text = 'This is some text\n\nThis is some more\tAnd some more\n     and     some spaces    \n'
+    expected.event_data.text = 'This is some text This is some'
+    expected.event_data.length = 65
+    spyOn(window, 'getSelection').and.returnValue(text)
+
+    window.GOVUK.triggerEvent(window, 'copy')
+    expect(window.dataLayer[0]).toEqual(expected)
+  })
+
+  it('only records a maximum of 30 characters', function () {
+    var text = "The first problem is where to get a lot of text. That's actually not so hard if you think about it - all you have to do is write some words down, any words that come to mind."
+    expected.event_data.text = 'The first problem is where to '
+    expected.event_data.length = 174
+    spyOn(window, 'getSelection').and.returnValue(text)
+
+    window.GOVUK.triggerEvent(window, 'copy')
+    expect(window.dataLayer[0]).toEqual(expected)
+  })
+
+  it('redacts PII from the text it collects', function () {
+    var text = 'some email@example.com SW1A 2AA Jan 1st 1990'
+    expected.event_data.text = 'some [email] [postcode] [date]'
+    expected.event_data.length = 30
+    spyOn(window, 'getSelection').and.returnValue(text)
+
+    window.GOVUK.triggerEvent(window, 'copy')
+    expect(window.dataLayer[0]).toEqual(expected)
+  })
+})

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.spec.js
@@ -40,7 +40,7 @@ describe('Google Analytics schemas', function () {
         tool_name: undefined,
         percent_scrolled: undefined,
         video_current_time: this.undefined,
-        video_duration: this.undefined,
+        length: this.undefined,
         video_percent: this.undefined
       }
     }
@@ -75,7 +75,7 @@ describe('Google Analytics schemas', function () {
         tool_name: undefined,
         percent_scrolled: undefined,
         video_current_time: this.undefined,
-        video_duration: this.undefined,
+        length: this.undefined,
         video_percent: this.undefined
       }
     }
@@ -110,7 +110,7 @@ describe('Google Analytics schemas', function () {
         tool_name: undefined,
         percent_scrolled: undefined,
         video_current_time: this.undefined,
-        video_duration: this.undefined,
+        length: this.undefined,
         video_percent: this.undefined
       }
     }

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-video-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-video-tracker.spec.js
@@ -50,7 +50,7 @@ describe('Google Analytics video tracker', function () {
       expected.event_data.type = 'video'
       expected.event_data.text = 'An example video'
       expected.event_data.url = 'https://www.youtube.com/watch?v=abcdef'
-      expected.event_data.video_duration = 500
+      expected.event_data.length = 500
       expected.govuk_gem_version = 'aVersion'
     })
 
@@ -84,7 +84,7 @@ describe('Google Analytics video tracker', function () {
       expected.event_data.type = 'video'
       expected.event_data.text = 'An example video'
       expected.event_data.url = 'https://www.youtube.com/watch?v=abcdef'
-      expected.event_data.video_duration = 500
+      expected.event_data.length = 500
       expected.govuk_gem_version = 'aVersion'
       expected.event_data.event_name = 'video_start'
       expected.event_data.action = 'start'
@@ -161,7 +161,7 @@ describe('Google Analytics video tracker', function () {
       expected.event_data.type = 'video'
       expected.event_data.text = 'An example video'
       expected.event_data.url = 'https://www.youtube.com/watch?v=abcdef'
-      expected.event_data.video_duration = 500
+      expected.event_data.length = 500
       expected.event_data.event_name = 'video_progress'
       expected.event_data.action = 'progress'
       expected.govuk_gem_version = 'aVersion'


### PR DESCRIPTION
## What
- tracks text copy events within the browser
- copied text is determined using the window.getSelection() method, assuming that some text has been highlighted to copy, if not does not send an event
- strips PII, line breaks etc. from text

Have tested this in the major browsers, seems to be okay. Just in case I've wrapped the whole thing in a `try/catch` block to catch anything I've not thought of.

## Why
Part of the GA4 migration.

## Visual Changes
None.

Trello card: https://trello.com/c/s6uLhovR/751-add-tracking-browser-copy-events
