### PR TITLE
[WIP] Add blue bottom border to the blue nav menu

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -96,6 +96,18 @@ $after-button-padding-left: govuk-spacing(4);
 .gem-c-layout-super-navigation-header--blue-background {
   background: $govuk-brand-colour;
   border-top: 1px solid $govuk-brand-colour;
+
+  // Add a blue section to the bottom of the open menu
+  .gem-c-layout-super-navigation-header__content {
+    @include govuk-media-query($from: "desktop") {
+      &::after {
+        content: "";
+        height: 35px;
+        background-color: $govuk-brand-colour;
+        display: block;
+      }
+    }
+  }
 }
 
 .gem-c-layout-super-navigation-header__container {


### PR DESCRIPTION
## What
Add a blue bottom border to the nav menu contents to the blue nav menu, this is only displayed on desktop screen sizes.
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
<!-- What are the reasons behind this change being made? -->

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

### Before


### After
