### PR TITLE
Adjust option select JavaScript

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/components/option-select.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/option-select.js
@@ -172,7 +172,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       try {
         buttonAttributes = JSON.parse(buttonAttributes)
         for (var rawKey in buttonAttributes) {
-          var key = rawKey.replace(/_/i, '-').toLowerCase()
+          var key = rawKey.replace(/_/g, '-').toLowerCase()
           var rawValue = buttonAttributes[rawKey]
           var value = typeof rawValue === 'object' ? JSON.stringify(rawValue) : rawValue
           button.setAttribute('data-' + key, value)

--- a/spec/javascripts/components/option-select-spec.js
+++ b/spec/javascripts/components/option-select-spec.js
@@ -157,7 +157,7 @@ describe('An option select component', function () {
       $element = document.createElement('div')
       $element.innerHTML = html
       var buttonAttrs = {
-        ga4_expandable: '',
+        test_attribute_with_many_underscores: 'oh yes',
         ga4_event: {
           event_name: 'select_content',
           type: 'finder'
@@ -166,7 +166,7 @@ describe('An option select component', function () {
       $element.querySelector('.gem-c-option-select').setAttribute('data-button-data-attributes', JSON.stringify(buttonAttrs))
 
       new GOVUK.Modules.OptionSelect($element.querySelector('.gem-c-option-select')).init()
-      expect($($element).find('.gem-c-option-select__button').attr('data-ga4-expandable')).toBe('')
+      expect($($element).find('.gem-c-option-select__button').attr('data-test-attribute-with-many-underscores')).toBe('oh yes')
       expect($($element).find('.gem-c-option-select__button').attr('data-ga4-event')).toBe(JSON.stringify(buttonAttrs.ga4_event))
     })
 
@@ -176,7 +176,7 @@ describe('An option select component', function () {
       $element.querySelector('.gem-c-option-select').setAttribute('data-button-data-attributes', 'not JSON')
 
       new GOVUK.Modules.OptionSelect($element.querySelector('.gem-c-option-select')).init()
-      expect($($element).find('.gem-c-option-select__button').attr('data-ga4-expandable')).toBe(undefined)
+      expect($($element).find('.gem-c-option-select__button').attr('data-test-attribute-with-many-underscores')).toBe(undefined)
     })
   })
 


### PR DESCRIPTION
## What / why
Fixes a possible problem with the button data attributes functionality, where attribute names with more than one underscore might not have been properly converted. Noticed in https://github.com/alphagov/finder-frontend/pull/3224 relating to the expander component, which uses the same code for the same functionality.

## Visual Changes
None.
