### PR TITLE
Add documentation for the GA4 copy tracker

### DIFF
--- a/docs/analytics-ga4/ga4-all-trackers.md
+++ b/docs/analytics-ga4/ga4-all-trackers.md
@@ -4,15 +4,19 @@ For tracking different kinds of data on GOV.UK we have built several different t
 
 Most of the trackers work by adding a `data-module` attribute to an element along with additional data attributes to provide specific tracking information. Some components have this already built into their code by default. These components should also include a `disable_ga4` option as a failsafe.
 
-## Auto tracking
+## Auto tracker
 
 The [auto tracker](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-auto-tracker.md) is used to cause an event to occur as soon as a page has finished loading (but after a page view). This is used to track significant moments in journeys, such as the successful completion of a smart answer, or an error.
+
+## Copy tracker
+
+The [copy tracker](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-copy-tracker.md) fires an event when text is copied from a page.
 
 ## Ecommerce tracker
 
 The [ecommerce tracker](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-ecommerce-tracker.md) is used to track things like search results within a finder.
 
-## Event tracking
+## Event tracker
 
 The [event tracker](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-event-tracker.md) handles tracking on buttons or other interactive elements, such as tabs and details elements.
 
@@ -20,7 +24,7 @@ The [event tracker](https://github.com/alphagov/govuk_publishing_components/blob
 
 The [form tracker](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-form-tracker.md) is designed to capture data about a form when it has been submitted.
 
-## Link tracking
+## Link tracker
 
 There are several types of link tracking. To distinguish them and simplify the code, we define them as follows.
 

--- a/docs/analytics-ga4/ga4-copy-tracker.md
+++ b/docs/analytics-ga4/ga4-copy-tracker.md
@@ -1,0 +1,28 @@
+# Google Analytics 4 copy tracker
+
+This script creates an event when text is copied from a GOV.UK page. When initialised, it adds an event listener to the page for the `copy` event. An event will be fired if the following are true:
+
+- some text has been selected
+- the selected text is not inside an INPUT or TEXTAREA
+
+The second check is based around concerns over PII. Text copied from the body of a GOV.UK page should not include PII, but text inside a text input is written by users, and therefore could contain PII. Note that if text is selected spanning multiple elements including a text input, the browser automatically does not include the text from inputs.
+
+When a 'valid' copy event occurs, the following is sent to the dataLayer.
+
+```JSON
+{
+  "event": "event_data",
+  "event_data": {
+    "event_name": "copy",
+    "type": "copy",
+    "action": "copy",
+    "method": "browser copy",
+    "text": "Some copied text",
+    "length": 245
+  }
+}
+```
+
+The `text` attribute contains the first 30 characters of the copied text, with PII removed.
+
+The `length` attribute shows the original number of characters that were copied.


### PR DESCRIPTION
## What
Adds some documentation for the GA4 copy tracker.

## Why
Forgot to add as part of https://github.com/alphagov/govuk_publishing_components/pull/3761

## Visual Changes
None.

Trello card: https://trello.com/c/s6uLhovR/751-add-tracking-browser-copy-events