### PR TITLE
Remove hardcoded text from GA4 'Feedback component' tracking, and add disable_ga4 option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Remove hardcoded text from GA4 'Feedback component' tracking, and add disable_ga4 option ([PR #3769](https://github.com/alphagov/govuk_publishing_components/pull/3769))
 * Add GA4 copy event tracker ([PR #3761](https://github.com/alphagov/govuk_publishing_components/pull/3761))
 
 ## 37.0.0

--- a/app/views/govuk_publishing_components/components/_feedback.html.erb
+++ b/app/views/govuk_publishing_components/components/_feedback.html.erb
@@ -9,10 +9,14 @@
   email_regex = /[^\s=\/?&]+(?:@|%40)[^\s=\/?&]+/
   url_without_pii = utf_encode(request.original_url.gsub(email_regex, '[email]'))
   path_without_pii = utf_encode(request.fullpath.gsub(email_regex, '[email]'))
+
+  disable_ga4 ||= false
+  data_module = "feedback"
+  data_module << " ga4-event-tracker" unless disable_ga4
 %>
 
-<div class="gem-c-feedback govuk-!-display-none-print" data-module="feedback ga4-event-tracker">
-  <%= render "govuk_publishing_components/components/feedback/yes_no_banner" %>
-  <%= render "govuk_publishing_components/components/feedback/problem_form", url_without_pii: url_without_pii %>
-  <%= render "govuk_publishing_components/components/feedback/survey_signup_form", path_without_pii: path_without_pii %>
+<div class="gem-c-feedback govuk-!-display-none-print" data-module="<%= data_module %>">
+  <%= render "govuk_publishing_components/components/feedback/yes_no_banner", disable_ga4: %>
+  <%= render "govuk_publishing_components/components/feedback/problem_form", url_without_pii: url_without_pii, disable_ga4: %>
+  <%= render "govuk_publishing_components/components/feedback/survey_signup_form", path_without_pii: path_without_pii, disable_ga4: %>
 </div>

--- a/app/views/govuk_publishing_components/components/docs/feedback.yml
+++ b/app/views/govuk_publishing_components/components/docs/feedback.yml
@@ -25,3 +25,8 @@ shared_accessibility_criteria:
 examples:
   default:
     data: {}
+  with_ga4_tracking_disabled:
+    description: |
+      Disables GA4 tracking on the feedback component. Tracking is enabled by default, which adds a data module and data-attributes with JSONs to the feedback buttons. See the [ga4-event-tracker documentation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-event-tracker.md) for more information.
+    data:
+      disable_ga4: true

--- a/app/views/govuk_publishing_components/components/feedback/_problem_form.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_problem_form.html.erb
@@ -38,15 +38,21 @@
         rows: 3
       } %>
 
-      <%= render "govuk_publishing_components/components/button", {
-        text: t("components.feedback.send"),
-        data_attributes: {
-          ga4_event: {
+      <%
+        unless disable_ga4 
+          ga4_submit_button_event = {
             event_name: "form_submit",
             type: "feedback",
             text: t("components.feedback.send", locale: :en),
             section: t("components.feedback.help_us_improve_govuk", locale: :en),
-          }
+          }.to_json
+        end
+      %>
+
+      <%= render "govuk_publishing_components/components/button", {
+        text: t("components.feedback.send"),
+        data_attributes: {
+          ga4_event: ga4_submit_button_event
         }
       } %>
 

--- a/app/views/govuk_publishing_components/components/feedback/_problem_form.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_problem_form.html.erb
@@ -44,8 +44,8 @@
           ga4_event: {
             event_name: "form_submit",
             type: "feedback",
-            text: "Send",
-            section: "Help us improve GOV.UK",
+            text: t("components.feedback.send", locale: :en),
+            section: t("components.feedback.help_us_improve_govuk", locale: :en),
           }
         }
       } %>

--- a/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
@@ -31,8 +31,8 @@
           ga4_event: {
             event_name: "form_submit",
             type: "feedback",
-            text: "Send me the survey",
-            section: "Help us improve GOV.UK",
+            text: t("components.feedback.send_me_survey", locale: :en),
+            section: t("components.feedback.help_us_improve_govuk", locale: :en),
           }
         }
       } %>

--- a/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
@@ -25,15 +25,21 @@
         describedby: "survey_explanation"
       } %>
 
-      <%= render "govuk_publishing_components/components/button", {
-        text: t("components.feedback.send_me_survey"),
-        data_attributes: {
-          ga4_event: {
+      <%
+        unless disable_ga4
+          ga4_send_button_event = {
             event_name: "form_submit",
             type: "feedback",
             text: t("components.feedback.send_me_survey", locale: :en),
             section: t("components.feedback.help_us_improve_govuk", locale: :en),
-          }
+          }.to_json
+        end
+      %>
+
+      <%= render "govuk_publishing_components/components/button", {
+        text: t("components.feedback.send_me_survey"),
+        data_attributes: {
+          ga4_event: ga4_send_button_event
         }
       } %>
 

--- a/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
@@ -1,3 +1,28 @@
+<%
+  unless disable_ga4
+    ga4_yes_button_event = {
+      "event_name": "form_submit",
+      "type": "feedback",
+      "text": t("components.feedback.yes", locale: :en), 
+      "section": t("components.feedback.is_this_page_useful", locale: :en),
+      }.to_json
+
+    ga4_no_button_event = {
+      "event_name": "form_submit",
+      "type": "feedback",
+      "text": t("components.feedback.no", locale: :en),
+      "section": t("components.feedback.is_this_page_useful", locale: :en)
+      }.to_json
+
+    ga4_problem_button_event = {
+      "event_name": "form_submit",
+      "type": "feedback",
+      "text": t("components.feedback.something_wrong", locale: :en),
+      "section": t("components.feedback.is_this_page_useful", locale: :en)
+    }.to_json
+  end
+%>
+
 <div class="gem-c-feedback__prompt gem-c-feedback__js-show js-prompt" tabindex="-1">
   <div class="gem-c-feedback__prompt-content">
     <div class="gem-c-feedback__prompt-questions js-prompt-questions" hidden>
@@ -20,14 +45,31 @@
             <% end %>
           </li>
           <li class="gem-c-feedback__option-list-item">
-            <button class="govuk-button gem-c-feedback__prompt-link js-page-is-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffYesClick" data-ga4-event="<%= { "event_name": "form_submit","type": "feedback","text": t("components.feedback.yes", locale: :en), "section": t("components.feedback.is_this_page_useful", locale: :en)}.to_json %>">
+            <%= tag.button(
+              class: "govuk-button gem-c-feedback__prompt-link js-page-is-useful",
+              data: {
+                track_category: "yesNoFeedbackForm",
+                track_action: "ffYesClick",
+                ga4_event: ga4_yes_button_event,
+              }) do %>
               <%= t("components.feedback.yes") %> <span class="govuk-visually-hidden"><%= t("components.feedback.is_useful") %></span>
-            </button>
+            <% end %>
           </li>
           <li class="gem-c-feedback__option-list-item">
-            <button class="govuk-button gem-c-feedback__prompt-link js-toggle-form js-page-is-not-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffNoClick" aria-controls="page-is-not-useful" aria-expanded="false" data-ga4-event="<%= {"event_name": "form_submit","type": "feedback","text": t("components.feedback.no", locale: :en), "section": t("components.feedback.is_this_page_useful", locale: :en)}.to_json %>">
+
+            <%= tag.button(
+              class: "govuk-button gem-c-feedback__prompt-link js-toggle-form js-page-is-not-useful",
+              aria: {
+                controls: "page-is-not-useful",
+                expanded: "false",
+              },
+              data: {
+                track_category: "yesNoFeedbackForm",
+                track_action: "ffNoClick",
+                ga4_event: ga4_no_button_event,
+              }) do %>
               <%= t("components.feedback.no") %> <span class="govuk-visually-hidden"><%= t("components.feedback.is_not_useful") %></span>
-            </button>
+            <% end %>
           </li>
         </ul>
       </div>
@@ -38,9 +80,19 @@
     </div>
 
     <div class="gem-c-feedback__prompt-questions gem-c-feedback__prompt-questions--something-is-wrong js-prompt-questions" hidden>
-      <button class="govuk-button gem-c-feedback__prompt-link js-toggle-form js-something-is-wrong" data-track-category="Onsite Feedback" data-track-action="GOV-UK Open Form" aria-controls="something-is-wrong" aria-expanded="false" data-ga4-event="<%= {"event_name": "form_submit","type": "feedback","text": t("components.feedback.something_wrong", locale: :en), "section": t("components.feedback.is_this_page_useful", locale: :en)}.to_json %>">
+      <%= tag.button(
+        class: "govuk-button gem-c-feedback__prompt-link js-toggle-form js-something-is-wrong",
+        aria: {
+          expanded: "false",
+          controls: "something-is-wrong"
+        },
+        data: {
+          track_category: "Onsite Feedback",
+          track_action: "GOV-UK Open Form",
+          ga4_event: ga4_problem_button_event,
+        }) do %>
         <%= t("components.feedback.something_wrong") %>
-      </button>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
@@ -20,12 +20,12 @@
             <% end %>
           </li>
           <li class="gem-c-feedback__option-list-item">
-            <button class="govuk-button gem-c-feedback__prompt-link js-page-is-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffYesClick" data-ga4-event='{"event_name":"form_submit","type":"feedback","text":"Yes", "section": "Is this page useful?"}'>
+            <button class="govuk-button gem-c-feedback__prompt-link js-page-is-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffYesClick" data-ga4-event="<%= { "event_name": "form_submit","type": "feedback","text": t("components.feedback.yes", locale: :en), "section": t("components.feedback.is_this_page_useful", locale: :en)}.to_json %>">
               <%= t("components.feedback.yes") %> <span class="govuk-visually-hidden"><%= t("components.feedback.is_useful") %></span>
             </button>
           </li>
           <li class="gem-c-feedback__option-list-item">
-            <button class="govuk-button gem-c-feedback__prompt-link js-toggle-form js-page-is-not-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffNoClick" aria-controls="page-is-not-useful" aria-expanded="false" data-ga4-event='{"event_name":"form_submit","type":"feedback","text":"No", "section": "Is this page useful?"}'>
+            <button class="govuk-button gem-c-feedback__prompt-link js-toggle-form js-page-is-not-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffNoClick" aria-controls="page-is-not-useful" aria-expanded="false" data-ga4-event="<%= {"event_name": "form_submit","type": "feedback","text": t("components.feedback.no", locale: :en), "section": t("components.feedback.is_this_page_useful", locale: :en)}.to_json %>">
               <%= t("components.feedback.no") %> <span class="govuk-visually-hidden"><%= t("components.feedback.is_not_useful") %></span>
             </button>
           </li>
@@ -38,7 +38,7 @@
     </div>
 
     <div class="gem-c-feedback__prompt-questions gem-c-feedback__prompt-questions--something-is-wrong js-prompt-questions" hidden>
-      <button class="govuk-button gem-c-feedback__prompt-link js-toggle-form js-something-is-wrong" data-track-category="Onsite Feedback" data-track-action="GOV-UK Open Form" aria-controls="something-is-wrong" aria-expanded="false" data-ga4-event='{"event_name":"form_submit","type":"feedback","text":"Report a problem with this page", "section": "Is this page useful?"}'>
+      <button class="govuk-button gem-c-feedback__prompt-link js-toggle-form js-something-is-wrong" data-track-category="Onsite Feedback" data-track-action="GOV-UK Open Form" aria-controls="something-is-wrong" aria-expanded="false" data-ga4-event="<%= {"event_name": "form_submit","type": "feedback","text": t("components.feedback.something_wrong", locale: :en), "section": t("components.feedback.is_this_page_useful", locale: :en)}.to_json %>">
         <%= t("components.feedback.something_wrong") %>
       </button>
     </div>


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Removes hardcoded `text` and `section` values from the GA4 Feedback tracking, using the translation variables instead
- Adds the `disable_ga4` variable to the component so that tracking can be disabled

## Why
<!-- What are the reasons behind this change being made? -->
https://trello.com/c/DbAXO3lU/556-stop-text-that-can-be-translated-using-hard-coded-text-values

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->
Adds another example to the component page

<img width="1039" alt="image" src="https://github.com/alphagov/govuk_publishing_components/assets/8880610/57ad1b4a-8c4e-4dbb-9442-cdb5bbd7ad84">

