### PR TITLE
Fix failing tests

### DIFF
--- a/app/assets/config/govuk_publishing_components_manifest.js
+++ b/app/assets/config/govuk_publishing_components_manifest.js
@@ -1,7 +1,7 @@
 // Pre-compile image and font assets from here and govuk-frontend
 //= link_tree ../images
+//= link_tree ../../../node_modules/govuk-frontend/govuk/assets/
 //= link_tree ../../../node_modules/govuk-frontend/govuk/assets/images
-//= link_tree ../../../node_modules/govuk-frontend/govuk/assets/fonts
 
 // Create asset files of each of the files in these directory
 //= link_directory ../javascripts/component_guide

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -16,8 +16,8 @@ elsif Gem.loaded_specs.key?("sassc-rails")
 end
 
 Rails.application.config.assets.paths += %W[
+  #{__dir__}/../../node_modules/govuk-frontend/govuk/assets/
   #{__dir__}/../../node_modules/govuk-frontend/govuk/assets/images
-  #{__dir__}/../../node_modules/govuk-frontend/govuk/assets/fonts
   #{__dir__}/../../node_modules/govuk-frontend/
   #{__dir__}/../../node_modules/
 ]


### PR DESCRIPTION
## What
Fix some failing tests.

- getting the error "No route matches [#{env['REQUEST_METHOD']}] #{env['PATH_INFO'].inspect}" running tests, relating to woff files
- also getting 404s trying to find some font files when looking at the component guide in a browser
- I think the paths in govuk-frontend have changed for fonts, so we need to adjust our manifest accordingly
- interestingly can't just add a manifest line for the whole of assets, still need to explicitly include the images path as well

![Screenshot 2023-12-13 at 13 25 18](https://github.com/alphagov/govuk_publishing_components/assets/861310/e1beedaf-e8f5-4268-b9fa-d926eb8646c8)


## Why
Blocking PR tests from passing.

## Visual Changes
None.
