### PR TITLE
Silence Sass deprecation warnings for dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add GA4 copy event tracker ([PR #3761](https://github.com/alphagov/govuk_publishing_components/pull/3761))
+* Silence Sass deprecation warnings for dependencies ([PR #3771](https://github.com/alphagov/govuk_publishing_components/pull/3771))
 
 ## 37.0.0
 

--- a/spec/dummy/config/initializers/dartsass.rb
+++ b/spec/dummy/config/initializers/dartsass.rb
@@ -6,3 +6,5 @@ APP_STYLESHEETS = {
 
 all_stylesheets = APP_STYLESHEETS.merge(GovukPublishingComponents::Config.all_stylesheets)
 Rails.application.config.dartsass.builds = all_stylesheets
+
+Rails.application.config.dartsass.build_options << " --quiet-deps"


### PR DESCRIPTION
## What
Silence Sass deprecation warnings for dependencies.

## Why

GOV.UK Frontend displays the following deprecation warnings:
```
Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.
Recommendation: math.div(200%, 3) or calc(200% / 3)
More info and automated migrator: https://sass-lang.com/d/slash-div
```

We are unable to fix the underlying issues so have silenced the warnings.

See https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#override-with-your-own-css.

## Visual Changes

None.

## Anything else

Issues will be created for deprecation warnings not originating from dependencies e.g.
```
Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.
Recommendation: math.div($number-circle-size-large, 2) or calc($number-circle-size-large / 2)
More info and automated migrator: https://sass-lang.com/d/slash-div
│
25 │ margin-left: govuk-em(($number-circle-size-large / 2) - ($stroke-width / 2), 16);
│                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
│ app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss 25:26  step-nav-line-position-large()
```