### PR TITLE
Fix duplicate font download issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Add GA4 copy event tracker ([PR #3761](https://github.com/alphagov/govuk_publishing_components/pull/3761))
 * Silence Sass deprecation warnings for dependencies ([PR #3771](https://github.com/alphagov/govuk_publishing_components/pull/3771))
+* Fix duplicate font download issue ([PR #3772](https://github.com/alphagov/govuk_publishing_components/pull/3772))
 
 ## 37.0.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
@@ -1,3 +1,4 @@
+@import "govuk_publishing_components/individual_component_support";
 @import "govuk_publishing_components/components/search";
 @import "govuk_publishing_components/components/skip-link";
 @import "govuk/components/header/header";


### PR DESCRIPTION
## What

Fix duplicate font download issue.

## Why

This prevents inclusion of `@font-face` declarations (from `_layout-header.css`) which are not needed since they are served from elsewhere e.g. Static or the Component Guide stylesheets.

See https://frontend.design-system.service.gov.uk/sass-api-reference/#govuk-include-default-font-face.

## Visual Changes

None.