### PR TITLE
Version 37.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 37.1.0
 
 * Remove hardcoded text from GA4 'Feedback component' tracking, and add disable_ga4 option ([PR #3769](https://github.com/alphagov/govuk_publishing_components/pull/3769))
 * Add GA4 copy event tracker ([PR #3761](https://github.com/alphagov/govuk_publishing_components/pull/3761))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (37.0.0)
+    govuk_publishing_components (37.1.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "37.0.0".freeze
+  VERSION = "37.1.0".freeze
 end


### PR DESCRIPTION
## 37.1.0

* Remove hardcoded text from GA4 'Feedback component' tracking, and add disable_ga4 option ([PR #3769](https://github.com/alphagov/govuk_publishing_components/pull/3769))
* Add GA4 copy event tracker ([PR #3761](https://github.com/alphagov/govuk_publishing_components/pull/3761))
* Silence Sass deprecation warnings for dependencies ([PR #3771](https://github.com/alphagov/govuk_publishing_components/pull/3771))
* Fix duplicate font download issue ([PR #3772](https://github.com/alphagov/govuk_publishing_components/pull/3772))
