### PR TITLE
Fix failing test

### DIFF
--- a/spec/component_guide/component_example_accessibility_testing_spec.rb
+++ b/spec/component_guide/component_example_accessibility_testing_spec.rb
@@ -15,7 +15,7 @@ describe "Component example with automated testing", js: true do
     visit "/component-guide/test_component_with_a11y_issue"
     expect(page).to have_selector(".js-test-a11y-failed.js-test-a11y-finished")
 
-    expect(page.driver.browser.logs.get(:browser).map { |e| e.message if e.message.match(/Accessibility issues/) }).not_to be_empty
+    expect(page.driver.browser.logs.get(:browser)[0].message.include?("Accessibility issues"))
 
     selector_with_error = page.first(".selector").text
     expect(page).to have_selector(selector_with_error, visible: false)


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Change how a test grabs a console log message
- I think the array of console logs now only has one entry in it with all the console logs in, instead of one entry per console log. Therefore we only need to check the first entry for the inclusion of the 'Accessibility issues' message

## Why
<!-- What are the reasons behind this change being made? -->
- Fixes a failing test

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

### Before


### After
