### PR TITLE
Delete unused builds folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Delete unused builds folder ([PR #3778](https://github.com/alphagov/govuk_publishing_components/pull/3778))
+
 ## 37.1.0
 
 * Remove hardcoded text from GA4 'Feedback component' tracking, and add disable_ga4 option ([PR #3769](https://github.com/alphagov/govuk_publishing_components/pull/3769))

--- a/app/assets/config/govuk_publishing_components_manifest.js
+++ b/app/assets/config/govuk_publishing_components_manifest.js
@@ -11,5 +11,3 @@
 //= link govuk_publishing_components/vendor/modernizr.js
 //= link govuk_publishing_components/vendor/lux/lux-reporter.js
 //= link govuk_publishing_components/vendor/lux/lux-measurer.js
-
-//= link_tree ../builds


### PR DESCRIPTION
## What

Delete unused builds folder.

## Why

Fix `Sprockets::ArgumentError: link_tree argument must be a directory (Sprockets::ArgumentError)`.

The builds folder isn't required on its own; it's only necessary for the application (see [dummy app manifest here](https://github.com/alphagov/govuk_publishing_components/blob/main/spec/dummy/app/assets/config/manifest.js#L5)). The Dart Sass initializer (see [dummy app config here](https://github.com/alphagov/govuk_publishing_components/blob/main/spec/dummy/config/initializers/dartsass.rb), for example) compiles all Sass entry points, including those from the Publishing Components.

## Visual Changes

None.