### PR TITLE
Remove duplicate GA4 tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Remove duplicate GA4 tracking ([PR #3781](https://github.com/alphagov/govuk_publishing_components/pull/3781))
 * Delete unused builds folder ([PR #3778](https://github.com/alphagov/govuk_publishing_components/pull/3778))
 
 ## 37.1.0

--- a/app/views/govuk_publishing_components/components/_metadata.html.erb
+++ b/app/views/govuk_publishing_components/components/_metadata.html.erb
@@ -65,11 +65,7 @@
                     class="gem-c-metadata__definition-link govuk-!-display-none-print js-see-all-updates-link"
                     data-track-category="content-history"
                     data-track-action="see-all-updates-link-clicked"
-                    data-track-label="history"
-                    <% unless disable_ga4 %>
-                      data-module="ga4-link-tracker"
-                      data-ga4-link="<%= ga4_object %>"
-                    <% end%>>
+                    data-track-label="history">
             <%= t("components.metadata.see_all_updates") %>
           </a>
         <% end %>

--- a/spec/components/metadata_spec.rb
+++ b/spec/components/metadata_spec.rb
@@ -223,11 +223,6 @@ describe "Metadata", type: :view do
       "action": "opened",
     }.to_json
 
-    assert_select ".js-see-all-updates-link" do |see_all_updates_link|
-      expect(see_all_updates_link.attr("data-module").to_s).to eq "ga4-link-tracker"
-      expect(see_all_updates_link.attr("data-ga4-link").to_s).to eq expected_ga4_json
-    end
-
     assert_select ".gem-c-metadata__definition:nth-of-type(2)" do |alternate_see_all_updates_container|
       expect(alternate_see_all_updates_container.attr("data-module").to_s).to eq "ga4-link-tracker"
       expect(alternate_see_all_updates_container.attr("data-ga4-track-links-only").to_s).to eq ""


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Having the tracking on this link triggers a link click and a select_content as it expands an accordion on the same page. So we remove the link click tracking so only one event fires for the interaction. Example of the issue: https://www.gov.uk/government/consultations/primate-licensing-scheme on the 'See all updates' link.

## Why
<!-- What are the reasons behind this change being made? -->
- https://trello.com/c/jf1V3D02/770-placeholder-duplicate-content-history-events-firing-on-some-pages

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
