### PR TITLE
Details component GA4 tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Details component GA4 tracking ([PR #3786](https://github.com/alphagov/govuk_publishing_components/pull/3786))
+
 ## 37.1.1
 
 * Make global relative links absolute ([PR #3699](https://github.com/alphagov/govuk_publishing_components/pull/3699))

--- a/app/views/govuk_publishing_components/components/_details.html.erb
+++ b/app/views/govuk_publishing_components/components/_details.html.erb
@@ -2,23 +2,39 @@
   add_gem_component_stylesheet("details")
 
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
-
   open ||= nil
+  disable_ga4 ||= false
+  @ga4 ||= OpenStruct.new(index_section: 0) unless disable_ga4
+  @ga4[:index_section] += 1 unless disable_ga4
+  ga4_attributes ||= {}
+
   margin_bottom ||= 3
   css_classes = %w(gem-c-details govuk-details)
   css_classes << shared_helper.get_margin_bottom
 
   details_data_attributes = {}
   details_data_attributes[:module] = 'govuk-details gem-details'
+  details_data_attributes[:module] = 'govuk-details gem-details ga4-event-tracker' unless disable_ga4
 
   data_attributes ||= {}
   data_attributes[:details_track_click] = ''
+  unless disable_ga4
+    ga4_event = {
+      event_name: "select_content",
+      type: "detail",
+      text: title,
+      section: title,
+      index_section: @ga4[:index_section],
+    }
+    ga4_event.merge!(ga4_attributes)
+    data_attributes[:ga4_event] = ga4_event
+  end
 
   summary_aria_attributes ||= {}
 %>
 <%= tag.details class: css_classes, data: details_data_attributes, open: open do %>
   <%= tag.summary class: "govuk-details__summary", data: data_attributes, aria: summary_aria_attributes do %>
-    <span class="govuk-details__summary-text">
+    <span class="govuk-details__summary-text" <% unless disable_ga4 %>data-ga4-expandable<% end %>>
       <%= title %>
     </span>
   <% end %>

--- a/app/views/govuk_publishing_components/components/docs/details.yml
+++ b/app/views/govuk_publishing_components/components/docs/details.yml
@@ -61,6 +61,27 @@ examples:
         tracking: GTM-123AB
       block: |
         We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post.
+  with_ga4_tracking:
+    description: |
+      GA4 tracking is mostly handled internally by the component, apart from the required attribute `index_section_count`. This records the number of details components on the page and must be passed by the hosting application. Other GA4 attributes can also be passed if required, including to override attributes set by the component (for some reason this doesn't work in the component guide but works in applications).
+
+      The tracking automatically includes `index_section` as the index of the component on the page compared with other instances of the component that are also being tracked, e.g. the first details component on a page will be `index_section` 1, the second `index_section` 2, etc.
+
+      Link tracking for the contents of the details component is not included due to varying tracking requirements. If you need to track links in the component, wrap it in the application with the [GA4 link tracker](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-link-tracker.md).
+    data:
+      title: What did the ground say to the train?
+      ga4_attributes: {
+        index_section_count: 6,
+        type: "not the default"
+      }
+      block: |
+        Between you and me, I've been tracked.
+  disable_ga4_tracking:
+    description: Disables GA4 tracking on the component. Tracking is enabled by default.
+    data:
+      title: No tracking here
+      disable_ga4: true
+      block: Or here, but thanks for looking.
   open:
     data:
       title: Help with nationality

--- a/spec/components/details_spec.rb
+++ b/spec/components/details_spec.rb
@@ -10,8 +10,8 @@ describe "Details", type: :view do
       "This is more info"
     end
 
-    assert_select "details.gem-c-details"
-    assert_select ".govuk-details__summary-text", text: "Some title"
+    assert_select "details.gem-c-details[data-module='govuk-details gem-details ga4-event-tracker']"
+    assert_select ".govuk-details__summary-text[data-ga4-expandable]", text: "Some title"
     assert_select ".govuk-details__text", text: "This is more info"
   end
 
@@ -65,5 +65,38 @@ describe "Details", type: :view do
     )
 
     assert_select '.govuk-details.govuk-\!-margin-bottom-3'
+  end
+
+  it "increments the GA4 index_section parameter when more than one component instance" do
+    render_component(title: "first details")
+    assert_select '.govuk-details__summary[data-ga4-event=\'{"event_name":"select_content","type":"detail","text":"first details","section":"first details","index_section":1}\']'
+
+    render_component(title: "second details")
+    assert_select '.govuk-details__summary[data-ga4-event=\'{"event_name":"select_content","type":"detail","text":"second details","section":"second details","index_section":2}\']'
+  end
+
+  it "accepts GA4 event data parameters" do
+    render_component(
+      title: "some title",
+      ga4_attributes: { index_section_count: 12 },
+    )
+    assert_select '.govuk-details__summary[data-ga4-event=\'{"event_name":"select_content","type":"detail","text":"some title","section":"some title","index_section":1,"index_section_count":12}\']'
+  end
+
+  it "can override GA4 event data parameters" do
+    render_component(
+      title: "some title",
+      ga4_attributes: { type: "a mouse!", index_section_count: 12 },
+    )
+    assert_select '.govuk-details__summary[data-ga4-event=\'{"event_name":"select_content","type":"a mouse!","text":"some title","section":"some title","index_section":1,"index_section_count":12}\']'
+  end
+
+  it "can disable GA4" do
+    render_component(
+      title: "some title",
+      disable_ga4: true,
+    )
+    assert_select ".govuk-details__summary[data-ga4-event]", false
+    assert_select ".govuk-details__summary-text[data-ga4-expandable]", false
   end
 end


### PR DESCRIPTION
## What
- adds GA4 tracking (by default) to the details component
- includes disable_ga4 option to disable tracking
- uses an OpenStruct to record the index of details components on a page for the `index_section` GA4 attribute
- total number of details components is also required for `index_section_count` attribute, but cannot determine automatically
- instead can pass a hash of GA4 attributes, which are then merged with the defaults
- passing can allow existing attributes to be overridden
- tracking on links not included owing to varying requirements, better to wrap the component in the link tracker in applications, where tracking is required

## Why
Part of the GA4 migration.

## Visual Changes
None.

Trello card: https://trello.com/c/xhASj1rp/765-add-tracking-to-details-component