### PR TITLE
[DO NOT MERGE] Refactor image card tracking approach #1

### DIFF
--- a/app/views/govuk_publishing_components/components/_image_card.html.erb
+++ b/app/views/govuk_publishing_components/components/_image_card.html.erb
@@ -3,6 +3,7 @@
 
   sizes ||= false
   brand ||= false
+  disable_ga4 ||= false
 
   brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)
   card_helper = GovukPublishingComponents::Presenters::ImageCardHelper.new(local_assigns, brand_helper)
@@ -35,7 +36,8 @@
   extra_link_classes << brand_helper.color_class
 
   data_modules = %w[]
-  data_modules << "gem-track-click ga4-link-tracker" if card_helper.is_tracking?
+  data_modules << "gem-track-click" if card_helper.is_tracking?
+  data_modules << "ga4-link-tracker" unless disable_ga4
   data_modules << "image-card" if card_helper.youtube_video_id
 %>
 <% if card_helper.href || card_helper.extra_details.any? %>

--- a/app/views/govuk_publishing_components/components/docs/image_card.yml
+++ b/app/views/govuk_publishing_components/components/docs/image_card.yml
@@ -246,7 +246,7 @@ examples:
         <%= component %>
       </div>
   with_data_attributes:
-    description: Data attributes can be applied as required. Note that the component does not include built in tracking. If this is required consider using the [track click script](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics/track-click.md).
+    description: Data attributes can be applied as required. Note that the component does not include built in tracking for UA. If this is required consider using the [track click script](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics/track-click.md).
     data:
       href: "/i-am-not-a-valid-link"
       href_data_attributes: {
@@ -276,6 +276,32 @@ examples:
           }
         }
       ]
+  with_ga4_tracking:
+    description: The link tracker is enabled by default on the image card component, but in order to track `data-ga4-link` data must be passed to the component. See the [GA4 link tracker documentation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-link-tracker.md) for more information.
+    data:
+      href: "/not-a-page"
+      image_src: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG"
+      image_alt: "some meaningful alt text please"
+      heading_text: "News headline"
+      href_data_attributes: {
+        ga4_link: {
+          event_name: "navigation",
+          type: "homepage",
+          index_link: 1,
+          index_section: 1,
+          index_section_count: 1,
+          index_total: 1,
+          section: "name of section"
+        }
+      }
+  without_ga4_tracking:
+    description: Disables GA4 tracking.
+    data:
+      href: "/not-a-page"
+      image_src: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG"
+      image_alt: "some meaningful alt text please"
+      heading_text: "News headline"
+      disable_ga4: true
   with_metadata:
     description: Can be used for links to people pages to indicate payment type
     data:

--- a/spec/components/image_card_spec.rb
+++ b/spec/components/image_card_spec.rb
@@ -11,8 +11,9 @@ describe "ImageCard", type: :view do
 
   it "shows an image" do
     render_component(href: "#", image_src: "/moo.jpg", image_alt: "some meaningful alt text")
+    assert_select ".gem-c-image-card[data-module='ga4-link-tracker']"
     assert_select ".gem-c-image-card .gem-c-image-card__image[src='/moo.jpg'][alt='some meaningful alt text']"
-    assert_select ".gem-c-image-card[data-module='gem-track-click ga4-link-tracker']", false
+    assert_select ".gem-c-image-card[data-module='gem-track-click']", false
   end
 
   it "shows heading text" do
@@ -129,6 +130,11 @@ describe "ImageCard", type: :view do
     assert_select ".gem-c-image-card__title-link[data-track-category='cat']"
   end
 
+  it "can disable GA4 tracking" do
+    render_component(href: "#", image_src: "/moo.jpg", image_alt: "alt text", disable_ga4: true)
+    assert_select ".gem-c-image-card[data-module='ga4-link-tracker']", false
+  end
+
   it "applies tracking attributes for extra details" do
     render_component(href: "#", extra_details: [{ href: "/", text: "1", data_attributes: { track_category: "cat" } }])
     assert_select ".gem-c-image-card[data-module='gem-track-click ga4-link-tracker']"
@@ -180,7 +186,7 @@ describe "ImageCard", type: :view do
 
   it "adds the imagecard module if youtube video id added" do
     render_component(youtube_video_id: "EXAMPLE", image_src: "/moo.jpg", image_alt: "some meaningful alt text", sizes: "100vw, 300vw")
-    assert_select ".gem-c-image-card[data-module='image-card']"
+    assert_select ".gem-c-image-card[data-module='ga4-link-tracker image-card']"
   end
 
   it "generates youtube fallback link if youtube video id supplied" do


### PR DESCRIPTION
## What
Rework how GA4 tracking is done on the image card component. This is an experimental approach (see also https://github.com/alphagov/govuk_publishing_components/pull/3789)

Specifically:

- add the GA4 link tracker by default to the component
- document how this works - that `data-ga4-link` data still needs to be passed to the component for tracking to work
- include a `disable_ga4` option (as per our other components with tracking)

Pros:

- decouples the GA4 tracking from the UA tracking (ahead of removing the UA tracking)
- more clearly defines and documents how GA4 tracking should work

Cons:

- initialises the JS module for GA4 link tracking on all instances of the component, whether they are configured for tracking or not

## Why
Part of the GA4 migration.

## Visual Changes
None.

Trello card: https://trello.com/c/IymJPytQ/762-sort-out-image-card-component-tracking