### PR TITLE
Refactor image card tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Refactor image card tracking ([PR #3789](https://github.com/alphagov/govuk_publishing_components/pull/3789))
 * Details component GA4 tracking ([PR #3786](https://github.com/alphagov/govuk_publishing_components/pull/3786))
 
 ## 37.1.1

--- a/app/views/govuk_publishing_components/components/_image_card.html.erb
+++ b/app/views/govuk_publishing_components/components/_image_card.html.erb
@@ -7,13 +7,13 @@
   brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)
   card_helper = GovukPublishingComponents::Presenters::ImageCardHelper.new(local_assigns, brand_helper)
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
-
-  classes = %w[gem-c-image-card]
-  classes << "govuk-grid-row" if card_helper.two_thirds
-  classes << "gem-c-image-card--large" if card_helper.large
-  classes << "gem-c-image-card--two-thirds" if card_helper.two_thirds
-  classes << "gem-c-image-card--no-image" unless (card_helper.image_src || card_helper.youtube_video_id)
-  classes << brand_helper.brand_class if brand_helper.brand_class
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("gem-c-image-card")
+  component_helper.add_class("govuk-grid-row") if card_helper.two_thirds
+  component_helper.add_class("gem-c-image-card--large") if card_helper.large
+  component_helper.add_class("gem-c-image-card--two-thirds") if card_helper.two_thirds
+  component_helper.add_class("gem-c-image-card--no-image") unless (card_helper.image_src || card_helper.youtube_video_id)
+  component_helper.add_class(brand_helper.brand_class) if brand_helper.brand_class
 
   text_wrapper_classes = %w[gem-c-image-card__text-wrapper]
   text_wrapper_classes << "gem-c-image-card__text-wrapper--two-thirds" if card_helper.two_thirds
@@ -34,12 +34,12 @@
   ]
   extra_link_classes << brand_helper.color_class
 
-  data_modules = %w[]
-  data_modules << "gem-track-click ga4-link-tracker" if card_helper.is_tracking?
-  data_modules << "image-card" if card_helper.youtube_video_id
+  component_helper.add_data_attribute({ module: "gem-track-click" }) if card_helper.is_tracking?
+  component_helper.add_data_attribute({ module: "image-card" }) if card_helper.youtube_video_id
+  component_helper.set_lang(card_helper.lang)
 %>
 <% if card_helper.href || card_helper.extra_details.any? %>
-  <%= content_tag(:div, class: classes, "data-module": data_modules, lang: card_helper.lang) do %>
+  <%= tag.div(**component_helper.all_attributes) do %>
     <%= content_tag(:div, class: text_wrapper_classes) do %>
       <div class="gem-c-image-card__header-and-context-wrapper">
         <% if card_helper.heading_text %>

--- a/app/views/govuk_publishing_components/components/docs/image_card.yml
+++ b/app/views/govuk_publishing_components/components/docs/image_card.yml
@@ -12,6 +12,7 @@ accessibility_criteria: |
   - include alt text for images when present
   - not have duplicate links for the image and the text
   - if the contents of the component are in a different language than the rest of the document, include an appropriate `lang` attribute to correctly identify the language used in the component
+uses_component_wrapper_helper: true
 shared_accessibility_criteria:
   - link
 embed: |
@@ -276,6 +277,23 @@ examples:
           }
         }
       ]
+  with_ga4_tracking:
+    description: The component does not include an option for GA4 tracking, but data attributes to enable the [GA4 link tracker](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-link-tracker.md) can be passed as shown.
+    data:
+      href: "/not-a-page"
+      image_src: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG"
+      image_alt: "some meaningful alt text please"
+      heading_text: "News headline"
+      data_attributes:
+        module: "ga4-link-tracker"
+        ga4_link:
+          event_name: "navigation"
+          type: "homepage"
+          index_section: 1
+          index_link: 1
+          index_section_count: 1
+          index_total: 1
+          section: "homepage"
   with_metadata:
     description: Can be used for links to people pages to indicate payment type
     data:
@@ -293,17 +311,6 @@ examples:
         }
       ]
       extra_details_no_indent: true
-  with_lang:
-    description: |
-      Pass through an appropriate `lang` to set a HTML lang attribute for the component.
-
-      The `lang` attribute **must** be set to a [valid BCP47 string](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang#Language_tag_syntax). A valid code can be the two or three letter language code - for example, English is `en` or `eng`, Korean is `ko` or `kor` - but if in doubt please check.
-    data:
-      href: "/not-a-page"
-      image_src: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG"
-      image_alt: "some meaningful alt text please"
-      heading_text: Yr hyn rydym ni'n ei wneud
-      lang: cy
   with_sizes_attribute:
     description: |
       `sizes` is an attribute that makes use of html's native responsive images functionality.

--- a/spec/components/image_card_spec.rb
+++ b/spec/components/image_card_spec.rb
@@ -125,24 +125,19 @@ describe "ImageCard", type: :view do
 
   it "applies tracking attributes" do
     render_component(href: "#", href_data_attributes: { track_category: "cat" }, heading_text: "test")
-    assert_select ".gem-c-image-card[data-module='gem-track-click ga4-link-tracker']"
+    assert_select ".gem-c-image-card[data-module='gem-track-click']"
     assert_select ".gem-c-image-card__title-link[data-track-category='cat']"
   end
 
   it "applies tracking attributes for extra details" do
     render_component(href: "#", extra_details: [{ href: "/", text: "1", data_attributes: { track_category: "cat" } }])
-    assert_select ".gem-c-image-card[data-module='gem-track-click ga4-link-tracker']"
+    assert_select ".gem-c-image-card[data-module='gem-track-click']"
     assert_select ".gem-c-image-card__list-item a[data-track-category='cat']"
   end
 
   it "shows metadata" do
     render_component(href: "#", metadata: "Unpaid")
     assert_select ".gem-c-image-card__metadata", text: "Unpaid"
-  end
-
-  it "applies lang attribute when lang is specified" do
-    render_component(href: "#", lang: "cy")
-    assert_select ".gem-c-image-card[lang='cy']"
   end
 
   it "applies lazy loading attribute when lazy is specified" do


### PR DESCRIPTION
## What
Rework how GA4 tracking is done on the image card component (prototyped a different approach in https://github.com/alphagov/govuk_publishing_components/pull/3788)

Specifically:

- don't include any tracking at all on the component 😱 
- refactor the component to use the component wrapper helper...
- ...which allows any data attributes to be passed safely to the component without overwriting existing ones
- ...meaning that the link tracker and required data attributes can be passed to the component where required

Pros:

- another component using the component wrapper helper
- no additional code for tracking on the component, all handled by passing options

Cons:

- arguably a breaking change, as the current tracking for the homepage uses of the image card will stop working

This PR removes the test for passing a `lang` attribute to the component, as this functionality is now provided by the component wrapper helper.

## Why
Part of the GA4 migration.

## Visual Changes
None.

Trello card: https://trello.com/c/IymJPytQ/762-sort-out-image-card-component-tracking