### PR TITLE
Add timestamp value to GA4 dataLayer pushes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add timestamp value to GA4 dataLayer pushes ([PR #3790](https://github.com/alphagov/govuk_publishing_components/pull/3790))
 * Allow GA4 tracking on dev docs ([PR #3802](https://github.com/alphagov/govuk_publishing_components/pull/3802))
 * Ensure all GA4 data values are strings ([PR #3800](https://github.com/alphagov/govuk_publishing_components/pull/3800))
 * Refactor image card tracking ([PR #3789](https://github.com/alphagov/govuk_publishing_components/pull/3789))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -34,8 +34,14 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
       return navigator.userAgent
     },
 
+    getTimestamp: function () {
+      return Date.now().toString()
+    },
+
     sendData: function (data) {
       data.govuk_gem_version = this.getGemVersion()
+      data.timestamp = this.getTimestamp()
+
       // set this in the console as a debugging aid
       if (window.GOVUK.analyticsGa4.showDebug) {
         if (data.event_data) {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-auto-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-auto-tracker.spec.js
@@ -24,6 +24,7 @@ describe('Google Analytics auto tracker', function () {
     element = document.createElement('form')
     document.body.appendChild(element)
     agreeToCookies()
+    spyOn(GOVUK.analyticsGa4.core, 'getTimestamp').and.returnValue('123456')
   })
 
   afterEach(function () {
@@ -100,6 +101,7 @@ describe('Google Analytics auto tracker', function () {
         index_section_count: undefined
       }
       expected.govuk_gem_version = 'aVersion'
+      expected.timestamp = '123456'
 
       var attributes = {
         event_name: 'select_content',
@@ -130,6 +132,7 @@ describe('Google Analytics auto tracker', function () {
       expected.event_data.type = 'tabs'
       expected.event_data.text = '/[date]/[postcode]/[email]'
       expected.govuk_gem_version = 'aVersion'
+      expected.timestamp = '123456'
 
       var attributes = {
         event_name: 'select_content',

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-copy-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-copy-tracker.spec.js
@@ -20,6 +20,8 @@ describe('Google Analytics 4 copy tracker', function () {
     expected.event_data.action = 'copy'
     expected.event_data.method = 'browser copy'
     expected.govuk_gem_version = 'aVersion'
+    spyOn(GOVUK.analyticsGa4.core, 'getTimestamp').and.returnValue('123456')
+    expected.timestamp = '123456'
   })
 
   it('triggers a GA4 event when the copy event is fired', function () {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
@@ -58,13 +58,15 @@ describe('GA4 core', function () {
   })
 
   it('pushes data to the dataLayer', function () {
+    spyOn(GOVUK.analyticsGa4.core, 'getTimestamp').and.returnValue('123456')
     var data = {
       hello: 'I must be going'
     }
     GOVUK.analyticsGa4.core.sendData(data)
     expect(window.dataLayer[0]).toEqual({
       hello: 'I must be going',
-      govuk_gem_version: 'aVersion'
+      govuk_gem_version: 'aVersion',
+      timestamp: '123456'
     })
   })
 
@@ -116,7 +118,8 @@ describe('GA4 core', function () {
     var expected = schemas.mergeProperties(data, 'test')
     expected.govuk_gem_version = 'aVersion'
     expected.event_data.index.index_link = '3'
-
+    expected.timestamp = '123456'
+    spyOn(GOVUK.analyticsGa4.core, 'getTimestamp').and.returnValue('123456')
     GOVUK.analyticsGa4.core.applySchemaAndSendData(data, 'test')
     expect(window.dataLayer[0]).toEqual(expected)
   })
@@ -650,6 +653,13 @@ describe('GA4 core', function () {
         expect(builtEcommerceObject).toEqual(expectedEcommerceObject)
         expect(builtEcommerceObject.search_results.ecommerce.items.length).toEqual(200)
       })
+    })
+
+    it('populates the timestamp value correctly', function () {
+      GOVUK.analyticsGa4.core.sendData({})
+      var timestamp = Date.now().toString()
+
+      expect(window.dataLayer[0].timestamp).toEqual(timestamp)
     })
   })
 })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.spec.js
@@ -21,6 +21,7 @@ describe('Google Analytics event tracker', function () {
     window.dataLayer = []
     element = document.createElement('div')
     agreeToCookies()
+    spyOn(GOVUK.analyticsGa4.core, 'getTimestamp').and.returnValue('123456')
   })
 
   afterEach(function () {
@@ -106,6 +107,7 @@ describe('Google Analytics event tracker', function () {
       expected.event_data.type = 'tabs'
       expected.event_data.text = ''
       expected.govuk_gem_version = 'aVersion'
+      expected.timestamp = '123456'
 
       var attributes = {
         event_name: 'select_content',
@@ -136,6 +138,7 @@ describe('Google Analytics event tracker', function () {
       expected.event = 'event_data'
       expected.event_data.event_name = 'select_content'
       expected.govuk_gem_version = 'aVersion'
+      expected.timestamp = '123456'
 
       attributes = {
         event_name: 'select_content'
@@ -175,12 +178,14 @@ describe('Google Analytics event tracker', function () {
       expected1.event_data.event_name = 'event1-name'
       expected1.event_data.text = ''
       expected1.govuk_gem_version = 'aVersion'
+      expected1.timestamp = '123456'
 
       expected2 = new GOVUK.analyticsGa4.Schemas().eventSchema()
       expected2.event = 'event_data'
       expected2.event_data.event_name = 'event2-name'
       expected2.event_data.text = ''
       expected2.govuk_gem_version = 'aVersion'
+      expected2.timestamp = '123456'
 
       var attributes1 = {
         event_name: 'event1-name'
@@ -230,6 +235,7 @@ describe('Google Analytics event tracker', function () {
       expected.event_data.action = 'opened'
       expected.event_data.text = 'some text'
       expected.govuk_gem_version = 'aVersion'
+      expected.timestamp = '123456'
 
       expect(window.dataLayer[0]).toEqual(expected)
 
@@ -238,6 +244,7 @@ describe('Google Analytics event tracker', function () {
       expected.event_data.action = 'closed'
       expected.event_data.text = 'some text'
       expected.govuk_gem_version = 'aVersion'
+      expected.timestamp = '123456'
 
       element.setAttribute('aria-expanded', 'true')
       element.click()
@@ -268,6 +275,7 @@ describe('Google Analytics event tracker', function () {
       expected.event_data.action = 'opened'
       expected.event_data.text = 'some text'
       expected.govuk_gem_version = 'aVersion'
+      expected.timestamp = '123456'
 
       expect(window.dataLayer[0]).toEqual(expected)
 
@@ -276,6 +284,7 @@ describe('Google Analytics event tracker', function () {
       expected.event_data.action = 'closed'
       expected.event_data.text = 'some text'
       expected.govuk_gem_version = 'aVersion'
+      expected.timestamp = '123456'
 
       clickOn.setAttribute('open', '')
       clickOn.click()
@@ -308,6 +317,7 @@ describe('Google Analytics event tracker', function () {
       expected.event_data.event_name = 'event-name'
       expected.event_data.text = 'Show'
       expected.govuk_gem_version = 'aVersion'
+      expected.timestamp = '123456'
 
       expect(window.dataLayer[0]).toEqual(expected)
 
@@ -317,6 +327,7 @@ describe('Google Analytics event tracker', function () {
       expected.event_data.event_name = 'event-name'
       expected.event_data.text = 'Hide'
       expected.govuk_gem_version = 'aVersion'
+      expected.timestamp = '123456'
 
       element.querySelector('[aria-expanded]').setAttribute('aria-expanded', 'true')
       element.querySelector('button').textContent = 'Hide'
@@ -351,6 +362,7 @@ describe('Google Analytics event tracker', function () {
       expected.event_data.event_name = 'event-name'
       expected.event_data.text = 'Example'
       expected.govuk_gem_version = 'aVersion'
+      expected.timestamp = '123456'
 
       expect(window.dataLayer[0]).toEqual(expected)
 
@@ -360,6 +372,7 @@ describe('Google Analytics event tracker', function () {
       expected.event_data.event_name = 'event-name'
       expected.event_data.text = 'Example'
       expected.govuk_gem_version = 'aVersion'
+      expected.timestamp = '123456'
 
       element.setAttribute('open', '')
       clickOn.click()
@@ -486,6 +499,7 @@ describe('Google Analytics event tracker', function () {
       expected.event_data.type = 'feedback'
       expected.event_data.section = 'Is this page useful?'
       expected.govuk_gem_version = 'aVersion'
+      expected.timestamp = '123456'
     })
 
     it('should track "Yes" button clicks', function () {
@@ -523,6 +537,7 @@ describe('Google Analytics event tracker', function () {
       expected.event_data.event_name = 'select_content'
       expected.event_data.type = 'header menu bar'
       expected.govuk_gem_version = 'aVersion'
+      expected.timestamp = '123456'
       var buttons = document.querySelectorAll('button')
       expected.event_data.index_total = buttons.length + ''
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
@@ -24,6 +24,7 @@ describe('Google Analytics form tracking', function () {
     element = document.createElement('form')
     document.body.appendChild(element)
     agreeToCookies()
+    spyOn(GOVUK.analyticsGa4.core, 'getTimestamp').and.returnValue('123456')
   })
 
   afterEach(function () {
@@ -90,6 +91,7 @@ describe('Google Analytics form tracking', function () {
       expected.event_data.action = 'Continue'
       expected.event_data.tool_name = 'What is the title of this smart answer?'
       expected.govuk_gem_version = 'aVersion'
+      expected.timestamp = '123456'
       var tracker = new GOVUK.Modules.Ga4FormTracker(element)
       tracker.init()
     })
@@ -243,6 +245,7 @@ describe('Google Analytics form tracking', function () {
       expected.event_data.action = 'Continue'
       expected.event_data.tool_name = 'What is the title of this smart answer?'
       expected.govuk_gem_version = 'aVersion'
+      expected.timestamp = '123456'
       var tracker = new GOVUK.Modules.Ga4FormTracker(element)
       tracker.init()
     })
@@ -281,6 +284,7 @@ describe('Google Analytics form tracking', function () {
       expected.event_data.action = 'Continue'
       expected.event_data.tool_name = 'What is the title of this smart answer?'
       expected.govuk_gem_version = 'aVersion'
+      expected.timestamp = '123456'
       var tracker = new GOVUK.Modules.Ga4FormTracker(element)
       tracker.init()
     })
@@ -344,6 +348,7 @@ describe('Google Analytics form tracking', function () {
       expected.event_data.section = 'Search'
       expected.event_data.action = 'search'
       expected.govuk_gem_version = 'aVersion'
+      expected.timestamp = '123456'
       var tracker = new GOVUK.Modules.Ga4FormTracker(element)
       tracker.init()
     })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
@@ -37,7 +37,9 @@ describe('GA4 link tracker', function () {
     expected.event_data.event_name = 'navigation'
     expected.govuk_gem_version = 'aVersion'
     expected.event_data.link_domain = 'https://www.gov.uk'
+    expected.timestamp = '123456'
     agreeToCookies()
+    spyOn(GOVUK.analyticsGa4.core, 'getTimestamp').and.returnValue('123456')
   })
 
   afterEach(function () {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
@@ -15,6 +15,7 @@ describe('Google Tag Manager page view tracking', function () {
     expected = {
       event: 'page_view',
       govuk_gem_version: 'aVersion',
+      timestamp: '123456',
       page_view: {
         location: document.location.href,
         referrer: document.referrer,
@@ -62,6 +63,7 @@ describe('Google Tag Manager page view tracking', function () {
         spelling_suggestion: undefined
       }
     }
+    spyOn(GOVUK.analyticsGa4.core, 'getTimestamp').and.returnValue('123456')
     window.dataLayer = []
   })
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-print-intent-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-print-intent-tracker.spec.js
@@ -18,6 +18,8 @@ describe('Google Analytics 4 print intent tracker', function () {
     expected.event_data.type = 'print page'
     expected.event_data.method = 'browser print'
     expected.govuk_gem_version = 'aVersion'
+    expected.timestamp = '123456'
+    spyOn(GOVUK.analyticsGa4.core, 'getTimestamp').and.returnValue('123456')
   })
 
   it('triggers a GA4 event when the \'beforeprint\' event is fired', function () {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.spec.js
@@ -14,7 +14,9 @@ describe('GA4 scroll tracker', function () {
     expected.event_data.action = 'scroll'
     expected.event_data.event_name = 'scroll'
     expected.govuk_gem_version = 'gem-version'
+    expected.timestamp = '123456'
     spyOn(GOVUK.analyticsGa4.core, 'getGemVersion').and.returnValue('gem-version')
+    spyOn(GOVUK.analyticsGa4.core, 'getTimestamp').and.returnValue('123456')
   })
 
   afterEach(function () {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.spec.js
@@ -24,6 +24,10 @@ describe('A specialist link tracker', function () {
     window.history.replaceState(null, null, '#')
   })
 
+  beforeEach(function () {
+    spyOn(GOVUK.analyticsGa4.core, 'getTimestamp').and.returnValue('123456')
+  })
+
   describe('when tracking external links', function () {
     beforeEach(function () {
       window.dataLayer = []
@@ -34,6 +38,8 @@ describe('A specialist link tracker', function () {
       expected.event_data.method = 'primary click'
       expected.event_data.external = 'true'
       expected.govuk_gem_version = 'aVersion'
+      expected.timestamp = '123456'
+
       links = document.createElement('div')
       /* The link_domain, external and path attributes exist so we can hardcode what the expected value is for each test.
       The value differs for each link, so we can't hardcode the expected value inside the test itself. */
@@ -295,6 +301,7 @@ describe('A specialist link tracker', function () {
       expected.event_data.type = 'generic download'
       expected.event_data.method = 'primary click'
       expected.govuk_gem_version = 'aVersion'
+      expected.timestamp = '123456'
 
       links = document.createElement('div')
       /* The link_domain, external and path attributes exist so we can hardcode what the expected value is for each test.
@@ -447,6 +454,7 @@ describe('A specialist link tracker', function () {
         expected.event_data.text = link.innerText.trim()
         expected.event_data.type = 'generic link'
         expected.govuk_gem_version = 'aVersion'
+        expected.timestamp = '123456'
         expected.event_data.external = 'true'
 
         expect(window.dataLayer[0]).toEqual(expected)
@@ -548,6 +556,7 @@ describe('A specialist link tracker', function () {
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.text = link.innerText.trim()
         expected.govuk_gem_version = 'aVersion'
+        expected.timestamp = '123456'
         expect(window.dataLayer[0]).toEqual(expected)
       }
     })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-video-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-video-tracker.spec.js
@@ -24,6 +24,7 @@ describe('Google Analytics video tracker', function () {
         }
       }
     }
+    spyOn(GOVUK.analyticsGa4.core, 'getTimestamp').and.returnValue('123456')
   })
 
   it('performs initial setup', function () {
@@ -52,6 +53,7 @@ describe('Google Analytics video tracker', function () {
       expected.event_data.url = 'https://www.youtube.com/watch?v=abcdef'
       expected.event_data.length = '500'
       expected.govuk_gem_version = 'aVersion'
+      expected.timestamp = '123456'
     })
 
     it('when a video starts', function () {
@@ -86,6 +88,7 @@ describe('Google Analytics video tracker', function () {
       expected.event_data.url = 'https://www.youtube.com/watch?v=abcdef'
       expected.event_data.length = '500'
       expected.govuk_gem_version = 'aVersion'
+      expected.timestamp = '123456'
       expected.event_data.event_name = 'video_start'
       expected.event_data.action = 'start'
       expected.event_data.video_current_time = '0'
@@ -165,6 +168,7 @@ describe('Google Analytics video tracker', function () {
       expected.event_data.event_name = 'video_progress'
       expected.event_data.action = 'progress'
       expected.govuk_gem_version = 'aVersion'
+      expected.timestamp = '123456'
 
       jasmine.clock().install()
     })


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Adds a `timestamp` value sent with each dataLayer push. `timestamp` is the user's unix timestamp.
- Most of the tests I used `spyOn` to fake the timestamp as `123456`, probably necessary as it's impossible to predict what the timestamp will be before vs after some tracking code has run. However I've added one test in `ga4-core` that tests the actual timestamp and it works. I think because the test is so simple, modern computers are fast enough that it can grab the timestamp for the expected and actual value, and it's so fast that the timestamp wouldn't have incremented yet.
- Will add a CHANGELOG once approved as I suspect this won't be merged until 2024.

## Why
<!-- What are the reasons behind this change being made? -->
- So that the PAs can easily sort the events to see a users journey 

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
