### PR TITLE
[DO NOT MERGE] Use existing meta tag to get GA4 search result count

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -68,6 +68,19 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
       return window.GOVUK.analyticsGa4.vars.gem_version || 'not found'
     },
 
+    getMetaContent: function (name) {
+      var tag = document.querySelector('meta[name="govuk:' + name + '"]')
+      if (tag) {
+        var contentAttribute = tag.getAttribute('content')
+        if (contentAttribute === '') {
+          return undefined
+        }
+        return contentAttribute
+      } else {
+        return undefined
+      }
+    },
+
     sortEventData: function (eventData) {
       if (!Object.keys) { // check for IE9 and below
         return eventData

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
@@ -7,6 +7,7 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
 
   var PageViewTracker = {
     PIIRemover: new window.GOVUK.analyticsGa4.PIIRemover(), // imported in analytics-ga4.js
+    getMetaContent: window.GOVUK.analyticsGa4.core.getMetaContent,
     nullValue: undefined,
 
     init: function (referrer) {
@@ -131,19 +132,6 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
       var vw = Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0)
       var vh = Math.max(document.documentElement.clientHeight || 0, window.innerHeight || 0)
       return vw + 'x' + vh
-    },
-
-    getMetaContent: function (name) {
-      var tag = document.querySelector('meta[name="govuk:' + name + '"]')
-      if (tag) {
-        var contentAttribute = tag.getAttribute('content')
-        if (contentAttribute === '') {
-          return undefined
-        }
-        return contentAttribute
-      } else {
-        return this.nullValue
-      }
     },
 
     getElementAttribute: function (attributeName) {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
@@ -68,6 +68,32 @@ describe('GA4 core', function () {
     })
   })
 
+  describe('metatags', function () {
+    afterEach(function () {
+      var head = document.getElementsByTagName('head')[0]
+      var metas = document.querySelectorAll("[name^='govuk']")
+      for (var i = 0; i < metas.length; i++) {
+        head.removeChild(metas[i])
+      }
+    })
+
+    function createMetaTags (key, value) {
+      var metatag = document.createElement('meta')
+      metatag.setAttribute('name', 'govuk:' + key)
+      metatag.setAttribute('content', value)
+      document.getElementsByTagName('head')[0].appendChild(metatag)
+    }
+
+    it('can be read when a metatag exists', function () {
+      createMetaTags('example', 'of a thing')
+      expect(GOVUK.analyticsGa4.core.getMetaContent('example')).toEqual('of a thing')
+    })
+
+    it('can be read when a metatag does not exist', function () {
+      expect(GOVUK.analyticsGa4.core.getMetaContent('notreal')).toEqual(undefined)
+    })
+  })
+
   describe('query strings allow pushing to a fake dataLayer', function () {
     var data
 


### PR DESCRIPTION
## What
Get the number of search results for GA4 ecommerce search result events from the already provided meta tag, rather than reading it from the HTML.

## Why
We've had to jump through a few hoops with reading the number from the page (for example stripping out commas) and this process is largely a bit brittle anyway as it could be broken if the UI changes. At the time of writing I don't think we knew there was a metatag with the number in already, and this is a better place to read it from.

## Visual Changes
None.

Trello card: https://trello.com/c/uPzYr44q/771-use-search-results-count-meta-tag-to-grab-the-amount-of-search-results-for-finder-frontend-ecommerce-tracking