### PR TITLE
Ensure all GA4 data values are strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Ensure all GA4 data values are strings ([PR #3800](https://github.com/alphagov/govuk_publishing_components/pull/3800))
 * Refactor image card tracking ([PR #3789](https://github.com/alphagov/govuk_publishing_components/pull/3789))
 * Details component GA4 tracking ([PR #3786](https://github.com/alphagov/govuk_publishing_components/pull/3786))
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.js
@@ -75,14 +75,14 @@
   // given an object and a key, insert a value into object[key] if it exists
   Schemas.prototype.addToObject = function (obj, key, value) {
     if (key in obj) {
-      obj[key] = value
+      obj[key] = value + '' // ensure is a string
       return obj
     } else {
       // check for one level of nesting in the object
       for (var property in obj) {
         if (this.isAnObject(obj[property])) {
           if (key in obj[property]) {
-            obj[property][key] = value
+            obj[property][key] = value + '' // ensure is a string
             return obj
           }
         }

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-auto-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-auto-tracker.spec.js
@@ -95,7 +95,7 @@ describe('Google Analytics auto tracker', function () {
       expected.event_data.event_name = 'select_content'
       expected.event_data.type = 'tabs'
       expected.event_data.index = {
-        index_section: 7,
+        index_section: '7',
         index_link: undefined,
         index_section_count: undefined
       }

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-copy-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-copy-tracker.spec.js
@@ -25,7 +25,7 @@ describe('Google Analytics 4 copy tracker', function () {
   it('triggers a GA4 event when the copy event is fired', function () {
     var text = 'This is some text'
     expected.event_data.text = text
-    expected.event_data.length = 17
+    expected.event_data.length = '17'
     spyOn(window, 'getSelection').and.returnValue(text)
 
     window.GOVUK.triggerEvent(window, 'copy')
@@ -65,7 +65,7 @@ describe('Google Analytics 4 copy tracker', function () {
   it('cleans line breaks and other characters from copied text', function () {
     var text = 'This is some text\n\nThis is some more\tAnd some more\n     and     some spaces    \n'
     expected.event_data.text = 'This is some text This is some'
-    expected.event_data.length = 65
+    expected.event_data.length = '65'
     spyOn(window, 'getSelection').and.returnValue(text)
 
     window.GOVUK.triggerEvent(window, 'copy')
@@ -75,7 +75,7 @@ describe('Google Analytics 4 copy tracker', function () {
   it('only records a maximum of 30 characters', function () {
     var text = "The first problem is where to get a lot of text. That's actually not so hard if you think about it - all you have to do is write some words down, any words that come to mind."
     expected.event_data.text = 'The first problem is where to '
-    expected.event_data.length = 174
+    expected.event_data.length = '174'
     spyOn(window, 'getSelection').and.returnValue(text)
 
     window.GOVUK.triggerEvent(window, 'copy')
@@ -85,7 +85,7 @@ describe('Google Analytics 4 copy tracker', function () {
   it('redacts PII from the text it collects', function () {
     var text = 'some email@example.com SW1A 2AA Jan 1st 1990'
     expected.event_data.text = 'some [email] [postcode] [date]'
-    expected.event_data.length = 30
+    expected.event_data.length = '30'
     spyOn(window, 'getSelection').and.returnValue(text)
 
     window.GOVUK.triggerEvent(window, 'copy')

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
@@ -115,7 +115,7 @@ describe('GA4 core', function () {
     var schemas = new window.GOVUK.analyticsGa4.Schemas()
     var expected = schemas.mergeProperties(data, 'test')
     expected.govuk_gem_version = 'aVersion'
-    expected.event_data.index.index_link = 3
+    expected.event_data.index.index_link = '3'
 
     GOVUK.analyticsGa4.core.applySchemaAndSendData(data, 'test')
     expect(window.dataLayer[0]).toEqual(expected)

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.spec.js
@@ -524,7 +524,7 @@ describe('Google Analytics event tracker', function () {
       expected.event_data.type = 'header menu bar'
       expected.govuk_gem_version = 'aVersion'
       var buttons = document.querySelectorAll('button')
-      expected.event_data.index_total = buttons.length
+      expected.event_data.index_total = buttons.length + ''
 
       for (var i = 0; i < buttons.length; i++) {
         window.dataLayer = []
@@ -534,8 +534,8 @@ describe('Google Analytics event tracker', function () {
           type: 'header menu bar',
           text: button.textContent,
           section: button.textContent,
-          index_section: i + 1,
-          index_total: buttons.length
+          index_section: i + 1 + '',
+          index_total: buttons.length + ''
         }))
 
         button.click()
@@ -543,7 +543,7 @@ describe('Google Analytics event tracker', function () {
         expected.event_data.text = button.textContent
         expected.event_data.section = button.textContent
         expected.event_data.index = {
-          index_section: i + 1,
+          index_section: i + 1 + '',
           index_link: undefined,
           index_section_count: undefined
         }

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
@@ -101,7 +101,7 @@ describe('GA4 link tracker', function () {
       expected.event_data.method = 'primary click'
       expected.event_data.external = 'false'
       expected.event_data.index = {
-        index_link: 1,
+        index_link: '1',
         index_section: undefined,
         index_section_count: undefined
       }
@@ -206,7 +206,7 @@ describe('GA4 link tracker', function () {
       expected.event_data.type = 'a link'
       expected.event_data.external = 'false'
       expected.event_data.index = {
-        index_link: 1,
+        index_link: '1',
         index_section: undefined,
         index_section_count: undefined
       }
@@ -414,7 +414,7 @@ describe('GA4 link tracker', function () {
 
       initModule(element, true)
 
-      expect(window.dataLayer[0].event_data.index).toEqual({ index_link: 123, index_section: undefined, index_section_count: undefined })
+      expect(window.dataLayer[0].event_data.index).toEqual({ index_link: '123', index_section: undefined, index_section_count: undefined })
     })
   })
 
@@ -427,7 +427,7 @@ describe('GA4 link tracker', function () {
 
       initModule(element, true)
 
-      expect(window.dataLayer[0].event_data.index).toEqual({ index_link: 123, index_section: undefined, index_section_count: undefined })
+      expect(window.dataLayer[0].event_data.index).toEqual({ index_link: '123', index_section: undefined, index_section_count: undefined })
     })
   })
 
@@ -444,7 +444,7 @@ describe('GA4 link tracker', function () {
       initModule(element, false)
       link.click()
 
-      expect(window.dataLayer[0].event_data.index).toEqual({ index_link: 3, index_section: 1, index_section_count: 2 })
+      expect(window.dataLayer[0].event_data.index).toEqual({ index_link: '3', index_section: '1', index_section_count: '2' })
     })
   })
 
@@ -460,7 +460,7 @@ describe('GA4 link tracker', function () {
       initModule(element, false)
       link.click()
 
-      expect(window.dataLayer[0].event_data.index).toEqual({ index_section: 1, index_section_count: 2, index_link: undefined })
+      expect(window.dataLayer[0].event_data.index).toEqual({ index_section: '1', index_section_count: '2', index_link: undefined })
     })
   })
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.spec.js
@@ -39,9 +39,9 @@ describe('Google Analytics schemas', function () {
         link_domain: undefined,
         tool_name: undefined,
         percent_scrolled: undefined,
-        video_current_time: this.undefined,
-        length: this.undefined,
-        video_percent: this.undefined
+        video_current_time: undefined,
+        length: undefined,
+        video_percent: undefined
       }
     }
     var returned = schemas.mergeProperties(data, 'example')
@@ -74,9 +74,9 @@ describe('Google Analytics schemas', function () {
         link_domain: undefined,
         tool_name: undefined,
         percent_scrolled: undefined,
-        video_current_time: this.undefined,
-        length: this.undefined,
-        video_percent: this.undefined
+        video_current_time: undefined,
+        length: undefined,
+        video_percent: undefined
       }
     }
     var returned = schemas.mergeProperties(data, 'example')
@@ -97,7 +97,7 @@ describe('Google Analytics schemas', function () {
         url: undefined,
         text: undefined,
         index: {
-          index_link: 1,
+          index_link: '1',
           index_section: undefined,
           index_section_count: undefined
         },
@@ -109,9 +109,45 @@ describe('Google Analytics schemas', function () {
         link_domain: undefined,
         tool_name: undefined,
         percent_scrolled: undefined,
-        video_current_time: this.undefined,
-        length: this.undefined,
-        video_percent: this.undefined
+        video_current_time: undefined,
+        length: undefined,
+        video_percent: undefined
+      }
+    }
+    var returned = schemas.mergeProperties(data, 'example')
+    expect(returned).toEqual(expected)
+  })
+
+  it('ensures that all attribute values are strings', function () {
+    var data = {
+      event_name: 4,
+      index_link: 1,
+      section: '3',
+      action: '5_string'
+    }
+    var expected = {
+      event: 'example',
+      event_data: {
+        event_name: '4',
+        type: undefined,
+        url: undefined,
+        text: undefined,
+        index: {
+          index_link: '1',
+          index_section: undefined,
+          index_section_count: undefined
+        },
+        index_total: undefined,
+        section: '3',
+        action: '5_string',
+        external: undefined,
+        method: undefined,
+        link_domain: undefined,
+        tool_name: undefined,
+        percent_scrolled: undefined,
+        video_current_time: undefined,
+        length: undefined,
+        video_percent: undefined
       }
     }
     var returned = schemas.mergeProperties(data, 'example')

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.spec.js
@@ -75,7 +75,7 @@ describe('GA4 scroll tracker', function () {
       scrollTracker = new GOVUK.Modules.Ga4ScrollTracker(el)
       scrollTracker.init()
       expected.event_data.type = 'heading'
-      expected.event_data.index.index_section_count = 3
+      expected.event_data.index.index_section_count = '3'
     })
 
     afterEach(function () {
@@ -85,7 +85,7 @@ describe('GA4 scroll tracker', function () {
     it('should send a tracking event on initialisation for headings that are already visible', function () {
       expected.event_data.text = 'Heading 1'
       expected.event_data.section = 'Heading 1'
-      expected.event_data.index.index_section = 1
+      expected.event_data.index.index_section = '1'
       expect(window.dataLayer[0]).toEqual(expected)
     })
 
@@ -99,7 +99,7 @@ describe('GA4 scroll tracker', function () {
       expect(window.dataLayer.length).toEqual(1)
       expected.event_data.text = 'Heading 1'
       expected.event_data.section = 'Heading 1'
-      expected.event_data.index.index_section = 1
+      expected.event_data.index.index_section = '1'
       expect(window.dataLayer[0]).toEqual(expected)
 
       el.querySelector('h3').style.marginTop = '0px'
@@ -110,7 +110,7 @@ describe('GA4 scroll tracker', function () {
       expect(window.dataLayer.length).toEqual(2)
       expected.event_data.text = 'Heading 3'
       expected.event_data.section = 'Heading 3'
-      expected.event_data.index.index_section = 3
+      expected.event_data.index.index_section = '3'
       expect(window.dataLayer[1]).toEqual(expected)
     })
 
@@ -118,7 +118,7 @@ describe('GA4 scroll tracker', function () {
       expect(window.dataLayer.length).toEqual(1)
       expected.event_data.text = 'Heading 1'
       expected.event_data.section = 'Heading 1'
-      expected.event_data.index.index_section = 1
+      expected.event_data.index.index_section = '1'
       expect(window.dataLayer[0]).toEqual(expected)
 
       el.querySelector('h2').style.display = 'block'
@@ -128,7 +128,7 @@ describe('GA4 scroll tracker', function () {
 
       expected.event_data.text = 'Heading 2'
       expected.event_data.section = 'Heading 2'
-      expected.event_data.index.index_section = 2
+      expected.event_data.index.index_section = '2'
       expect(window.dataLayer[1]).toEqual(expected)
       expect(window.dataLayer.length).toEqual(2)
     })
@@ -137,7 +137,7 @@ describe('GA4 scroll tracker', function () {
       expect(window.dataLayer.length).toEqual(1)
       expected.event_data.text = 'Heading 1'
       expected.event_data.section = 'Heading 1'
-      expected.event_data.index.index_section = 1
+      expected.event_data.index.index_section = '1'
       expect(window.dataLayer[0]).toEqual(expected)
 
       var pageHeight = document.querySelector('body').clientHeight
@@ -148,7 +148,7 @@ describe('GA4 scroll tracker', function () {
       expect(window.dataLayer.length).toEqual(2)
       expected.event_data.text = 'Heading 3'
       expected.event_data.section = 'Heading 3'
-      expected.event_data.index.index_section = 3
+      expected.event_data.index.index_section = '3'
       expect(window.dataLayer[1]).toEqual(expected)
 
       document.querySelector('body').removeAttribute('style')
@@ -158,7 +158,7 @@ describe('GA4 scroll tracker', function () {
       expect(window.dataLayer.length).toEqual(1)
       expected.event_data.text = 'Heading 1'
       expected.event_data.section = 'Heading 1'
-      expected.event_data.index.index_section = 1
+      expected.event_data.index.index_section = '1'
       expect(window.dataLayer[0]).toEqual(expected)
 
       el.querySelector('h4').style.display = 'block'
@@ -286,7 +286,7 @@ describe('GA4 scroll tracker', function () {
       scrollTracker = new GOVUK.Modules.Ga4ScrollTracker(el)
       scrollTracker.init()
       expected.event_data.type = 'marker'
-      expected.event_data.index.index_section_count = 3
+      expected.event_data.index.index_section_count = '3'
     })
 
     afterEach(function () {
@@ -296,7 +296,7 @@ describe('GA4 scroll tracker', function () {
     it('should send a tracking event on initialisation for headings that are already visible', function () {
       expected.event_data.text = 'Heading 1'
       expected.event_data.section = 'Heading 1'
-      expected.event_data.index.index_section = 1
+      expected.event_data.index.index_section = '1'
       expect(window.dataLayer[0]).toEqual(expected)
     })
 
@@ -310,7 +310,7 @@ describe('GA4 scroll tracker', function () {
       expect(window.dataLayer.length).toEqual(1)
       expected.event_data.text = 'Heading 1'
       expected.event_data.section = 'Heading 1'
-      expected.event_data.index.index_section = 1
+      expected.event_data.index.index_section = '1'
       expect(window.dataLayer[0]).toEqual(expected)
 
       el.querySelector('h3').style.marginTop = '0px'
@@ -321,7 +321,7 @@ describe('GA4 scroll tracker', function () {
       expect(window.dataLayer.length).toEqual(2)
       expected.event_data.text = 'Heading 3'
       expected.event_data.section = 'Heading 3'
-      expected.event_data.index.index_section = 3
+      expected.event_data.index.index_section = '3'
       expect(window.dataLayer[1]).toEqual(expected)
     })
 
@@ -329,7 +329,7 @@ describe('GA4 scroll tracker', function () {
       expect(window.dataLayer.length).toEqual(1)
       expected.event_data.text = 'Heading 1'
       expected.event_data.section = 'Heading 1'
-      expected.event_data.index.index_section = 1
+      expected.event_data.index.index_section = '1'
       expect(window.dataLayer[0]).toEqual(expected)
 
       el.querySelector('h2').style.display = 'block'
@@ -339,7 +339,7 @@ describe('GA4 scroll tracker', function () {
 
       expected.event_data.text = 'Heading 2'
       expected.event_data.section = 'Heading 2'
-      expected.event_data.index.index_section = 2
+      expected.event_data.index.index_section = '2'
       expect(window.dataLayer[1]).toEqual(expected)
       expect(window.dataLayer.length).toEqual(2)
     })
@@ -348,7 +348,7 @@ describe('GA4 scroll tracker', function () {
       expect(window.dataLayer.length).toEqual(1)
       expected.event_data.text = 'Heading 1'
       expected.event_data.section = 'Heading 1'
-      expected.event_data.index.index_section = 1
+      expected.event_data.index.index_section = '1'
       expect(window.dataLayer[0]).toEqual(expected)
 
       var pageHeight = document.querySelector('body').clientHeight
@@ -359,7 +359,7 @@ describe('GA4 scroll tracker', function () {
       expect(window.dataLayer.length).toEqual(2)
       expected.event_data.text = 'Heading 3'
       expected.event_data.section = 'Heading 3'
-      expected.event_data.index.index_section = 3
+      expected.event_data.index.index_section = '3'
       expect(window.dataLayer[1]).toEqual(expected)
 
       document.querySelector('body').removeAttribute('style')
@@ -369,7 +369,7 @@ describe('GA4 scroll tracker', function () {
       expect(window.dataLayer.length).toEqual(1)
       expected.event_data.text = 'Heading 1'
       expected.event_data.section = 'Heading 1'
-      expected.event_data.index.index_section = 1
+      expected.event_data.index.index_section = '1'
       expect(window.dataLayer[0]).toEqual(expected)
 
       el.querySelector('h4').style.display = 'block'
@@ -418,8 +418,8 @@ describe('GA4 scroll tracker', function () {
       expected.event_data.text = 'Heading 1'
       expected.event_data.section = 'Heading 1'
       expected.event_data.type = 'heading'
-      expected.event_data.index.index_section = 1
-      expected.event_data.index.index_section_count = 2
+      expected.event_data.index.index_section = '1'
+      expected.event_data.index.index_section_count = '2'
       expect(window.dataLayer[0]).toEqual(expected)
     })
   })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-video-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-video-tracker.spec.js
@@ -50,7 +50,7 @@ describe('Google Analytics video tracker', function () {
       expected.event_data.type = 'video'
       expected.event_data.text = 'An example video'
       expected.event_data.url = 'https://www.youtube.com/watch?v=abcdef'
-      expected.event_data.length = 500
+      expected.event_data.length = '500'
       expected.govuk_gem_version = 'aVersion'
     })
 
@@ -58,8 +58,8 @@ describe('Google Analytics video tracker', function () {
       videoTracker.trackVideo(event, 'VideoUnstarted')
       expected.event_data.event_name = 'video_start'
       expected.event_data.action = 'start'
-      expected.event_data.video_current_time = 0
-      expected.event_data.video_percent = 0
+      expected.event_data.video_current_time = '0'
+      expected.event_data.video_percent = '0'
 
       expect(window.dataLayer[0]).toEqual(expected)
       // stop the interval from continuing and interfering with other tests
@@ -70,8 +70,8 @@ describe('Google Analytics video tracker', function () {
       videoTracker.trackVideo(event, 'VideoEnded')
       expected.event_data.event_name = 'video_complete'
       expected.event_data.action = 'complete'
-      expected.event_data.video_current_time = 0
-      expected.event_data.video_percent = 100
+      expected.event_data.video_current_time = '0'
+      expected.event_data.video_percent = '100'
 
       expect(window.dataLayer[0]).toEqual(expected)
     })
@@ -84,12 +84,12 @@ describe('Google Analytics video tracker', function () {
       expected.event_data.type = 'video'
       expected.event_data.text = 'An example video'
       expected.event_data.url = 'https://www.youtube.com/watch?v=abcdef'
-      expected.event_data.length = 500
+      expected.event_data.length = '500'
       expected.govuk_gem_version = 'aVersion'
       expected.event_data.event_name = 'video_start'
       expected.event_data.action = 'start'
-      expected.event_data.video_current_time = 0
-      expected.event_data.video_percent = 0
+      expected.event_data.video_current_time = '0'
+      expected.event_data.video_percent = '0'
     })
 
     it('with a time as the first parameter', function () {
@@ -161,7 +161,7 @@ describe('Google Analytics video tracker', function () {
       expected.event_data.type = 'video'
       expected.event_data.text = 'An example video'
       expected.event_data.url = 'https://www.youtube.com/watch?v=abcdef'
-      expected.event_data.length = 500
+      expected.event_data.length = '500'
       expected.event_data.event_name = 'video_progress'
       expected.event_data.action = 'progress'
       expected.govuk_gem_version = 'aVersion'
@@ -177,8 +177,8 @@ describe('Google Analytics video tracker', function () {
       event.target.getCurrentTime = function () {
         return 125
       }
-      expected.event_data.video_current_time = 125
-      expected.event_data.video_percent = 25
+      expected.event_data.video_current_time = '125'
+      expected.event_data.video_percent = '25'
 
       videoTracker.trackVideo(event, 'VideoPlaying')
       jasmine.clock().tick(1000)
@@ -189,8 +189,8 @@ describe('Google Analytics video tracker', function () {
       event.target.getCurrentTime = function () {
         return 250
       }
-      expected.event_data.video_current_time = 250
-      expected.event_data.video_percent = 50
+      expected.event_data.video_current_time = '250'
+      expected.event_data.video_percent = '50'
 
       videoTracker.trackVideo(event, 'VideoPlaying')
       jasmine.clock().tick(1000)
@@ -201,8 +201,8 @@ describe('Google Analytics video tracker', function () {
       event.target.getCurrentTime = function () {
         return 375
       }
-      expected.event_data.video_current_time = 375
-      expected.event_data.video_percent = 75
+      expected.event_data.video_current_time = '375'
+      expected.event_data.video_percent = '75'
 
       videoTracker.trackVideo(event, 'VideoPlaying')
       jasmine.clock().tick(1000)
@@ -213,8 +213,8 @@ describe('Google Analytics video tracker', function () {
       event.target.getCurrentTime = function () {
         return 250
       }
-      expected.event_data.video_current_time = 250
-      expected.event_data.video_percent = 50
+      expected.event_data.video_current_time = '250'
+      expected.event_data.video_percent = '50'
 
       videoTracker.trackVideo(event, 'VideoPlaying')
       jasmine.clock().tick(1000)


### PR DESCRIPTION
## What
- change the schema code when merging properties to automatically convert all data to strings
- currently passing numbers for various data attributes (e.g. index_section) and all should be consistent types
- updating various tests accordingly

Have looked at various options for converting integers to strings in JS. `2 + ''` seems to be the most widely supported, fastest and least likely to break of the available options, but happy to discuss.

## Why
Part of the GA4 migration.

## Visual Changes
None.

Trello card: https://trello.com/c/nPhYtY0j/761-address-inconsistency-in-index-property-data-types
