### PR TITLE
Improve print views: Inverse header, Inverse title, footer

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_inverse-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_inverse-header.scss
@@ -27,3 +27,17 @@
 .gem-c-inverse-header--padding-top {
   padding-top: govuk-spacing(3);
 }
+
+@include govuk-media-query($media-type: print) {
+  .gem-c-inverse-header {
+    background-color: govuk-colour("white");
+    color: govuk-colour("black");
+    padding: 0;
+    margin: 0;
+  }
+
+  .gem-c-inverse-header .gem-c-inverse-header__supplement,
+  .gem-c-inverse-header .publication-header__last-changed {
+    color: govuk-colour("black");
+  }
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-footer.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-footer.scss
@@ -20,3 +20,9 @@
   // the right column.
   margin-bottom: 20px;
 }
+
+@include govuk-media-query($media-type: print) {
+  .gem-c-layout-footer {
+    display: none;
+  }
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/_organisation-logo.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_organisation-logo.scss
@@ -158,3 +158,10 @@
   @include crest("wales_crest");
   @include tall-crest;
 }
+
+@include govuk-media-query($media-type: print) {
+  .gem-c-organisation-logo__container {
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
+  }
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/_title.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_title.scss
@@ -32,6 +32,10 @@
 }
 
 @include govuk-media-query($media-type: print) {
+  .gem-c-title--inverse {
+    color: govuk-colour("black");
+  }
+
   .gem-c-title__context {
     margin: 0;
   }


### PR DESCRIPTION
## What
With `govuk-media-query($media-type: print)`:
* Set `gem-c-inverse-header` background to white, color to black, remove margin and padding.
* Set `gem-c-title--inverse`, `publication-header__last-changed` color to black.
* Set `gem-c-layout-footer` to `display: none`.
* Set `print-color-adjust` for organisational logos to `exact`.

## Why
This reverts these components back to the status quo before pull <https://github.com/alphagov/govuk_publishing_components/pull/3110>, while using the current project style conventions. This is important for accessibility, such that print publications are readable on GOV.UK.

## Visual Changes

### Before

#### Chrome print preview, 'background graphics' setting off

`gem-c-inverse-header`, `gem-c-title--inverse` and `publication-header__last-changed`:

![](https://github.com/alphagov/govuk_publishing_components/assets/28735593/ba348516-d1b9-445e-9a14-884bc452958d)

Homepage preview, showing footer changes:

![](https://github.com/alphagov/govuk_publishing_components/assets/28735593/32710317-5ccb-493d-80b6-7f4071ec0dd6)

Organisational logo:

![](https://github.com/alphagov/govuk_publishing_components/assets/28735593/c9f9332e-9c7e-46bc-9065-45a1fa3e7136)

#### Chrome print preview, 'background graphics' setting on

`gem-c-inverse-header`, `gem-c-title--inverse` and `publication-header__last-changed`:

![](https://github.com/alphagov/govuk_publishing_components/assets/28735593/7cac06f4-9593-4f19-9c3a-8f66d7a074f5)

Homepage preview, showing footer changes:

![](https://github.com/alphagov/govuk_publishing_components/assets/28735593/1fa1171c-231b-4ae2-a450-20929e02c96e)

Organisational logo:

![](https://github.com/alphagov/govuk_publishing_components/assets/28735593/a84f914a-a00c-4033-a7b6-3ddd4acf80f6)

### After

#### Chrome print preview, 'background graphics' setting off

`gem-c-inverse-header`, `gem-c-title--inverse` and `publication-header__last-changed`:

![](https://github.com/alphagov/govuk_publishing_components/assets/28735593/d85dc100-0790-4851-87ae-eaef69d881d5)

Homepage preview, showing footer changes:

![image](https://github.com/alphagov/govuk_publishing_components/assets/28735593/911d05cc-2784-494b-be67-a970c8171534)

Organisational logo:

![](https://github.com/alphagov/govuk_publishing_components/assets/28735593/a84f914a-a00c-4033-a7b6-3ddd4acf80f6)

#### Chrome print preview, 'background graphics' setting on

`gem-c-inverse-header`, `gem-c-title--inverse` and `publication-header__last-changed`:

![](https://github.com/alphagov/govuk_publishing_components/assets/28735593/d85dc100-0790-4851-87ae-eaef69d881d5)

Homepage preview, showing footer changes:

![](https://github.com/alphagov/govuk_publishing_components/assets/28735593/c058840f-e973-4aa6-a8af-6bedc3c6e133)

Organisational logo:

![](https://github.com/alphagov/govuk_publishing_components/assets/28735593/a84f914a-a00c-4033-a7b6-3ddd4acf80f6)