### PR TITLE
Allow GA4 tracking on dev docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Allow GA4 tracking on dev docs ([PR #3802](https://github.com/alphagov/govuk_publishing_components/pull/3802))
 * Ensure all GA4 data values are strings ([PR #3800](https://github.com/alphagov/govuk_publishing_components/pull/3800))
 * Refactor image card tracking ([PR #3789](https://github.com/alphagov/govuk_publishing_components/pull/3789))
 * Details component GA4 tracking ([PR #3786](https://github.com/alphagov/govuk_publishing_components/pull/3786))

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-settings.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-settings.js
@@ -1,0 +1,109 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  function CookieSettings ($module) {
+    this.$module = $module
+  }
+
+  CookieSettings.prototype.init = function () {
+    this.$module.submitSettingsForm = this.submitSettingsForm.bind(this)
+
+    document.querySelector('form[data-module=cookie-settings]')
+      .addEventListener('submit', this.$module.submitSettingsForm)
+
+    this.setInitialFormValues()
+  }
+
+  CookieSettings.prototype.setInitialFormValues = function () {
+    if (!window.GOVUK.cookie('cookies_policy')) {
+      window.GOVUK.setDefaultConsentCookie()
+    }
+
+    var currentConsentCookie = window.GOVUK.cookie('cookies_policy')
+    var currentConsentCookieJSON = JSON.parse(currentConsentCookie)
+
+    // We don't need the essential value as this cannot be changed by the user
+    delete currentConsentCookieJSON.essential
+
+    for (var cookieType in currentConsentCookieJSON) {
+      var radioButton
+
+      if (currentConsentCookieJSON[cookieType]) {
+        radioButton = document.querySelector('input[name=cookies-' + cookieType + '][value=on]')
+      } else {
+        radioButton = document.querySelector('input[name=cookies-' + cookieType + '][value=off]')
+      }
+
+      if (radioButton) {
+        radioButton.checked = true
+      }
+    }
+  }
+
+  CookieSettings.prototype.submitSettingsForm = function (event) {
+    event.preventDefault()
+
+    var formInputs = event.target.getElementsByTagName('input')
+    var options = {}
+
+    for (var i = 0; i < formInputs.length; i++) {
+      var input = formInputs[i]
+      if (input.checked) {
+        var name = input.name.replace('cookies-', '')
+        var value = input.value === 'on'
+
+        options[name] = value
+      }
+    }
+
+    window.GOVUK.setConsentCookie(options)
+    window.GOVUK.setCookie('cookies_preferences_set', true, { days: 365 })
+
+    this.fireAnalyticsEvent(options)
+
+    this.showConfirmationMessage()
+
+    return false
+  }
+
+  CookieSettings.prototype.fireAnalyticsEvent = function (consent) {
+    var eventLabel = ''
+
+    for (var option in consent) {
+      var optionValue = consent[option] ? 'yes' : 'no'
+      eventLabel += option + '-' + optionValue + ' '
+    }
+
+    if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
+      window.GOVUK.analytics.trackEvent('cookieSettings', 'Save changes', { label: eventLabel })
+    }
+  }
+
+  CookieSettings.prototype.showConfirmationMessage = function () {
+    var confirmationMessage = document.querySelector('div[data-cookie-confirmation]')
+    // hide the message if already visible so assistive tech is triggered when it appears
+    confirmationMessage.style.display = 'none'
+    var previousPageLink = document.querySelector('.cookie-settings__prev-page')
+    var referrer = CookieSettings.prototype.getReferrerLink()
+
+    document.body.scrollTop = document.documentElement.scrollTop = 0
+
+    if (previousPageLink) {
+      if (referrer && referrer !== document.location.pathname) {
+        previousPageLink.href = referrer
+        previousPageLink.style.display = 'inline'
+      } else {
+        previousPageLink.style.display = 'none'
+      }
+    }
+
+    confirmationMessage.style.display = 'block'
+  }
+
+  CookieSettings.prototype.getReferrerLink = function () {
+    return document.referrer ? new URL(document.referrer).pathname : false
+  }
+
+  Modules.CookieSettings = CookieSettings
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/govuk_publishing_components/load-analytics.js
+++ b/app/assets/javascripts/govuk_publishing_components/load-analytics.js
@@ -21,6 +21,9 @@ window.GOVUK.loadAnalytics = {
   developmentDomains: [
     'localhost', '127.0.0.1', '0.0.0.0'
   ],
+  devdocsDomains: [
+    'docs.publishing.service.gov.uk'
+  ],
 
   // For Universal Analytics' cross domain tracking. linkedDomains is defined by the require statement at the top of the file.
   linkedDomains: window.GOVUK.analytics.linkedDomains,
@@ -28,22 +31,33 @@ window.GOVUK.loadAnalytics = {
   ga4EnvironmentVariables: {
     // initialiseGA4 is used to enable/disable GA4 on specific environments
     production: {
-      initialiseGA4: true
+      initialiseGA4: true,
+      id: 'GTM-MG7HG5W'
     },
     staging: {
       initialiseGA4: true,
+      id: 'GTM-MG7HG5W',
       auth: 'oJWs562CxSIjZKn_GlB5Bw',
       preview: 'env-5'
     },
     integration: {
       initialiseGA4: true,
+      id: 'GTM-MG7HG5W',
       auth: 'C7iYdcsOlYgGmiUJjZKrHQ',
       preview: 'env-4'
     },
     development: {
       initialiseGA4: true,
+      id: 'GTM-MG7HG5W',
       auth: 'bRiZ-jiEHtw6hHpGd6dF9w',
       preview: 'env-3'
+    },
+    devdocs: {
+      initialiseGA4: true,
+      id: 'GTM-TNKCK97',
+      // auth and preview not required for devdocs
+      auth: '',
+      preview: ''
     }
   },
 
@@ -87,6 +101,8 @@ window.GOVUK.loadAnalytics = {
       environment = 'integration'
     } else if (this.arrayContains(currentDomain, this.developmentDomains) || currentDomain.indexOf('.dev.gov.uk') !== -1) {
       environment = 'development'
+    } else if (this.arrayContains(currentDomain, this.devdocsDomains)) {
+      environment = 'devdocs'
     }
 
     // If we recognise the environment (i.e. the string isn't empty), load in GA4
@@ -95,7 +111,7 @@ window.GOVUK.loadAnalytics = {
       if (typeof window.GOVUK.analyticsGa4.init !== 'undefined' && this.ga4EnvironmentVariables[environment].initialiseGA4) {
         window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
         window.GOVUK.analyticsGa4.vars = window.GOVUK.analyticsGa4.vars || {}
-        window.GOVUK.analyticsGa4.vars.id = 'GTM-MG7HG5W'
+        window.GOVUK.analyticsGa4.vars.id = this.ga4EnvironmentVariables[environment].id
         window.GOVUK.analyticsGa4.vars.auth = this.ga4EnvironmentVariables[environment].auth
         window.GOVUK.analyticsGa4.vars.preview = this.ga4EnvironmentVariables[environment].preview
         window.GOVUK.analyticsGa4.vars.environment = environment // Used for testing and debugging

--- a/app/assets/javascripts/govuk_publishing_components/load-analytics.js
+++ b/app/assets/javascripts/govuk_publishing_components/load-analytics.js
@@ -3,63 +3,75 @@
 //= require govuk_publishing_components/analytics/linked-domains
 
 window.GOVUK.loadAnalytics = {
-  productionDomains: [
-    'www.gov.uk',
-    'www-origin.publishing.service.gov.uk',
-    'assets.publishing.service.gov.uk'
-  ],
-  stagingDomains: [
-    'www.staging.publishing.service.gov.uk',
-    'www-origin.staging.publishing.service.gov.uk',
-    'assets.staging.publishing.service.gov.uk'
-  ],
-  integrationDomains: [
-    'www.integration.publishing.service.gov.uk',
-    'www-origin.integration.publishing.service.gov.uk',
-    'assets.integration.publishing.service.gov.uk'
-  ],
-  developmentDomains: [
-    'localhost', '127.0.0.1', '0.0.0.0'
-  ],
-  devdocsDomains: [
-    'docs.publishing.service.gov.uk'
+  domains: [
+    {
+      // need to have this one at the start, see loadGa4 function
+      name: 'development',
+      domains: [
+        'localhost',
+        '127.0.0.1',
+        '0.0.0.0',
+        'dev.gov.uk'
+      ],
+      initialiseGA4: true,
+      id: 'GTM-MG7HG5W',
+      auth: 'bRiZ-jiEHtw6hHpGd6dF9w',
+      preview: 'env-3',
+      gaProperty: 'UA-UNSET',
+      gaPropertyCrossDomain: 'UA-UNSET'
+    },
+    {
+      name: 'production',
+      domains: [
+        'www.gov.uk',
+        'www-origin.publishing.service.gov.uk',
+        'assets.publishing.service.gov.uk'
+      ],
+      initialiseGA4: true,
+      id: 'GTM-MG7HG5W',
+      gaProperty: 'UA-26179049-1',
+      gaPropertyCrossDomain: 'UA-145652997-1'
+    },
+    {
+      name: 'staging',
+      domains: [
+        'www.staging.publishing.service.gov.uk',
+        'www-origin.staging.publishing.service.gov.uk',
+        'assets.staging.publishing.service.gov.uk'
+      ],
+      initialiseGA4: true,
+      id: 'GTM-MG7HG5W',
+      auth: 'oJWs562CxSIjZKn_GlB5Bw',
+      preview: 'env-5',
+      gaProperty: 'UA-26179049-20',
+      gaPropertyCrossDomain: 'UA-145652997-1'
+    },
+    {
+      name: 'integration',
+      domains: [
+        'www.integration.publishing.service.gov.uk',
+        'www-origin.integration.publishing.service.gov.uk',
+        'assets.integration.publishing.service.gov.uk'
+      ],
+      initialiseGA4: true,
+      id: 'GTM-MG7HG5W',
+      auth: 'C7iYdcsOlYgGmiUJjZKrHQ',
+      preview: 'env-4',
+      gaProperty: 'UA-26179049-22',
+      gaPropertyCrossDomain: 'UA-145652997-1'
+    },
+    {
+      name: 'devdocs',
+      domains: [
+        'docs.publishing.service.gov.uk'
+      ],
+      initialiseGA4: true,
+      id: 'GTM-TNKCK97'
+    }
   ],
 
   // For Universal Analytics' cross domain tracking. linkedDomains is defined by the require statement at the top of the file.
   linkedDomains: window.GOVUK.analytics.linkedDomains,
-
-  ga4EnvironmentVariables: {
-    // initialiseGA4 is used to enable/disable GA4 on specific environments
-    production: {
-      initialiseGA4: true,
-      id: 'GTM-MG7HG5W'
-    },
-    staging: {
-      initialiseGA4: true,
-      id: 'GTM-MG7HG5W',
-      auth: 'oJWs562CxSIjZKn_GlB5Bw',
-      preview: 'env-5'
-    },
-    integration: {
-      initialiseGA4: true,
-      id: 'GTM-MG7HG5W',
-      auth: 'C7iYdcsOlYgGmiUJjZKrHQ',
-      preview: 'env-4'
-    },
-    development: {
-      initialiseGA4: true,
-      id: 'GTM-MG7HG5W',
-      auth: 'bRiZ-jiEHtw6hHpGd6dF9w',
-      preview: 'env-3'
-    },
-    devdocs: {
-      initialiseGA4: true,
-      id: 'GTM-TNKCK97',
-      // auth and preview not required for devdocs
-      auth: '',
-      preview: ''
-    }
-  },
 
   loadUa: function (currentDomain) {
     currentDomain = currentDomain || window.location.hostname
@@ -71,17 +83,14 @@ window.GOVUK.loadAnalytics = {
     window.GOVUK.analyticsVars.gaProperty = 'UA-UNSET'
     window.GOVUK.analyticsVars.gaPropertyCrossDomain = 'UA-UNSET'
 
-    if (this.arrayContains(currentDomain, this.productionDomains)) {
-      window.GOVUK.analyticsVars.gaProperty = 'UA-26179049-1'
-      window.GOVUK.analyticsVars.gaPropertyCrossDomain = 'UA-145652997-1'
-    } else if (this.arrayContains(currentDomain, this.stagingDomains)) {
-      window.GOVUK.analyticsVars.gaProperty = 'UA-26179049-20'
-      window.GOVUK.analyticsVars.gaPropertyCrossDomain = 'UA-145652997-1'
-    } else if (this.arrayContains(currentDomain, this.integrationDomains)) {
-      window.GOVUK.analyticsVars.gaProperty = 'UA-26179049-22'
-      window.GOVUK.analyticsVars.gaPropertyCrossDomain = 'UA-145652997-1'
+    for (var i = 0; i < this.domains.length; i++) {
+      var current = this.domains[i]
+      if (this.arrayContains(currentDomain, current.domains)) {
+        window.GOVUK.analyticsVars.gaProperty = current.gaProperty
+        window.GOVUK.analyticsVars.gaPropertyCrossDomain = current.gaPropertyCrossDomain
+        break
+      }
     }
-
     // Load universal analytics
     if (typeof window.GOVUK.analyticsInit !== 'undefined') {
       window.GOVUK.analyticsInit()
@@ -90,31 +99,29 @@ window.GOVUK.loadAnalytics = {
 
   loadGa4: function (currentDomain) {
     currentDomain = currentDomain || window.location.hostname
-    var environment = ''
-
-    // Categorise current environment
-    if (this.arrayContains(currentDomain, this.productionDomains)) {
-      environment = 'production'
-    } else if (this.arrayContains(currentDomain, this.stagingDomains)) {
-      environment = 'staging'
-    } else if (this.arrayContains(currentDomain, this.integrationDomains)) {
-      environment = 'integration'
-    } else if (this.arrayContains(currentDomain, this.developmentDomains) || currentDomain.indexOf('.dev.gov.uk') !== -1) {
-      environment = 'development'
-    } else if (this.arrayContains(currentDomain, this.devdocsDomains)) {
-      environment = 'devdocs'
+    var environment = false
+    // lots of dev domains, so simplify the matching process
+    if (currentDomain.match(/\/{2}[a-zA-Z0-9.]+dev\.gov\.uk/)) {
+      environment = this.domains[0]
+    } else {
+      for (var i = 0; i < this.domains.length; i++) {
+        if (this.arrayContains(currentDomain, this.domains[i].domains)) {
+          environment = this.domains[i]
+          break
+        }
+      }
     }
 
     // If we recognise the environment (i.e. the string isn't empty), load in GA4
     if (environment) {
       // If analytics-ga4.js exists and our detected environment has 'initialiseGA4' set to true, load GA4.
-      if (typeof window.GOVUK.analyticsGa4.init !== 'undefined' && this.ga4EnvironmentVariables[environment].initialiseGA4) {
+      if (typeof window.GOVUK.analyticsGa4.init !== 'undefined' && environment.initialiseGA4) {
         window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
         window.GOVUK.analyticsGa4.vars = window.GOVUK.analyticsGa4.vars || {}
-        window.GOVUK.analyticsGa4.vars.id = this.ga4EnvironmentVariables[environment].id
-        window.GOVUK.analyticsGa4.vars.auth = this.ga4EnvironmentVariables[environment].auth
-        window.GOVUK.analyticsGa4.vars.preview = this.ga4EnvironmentVariables[environment].preview
-        window.GOVUK.analyticsGa4.vars.environment = environment // Used for testing and debugging
+        window.GOVUK.analyticsGa4.vars.id = environment.id
+        window.GOVUK.analyticsGa4.vars.auth = environment.auth
+        window.GOVUK.analyticsGa4.vars.preview = environment.preview
+        window.GOVUK.analyticsGa4.vars.environment = environment.name // Used for testing and debugging
 
         window.GOVUK.analyticsGa4.vars.gem_version = 'not found'
         var gemMeta = document.querySelector('meta[name="govuk:components_gem_version"]')

--- a/spec/javascripts/govuk_publishing_components/lib/cookie-settings-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/cookie-settings-spec.js
@@ -1,0 +1,198 @@
+/* eslint-env jasmine */
+var GOVUK = window.GOVUK || {}
+
+describe('cookieSettings', function () {
+  var container,
+    element,
+    confirmationContainer,
+    fakePreviousURL
+
+  beforeEach(function () {
+    GOVUK.Modules.CookieSettings.prototype.getReferrerLink = function () {
+      return fakePreviousURL
+    }
+
+    container = document.createElement('div')
+    container.innerHTML =
+      '<form data-module="cookie-settings">' +
+        '<input type="radio" id="settings-on" name="cookies-settings" value="on">' +
+        '<input type="radio" id="settings-off" name="cookies-settings" value="off">' +
+        '<input type="radio" name="cookies-usage" value="on">' +
+        '<input type="radio" name="cookies-usage" value="off">' +
+        '<input type="radio" name="cookies-campaigns" value="on">' +
+        '<input type="radio" name="cookies-campaigns" value="off">' +
+        '<button id="submit-button" type="submit">Submit</button>' +
+      '</form>'
+
+    document.body.appendChild(container)
+
+    confirmationContainer = document.createElement('div')
+    confirmationContainer.style.display = 'none'
+    confirmationContainer.setAttribute('data-cookie-confirmation', 'true')
+    confirmationContainer.innerHTML =
+      '<a class="cookie-settings__prev-page" href="#">View previous page</a>'
+
+    document.body.appendChild(confirmationContainer)
+
+    element = document.querySelector('[data-module=cookie-settings]')
+  })
+
+  afterEach(function () {
+    document.body.removeChild(container)
+    document.body.removeChild(confirmationContainer)
+  })
+
+  describe('setInitialFormValues', function () {
+    it('sets a consent cookie by default', function () {
+      GOVUK.cookie('cookies_policy', null)
+      spyOn(window.GOVUK, 'setDefaultConsentCookie').and.callThrough()
+
+      new GOVUK.Modules.CookieSettings(element).init()
+
+      expect(window.GOVUK.setDefaultConsentCookie).toHaveBeenCalled()
+    })
+
+    it('sets all radio buttons to the default values', function () {
+      new GOVUK.Modules.CookieSettings(element).init()
+
+      var radioButtons = element.querySelectorAll('input[value=on]')
+      var consentCookieJSON = JSON.parse(window.GOVUK.cookie('cookies_policy'))
+
+      for (var i = 0; i < radioButtons.length; i++) {
+        var name = radioButtons[i].name.replace('cookies-', '')
+
+        if (consentCookieJSON[name]) {
+          expect(radioButtons[i].checked).toBeTruthy()
+        } else {
+          expect(radioButtons[i].checked).not.toBeTruthy()
+        }
+      }
+    })
+
+    it('does not error if not all options are present', function () {
+      element.innerHTML =
+      '<form data-module="cookie-settings">' +
+        '<input type="radio" id="settings-on" name="cookies-settings" value="on">' +
+        '<input type="radio" id="settings-off" name="cookies-settings" value="off">' +
+        '<button id="submit-button" type="submit">Submit</button>' +
+      '</form>'
+
+      new GOVUK.Modules.CookieSettings(element).init()
+
+      var radioButtons = element.querySelectorAll('input[value=on]')
+      var consentCookieJSON = JSON.parse(window.GOVUK.cookie('cookies_policy'))
+
+      for (var i = 0; i < radioButtons.length; i++) {
+        var name = radioButtons[i].name.replace('cookies-', '')
+
+        if (consentCookieJSON[name]) {
+          expect(radioButtons[i].checked).toBeTruthy()
+        } else {
+          expect(radioButtons[i].checked).not.toBeTruthy()
+        }
+      }
+    })
+  })
+
+  describe('submitSettingsForm', function () {
+    it('updates consent cookie with any changes', function () {
+      spyOn(window.GOVUK, 'setConsentCookie').and.callThrough()
+
+      new GOVUK.Modules.CookieSettings(element).init()
+
+      element.querySelector('#settings-on').checked = false
+      element.querySelector('#settings-off').checked = true
+
+      var button = element.querySelector('#submit-button')
+      button.click()
+
+      var cookie = JSON.parse(GOVUK.cookie('cookies_policy'))
+
+      expect(window.GOVUK.setConsentCookie).toHaveBeenCalledWith({ settings: false, usage: false, campaigns: false })
+      expect(cookie.settings).toBeFalsy()
+    })
+
+    it('sets cookies_preferences_set cookie on form submit', function () {
+      spyOn(window.GOVUK, 'setCookie').and.callThrough()
+
+      new GOVUK.Modules.CookieSettings(element).init()
+
+      GOVUK.cookie('cookies_preferences_set', null)
+
+      expect(GOVUK.cookie('cookies_preferences_set')).toEqual(null)
+
+      var button = element.querySelector('#submit-button')
+      button.click()
+
+      expect(window.GOVUK.setCookie).toHaveBeenCalledWith('cookies_preferences_set', true, { days: 365 })
+      expect(GOVUK.cookie('cookies_preferences_set')).toBeTruthy()
+    })
+
+    it('fires a Google Analytics event', function () {
+      spyOn(GOVUK.analytics, 'trackEvent').and.callThrough()
+
+      new GOVUK.Modules.CookieSettings(element).init()
+
+      element.querySelector('#settings-on').checked = false
+      element.querySelector('#settings-off').checked = true
+
+      var button = element.querySelector('#submit-button')
+      button.click()
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('cookieSettings', 'Save changes', { label: 'settings-no usage-no campaigns-no ' })
+    })
+  })
+
+  describe('showConfirmationMessage', function () {
+    it('sets the previous referrer link if one is present', function () {
+      fakePreviousURL = '/student-finance'
+
+      new GOVUK.Modules.CookieSettings(element).init()
+
+      var button = element.querySelector('#submit-button')
+      button.click()
+
+      var previousLink = document.querySelector('.cookie-settings__prev-page')
+
+      expect(previousLink.style.display).toEqual('inline')
+      expect(previousLink.href).toContain('/student-finance')
+    })
+
+    it('does not set a referrer if one is not present', function () {
+      fakePreviousURL = null
+
+      new GOVUK.Modules.CookieSettings(element).init()
+
+      var button = element.querySelector('#submit-button')
+      button.click()
+
+      var previousLink = document.querySelector('.cookie-settings__prev-page')
+
+      expect(previousLink.style.display).toEqual('none')
+    })
+
+    it('does not set a referrer if URL is the same as current page (cookies page)', function () {
+      fakePreviousURL = document.location.pathname
+
+      new GOVUK.Modules.CookieSettings(element).init()
+
+      var button = element.querySelector('#submit-button')
+      button.click()
+
+      var previousLink = document.querySelector('.cookie-settings__prev-page')
+
+      expect(previousLink.style.display).toEqual('none')
+    })
+
+    it('shows a confirmation message', function () {
+      var confirmationMessage = document.querySelector('[data-cookie-confirmation]')
+
+      new GOVUK.Modules.CookieSettings(element).init()
+
+      var button = element.querySelector('#submit-button')
+      button.click()
+
+      expect(confirmationMessage.style.display).toEqual('block')
+    })
+  })
+})

--- a/spec/javascripts/govuk_publishing_components/load-analytics.spec.js
+++ b/spec/javascripts/govuk_publishing_components/load-analytics.spec.js
@@ -74,7 +74,7 @@ describe('Analytics loading', function () {
 
     it('loads GA4 on development domains', function () {
       var domains = [
-        'localhost', '127.0.0.1', '0.0.0.0', 'static.dev.gov.uk'
+        'localhost', '127.0.0.1', '0.0.0.0', '//static.dev.gov.uk'
       ]
 
       for (var i = 0; i < domains.length; i++) {
@@ -133,10 +133,10 @@ describe('Analytics loading', function () {
     })
 
     it('doesnt load GA4 variables if initialiseGA4 is set to false', function () {
-      window.GOVUK.loadAnalytics.ga4EnvironmentVariables.production.initialiseGA4 = false
-      window.GOVUK.loadAnalytics.loadGa4('www.gov.uk')
+      window.GOVUK.loadAnalytics.domains[0].initialiseGA4 = false
+      window.GOVUK.loadAnalytics.loadGa4('localhost')
       expect(window.GOVUK.analyticsGa4.vars).toEqual(null)
-      window.GOVUK.loadAnalytics.ga4EnvironmentVariables.production.initialiseGA4 = true
+      window.GOVUK.loadAnalytics.domains[0].initialiseGA4 = true
     })
   })
 


### PR DESCRIPTION
## What
Changes necessary to support allowing the [dev docs](https://docs.publishing.service.gov.uk/) to use the GA4 tracking code in the gem. See this [related PR](https://github.com/alphagov/govuk-developer-docs/pull/4376). Specifically:

- adjust the GA4 initialisation code to include variables for the tracking on the dev docs
- include the code from `frontend` for the cookie settings page, as it will now be used in more than just `frontend` (another PR will be raised later to remove this from `frontend`)
- refactor the code in load analytics

## Why
We want to extend GA4 tracking to the whole of the dev docs, not just the implementation record section.

## Visual Changes
None.

Trello card: https://trello.com/c/kA66mxak/755-extend-analytics-to-all-of-dev-docs