### PR TITLE
Remove hyphens and downcase the GA4 publishing government value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Remove hyphens and downcase the GA4 publishing government value ([PR #3808](https://github.com/alphagov/govuk_publishing_components/pull/3808))
+
 ## 37.2.1
 
 * Revert changes to fix Sass deprecation warnings ([PR #3810](https://github.com/alphagov/govuk_publishing_components/pull/3810))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
@@ -45,7 +45,7 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
             first_published_at: this.stripTimeFrom(this.getMetaContent('first-published-at')),
             updated_at: this.stripTimeFrom(this.getMetaContent('updated-at')),
             public_updated_at: this.stripTimeFrom(this.getMetaContent('public-updated-at')),
-            publishing_government: this.getMetaContent('publishing-government') || this.getMetaContent('ga4-publishing-government'),
+            publishing_government: this.removeHyphensAndDowncase(this.getMetaContent('publishing-government') || this.getMetaContent('ga4-publishing-government')),
             political_status: this.getMetaContent('political-status') || this.getMetaContent('ga4-political-status'),
             primary_publishing_organisation: this.getMetaContent('primary-publishing-organisation'),
             organisations: this.getMetaContent('analytics:organisations'),
@@ -66,6 +66,12 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
           }
         }
         window.GOVUK.analyticsGa4.core.sendData(data)
+      }
+    },
+
+    removeHyphensAndDowncase: function (text) {
+      if (text) {
+        return text.replace(/-/g, ' ').toLowerCase()
       }
     },
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
@@ -277,6 +277,30 @@ describe('Google Tag Manager page view tracking', function () {
     expect(window.dataLayer[0]).toEqual(expected)
   })
 
+  it('handles removing hyphens and downcases from the publishing government meta tag', function () {
+    createMetaTags('ga4-publishing-government', '2005-To-2010-Labour-GOVERNMENT')
+    expected.page_view.publishing_government = '2005 to 2010 labour government'
+    GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
+    expect(window.dataLayer[0]).toEqual(expected)
+
+    createMetaTags('publishing-government', '2005-To-2010-Labour-GOVERNMENT-2')
+    expected.page_view.publishing_government = '2005 to 2010 labour government 2'
+    GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
+    expect(window.dataLayer[1]).toEqual(expected)
+  })
+
+  it('handles removing hyphens and downcases when the publishing government meta tags are falsy', function () {
+    createMetaTags('ga4-publishing-government', '')
+    expected.page_view.publishing_government = undefined
+    GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
+    expect(window.dataLayer[0]).toEqual(expected)
+
+    createMetaTags('publishing-government', '')
+    expected.page_view.publishing_government = undefined
+    GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
+    expect(window.dataLayer[1]).toEqual(expected)
+  })
+
   it('returns a pageview on a page marked with a political status', function () {
     createMetaTags('political-status', 'ongoing')
     expected.page_view.political_status = 'ongoing'


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Removes hyphens and downcases the GA4 publishing government values

## Why
<!-- What are the reasons behind this change being made? -->
- Prevents duplicate values being sent to GA4, due to slight differences in casing/spacing of the meta values
- https://trello.com/c/rxbAaj4N/769-publishing-government-being-collected-with-varying-formatting

## Visual Changes

None.
