### PR TITLE
Revert changes to fix Sass deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Revert changes to fix Sass deprecation warnings ([PR #3810](https://github.com/alphagov/govuk_publishing_components/pull/3810))
+
 ## 37.2.0
 
 * Add timestamp value to GA4 dataLayer pushes ([PR #3790](https://github.com/alphagov/govuk_publishing_components/pull/3790))

--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -165,7 +165,7 @@ $gem-guide-border-width: 1px;
   h3,
   h4 {
     margin-top: 0;
-    margin-bottom: calc($govuk-gutter / 2);
+    margin-bottom: $govuk-gutter / 2;
   }
 
   h3 a {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_contents-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_contents-list.scss
@@ -40,7 +40,7 @@
   list-style-type: none;
 
   @include govuk-media-query($from: tablet) {
-    padding-top: calc(govuk-spacing(6) / 4);
+    padding-top: govuk-spacing(6) / 4;
   }
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -186,7 +186,7 @@
   @include govuk-font($size: false);
   font-size: 16px;
   font-size: govuk-px-to-rem(16px);
-  margin: 0 0 calc(govuk-spacing(3) / 2);
+  margin: 0 0 (govuk-spacing(3) / 2);
   color: govuk-colour("dark-grey", $legacy: "grey-1");
 
   @include govuk-media-query($from: tablet) {
@@ -196,7 +196,7 @@
 
 .gem-c-image-card__description {
   @include govuk-font($size: 19);
-  padding-top: calc(govuk-spacing(3) / 2);
+  padding-top: (govuk-spacing(3) / 2);
   word-wrap: break-word;
 }
 
@@ -204,7 +204,7 @@
   @include govuk-font($size: 19);
   position: relative;
   z-index: 2;
-  padding: calc(govuk-spacing(3) / 2) 0 0 0;
+  padding: (govuk-spacing(3) / 2) 0 0 0;
   margin: 0;
   list-style: none;
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_modal-dialogue.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_modal-dialogue.scss
@@ -46,7 +46,7 @@ $govuk-modal-wide-breakpoint: $govuk-page-width + $govuk-modal-margin * 2 + $gov
     bottom: inherit;
     left: inherit;
     width: auto;
-    max-width: $govuk-page-width * calc(2 / 3);
+    max-width: $govuk-page-width * 2 / 3;
     height: auto;
     margin: $govuk-modal-margin auto;
     border: $govuk-border-width-form-element solid $govuk-input-border-colour;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -65,7 +65,7 @@ $large-input-size: 50px;
 }
 
 .gem-c-search__input[type="search"] { // overly specific to prevent some overrides from outside
-  @include govuk-font($size: 19, $line-height: calc(28 / 19));
+  @include govuk-font($size: 19, $line-height: (28 / 19));
   margin: 0;
   width: 100%;
   height: govuk-em(40, 16);
@@ -108,7 +108,7 @@ $large-input-size: 50px;
 
 @mixin icon-positioning($container-size) {
   $icon-dimension: 20px;
-  $icon-position: calc(($container-size - $icon-dimension) / 2);
+  $icon-position: ($container-size - $icon-dimension) / 2;
 
   display: block;
   pointer-events: none;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_share-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_share-links.scss
@@ -18,7 +18,7 @@ $share-button-height: 30px;
   padding-left: ($share-button-width + govuk-spacing(2));
   padding-right: govuk-spacing(2);
   margin-bottom: govuk-spacing(2);
-  font-size: calc($share-button-height / 2);
+  font-size: $share-button-height / 2;
 }
 
 .gem-c-share-links__link {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-related.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-related.scss
@@ -32,7 +32,7 @@
   }
 
   .gem-c-step-nav-related__pretitle {
-    margin-bottom: calc(govuk-spacing(6) / 4);
+    margin-bottom: govuk-spacing(6) / 4;
   }
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
@@ -17,12 +17,12 @@ $top-border: solid 1px govuk-colour("mid-grey", $legacy: "grey-3");
 
 @mixin step-nav-line-position {
   left: 0;
-  margin-left: govuk-em(calc($number-circle-size / 2) - calc($stroke-width / 2), 16);
+  margin-left: govuk-em(($number-circle-size / 2) - ($stroke-width / 2), 16);
 }
 
 @mixin step-nav-line-position-large {
   left: 0;
-  margin-left: govuk-em(calc($number-circle-size-large / 2) - calc($stroke-width / 2), 16);
+  margin-left: govuk-em(($number-circle-size-large / 2) - ($stroke-width / 2), 16);
 }
 
 // custom mixin as govuk-font does undesirable things at different breakpoints
@@ -260,8 +260,8 @@ $top-border: solid 1px govuk-colour("mid-grey", $legacy: "grey-3");
     z-index: 6;
     bottom: 0;
     left: 0;
-    margin-left: calc($number-circle-size / 4);
-    width: calc($number-circle-size / 2);
+    margin-left: $number-circle-size / 4;
+    width: $number-circle-size / 2;
     height: 0;
     border-bottom: solid $stroke-width govuk-colour("mid-grey", $legacy: "grey-2");
   }
@@ -278,8 +278,8 @@ $top-border: solid 1px govuk-colour("mid-grey", $legacy: "grey-3");
   .gem-c-step-nav--large & {
     @include govuk-media-query($from: tablet) {
       &::before {
-        margin-left: calc($number-circle-size-large / 4);
-        width: calc($number-circle-size-large / 2);
+        margin-left: $number-circle-size-large / 4;
+        width: $number-circle-size-large / 2;
       }
 
       &::after {
@@ -508,9 +508,9 @@ $top-border: solid 1px govuk-colour("mid-grey", $legacy: "grey-3");
     z-index: 5;
     top: .6em; // position the dot to align with the first row of text in the link
     left: -(govuk-spacing(6) + govuk-spacing(3));
-    margin-top: - calc($stroke-width / 2);
-    margin-left: calc($number-circle-size / 2);
-    width: calc($number-circle-size / 2);
+    margin-top: -($stroke-width / 2);
+    margin-left: ($number-circle-size / 2);
+    width: $number-circle-size / 2;
     height: $stroke-width;
     background: govuk-colour("black");
   }
@@ -519,7 +519,7 @@ $top-border: solid 1px govuk-colour("mid-grey", $legacy: "grey-3");
     @include govuk-media-query($from: tablet) {
       &::before {
         left: -(govuk-spacing(9));
-        margin-left: calc($number-circle-size-large / 2);
+        margin-left: ($number-circle-size-large / 2);
       }
     }
   }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_table.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_table.scss
@@ -8,7 +8,7 @@ $table-header-background-colour: govuk-colour("light-grey", $legacy: "grey-3");
 $sort-link-active-colour: govuk-colour("white");
 $sort-link-arrow-size: 14px;
 $sort-link-arrow-size-small: 8px;
-$sort-link-arrow-spacing: calc($sort-link-arrow-size / 2);
+$sort-link-arrow-spacing: $sort-link-arrow-size / 2;
 $table-row-hover-background-colour: rgba(43, 140, 196, .2);
 $table-row-even-background-colour: govuk-colour("light-grey", $legacy: "grey-4");
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_warning-callout.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_warning-callout.scss
@@ -23,10 +23,10 @@
     padding-left: $icon-size;
 
     // Center the icon around the baseline
-    padding-top: calc(($icon-size - $line-height-mobile) / 2);
+    padding-top: ($icon-size - $line-height-mobile) / 2;
 
     @include govuk-media-query($from: tablet) {
-      padding-top: calc(($icon-size - $line-height-tablet) / 2);
+      padding-top: ($icon-size - $line-height-tablet) / 2;
     }
 
     p {

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_markdown-typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_markdown-typography.scss
@@ -3,7 +3,7 @@
 
   @include govuk-font($size: 16);
 
-  $gutter-two-thirds: $govuk-gutter - calc($govuk-gutter / 3);
+  $gutter-two-thirds: $govuk-gutter - ($govuk-gutter / 3);
 
   ol,
   ul,

--- a/app/assets/stylesheets/govuk_publishing_components/components/mixins/_grid-helper.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/mixins/_grid-helper.scss
@@ -48,7 +48,7 @@
 ///  }
 ///
 @mixin columns($items, $columns, $selector: "*", $flow: row) {
-  $rows: ceil(calc($items / $columns));
+  $rows: ceil($items / $columns);
 
   display: -ms-grid;
   display: grid;


### PR DESCRIPTION
## What

Revert changes to fix Sass deprecation warnings

## Why

Due to compile errors when running `yarn jasmine:prepare` from an application.

## Visual Changes

None.