### PR TITLE
Version 37.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 37.2.1
 
 * Revert changes to fix Sass deprecation warnings ([PR #3810](https://github.com/alphagov/govuk_publishing_components/pull/3810))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (37.2.0)
+    govuk_publishing_components (37.2.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "37.2.0".freeze
+  VERSION = "37.2.1".freeze
 end


### PR DESCRIPTION
## 37.2.1

* Revert changes to fix Sass deprecation warnings ([PR #3810](https://github.com/alphagov/govuk_publishing_components/pull/3810))
