### PR TITLE
Change social media links advice text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Remove hyphens and downcase the GA4 publishing government value ([PR #3808](https://github.com/alphagov/govuk_publishing_components/pull/3808))
 * Fix Sass negative mixin / value issue ([PR #3816](https://github.com/alphagov/govuk_publishing_components/pull/3816))
+* Change social media links advice text ([PR #3814](https://github.com/alphagov/govuk_publishing_components/pull/3814))
 
 ## 37.2.1
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -305,7 +305,7 @@ en:
       label: Search on GOV.UK
       search_button: Search
     share_links:
-      all_opens_in_new_tab: Sharing will open the page in a new tab
+      all_opens_in_new_tab: The following links open in a new tab
       opens_in_new_tab: "(opens in new tab)"
     show_password:
       announce_hide: Your password is hidden


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
On pages such as the social media feeds “Sharing will open the page in the new tab” is confusing and not accurate. Suggestion that the copy should be something like “The following links open in a new tab" to be clearer.

## Why
<!-- What are the reasons behind this change being made? -->
To help users understand what happens on their browse when sharing and it shouldn’t be confusing.

[Trello ticket](https://trello.com/c/UeGITj5l/2276-update-social-media-tab-copy-in-the-gem-s)

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

The screenshots below reflect the old proposed wording. After some discussion, the new wording is "The following links open in a new tab". I have not remade the screenshots.

### Before

![before](https://github.com/alphagov/govuk_publishing_components/assets/893013/cf8eae0e-755e-4a90-b8fe-902ad934ce7c)

### After

![after](https://github.com/alphagov/govuk_publishing_components/assets/893013/0e5f94bf-68ae-454e-9e16-b260a4614eb4)
