### PR TITLE
Fix Sass negative mixin / value issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Remove hyphens and downcase the GA4 publishing government value ([PR #3808](https://github.com/alphagov/govuk_publishing_components/pull/3808))
+* Fix Sass negative mixin / value issue ([PR #3816](https://github.com/alphagov/govuk_publishing_components/pull/3816))
 
 ## 37.2.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
@@ -449,7 +449,7 @@ $top-border: solid 1px govuk-colour("mid-grey", $legacy: "grey-3");
 
   .gem-c-step-nav--large & + .gem-c-step-nav__list {
     @include govuk-media-query($from: tablet) {
-      margin-top: -govuk-spacing(3);
+      margin-top: -(govuk-spacing(3));
     }
   }
 }


### PR DESCRIPTION
## What
Fix Sass negative mixin / value issue for [step by step navigation (with links)](https://components.publishing.service.gov.uk/component-guide/step_by_step_nav/with_links/preview) component.

## Why

Invalid CSS is compiled:
```
@media (min-width: 40.0625em)
.gem-c-step-nav--large .gem-c-step-nav__paragraph+.gem-c-step-nav__list {
    margin-top: -govuk-spacing(3);
}
```

## Visual Changes

### Before

<img width="1655" alt="Screenshot 2024-01-12 at 12 48 04" src="https://github.com/alphagov/govuk_publishing_components/assets/87758239/14c1dcb5-acbe-4bbb-9fd4-ddbc819a7b63">

### After

<img width="1655" alt="Screenshot 2024-01-12 at 12 48 12" src="https://github.com/alphagov/govuk_publishing_components/assets/87758239/7dfcb5f4-9cbf-4c04-accb-433b470f6c69">