### PR TITLE
Improve reliability of grabbing GA4 search term value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Improve reliability of grabbing GA4 search term value ([PR #3818](https://github.com/alphagov/govuk_publishing_components/pull/3818))
+
 ## 37.2.3
 
 * Add GOVUK logo to GovernmentOrganization schema.org schemas ([PR #3827](https://github.com/alphagov/govuk_publishing_components/pull/3827))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
@@ -80,18 +80,26 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
     },
 
     getSearchTerm: function () {
-      var queryString = window.GOVUK.analyticsGa4.core.trackFunctions.getSearch()
+      // Using the data-attribute has the benefit that none of the characters are URI encoded i.e. [] remains [] instead of %5B%5D.
+      var searchTerm = this.getElementAttribute('data-ga4-search-query')
 
-      if (!queryString) {
-        return undefined
-      }
-
-      var searchTerm = queryString.match(/keywords=([^&]*)/)
+      /*
+        Fallback to the keywords URL parameter if the attribute does not exist.
+        There is a small downside to this method. If the user uses an & in their search term, it breaks as we can't determine
+        if this & is a part of their search term or the start of another query parameter.
+        The potential solution may be to URL encode the keywords parameter in finder-frontend.
+      */
       if (!searchTerm) {
-        return undefined
+        var queryString = window.GOVUK.analyticsGa4.core.trackFunctions.getSearch()
+
+        searchTerm = queryString.match(/keywords=([^&]*)/)
+        if (!searchTerm) {
+          return undefined
+        }
+        searchTerm = searchTerm[0].replace('keywords=', '')
+        searchTerm = decodeURIComponent(searchTerm).replace(/'&quot;'/g, '"')
       }
 
-      searchTerm = searchTerm[0].replace('keywords=', '')
       searchTerm = window.GOVUK.analyticsGa4.core.trackFunctions.standardiseSearchTerm(searchTerm)
 
       return searchTerm


### PR DESCRIPTION
## What
- Currently we populate the GA4 Pageview `search_term` parameter by using regex - we grab it from the URLs `keywords` query string parameter. This has two downsides. 
- The first downside was identified by PAs. Symbols are being added in odd ways via `keywords` which causes inconsistency between the other ways we add search terms to GA4 (i.e. it differs from how the search term appears in the form tracker/ecommerce tracker.)
- The second downside I noticed during testing is that using the `keywords=` method does not work properly if the user's keyword contains an ampersand.  This is because our regex uses `&` to signal the end of the search term. However we can't tell whether this an ampersand is actually a part of their search term, or is the end of their search term and the start of another query parameter. This is a `finder-frontend` issue as it should encode the `&` in search terms before it places them into the URL.
    - For example their search term could be `B&Q`, which would be`&keywords=B&Q` in the URL. Regex wise, we have no idea of knowing if their search term was actually just `B`, with `&Q` being the start of another URL parameter. The fix would be to go into `finder-frontend` and encode the search term in the URL so the search term's ampersand becomes `%26`. Therefore the search term would become`B%26Q` and our regex would still work
    - I attempted looking into this in `finder-frontend` but the issue is a bit confusing - I think it's because the URL gets encoded in multiple places - so if you try and encode the keyword it gets encoded too many times so the `%` symbols that were the result of the first pass of keyword encoding end up gets encoded as well.
- For now to solve this, we can use a data attribute already available. The ecommerce tracker in `finder-frontend` populates a data attribute called `data-ga4-search-query` with the search term. The value doesn't have any issues with encoding so we can use it here. The `keywords` query string only exists where ecommerce tracking is present, so we should just be able to use this attribute.
- Have kept the `keywords` parameter code in as a fallback, but can remove it if preferred.
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
<!-- What are the reasons behind this change being made? -->
- Our `search_term` parameter had URL encoded characters in it. Our ecommerce `term` parameter didn't. This caused inconsistencies between the two when a user had symbols in their search term.
- https://trello.com/b/rm8pjAAk/ga4-gtm-implementation-ga4-team-user-experience-govuk

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.