### PR TITLE
Allow attachment to pass tracking to details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Allow attachment to pass tracking to details ([PR #3820](https://github.com/alphagov/govuk_publishing_components/pull/3820))
 * Allow GA4 link tracker to track to multiple child classes ([PR #3835](https://github.com/alphagov/govuk_publishing_components/pull/3835))
 
 ## 37.2.4

--- a/app/views/govuk_publishing_components/components/_attachment.html.erb
+++ b/app/views/govuk_publishing_components/components/_attachment.html.erb
@@ -7,6 +7,7 @@
   hide_order_copy_link ||= false
   attributes = []
   data_attributes ||= {}
+  details_ga4_attributes ||= {}
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
 
   container_class_names = %w[gem-c-attachment govuk-!-display-none-print]
@@ -118,7 +119,8 @@
     <% if attachment.alternative_format_contact_email %>
       <%= tag.p t("components.attachment.request_format_text"), class: "gem-c-attachment__metadata" %>
       <%= render "govuk_publishing_components/components/details", {
-        title: t("components.attachment.request_format_cta")
+        title: t("components.attachment.request_format_cta"),
+        ga4_attributes: details_ga4_attributes,
       } do %>
         <%= t("components.attachment.request_format_details_html", alternative_format_contact_email: attachment.alternative_format_contact_email) %>
       <% end %>

--- a/app/views/govuk_publishing_components/components/docs/attachment.yml
+++ b/app/views/govuk_publishing_components/components/docs/attachment.yml
@@ -76,6 +76,19 @@ examples:
         content_type: application/pdf
         file_size: 20000
         alternative_format_contact_email: defra.helpline@defra.gsi.gov.uk
+  with_contact_email_and_ga4_tracking:
+    description: The attachment component can contain the details component as shown. The details component provides all of its own GA4 tracking, but in most situations also requires an `index_section_count` attribute to be passed manually. This can be done via the attachment component as shown (along with any other needed GA4 attributes).
+    data:
+      attachment:
+        title: "Department for Transport information asset register"
+        url: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/747661/department-for-transport-information-asset-register.csv
+        filename: department-for-transport-information-asset-register.csv
+        content_type: application/pdf
+        file_size: 20000
+        alternative_format_contact_email: defra.helpline@defra.gsi.gov.uk
+      details_ga4_attributes: {
+        index_section_count: 4
+      }
   with_data_attributes:
     data:
       attachment:

--- a/spec/components/attachment_spec.rb
+++ b/spec/components/attachment_spec.rb
@@ -89,6 +89,32 @@ describe "Attachment", type: :view do
     assert_select "a[href='mailto:defra.helpline@defra.gsi.gov.uk']"
   end
 
+  it "shows section to request a different format with GA4 tracking on the details component" do
+    render_component(
+      attachment: {
+        title: "Attachment",
+        url: "attachment",
+        content_type: "application/vnd.oasis.opendocument.spreadsheet",
+        alternative_format_contact_email: "defra.helpline@defra.gsi.gov.uk",
+      },
+      details_ga4_attributes: {
+        index_section_count: 4,
+        another_attribute: "here",
+      },
+    )
+    assert_select "a[href='mailto:defra.helpline@defra.gsi.gov.uk']"
+    attributes = {
+      event_name: "select_content",
+      type: "detail",
+      text: "Request an accessible format.",
+      section: "Request an accessible format.",
+      index_section: 1,
+      index_section_count: 4,
+      another_attribute: "here",
+    }.to_json
+    assert_select ".govuk-details__summary[data-ga4-event='#{attributes}']"
+  end
+
   it "does not show opendocument metadata if disabled" do
     render_component(
       attachment: {


### PR DESCRIPTION
## What
- extend the attachment component (which can contain the details component) to allow GA4 tracking attributes to be passed through to the details component
- details component does most of its own tracking but requires the `index_section_count` attribute to be passed manually

## Why
Part of the GA4 migration.

## Visual Changes
No changes to the component, but have added an extra entry in the attachment doc, so will trigger a diff.

Trello card: https://trello.com/c/xhASj1rp/765-add-tracking-to-details-component