### PR TITLE
Version 37.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 37.2.2
 
 * Remove hyphens and downcase the GA4 publishing government value ([PR #3808](https://github.com/alphagov/govuk_publishing_components/pull/3808))
 * Fix Sass negative mixin / value issue ([PR #3816](https://github.com/alphagov/govuk_publishing_components/pull/3816))
 * Change social media links advice text ([PR #3814](https://github.com/alphagov/govuk_publishing_components/pull/3814))
+* Remove current-location.js ([PR #3812](https://github.com/alphagov/govuk_publishing_components/pull/3812))
 
 ## 37.2.1
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (37.2.1)
+    govuk_publishing_components (37.2.2)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -215,14 +215,14 @@ GEM
     mini_portile2 (2.8.5)
     minitest (5.20.0)
     mutex_m (0.2.0)
-    net-imap (0.4.7)
+    net-imap (0.4.9.1)
       date
       net-protocol
     net-pop (0.1.2)
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.4.0)
+    net-smtp (0.4.0.1)
       net-protocol
     netrc (0.11.0)
     nio4r (2.7.0)
@@ -431,7 +431,7 @@ GEM
     percy-capybara (5.0.0)
       capybara (>= 3)
     plek (5.0.0)
-    prometheus_exporter (2.0.8)
+    prometheus_exporter (2.1.0)
       webrick
     pry (0.14.1)
       coderay (~> 1.1)
@@ -569,10 +569,10 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    sentry-rails (5.15.2)
+    sentry-rails (5.16.1)
       railties (>= 5.0)
-      sentry-ruby (~> 5.15.2)
-    sentry-ruby (5.15.2)
+      sentry-ruby (~> 5.16.1)
+    sentry-ruby (5.16.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
     smart_properties (1.17.0)
     sprockets (4.2.1)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "37.2.1".freeze
+  VERSION = "37.2.2".freeze
 end


### PR DESCRIPTION
## 37.2.2

* Remove hyphens and downcase the GA4 publishing government value ([PR #3808](https://github.com/alphagov/govuk_publishing_components/pull/3808))
* Fix Sass negative mixin / value issue ([PR #3816](https://github.com/alphagov/govuk_publishing_components/pull/3816))
* Change social media links advice text ([PR #3814](https://github.com/alphagov/govuk_publishing_components/pull/3814))
* Remove current-location.js ([PR #3812](https://github.com/alphagov/govuk_publishing_components/pull/3812))