### PR TITLE
Add GOVUK logo to GovernmentOrganization schema.org schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add GOVUK logo to GovernmentOrganization schema.org schemas ([PR #3827](https://github.com/alphagov/govuk_publishing_components/pull/3827))
+
 ## 37.2.2
 
 * Remove hyphens and downcase the GA4 publishing government value ([PR #3808](https://github.com/alphagov/govuk_publishing_components/pull/3808))

--- a/lib/govuk_publishing_components/presenters/machine_readable/organisation_schema.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/organisation_schema.rb
@@ -19,6 +19,7 @@ module GovukPublishingComponents
           "name" => page.title,
           "description" => page.description || page.body,
         }
+        .merge(govuk_logo)
         .merge(members)
         .merge(parent_organisations)
         .merge(sub_organisations)
@@ -81,6 +82,15 @@ module GovukPublishingComponents
 
       def role_url(minister)
         "#{website_root}#{minister['role_href']}"
+      end
+
+      def govuk_logo
+        logo = page.local_assigns[:logo_url]
+        return {} unless logo
+
+        {
+          "logo" => logo,
+        }
       end
 
       def website_root

--- a/spec/lib/govuk_publishing_components/presenters/schema_org_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/schema_org_spec.rb
@@ -363,11 +363,40 @@ RSpec.describe GovukPublishingComponents::Presenters::SchemaOrg do
       structured_data = generate_structured_data(
         content_item:,
         schema: :organisation,
+        logo_url: "https://example.png",
       ).structured_data
 
       expect(structured_data["@type"]).to eq("GovernmentOrganization")
       expect(structured_data["name"]).to eq("Ministry of Magic")
       expect(structured_data["description"]).to eq("The magical ministry.")
+      expect(structured_data["logo"]).to eq("https://example.png")
+      expect(structured_data["mainEntityOfPage"]["@id"]).to eq("http://www.dev.gov.uk/ministry-of-magic")
+      expect(structured_data["potentialAction"]).to eq(search_action)
+    end
+
+    it "generates schema.org GovernmentOrganization when logo_url does not exist in the page's local_assigns" do
+      content_item = generate_org(
+        "base_path" => "/ministry-of-magic",
+        "title" => "Ministry of Magic",
+        "description" => "The magical ministry.",
+      )
+
+      search_action = {
+        "@type": "SearchAction",
+        "description": "Find all content from Ministry of Magic",
+        "target": "http://www.dev.gov.uk/search/all?keywords={query}&order=relevance&organisations%5B%5D=ministry-of-magic",
+        "query": "required",
+      }
+
+      structured_data = generate_structured_data(
+        content_item:,
+        schema: :organisation,
+      ).structured_data
+
+      expect(structured_data["@type"]).to eq("GovernmentOrganization")
+      expect(structured_data["name"]).to eq("Ministry of Magic")
+      expect(structured_data["description"]).to eq("The magical ministry.")
+      expect(structured_data["logo"]).to eq(nil)
       expect(structured_data["mainEntityOfPage"]["@id"]).to eq("http://www.dev.gov.uk/ministry-of-magic")
       expect(structured_data["potentialAction"]).to eq(search_action)
     end


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Adds a reference to the GOVUK logo in our `schema.org` `GovernmentOrganization` schema. 
- This schema is used by organisation index pages such as https://www.gov.uk/government/organisations/cabinet-office to provide metadata about the page to machines i.e. Google Search results.

## Why
<!-- What are the reasons behind this change being made? -->
- There is an issue on organisation pages in Google search results right now as Google is picking a random image from the organisation pages to feature next to the search results on Google. For example on this search result, it is using the our currently "Featured" image on the cabinet office page as the image next to the search result: https://www.google.com/search?q=cabinet-office
- This is a problem as we do not have control over which image it picks. Google seems to decide what image they think is best. There is a "Related people" section on organisation pages that feature photos of people. Sometimes these photos of people are appearing next to search results for government organisations, which we do not want due to potential interpretations arising from this.
- Initially, I was going to use the meta tag Google provides, which would disable Google from showing image previews on organisation search results entirely. I raised a PR for this in `collections`: https://github.com/alphagov/collections/pull/3504
- However, our Lead PM has suggested we try this first, so that hopefully Google picks the GOVUK logo as the best image, and the GOVUK logo shows up instead of the wrong image or no image at all.

## Testing

Have tested this and it works in `collections`. I have also written it to not crash if `logo_url` happened to no longer exist. `logo_url` is added to `page.local_assigns` for us in `app/views/govuk_publishing_components/components/_machine_readable_metadata.html.erb`.

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.