### PR TITLE
Hide our cookie banner when JS is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Allow GA4 link tracker to track to multiple child classes ([PR #3835](https://github.com/alphagov/govuk_publishing_components/pull/3835))
 * Add GA4 link tracking to govspeak callout links ([PR #3843](https://github.com/alphagov/govuk_publishing_components/pull/3843))
 * Allow inputs to be exempt from GA4 form tracker [REDACT] code ([PR #3848](https://github.com/alphagov/govuk_publishing_components/pull/3848))
+* Hide our cookie banner when JS is disabled ([PR #3830](https://github.com/alphagov/govuk_publishing_components/pull/3830))
 
 ## 37.2.4
 

--- a/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
@@ -26,13 +26,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
     this.$acceptCookiesButton = this.$module.querySelector('button[data-accept-cookies]')
     if (this.$acceptCookiesButton) {
-      this.$acceptCookiesButton.style.display = 'block'
       this.$acceptCookiesButton.addEventListener('click', this.$module.setCookieConsent)
     }
 
     this.$rejectCookiesButton = this.$module.querySelector('button[data-reject-cookies]')
     if (this.$rejectCookiesButton) {
-      this.$rejectCookiesButton.style.display = 'block'
       this.$rejectCookiesButton.addEventListener('click', this.$module.rejectCookieConsent)
     }
 
@@ -45,7 +43,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       var shouldHaveCookieMessage = (this.$module && window.GOVUK.cookie('cookies_preferences_set') !== 'true')
 
       if (shouldHaveCookieMessage) {
-        this.$module.style.display = 'block'
+        this.$module.removeAttribute('hidden')
 
         // Set the default consent cookie if it isn't already present
         if (!window.GOVUK.cookie('cookies_policy')) {
@@ -53,18 +51,13 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         }
 
         window.GOVUK.deleteUnconsentedCookies()
-      } else {
-        this.$module.style.display = 'none'
       }
-    } else {
-      this.$module.style.display = 'none'
     }
   }
 
   CookieBanner.prototype.hideCookieMessage = function (event) {
     if (this.$module) {
       this.$module.hidden = true
-      this.$module.style.display = 'none'
       window.GOVUK.cookie('cookies_preferences_set', 'true', { days: 365 })
     }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
@@ -1,23 +1,12 @@
 @import "govuk_publishing_components/individual_component_support";
 @import "govuk/components/cookie-banner/cookie-banner";
 
-.gem-c-cookie-banner .govuk-button-group[hidden] {
-  display: none;
-}
-
-.govuk-cookie-banner .govuk-cookie-banner__heading[hidden] {
-  display: none;
-}
-
-.js-enabled {
-  .gem-c-cookie-banner {
-    display: none; // shown with JS, always on for non-JS
+.gem-c-cookie-banner {
+  [hidden],
+  .govuk-button-group[hidden],
+  .govuk-cookie-banner__heading[hidden] {
+    display: none;
   }
-}
-
-// can't be used without js so implement there
-.gem-c-cookie-banner .gem-c-button {
-  display: none;
 }
 
 .gem-c-cookie-banner__confirmation {

--- a/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
@@ -34,7 +34,7 @@
   disable_ga4 ||= false
 %>
 
-<div id="<%= id %>" class="<%= css_classes.join(' ') %>" data-module="cookie-banner" data-nosnippet role="region" aria-label="<%= title %>">
+<div id="<%= id %>" class="<%= css_classes.join(' ') %>" data-module="cookie-banner" data-nosnippet role="region" aria-label="<%= title %>" hidden>
   <div class="govuk-cookie-banner__message govuk-width-container">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/app/views/govuk_publishing_components/components/docs/cookie_banner.yml
+++ b/app/views/govuk_publishing_components/components/docs/cookie_banner.yml
@@ -1,11 +1,11 @@
 name: Cookie banner
 description: Help users manage their personal data by telling them when you store cookies on their device.
 body: |
-  By default the cookie banner is shown to all users with just a link to the settings page. If JavaScript is on this is enhanced to show accept/reject buttons if preferences aren't set, or to hide the banner if they are.
+  By default the cookie banner is hidden. If JavaScript is enabled, the banner is displayed if cookie preferences are not set. The banner will stay hidden if cookie preferences are already set.
 
   Setting `data-hide-cookie-banner="true"` on any link inside the banner will overwrite the default action and when clicked will dismiss the cookie banner for a period of 365 days (approx. 1 year).
 
-  If the examples below are not showing the banner, make sure the `cookies_preferences_set` cookie is not present or is set to false.
+  If the examples below are not showing the banner, make sure JS is enabled, and the `cookies_preferences_set` cookie is not present or is set to false.
 accessibility_criteria: |
   Text in the cookie banner must be clear and unambiguous and should provide a way to dismiss the message.
 shared_accessibility_criteria:

--- a/spec/javascripts/components/cookie-banner-spec.js
+++ b/spec/javascripts/components/cookie-banner-spec.js
@@ -14,7 +14,7 @@ describe('Cookie banner', function () {
     container = document.createElement('div')
 
     container.innerHTML =
-      '<div id="global-cookie-message" class="gem-c-cookie-banner govuk-clearfix govuk-cookie-banner js-banner-wrapper" data-module="cookie-banner" data-nosnippet="" role="region" aria-label="Cookies on GOV.UK">' +
+      '<div id="global-cookie-message" class="gem-c-cookie-banner govuk-clearfix govuk-cookie-banner js-banner-wrapper" data-module="cookie-banner" data-nosnippet="" role="region" aria-label="Cookies on GOV.UK" hidden>' +
           '<div class="govuk-cookie-banner__message govuk-width-container">' +
               '<div class="govuk-grid-row">' +
                   '<div class="govuk-grid-column-two-thirds">' +
@@ -92,6 +92,25 @@ describe('Cookie banner', function () {
     new GOVUK.Modules.CookieBanner(element).init()
 
     expect(element).toBeHidden()
+  })
+
+  it('should have the hidden attribute by default, and remove it once the JS loads when cookies are not set', function () {
+    var element = document.querySelector('[data-module="cookie-banner"]')
+    expect(element.hasAttribute('hidden')).toEqual(true)
+    expect(element.offsetParent).toEqual(null)
+    new GOVUK.Modules.CookieBanner(element).init()
+    expect(element.hasAttribute('hidden')).toEqual(false)
+    expect(!!element.offsetParent).toEqual(true)
+  })
+
+  it('should have the hidden attribute by default, and leave it when cookies are set', function () {
+    GOVUK.cookie('cookies_preferences_set', 'true', { days: 365 })
+    var element = document.querySelector('[data-module="cookie-banner"]')
+    expect(element.offsetParent).toEqual(null)
+    expect(element.hasAttribute('hidden')).toEqual(true)
+    new GOVUK.Modules.CookieBanner(element).init()
+    expect(element.offsetParent).toEqual(null)
+    expect(element.hasAttribute('hidden')).toEqual(true)
   })
 
   it('sets a default consent cookie', function () {


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Hides our cookie banner when JS is disabled
- Tested in `static` with Chrome/Firefox/Safari on Mac, and IE11 on Windows
- Has approval from our privacy people. Data protection officer: _"agrees it sounds fine, so long as we have the cookie notice linked at the bottom of the page (no message or banner necessary)"_ 
## Why
<!-- What are the reasons behind this change being made? -->
- We've had a couple of users who use the page without JavaScript mention to us that the banner is displayed. I assume the main issue being it takes up a lot of screen space for them.

### Static troubleshooting
If you want to test it on `static` but have issues try this. I keep having issues with my `static` updating its assets, so to get `static` to work I had to:

- Change _public_layout.html.erb in publishing components to use `<link rel="stylesheet" href="/assets/static/application.css" media="all">` as the application stylesheet
- Change load-analytics.js to use `<script src="/assets/static/govuk_publishing_components/load-analytics.js"></script>`
- Change `application.js` to use `<script src="/assets/static/application.js" type="text/javascript"></script>`
- In `static`, run `bundle exec rake dartsass:watch`
- Hit save on `_cookie_banner.scss` so it compiles the CSS

## Visual Changes

### Before (JS disabled)

<img width="808" alt="image" src="https://github.com/alphagov/govuk_publishing_components/assets/8880610/cd8efae7-de98-4420-b4da-85505d6ce5b4">

### After (JS disabled)

<img width="808" alt="image" src="https://github.com/alphagov/govuk_publishing_components/assets/8880610/49e4d131-b062-4070-a8fd-c99a5a73b52d">
