### PR TITLE
Add GA4 tracking to warning text component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Improve reliability of grabbing GA4 search term value ([PR #3818](https://github.com/alphagov/govuk_publishing_components/pull/3818))
 * Update Cross Service Header component ([PR #3831](https://github.com/alphagov/govuk_publishing_components/pull/3831))
+* Add GA4 tracking to warning text component ([PR #3832](https://github.com/alphagov/govuk_publishing_components/pull/3832))
 
 ## 37.2.3
 

--- a/app/views/govuk_publishing_components/components/_warning_text.html.erb
+++ b/app/views/govuk_publishing_components/components/_warning_text.html.erb
@@ -14,9 +14,18 @@
   text_classes << "gem-c-warning-text__text--no-indent" if text_icon.empty?
   text_classes << "gem-c-warning-text__text--large" if large_font
   text_classes << "gem-c-warning-text__text--highlight" if highlight_text
+
+  disable_ga4 ||= false
+
+  ga4_data_attributes = {
+    "module": "ga4-link-tracker",
+    "ga4-track-links-only": "",
+    "ga4-link": { "event_name": "navigation", "type": "callout" }.to_json
+  } unless disable_ga4
+
 %>
 
-<%= tag.div id: id, class: "gem-c-warning-text govuk-warning-text" do %>
+<%= tag.div id: id, class: "gem-c-warning-text govuk-warning-text", data: ga4_data_attributes do %>
   <% unless text_icon.empty? %>
     <%= tag.span text_icon, class: "govuk-warning-text__icon", "aria-hidden": "true" %>
   <% end %>

--- a/app/views/govuk_publishing_components/components/docs/warning_text.yml
+++ b/app/views/govuk_publishing_components/components/docs/warning_text.yml
@@ -33,3 +33,10 @@ examples:
     data:
       text: "This is a heading 3"
       heading_level: 3
+  without_ga4_tracking:
+    description: |
+      Disables GA4 tracking on warning text links. Tracking is enabled by default, which adds a data module and data attributes to the component. See the [ga4-link-tracker documentation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-link-tracker.md) for more information.
+    data:
+      disable_ga4: true
+      text: "This is a heading 3"
+      heading_level: 3

--- a/spec/components/warning_text_spec.rb
+++ b/spec/components/warning_text_spec.rb
@@ -48,4 +48,18 @@ describe "warning text", type: :view do
     assert_select("h1.govuk-warning-text__text", text: /Because/i)
     assert_select("h1.govuk-warning-text__text .govuk-warning-text__assistive", text: /Warning/i)
   end
+
+  it "has GA4 link tracking" do
+    render_component(text: "Because", heading_level: 1)
+    assert_select("[data-module='ga4-link-tracker']")
+    assert_select('[data-ga4-link="{\"event_name\":\"navigation\",\"type\":\"callout\"}"]')
+    assert_select("[data-ga4-track-links-only]")
+  end
+
+  it "can disable GA4 link tracking" do
+    render_component(disable_ga4: true, text: "Because", heading_level: 1)
+    assert_select("[data-module='ga4-link-tracker']", false)
+    assert_select('[data-ga4-link="{\"event_name\":\"navigation\",\"type\":\"callout\"}"]', false)
+    assert_select("[data-ga4-track-links-only]", false)
+  end
 end


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
Adds GA4 tracking to the warning text component

## Why
<!-- What are the reasons behind this change being made? -->
https://trello.com/c/bh96e5IG/776-callout-link-tracking

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
