### PR TITLE
Version 37.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 37.2.4
 
 * Fix analytics consent ([PR #3833](https://github.com/alphagov/govuk_publishing_components/pull/3833))
 * Improve reliability of grabbing GA4 search term value ([PR #3818](https://github.com/alphagov/govuk_publishing_components/pull/3818))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (37.2.3)
+    govuk_publishing_components (37.2.4)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "37.2.3".freeze
+  VERSION = "37.2.4".freeze
 end


### PR DESCRIPTION
## 37.2.4

* Fix analytics consent ([PR #3833](https://github.com/alphagov/govuk_publishing_components/pull/3833))
* Improve reliability of grabbing GA4 search term value ([PR #3818](https://github.com/alphagov/govuk_publishing_components/pull/3818))
* Update Cross Service Header component ([PR #3831](https://github.com/alphagov/govuk_publishing_components/pull/3831))
* Add GA4 tracking to warning text component ([PR #3832](https://github.com/alphagov/govuk_publishing_components/pull/3832))