### PR TITLE
Add tracking to back link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add tracking to back link ([PR #3840](https://github.com/alphagov/govuk_publishing_components/pull/3840))
 * Allow attachment to pass tracking to details ([PR #3820](https://github.com/alphagov/govuk_publishing_components/pull/3820))
 * Allow GA4 link tracker to track to multiple child classes ([PR #3835](https://github.com/alphagov/govuk_publishing_components/pull/3835))
 

--- a/app/views/govuk_publishing_components/components/_back_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_back_link.html.erb
@@ -2,11 +2,10 @@
   add_gem_component_stylesheet("back-link")
 
   text ||= t('components.back_link.back')
-  data_attributes ||= nil
+  data_attributes ||= {}
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("gem-c-back-link govuk-back-link govuk-!-display-none-print")
 %>
-<%= link_to(
-  text,
-  href,
-  class: %w(gem-c-back-link govuk-back-link govuk-!-display-none-print),
-  data: data_attributes
-) %>
+<%= tag.a(**component_helper.all_attributes.merge!({ href: href })) do %>
+  <%= text %>
+<% end %>

--- a/app/views/govuk_publishing_components/components/_back_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_back_link.html.erb
@@ -3,8 +3,19 @@
 
   text ||= t('components.back_link.back')
   data_attributes ||= {}
+  disable_ga4 ||= false
+
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-back-link govuk-back-link govuk-!-display-none-print")
+  unless disable_ga4
+    ga4_link = {
+      event_name: "navigation",
+      type: "back",
+      url: href,
+    }
+    component_helper.add_data_attribute({ module: "ga4-link-tracker" })
+    component_helper.add_data_attribute({ ga4_link: ga4_link })
+  end
 %>
 <%= tag.a(**component_helper.all_attributes.merge!({ href: href })) do %>
   <%= text %>

--- a/app/views/govuk_publishing_components/components/docs/back_link.yml
+++ b/app/views/govuk_publishing_components/components/docs/back_link.yml
@@ -15,3 +15,9 @@ examples:
     data:
       text: 'Back to document list'
       href: '#'
+  without_ga4_tracking:
+    description: |
+      Disables GA4 tracking on the component. Tracking is enabled by default. This adds a data module and data-attributes with JSON data. See the [ga4-link-tracker documentation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-link-tracker.md) for more information.
+    data:
+      href: '#'
+      disable_ga4: true

--- a/app/views/govuk_publishing_components/components/docs/back_link.yml
+++ b/app/views/govuk_publishing_components/components/docs/back_link.yml
@@ -6,6 +6,7 @@ shared_accessibility_criteria:
 - link
 govuk_frontend_components:
   - back-link
+uses_component_wrapper_helper: true
 examples:
   default:
     data:
@@ -14,8 +15,3 @@ examples:
     data:
       text: 'Back to document list'
       href: '#'
-  with_data_attributes:
-    data:
-      href: '#'
-      data_attributes:
-        an_attribute: the value

--- a/spec/components/back_link_spec.rb
+++ b/spec/components/back_link_spec.rb
@@ -14,6 +14,7 @@ describe "Back Link", type: :view do
   it "renders a back link correctly" do
     render_component(href: "/back-me")
     assert_select '.govuk-back-link[href="/back-me"]', text: "Back"
+    assert_select '.govuk-back-link[data-module="ga4-link-tracker"]'
   end
 
   it "can render in welsh" do
@@ -24,5 +25,11 @@ describe "Back Link", type: :view do
   it "renders a back link with data attributes" do
     render_component(href: "/back-me", data_attributes: { tracking: "GT-123" })
     assert_select '.govuk-back-link[data-tracking="GT-123"]'
+  end
+
+  it "allows tracking to be disabled" do
+    render_component(href: "/back-me", disable_ga4: true)
+    assert_select ".govuk-back-link"
+    assert_select '.govuk-back-link[data-module="ga4-link-tracker"]', false
   end
 end


### PR DESCRIPTION
## What
Adds tracking by default to the back link component.

## Why
Part of the GA4 migration.

## Visual Changes
None (apart from changes to the component guide)

Trello card: https://trello.com/c/Z5FYBU5o/782-back-links
