### PR TITLE
Add GA4 link tracking to govspeak callout links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add tracking to back link ([PR #3840](https://github.com/alphagov/govuk_publishing_components/pull/3840))
 * Allow attachment to pass tracking to details ([PR #3820](https://github.com/alphagov/govuk_publishing_components/pull/3820))
 * Allow GA4 link tracker to track to multiple child classes ([PR #3835](https://github.com/alphagov/govuk_publishing_components/pull/3835))
+* Add GA4 link tracking to govspeak callout links ([PR #3843](https://github.com/alphagov/govuk_publishing_components/pull/3843))
 
 ## 37.2.4
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
@@ -52,6 +52,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
         for (var i = 0; i < classes.length; i++) {
           if (target.closest('.' + classes[i].trim())) {
+            // Stops the link tracker firing twice if the link itself has data-ga4-link, and the parent element does as well.
+            if (target.closest('[data-ga4-link]') !== target.closest('[data-ga4-limit-to-element-class]')) {
+              return
+            }
             this.trackClick(event)
           }
         }

--- a/app/views/govuk_publishing_components/components/_govspeak.html.erb
+++ b/app/views/govuk_publishing_components/components/_govspeak.html.erb
@@ -5,13 +5,30 @@
   direction_class = "direction-#{direction}" if local_assigns.include?(:direction)
   disable_youtube_expansions = local_assigns.fetch(:disable_youtube_expansions) if local_assigns.include?(:disable_youtube_expansions)
 
-  classes = []
-  classes << direction_class if direction_class
-  classes << "disable-youtube" if disable_youtube_expansions
-  classes << "gem-c-govspeak--inverse" if inverse
+  data_attributes ||= {}
+  disable_ga4 ||= false
+
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("gem-c-govspeak govuk-govspeak")
+  component_helper.add_class(direction_class) if direction_class
+  component_helper.add_class("disable_youtube") if disable_youtube_expansions
+  component_helper.add_class("gem-c-govspeak--inverse") if inverse
+  component_helper.add_data_attribute({ module: "govspeak" })
+
+  unless disable_ga4
+    ga4_link = {
+      event_name: "navigation",
+      type: "callout",
+    }
+
+    component_helper.add_data_attribute({ module: "ga4-link-tracker" })
+    component_helper.add_data_attribute({ ga4_track_links_only: "" })
+    component_helper.add_data_attribute({ ga4_limit_to_element_class: "call-to-action, info-notice, help-notice, advisory" })
+    component_helper.add_data_attribute({ ga4_link: ga4_link  })
+  end
 %>
 
-<div class="gem-c-govspeak govuk-govspeak <%= classes.join(" ") %>" data-module="govspeak">
+<%= tag.div(**component_helper.all_attributes) do %>
   <% if local_assigns.include?(:content) %>
     <% if content.html_safe? %>
       <%= content %>
@@ -32,4 +49,4 @@
   <% elsif block_given? %>
     <%= yield %>
   <% end %>
-</div>
+<% end %>

--- a/app/views/govuk_publishing_components/components/_govspeak.html.erb
+++ b/app/views/govuk_publishing_components/components/_govspeak.html.erb
@@ -5,30 +5,28 @@
   direction_class = "direction-#{direction}" if local_assigns.include?(:direction)
   disable_youtube_expansions = local_assigns.fetch(:disable_youtube_expansions) if local_assigns.include?(:disable_youtube_expansions)
 
-  data_attributes ||= {}
+  classes = []
+  classes << direction_class if direction_class
+  classes << "disable-youtube" if disable_youtube_expansions
+  classes << "gem-c-govspeak--inverse" if inverse
+
   disable_ga4 ||= false
 
-  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
-  component_helper.add_class("gem-c-govspeak govuk-govspeak")
-  component_helper.add_class(direction_class) if direction_class
-  component_helper.add_class("disable_youtube") if disable_youtube_expansions
-  component_helper.add_class("gem-c-govspeak--inverse") if inverse
-  component_helper.add_data_attribute({ module: "govspeak" })
+  data_modules = "govspeak"
+  data_modules << " ga4-link-tracker" unless disable_ga4
+  data_attributes = { module: data_modules }
 
   unless disable_ga4
-    ga4_link = {
-      event_name: "navigation",
-      type: "callout",
-    }
-
-    component_helper.add_data_attribute({ module: "ga4-link-tracker" })
-    component_helper.add_data_attribute({ ga4_track_links_only: "" })
-    component_helper.add_data_attribute({ ga4_limit_to_element_class: "call-to-action, info-notice, help-notice, advisory" })
-    component_helper.add_data_attribute({ ga4_link: ga4_link  })
+    data_attributes.merge!({
+      ga4_track_links_only: "",
+      ga4_limit_to_element_class: "call-to-action, info-notice, help-notice, advisory",
+      ga4_link: { "event_name": "navigation", "type": "callout" }.to_json,
+    })
   end
+
 %>
 
-<%= tag.div(**component_helper.all_attributes) do %>
+<%= tag.div(class: "gem-c-govspeak govuk-govspeak " + classes.join(" "), data: data_attributes) do %>
   <% if local_assigns.include?(:content) %>
     <% if content.html_safe? %>
       <%= content %>

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -914,3 +914,12 @@ examples:
             <p>Deforested area. Credit: Blue Ventures-Garth Cripps</p>
           </figcaption>
         </figure>
+  without_ga4_tracking:
+    description: |
+      Disables GA4 tracking on the component. Tracking is enabled by default. This adds a data module and data-attributes with JSON data. See the [ga4-link-tracker documentation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-link-tracker.md) for more information.
+    data:
+      block: |
+        <p>
+          <a href='https://www.gov.uk'>Hello World</a>
+        </p>
+      disable_ga4: true

--- a/spec/components/govspeak_spec.rb
+++ b/spec/components/govspeak_spec.rb
@@ -46,4 +46,15 @@ describe "Govspeak", type: :view do
 
     expect(rendered).to include("content-via-block")
   end
+
+  it "adds GA4 link tracking" do
+    render_component(
+      content: "<h1>content</h1>".html_safe,
+    )
+
+    assert_select ".gem-c-govspeak[data-module='govspeak ga4-link-tracker']"
+    assert_select ".gem-c-govspeak[data-ga4-track-links-only]"
+    assert_select ".gem-c-govspeak[data-ga4-limit-to-element-class='call-to-action, info-notice, help-notice, advisory']"
+    assert_select '.gem-c-govspeak[data-ga4-link="{\"event_name\":\"navigation\",\"type\":\"callout\"}"]'
+  end
 end


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Adds the `ga4-link-tracker` to the highest parent level element of `govspeak` content
- I tried to use the component wrapper, but it did not like the fact that this component uses classes that don't start with `js-`. So I reverted my component wrapper code in one of the commits.
- I had to write some code to make sure nested links with their own `data-ga4-link` don't end up firing tracking twice, as if the govspeak `<div>` that wraps all the content also has a `data-ga4-link` attribute on it then two link trackers would fire on the same link.

## Why
<!-- What are the reasons behind this change being made? -->
https://trello.com/c/bh96e5IG/776-add-tracking-callout-links

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None except adding the docs example