### PR TITLE
Improve component wrapper documentation

### DIFF
--- a/docs/component-wrapper-helper.md
+++ b/docs/component-wrapper-helper.md
@@ -2,27 +2,28 @@
 
 The component wrapper helper is designed to provide a standard way to wrap components so that common options can be passed without having to explicitly define them in the component.
 
-## Adding to a component
+## Basic use
 
-The helper can be added to a component by including the helper and replacing the component parent element as shown. Note that a `div` tag is only used as an example.
+The helper can be added to a component by including the helper and replacing the component parent element as shown. Note that `tag.div` can be replaced with any tag.
 
-```
-<% component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns) %>
-
+```ruby
+<%
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+%>
 <%= tag.div(**component_helper.all_attributes) do %>
   component content
 <% end %>
 ```
 
-You must also add the following line to the component documentation YAML file, in order that these extra options are shown when viewing the component in the component guide.
+You must also add this to the component documentation YAML file, in order that component wrapper options are shown in the component guide.
 
-```
+```yml
 uses_component_wrapper_helper: true
 ```
 
 ## Passing options
 
-The component wrapper helper accepts the following options.
+These options can be passed to any component that uses the component wrapper.
 
 - `id` - accepts a string for the element ID attribute
 - `data_attributes` - accepts a hash of data attributes
@@ -31,81 +32,47 @@ The component wrapper helper accepts the following options.
 - `role` - accepts a space separated string of roles
 - `lang` - accepts a language attribute value
 
+To prevent breaking [component isolation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/component_principles.md#a-component-is-isolated-when), passed classes should only be used for JavaScript hooks and not styling. All component styling should be included only in the component itself. Any passed classes should be prefixed with `js-`. To allow for extending this option, classes prefixed with `gem-c-`, `app-c-` or `govuk-` are also permitted, but should only be used within the component and not passed to it.
+
 The helper checks that any passed `id` attribute is valid, specifically that it does not start with a number or contain whitespace or contain any characters other than letters, numbers, and `_` or `-`. It also checks that role and lang attribute values are valid, along with some other checks detailed below.
 
-### Data and aria
+An example of passing data to a component with the component wrapper:
 
-The `data_attributes` and `aria` options must be Ruby hashes of the form that would normally be passed to the `tag` method. For example:
-
-```
+```ruby
 <%= render "govuk_publishing_components/components/example", {
+  classes: "js-example",
   data_attributes: {
     module: "example-module",
     other_data_attribute: "other",
   },
   aria: {
     describedby: "element-id",
-  }
+  },
 } %>
 ```
 
-The helper checks that passed aria attributes are valid, based on a hard coded list.
+## Advanced use
 
-### Classes
+The component wrapper includes several methods to make managing options easier, as shown below.
 
-Classes can be passed to components. To prevent breaking [component isolation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/component_principles.md#a-component-is-isolated-when), passed classes should only be used for JavaScript hooks and not styling. All component styling should be included only in the component itself.
-
-Any passed classes should be prefixed with `js-`. To allow for extending this option, classes prefixed with `gem-c-`, `app-c-` or `govuk-` are also permitted, but should only be used within the component and not passed to it.
-
-```
-<%= render "govuk_publishing_components/components/example", {
-  classes: "js-example"
-} %>
-```
-
-## Extending options
-
-The helper is designed to collect any options passed through `local_assigns` to minimise the amount of code required in the component. In many situations it will be necessary to include or override specific values in the component template, instead of always passing them into the component.
-
-The helper includes additional methods to make this possible.
-
-- `add_class("gem-c-example govuk-example")` - combines the given class with any passed classes, e.g. if `js-hook` had been passed, the result would be `js-hook gem-c-example govuk-example`
-- `set_id("my-id")` - overrides any passed ID with this one (IDs can't be combined)
-- `add_data_attribute({ module: "ga4-event-tracker" })` - combines the given data attributes with any that have been passed, merging duplicate keys, e.g. if `{ module: "gem-track-click", a: "1" }` had been passed, the result would be `{ module: "ga4-event-tracker gem-track-click", a: "1" }`
-- `add_aria_attribute()` - works the same as `add_data_attribute`
-- `add_role()` - works the same as `add_class`
-- `set_lang()` - works the same as `set_id`
-
-This is an example component template using some of these methods.
-
-```
+```ruby
 <%
-  helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
-  helper.add_class("gem-c-my-component")
-  helper.add_data_attribute({ module: "gem-track-click" })
-%>
+  # note that these variables do not explicitly need to be defined, shown here for clarity
+  classes ||= ""
+  id ||= nil
+  data_attributes ||= {}
+  aria_attributes ||= {}
+  role ||= nil
 
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("gem-c-example govuk-example") # combines the given class with any passed classes
+  component_helper.set_id("my-id") # overrides any passed 'id' with this one (can only have one id)
+  component_helper.add_data_attribute({ module: "ga4-event-tracker" }) # combines any passed 'data_attributes' with those given, merging duplicate keys, e.g. if `{ module: "gem-track-click", a: "1" }` had been passed, would result in `{ module: "ga4-event-tracker gem-track-click", a: "1" }`
+  component_helper.add_aria_attribute({ label: "my-label" }) # works like 'add_data_attribute'
+  component_helper.add_role("button") # works like 'add_class'
+  component_helper.set_lang("en") # works like 'set_id' (can only have one lang)
+%>
 <%= tag.div(**component_helper.all_attributes) do %>
   component content
 <% end %>
-```
-
-This is an example call to this component.
-
-```
-<%= render "govuk_publishing_components/components/example", {
-  classes: "js-hook",
-  data_attributes: {
-    module: "another-module",
-    example: "example"
-  }
-} %>
-```
-
-This would be the result.
-
-```
-<div class="gem-c-my-component js-hook" data-module="gem-track-click another-module" data-example="example">
-  component content
-</div>
 ```


### PR DESCRIPTION
## What
Improve the documentation for the component wrapper helper.

## Why
It was a bit long and although it explained everything the wrapper does, it went into perhaps too much detail. It was also hard to use when actually implementing the wrapper on a component, so I've grouped most of the options together into one example that can be more easily copied and pasted into code.

## Visual Changes
None. Well, some words, obviously.
