### PR TITLE
Remove DI cookie consent code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Remove DI cookie consent code ([PR #3846](https://github.com/alphagov/govuk_publishing_components/pull/3846))
 * Add tracking to back link ([PR #3840](https://github.com/alphagov/govuk_publishing_components/pull/3840))
 * Allow attachment to pass tracking to details ([PR #3820](https://github.com/alphagov/govuk_publishing_components/pull/3820))
 * Allow GA4 link tracker to track to multiple child classes ([PR #3835](https://github.com/alphagov/govuk_publishing_components/pull/3835))

--- a/app/assets/javascripts/govuk_publishing_components/analytics/init.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/init.js
@@ -11,25 +11,6 @@ var analyticsInit = function () {
     var crossDomainLinkedDomains = window.GOVUK.analyticsVars.linkedDomains || false
   }
 
-  window.GOVUK.Analytics.checkDigitalIdentityConsent = function (location) {
-    if (!location || !location.search) return
-    // this checks for the presence of the Digital Identity cookie consent query parameter and updates our consent cookie accordingly
-    // This is so that users don't see multiple cookie banners when they move between the different account management pages, as some will be on GOV.UK and others will be on the DI domain.
-    var digitalIdentityConsent = /([?&]cookie_consent=)(accept|reject)/.exec(location.search)
-    if (digitalIdentityConsent) {
-      if (digitalIdentityConsent[2] === 'accept') {
-        window.GOVUK.setConsentCookie({ usage: true })
-        // set cookies_preferences_set to true to prevent cookie banner showing
-        window.GOVUK.cookie('cookies_preferences_set', 'true')
-      } else if (digitalIdentityConsent[2] === 'reject') {
-        window.GOVUK.setConsentCookie({ usage: false })
-        window.GOVUK.cookie('cookies_preferences_set', 'true')
-      }
-    }
-  }
-
-  window.GOVUK.Analytics.checkDigitalIdentityConsent(window.location)
-
   var consentCookie = window.GOVUK.getConsentCookie()
   var dummyAnalytics = {
     addLinkedTrackerDomain: function () {},

--- a/spec/javascripts/govuk_publishing_components/analytics/analytics.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/analytics.spec.js
@@ -45,32 +45,6 @@ describe('GOVUK.Analytics', function () {
       expect(universalSetupArguments[1]).toEqual(['set', 'anonymizeIp', true])
       expect(universalSetupArguments[2]).toEqual(['set', 'allowAdFeatures', false])
     })
-
-    it('sets usage consent cookie to false when cookie_consent query string parameter has a value of "reject"', function () {
-      var location = {
-        protocol: 'https:',
-        hostname: 'site.example.com',
-        href: 'https://site.example.com/a/path?cookie_consent=reject',
-        search: '?cookie_consent=reject',
-        origin: 'https://site.example.com'
-      }
-      GOVUK.Analytics.checkDigitalIdentityConsent(location)
-      expect(GOVUK.getCookie('cookies_preferences_set')).toBe('true')
-      expect(GOVUK.getConsentCookie().usage).toBe(false)
-    })
-
-    it('sets usage consent cookie to true when cookie_consent query string parameter has a value of "accept"', function () {
-      var location = {
-        protocol: 'https:',
-        hostname: 'site.example.com',
-        href: 'https://site.example.com/a/path?cookie_consent=accept',
-        search: '?cookie_consent=accept',
-        origin: 'https://site.example.com'
-      }
-      GOVUK.Analytics.checkDigitalIdentityConsent(location)
-      expect(GOVUK.getCookie('cookies_preferences_set')).toBe('true')
-      expect(GOVUK.getConsentCookie().usage).toBe(true)
-    })
   })
 
   describe('extracting the default path for a page view', function () {


### PR DESCRIPTION
## What
Removes the cookie consent sharing code that relates to Digital Identity. This code was implemented to reduce the appearance of cookie banners when subscribing to emails on GOV.UK, as the journey takes the user between different sites.

Broadly, it works like this:

- coming from the DI site, the URL is decorated with either `?cookie_consent=accept` or `?cookie_consent=reject`
- this code checks the URL and if it finds this parameter, updates the local cookie preferences accordingly

## Why
Initial investigations suggest that this isn't in use in the DI code anymore - I've talked to @danacotoran and manually tested it, and the URL parameter this code looks for doesn't appear when moving from DI to GOV.UK.

We also need to remove this in order to move ahead with the [single consent API work](https://github.com/alphagov/govuk_publishing_components/pull/3829), as that code needs full control of our cookie settings.

## Visual Changes
None.

Trello card: https://trello.com/c/dmlTAzKB/140-implement-single-consent-api