### PR TITLE
Improve error messages for module starting

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -268,7 +268,7 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
           module.setAttribute('data-ga4-link', JSON.stringify(ga4LinkData))
         } catch (e) {
           // if there's a problem with the config, don't start the tracker
-          console.error('Unable to JSON.parse or JSON.stringify index: ' + e.message, window.location)
+          console.error('Unable to JSON.parse or JSON.stringify index: ', e, window.location)
         }
       },
 

--- a/app/assets/javascripts/govuk_publishing_components/modules.js
+++ b/app/assets/javascripts/govuk_publishing_components/modules.js
@@ -43,7 +43,7 @@
                 element.setAttribute('data-' + moduleNames[j] + '-module-started', true)
               } catch (e) {
                 // if there's a problem with the module, catch the error to allow other modules to start
-                console.error('Error starting ' + moduleName + ' component JS: ' + e.message, window.location)
+                console.error('Error starting ' + moduleName + ' component JS: ', e, window.location)
               }
             }
           }


### PR DESCRIPTION
## What
Improve the `console.error` messages in the console when modules (and GA4 modules) fail to start, by displaying the full error in the console, not just the message part, so it's easier to track down exactly why the module failed to start.

## Why
I was having a problem with a module and realised the error handling could be more helpful.

## Visual Changes
Original:

![Screenshot 2024-02-01 at 11 25 17](https://github.com/alphagov/govuk_publishing_components/assets/861310/cc8edf39-c13e-4771-8373-1df0861deded)

New:

![Screenshot 2024-02-01 at 11 23 34](https://github.com/alphagov/govuk_publishing_components/assets/861310/423b8ff2-ac50-4439-a454-4394db2cd7ca)

