### PR TITLE
Allow inputs to be exempt from GA4 form tracker [REDACT] code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Allow attachment to pass tracking to details ([PR #3820](https://github.com/alphagov/govuk_publishing_components/pull/3820))
 * Allow GA4 link tracker to track to multiple child classes ([PR #3835](https://github.com/alphagov/govuk_publishing_components/pull/3835))
 * Add GA4 link tracking to govspeak callout links ([PR #3843](https://github.com/alphagov/govuk_publishing_components/pull/3843))
+* Allow inputs to be exempt from GA4 form tracker [REDACT] code ([PR #3848](https://github.com/alphagov/govuk_publishing_components/pull/3848))
 
 ## 37.2.4
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
@@ -88,7 +88,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       } else if (inputNodename === 'SELECT' && elem.options[elem.selectedIndex].value) {
         input.answer = elem.options[elem.selectedIndex].text
       } else if (inputTypes.indexOf(inputType) !== -1 && elem.value) {
-        if (this.includeTextInputValues) {
+        if (this.includeTextInputValues || elem.hasAttribute('data-ga4-form-include-input')) {
           var PIIRemover = new window.GOVUK.analyticsGa4.PIIRemover()
           input.answer = PIIRemover.stripPIIWithOverride(elem.value, true, true)
         } else {

--- a/docs/analytics-ga4/ga4-form-tracker.md
+++ b/docs/analytics-ga4/ga4-form-tracker.md
@@ -19,7 +19,7 @@ The data attributes are used as follows:
 - `action` records the text of the form submission button e.g. `Continue`
 - `tool_name` records the overall name of the smart answer e.g. `How do I eat more healthily?`
 
-The script will automatically collect the answer submitted in the `text` field. For questions where multiple answers are possible, these will be comma separated. Where the answer is a text input, the value given is replaced with `[REDACTED]`, to avoid collecting personally identifiable information. If text should not be redacted, add a `data-ga4-form-include-text` attribute to the form.
+The script will automatically collect the answer submitted in the `text` field. For questions where multiple answers are possible, these will be comma separated. Where the answer is a text input, the value given is replaced with `[REDACTED]`, to avoid collecting personally identifiable information. If all inputs should not have their text redacted, add a `data-ga4-form-include-text` attribute to the form. If you only want a certain text input to be exempt from redaction, add a `data-ga4-form-include-input` attribute to that input element.
 
 In the example above, the following would be pushed to the dataLayer. Note that the schema automatically populates empty values, and that attributes not in the schema are ignored.
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
@@ -654,12 +654,17 @@ describe('GA4 core', function () {
         expect(builtEcommerceObject.search_results.ecommerce.items.length).toEqual(200)
       })
     })
+  })
 
-    it('populates the timestamp value correctly', function () {
-      GOVUK.analyticsGa4.core.sendData({})
-      var timestamp = Date.now().toString()
+  it('populates the timestamp value correctly', function () {
+    jasmine.clock().install()
+    jasmine.clock().mockDate(new Date(2050, 1, 1))
 
-      expect(window.dataLayer[0].timestamp).toEqual(timestamp)
-    })
+    GOVUK.analyticsGa4.core.sendData({})
+    var timestamp = Date.now().toString()
+
+    jasmine.clock().uninstall()
+
+    expect(window.dataLayer[0].timestamp).toEqual(timestamp)
   })
 })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
@@ -127,6 +127,18 @@ describe('Google Analytics form tracking', function () {
       expect(window.dataLayer[0]).toEqual(expected)
     })
 
+    it('does not redact data from text inputs that have data-ga4-form-include-input on them', function () {
+      element.innerHTML =
+        '<label for="textid">Label</label>' +
+        '<input type="text" id="textid" name="test-text" value="i should not be redacted but PII still runs email@example.com" data-ga4-form-include-input />' +
+        '<label for="textid2">Label</label>' +
+        '<input type="text" id="textid2" name="test-text-2" value="i should be redacted" />'
+      expected.event_data.text = 'i should not be redacted but PII still runs [email],[REDACTED]'
+
+      window.GOVUK.triggerEvent(element, 'submit')
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+
     it('redacts data from multiple text inputs', function () {
       element.innerHTML =
         '<label for="textid1">Label</label>' +


### PR DESCRIPTION
## What
- For the contact form tracking, there are three text inputs currently being collected on form submission
- The analysts are interested in collecting one of these text inputs. Therefore, I needed a way to only include that one for tracking and redact the rest.
- Therefore, a new data attribute called `data-ga4-form-include-input` has been added. If this is placed on the input, it will be included in the `text` list instead of being `[REDACTED]`
- Not using `data-ga4-form-include-text` as I don't want the other three inputs being included in the list. One of them is there user's name for contact form so doing it this way this instead makes sure that is not included in the contact form tracking.

## Why
<!-- What are the reasons behind this change being made? -->
- Progresses https://trello.com/c/jFRhH4Dh/783-adding-tracking-contact-form

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None