### PR TITLE
Update cookie event listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Update cookie event listeners ([PR #3849](https://github.com/alphagov/govuk_publishing_components/pull/3849))
 * Remove DI cookie consent code ([PR #3846](https://github.com/alphagov/govuk_publishing_components/pull/3846))
 * Add tracking to back link ([PR #3840](https://github.com/alphagov/govuk_publishing_components/pull/3840))
 * Allow attachment to pass tracking to details ([PR #3820](https://github.com/alphagov/govuk_publishing_components/pull/3820))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-auto-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-auto-tracker.js
@@ -16,8 +16,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     if (consentCookie && consentCookie.usage) {
       this.startModule()
     } else {
-      this.startModule = this.startModule.bind(this)
-      window.addEventListener('cookie-consent', this.startModule)
+      this.start = this.startModule.bind(this)
+      window.addEventListener('cookie-consent', this.start)
     }
   }
 
@@ -27,6 +27,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   Ga4AutoTracker.prototype.sendEvent = function () {
     if (window.dataLayer) {
+      window.removeEventListener('cookie-consent', this.start)
       try {
         var data = this.module.getAttribute(this.trackingTrigger)
         data = JSON.parse(data) || {}

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.js
@@ -16,14 +16,15 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     if (consentCookie && consentCookie.usage) {
       this.startModule()
     } else {
-      this.startModule = this.startModule.bind(this)
-      window.addEventListener('cookie-consent', this.startModule)
+      this.start = this.startModule.bind(this)
+      window.addEventListener('cookie-consent', this.start)
     }
   }
 
   // triggered by cookie-consent event, which happens when users consent to cookies
   Ga4EventTracker.prototype.startModule = function () {
     if (window.dataLayer) {
+      window.removeEventListener('cookie-consent', this.start)
       this.module.addEventListener('click', this.trackClick.bind(this), true) // useCapture must be true
     }
   }

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
@@ -18,14 +18,15 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     if (consentCookie && consentCookie.usage) {
       this.startModule()
     } else {
-      this.startModule = this.startModule.bind(this)
-      window.addEventListener('cookie-consent', this.startModule)
+      this.start = this.startModule.bind(this)
+      window.addEventListener('cookie-consent', this.start)
     }
   }
 
   // triggered by cookie-consent event, which happens when users consent to cookies
   Ga4FormTracker.prototype.startModule = function () {
     if (window.dataLayer) {
+      window.removeEventListener('cookie-consent', this.start)
       this.module.addEventListener('submit', this.trackFormSubmit.bind(this))
     }
   }

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
@@ -19,14 +19,15 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     if (consentCookie && consentCookie.usage) {
       this.startModule()
     } else {
-      this.startModule = this.startModule.bind(this)
-      window.addEventListener('cookie-consent', this.startModule)
+      this.start = this.startModule.bind(this)
+      window.addEventListener('cookie-consent', this.start)
     }
   }
 
   // triggered by cookie-consent event, which happens when users consent to cookies
   Ga4LinkTracker.prototype.startModule = function () {
     if (window.dataLayer) {
+      window.removeEventListener('cookie-consent', this.start)
       this.handleClick = this.handleClick.bind(this)
       this.handleMousedown = this.handleMousedown.bind(this)
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.js
@@ -22,12 +22,13 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     if (consentCookie && consentCookie.usage) {
       this.startModule()
     } else {
-      this.startModule = this.startModule.bind(this)
-      window.addEventListener('cookie-consent', this.startModule)
+      this.start = this.startModule.bind(this)
+      window.addEventListener('cookie-consent', this.start)
     }
   }
 
   Ga4ScrollTracker.prototype.startModule = function () {
+    window.removeEventListener('cookie-consent', this.start)
     if (window.GOVUK.analyticsGa4.vars.scrollTrackerStarted) {
       return
     }

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-smart-answer-results-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-smart-answer-results-tracker.js
@@ -15,8 +15,8 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
     if (consentCookie && consentCookie.usage) {
       this.startModule()
     } else {
-      this.startModule = this.startModule.bind(this)
-      window.addEventListener('cookie-consent', this.startModule)
+      this.start = this.startModule.bind(this)
+      window.addEventListener('cookie-consent', this.start)
     }
   }
 
@@ -25,6 +25,7 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
     // only run this code if the dataLayer exists and an element with a data-ga4-ecommerce-path
     // attribute exists as this indicates that ecommerce tracking is required
     if (window.dataLayer && this.module.querySelector('[data-ga4-ecommerce-path]')) {
+      window.removeEventListener('cookie-consent', this.start)
       this.trackResults()
       this.module.addEventListener('click', this.handleClick.bind(this))
     }

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/init-ga4.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/init-ga4.js
@@ -2,6 +2,7 @@ window.GOVUK = window.GOVUK || {}
 window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
 
 var initFunction = function () {
+  window.removeEventListener('cookie-consent', window.GOVUK.analyticsGa4.init)
   var consentCookie = window.GOVUK.getConsentCookie()
 
   if (consentCookie && consentCookie.usage) {

--- a/app/assets/javascripts/govuk_publishing_components/analytics/auto-scroll-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/auto-scroll-tracker.js
@@ -22,12 +22,13 @@ window.GOVUK.analyticsVars = window.GOVUK.analyticsVars || {};
     if (consentCookie && consentCookie.usage) {
       this.startModule()
     } else {
-      this.startModule = this.startModule.bind(this)
-      window.addEventListener('cookie-consent', this.startModule)
+      this.start = this.startModule.bind(this)
+      window.addEventListener('cookie-consent', this.start)
     }
   }
 
   AutoScrollTracker.prototype.startModule = function () {
+    window.removeEventListener('cookie-consent', this.start)
     if (window.GOVUK.analyticsVars.scrollTrackerStarted) {
       return
     }

--- a/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
@@ -10,15 +10,15 @@
 
   YoutubeLinkEnhancement.prototype.init = function () {
     if (!this.campaignCookiesAllowed()) {
-      this.startModule = this.startModule.bind(this)
-      window.addEventListener('cookie-consent', this.startModule)
+      this.start = this.startModule.bind(this)
+      window.addEventListener('cookie-consent', this.start)
       return
     }
     this.startModule()
   }
 
   YoutubeLinkEnhancement.prototype.startModule = function () {
-    window.removeEventListener('cookie-consent', this.startModule)
+    window.removeEventListener('cookie-consent', this.start)
     var $youtubeLinks = this.$element.querySelectorAll('a[href*="youtube.com"], a[href*="youtu.be"]')
 
     if ($youtubeLinks.length > 0) {

--- a/app/assets/javascripts/govuk_publishing_components/rum-loader.js
+++ b/app/assets/javascripts/govuk_publishing_components/rum-loader.js
@@ -19,6 +19,7 @@
   })()
 
   var insertScript = function () {
+    window.removeEventListener('cookie-consent', insertScript)
     var marker = document.querySelector('script[data-lux-reporter-script]')
 
     if (!marker) {
@@ -37,8 +38,6 @@
   if (parsedCookie.usage === true) {
     insertScript()
   } else {
-    window.addEventListener('cookie-consent', function () {
-      insertScript()
-    })
+    window.addEventListener('cookie-consent', insertScript)
   }
 })()

--- a/docs/javascript-modules.md
+++ b/docs/javascript-modules.md
@@ -52,13 +52,13 @@ AnExampleModule.prototype.init = function ($module) {
   if (consentCookie && consentCookie.usage) {
     this.startModule()
   } else {
-    this.startModule = this.startModule.bind(this)
-    window.addEventListener('cookie-consent', this.startModule)
+    this.start = this.startModule.bind(this)
+    window.addEventListener('cookie-consent', this.start)
   }
 }
 
 AnExampleModule.prototype.startModule = function () {
-  window.removeEventListener('cookie-consent', this.startModule)
+  window.removeEventListener('cookie-consent', this.start)
   // the rest of the module
 }
 ```

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-auto-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-auto-tracker.spec.js
@@ -48,13 +48,18 @@ describe('Google Analytics auto tracker', function () {
     it('starts the module on the same page as cookie consent is given', function () {
       denyCookies()
       var tracker = new GOVUK.Modules.Ga4AutoTracker(element)
-      spyOn(tracker, 'sendEvent')
+      spyOn(tracker, 'sendEvent').and.callThrough()
       tracker.init()
       expect(tracker.sendEvent).not.toHaveBeenCalled()
 
       // page has not been reloaded, user consents to cookies
       window.GOVUK.triggerEvent(window, 'cookie-consent')
       expect(tracker.sendEvent).toHaveBeenCalled()
+
+      // consent listener should be removed after triggering
+      tracker.sendEvent.calls.reset()
+      window.GOVUK.triggerEvent(window, 'cookie-consent')
+      expect(tracker.sendEvent).not.toHaveBeenCalled()
     })
 
     it('does not do anything if consent is not given', function () {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.spec.js
@@ -59,6 +59,11 @@ describe('Google Analytics event tracker', function () {
 
       element.click()
       expect(tracker.trackClick).toHaveBeenCalled()
+
+      tracker.trackClick.calls.reset()
+      window.GOVUK.triggerEvent(window, 'cookie-consent')
+      element.click()
+      expect(tracker.trackClick.calls.count()).toBe(1)
     })
 
     it('does not do anything if consent is not given', function () {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
@@ -57,9 +57,14 @@ describe('Google Analytics form tracking', function () {
 
       // page has not been reloaded, user consents to cookies
       window.GOVUK.triggerEvent(window, 'cookie-consent')
-
       window.GOVUK.triggerEvent(element, 'submit')
       expect(tracker.trackFormSubmit).toHaveBeenCalled()
+
+      // consent listener should be removed after triggering
+      tracker.trackFormSubmit.calls.reset()
+      window.GOVUK.triggerEvent(window, 'cookie-consent')
+      window.GOVUK.triggerEvent(element, 'submit')
+      expect(tracker.trackFormSubmit.calls.count()).toBe(1)
     })
 
     it('does not do anything if consent is not given', function () {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
@@ -74,9 +74,14 @@ describe('GA4 link tracker', function () {
 
       // page has not been reloaded, user consents to cookies
       window.GOVUK.triggerEvent(window, 'cookie-consent')
-
       element.click()
       expect(tracker.trackClick).toHaveBeenCalled()
+
+      // consent listener should be removed after triggering
+      tracker.trackClick.calls.reset()
+      window.GOVUK.triggerEvent(window, 'cookie-consent')
+      element.click()
+      expect(tracker.trackClick.calls.count()).toBe(1)
     })
 
     it('does not do anything if consent is not given', function () {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.spec.js
@@ -36,6 +36,7 @@ describe('GA4 scroll tracker', function () {
     window.removeEventListener('scroll', tracker.scrollEvent)
     window.removeEventListener('resize', tracker.resizeEvent)
     window.removeEventListener('dynamic-page-update', tracker.resetEvent)
+    window.removeEventListener('cookie-consent', tracker.startModule)
     clearInterval(tracker.interval)
   }
 
@@ -52,6 +53,24 @@ describe('GA4 scroll tracker', function () {
 
     expect(scrollTracker.getWindowDetails).toHaveBeenCalled()
     expect(scrollTracker2.getWindowDetails).not.toHaveBeenCalled()
+  })
+
+  it('starts the module when consent is given', function () {
+    window.GOVUK.deleteCookie('cookies_policy')
+    var el = document.createElement('div')
+    scrollTracker = new GOVUK.Modules.Ga4ScrollTracker(el)
+    spyOn(scrollTracker, 'startModule').and.callThrough()
+    scrollTracker.init()
+    expect(scrollTracker.startModule).not.toHaveBeenCalled()
+
+    // page has not been reloaded, user consents to cookies
+    window.GOVUK.triggerEvent(window, 'cookie-consent')
+    expect(scrollTracker.startModule).toHaveBeenCalled()
+
+    // consent listener should be removed after triggering
+    scrollTracker.startModule.calls.reset()
+    window.GOVUK.triggerEvent(window, 'cookie-consent')
+    expect(scrollTracker.startModule).not.toHaveBeenCalled()
   })
 
   describe('when tracking headings', function () {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-smart-answer-results-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-smart-answer-results-tracker.spec.js
@@ -91,6 +91,23 @@ describe('GA4 smart answer results tracking', function () {
     document.body.removeChild(smartAnswerResultsParentEl)
   })
 
+  it('starts the module when consent is given', function () {
+    window.GOVUK.deleteCookie('cookies_policy')
+    var smartAnswerTracker = new GOVUK.Modules.Ga4SmartAnswerResultsTracker(smartAnswerResultsParentEl)
+    spyOn(smartAnswerTracker, 'startModule').and.callThrough()
+    smartAnswerTracker.init()
+    expect(smartAnswerTracker.startModule).not.toHaveBeenCalled()
+
+    // page has not been reloaded, user consents to cookies
+    window.GOVUK.triggerEvent(window, 'cookie-consent')
+    expect(smartAnswerTracker.startModule).toHaveBeenCalled()
+
+    // consent listener should be removed after triggering
+    smartAnswerTracker.startModule.calls.reset()
+    window.GOVUK.triggerEvent(window, 'cookie-consent')
+    expect(smartAnswerTracker.startModule).not.toHaveBeenCalled()
+  })
+
   describe('on page load', function () {
     it('should push a nullified ecommerce object to the dataLayer', function () {
       new GOVUK.Modules.Ga4SmartAnswerResultsTracker(smartAnswerResultsParentEl).init()


### PR DESCRIPTION
## What
We have various bits of code that should only initialise if cookie consent is given. Since this can be given after page load (by the user clicking on the cookie banner) we have event listeners in place for the `cookie-consent` event, which is triggered by user consent.

The JS documentation states that these event listeners should be removed once triggered, but almost none of our code does this. This PR fixes this oversight, as well as updating some tests relating to these scripts. It also includes the same change for the RUM script, which is slightly different (hence a separate commit).

## Why
Following good practice. Also will make working on the single consent API changes easier. These commits were originally part of https://github.com/alphagov/govuk_publishing_components/pull/3829 but separating into their own PR to make that one smaller.

## Visual Changes
None.

Trello card: https://trello.com/c/dmlTAzKB/140-implement-single-consent-api