### PR TITLE
Update whitehall in component auditing

### DIFF
--- a/app/models/govuk_publishing_components/audit_comparer.rb
+++ b/app/models/govuk_publishing_components/audit_comparer.rb
@@ -14,7 +14,6 @@ module GovukPublishingComponents
           info-frontend
           service-manual-frontend
           smart-answers
-          whitehall
         ]
 
         @static_data = find_static(results)


### PR DESCRIPTION
## What / why
Remove `whitehall` from the list of applications in the component audits that rely on `static`. This list is used to check assets used within the application are correct for components used within the application. `Static` has a few component assets already included, this part of the audit uses that knowledge to stop highlighting things that could be problems, but aren't (for example, `static` includes the JS for the button component, so applications that rely on `static` don't need to duplicate include that JS as well).

- `whitehall` doesn't use static anymore, so removing it from list of applications that do
- makes no difference to the auditing results, fortunately

## Visual changes
None.