### PR TITLE
Allow other applications to use GA4 code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Allow other applications to use GA4 code ([PR #3851](https://github.com/alphagov/govuk_publishing_components/pull/3851))
 * Update cookie event listeners ([PR #3849](https://github.com/alphagov/govuk_publishing_components/pull/3849))
 * Remove DI cookie consent code ([PR #3846](https://github.com/alphagov/govuk_publishing_components/pull/3846))
 * Add tracking to back link ([PR #3840](https://github.com/alphagov/govuk_publishing_components/pull/3840))

--- a/app/assets/javascripts/govuk_publishing_components/dependencies.js
+++ b/app/assets/javascripts/govuk_publishing_components/dependencies.js
@@ -10,6 +10,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   // if statements ensure these functions don't execute during testing
   if (typeof window.GOVUK.loadAnalytics !== 'undefined') {
+    window.GOVUK.loadAnalytics.loadExtraDomains()
     if (typeof window.GOVUK.analyticsGa4.vars === 'undefined') {
       window.GOVUK.loadAnalytics.loadGa4()
     }

--- a/app/assets/javascripts/govuk_publishing_components/load-analytics.js
+++ b/app/assets/javascripts/govuk_publishing_components/load-analytics.js
@@ -70,6 +70,12 @@ window.GOVUK.loadAnalytics = {
     }
   ],
 
+  loadExtraDomains: function () {
+    if (Array.isArray(window.GOVUK.analyticsGa4Domains)) {
+      this.domains = this.domains.concat(window.GOVUK.analyticsGa4Domains)
+    }
+  },
+
   // For Universal Analytics' cross domain tracking. linkedDomains is defined by the require statement at the top of the file.
   linkedDomains: window.GOVUK.analytics.linkedDomains,
 

--- a/app/assets/javascripts/govuk_publishing_components/load-analytics.js
+++ b/app/assets/javascripts/govuk_publishing_components/load-analytics.js
@@ -99,18 +99,7 @@ window.GOVUK.loadAnalytics = {
 
   loadGa4: function (currentDomain) {
     currentDomain = currentDomain || window.location.hostname
-    var environment = false
-    // lots of dev domains, so simplify the matching process
-    if (currentDomain.match(/[a-zA-Z0-9.-]+dev\.gov\.uk/)) {
-      environment = this.domains[0]
-    } else {
-      for (var i = 0; i < this.domains.length; i++) {
-        if (this.arrayContains(currentDomain, this.domains[i].domains)) {
-          environment = this.domains[i]
-          break
-        }
-      }
-    }
+    var environment = this.getEnvironment(currentDomain)
 
     // If we recognise the environment (i.e. the string isn't empty), load in GA4
     if (environment) {
@@ -135,5 +124,18 @@ window.GOVUK.loadAnalytics = {
 
   arrayContains: function (valueToFind, array) {
     return array.indexOf(valueToFind) !== -1
+  },
+
+  getEnvironment: function (currentDomain) {
+    // lots of dev domains, so simplify the matching process
+    if (currentDomain.match(/[a-zA-Z0-9.-]+dev\.gov\.uk/)) {
+      return this.domains[0]
+    } else {
+      for (var i = 0; i < this.domains.length; i++) {
+        if (this.arrayContains(currentDomain, this.domains[i].domains)) {
+          return this.domains[i]
+        }
+      }
+    }
   }
 }

--- a/docs/load-analytics.md
+++ b/docs/load-analytics.md
@@ -15,3 +15,25 @@ The Google Analytics 4 environment variables are:
 - `id` - this is the Google Tag Manager ID used to identify our organisation so that analytics data is sent to the right account.
 - `preview` - this is an optional variable that is used to determine what GTM environment the analytics data is sent to. If this is empty, analytics data is sent to the production dashboard. If you wanted to have your integration analytics to an 'integration' dashboard, you would populate this variable with the relevant value.
 - `auth` - this is used to authenticate analytics data being sent to another dashboard, such as an 'integration' dashboard. This can be determined through the browser so they're not classified as secret.
+
+## Passing extra options
+
+If you wish to initialise the GA4 code on a new domain with different attributes, the code has been written to accept an array of additional values. Extra domains can be added before loading `dependencies.js` as below.
+
+```JavaScript
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.analyticsGa4Domains = [
+  {
+    name: 'my-domain',
+    domains: ['not-a-real-domain.co.org.uk'],
+    initialiseGA4: true,
+    // add your own details as required
+    id: 'id', // for GA4
+    auth: 'auth', // for GA4 (optional)
+    preview: 'preview', // for GA4 (optional)
+    gaProperty: 'gaProperty', // for UA
+    gaPropertyCrossDomain: 'gaPropertyCrossDomain' // for UA (optional)
+  }
+  // add further into the array as required
+]
+```

--- a/spec/javascripts/govuk_publishing_components/load-analytics.spec.js
+++ b/spec/javascripts/govuk_publishing_components/load-analytics.spec.js
@@ -138,6 +138,44 @@ describe('Analytics loading', function () {
       expect(window.GOVUK.analyticsGa4.vars).toEqual(null)
       window.GOVUK.loadAnalytics.domains[0].initialiseGA4 = true
     })
+
+    describe('when additional domain details are needed', function () {
+      afterEach(function () {
+        delete window.GOVUK.analyticsGa4Domains
+      })
+
+      it('defaults to the normal list when no extras are passed', function () {
+        var domains = window.GOVUK.loadAnalytics.domains
+        window.GOVUK.loadAnalytics.loadExtraDomains()
+        window.GOVUK.loadAnalytics.loadGa4()
+        expect(window.GOVUK.loadAnalytics.domains).toEqual(domains)
+      })
+
+      it('allows extra domains to be passed and appended to the existing list', function () {
+        var newDomain = {
+          name: 'test-domain',
+          domains: ['not-a-real-domain'],
+          initialiseGA4: true,
+          id: 'GTM-001'
+        }
+        window.GOVUK.analyticsGa4Domains = [newDomain]
+        window.GOVUK.loadAnalytics.loadExtraDomains()
+        expected = {
+          name: 'test-domain',
+          domains: ['not-a-real-domain'],
+          initialiseGA4: true,
+          id: 'GTM-001'
+        }
+        // the new domain gets appended to the end of the array
+        expect(window.GOVUK.loadAnalytics.domains[5]).toEqual(expected)
+
+        window.GOVUK.loadAnalytics.loadGa4('not-a-real-domain')
+        expect(window.GOVUK.analyticsGa4.vars.id).toEqual('GTM-001')
+        expect(window.GOVUK.analyticsGa4.vars.auth).toEqual(undefined)
+        expect(window.GOVUK.analyticsGa4.vars.preview).toEqual(undefined)
+        expect(window.GOVUK.analyticsGa4.vars.environment).toEqual('test-domain')
+      })
+    })
   })
 
   describe('for UA', function () {


### PR DESCRIPTION
## What / why
Extends the existing `load-analytics.js` to allow other domain details to be included when checking how to initialise GA4 (and UA, although this is soon to be deprecated). This is part of the work needed to allow the components gem analytics code to run on our publishing applications (we can also switch to using this method for the dev docs analytics, instead of hard coding the details here).

## Visual Changes
None.

