### PR TITLE
Add single cookie consent API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   of the commit log.
 
 ## Unreleased
+
+* Add single cookie consent API ([PR #3854](https://github.com/alphagov/govuk_publishing_components/pull/3854))
 * Update popular links in super navigation header ([PR #3904](https://github.com/alphagov/govuk_publishing_components/pull/3904))
 * Allow custom text for GA4 scroll tracker ([PR #3896](https://github.com/alphagov/govuk_publishing_components/pull/3896))
 * Ensure analytics stops firing if a user disables usage cookies on our cookie settings page ([PR #3893](https://github.com/alphagov/govuk_publishing_components/pull/3893))

--- a/app/assets/javascripts/govuk_publishing_components/domain-config.js
+++ b/app/assets/javascripts/govuk_publishing_components/domain-config.js
@@ -1,0 +1,73 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.vars = window.GOVUK.vars || {}
+window.GOVUK.vars.domains = [
+  {
+    // need to have this one at the start, see loadGa4 function
+    name: 'development',
+    domains: [
+      'localhost',
+      '127.0.0.1',
+      '0.0.0.0',
+      'dev.gov.uk'
+    ],
+    initialiseGA4: true,
+    id: 'GTM-MG7HG5W',
+    auth: 'bRiZ-jiEHtw6hHpGd6dF9w',
+    preview: 'env-3',
+    gaProperty: 'UA-UNSET',
+    gaPropertyCrossDomain: 'UA-UNSET',
+    consentApiUrl: 'staging'
+  },
+  {
+    name: 'production',
+    domains: [
+      'www.gov.uk',
+      'www-origin.publishing.service.gov.uk',
+      'assets.publishing.service.gov.uk'
+    ],
+    initialiseGA4: true,
+    id: 'GTM-MG7HG5W',
+    gaProperty: 'UA-26179049-1',
+    gaPropertyCrossDomain: 'UA-145652997-1',
+    consentApiUrl: 'production'
+  },
+  {
+    name: 'staging',
+    domains: [
+      'www.staging.publishing.service.gov.uk',
+      'www-origin.staging.publishing.service.gov.uk',
+      'assets.staging.publishing.service.gov.uk'
+    ],
+    initialiseGA4: true,
+    id: 'GTM-MG7HG5W',
+    auth: 'oJWs562CxSIjZKn_GlB5Bw',
+    preview: 'env-5',
+    gaProperty: 'UA-26179049-20',
+    gaPropertyCrossDomain: 'UA-145652997-1',
+    consentApiUrl: 'staging'
+  },
+  {
+    name: 'integration',
+    domains: [
+      'www.integration.publishing.service.gov.uk',
+      'www-origin.integration.publishing.service.gov.uk',
+      'assets.integration.publishing.service.gov.uk'
+    ],
+    initialiseGA4: true,
+    id: 'GTM-MG7HG5W',
+    auth: 'C7iYdcsOlYgGmiUJjZKrHQ',
+    preview: 'env-4',
+    gaProperty: 'UA-26179049-22',
+    gaPropertyCrossDomain: 'UA-145652997-1',
+    consentApiUrl: 'staging'
+  },
+  {
+    name: 'devdocs',
+    domains: [
+      'docs.publishing.service.gov.uk'
+    ],
+    initialiseGA4: true,
+    id: 'GTM-TNKCK97',
+    consentApiUrl: 'production'
+  }
+]

--- a/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
@@ -163,7 +163,7 @@
 
   YoutubeLinkEnhancement.prototype.campaignCookiesAllowed = function () {
     var cookiePolicy = window.GOVUK.getConsentCookie()
-    return cookiePolicy !== null ? cookiePolicy.campaigns : true
+    return cookiePolicy !== null ? cookiePolicy.campaigns : false
   }
 
   YoutubeLinkEnhancement.nextId = function () {

--- a/app/assets/javascripts/govuk_publishing_components/lib/single-consent-functions.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/single-consent-functions.js
@@ -1,0 +1,59 @@
+/* global GovSingleConsent */
+// = require govuk-single-consent/dist/singleconsent.iife.js
+
+(function (root) {
+  'use strict'
+  window.GOVUK = window.GOVUK || {}
+
+  window.GOVUK.singleConsent = {
+    init: function (callback) {
+      if (!window.GOVUK.useSingleConsentApi) {
+        return
+      }
+      callback = callback || this.apiCallback
+      // determine where we are and set the consent api URL accordingly
+      if (!this.url) {
+        this.url = 'staging'
+        var environment = window.GOVUK.loadAnalytics.getEnvironment(window.GOVUK.analyticsGa4.core.trackFunctions.getHostname())
+        if (environment) {
+          this.url = environment.consentApiUrl
+        }
+      }
+      // create the consent API object
+      this.consentApiObj = new GovSingleConsent(callback, this.url)
+    },
+
+    apiCallback: function (consents, consentsPreferencesSet, error) {
+      if (error) {
+        console.error('Single consent error: ', error, window.location)
+        return
+      }
+      if (consentsPreferencesSet) {
+        if (consents && consents.usage) {
+          window.GOVUK.triggerEvent(window, 'cookie-consent')
+        }
+      } else {
+        window.GOVUK.triggerEvent(window, 'show-cookie-banner')
+      }
+    },
+
+    setPreferences: function (type, options) {
+      if (window.GOVUK.useSingleConsentApi) {
+        try {
+          switch (type) {
+            case 'accept':
+              this.consentApiObj.setConsents(GovSingleConsent.ACCEPT_ALL)
+              break
+            case 'reject':
+              this.consentApiObj.setConsents(GovSingleConsent.REJECT_ALL)
+              break
+            default:
+              this.consentApiObj.setConsents(options)
+          }
+        } catch (e) {
+          console.error('Single consent ' + type + ' error: ', e, window.location)
+        }
+      }
+    }
+  }
+}(window))

--- a/app/assets/javascripts/govuk_publishing_components/load-analytics.js
+++ b/app/assets/javascripts/govuk_publishing_components/load-analytics.js
@@ -1,83 +1,12 @@
 //= require govuk_publishing_components/analytics
 //= require govuk_publishing_components/analytics-ga4
 //= require govuk_publishing_components/analytics/linked-domains
+//= require govuk_publishing_components/domain-config
 
 window.GOVUK.loadAnalytics = {
-  domains: [
-    {
-      // need to have this one at the start, see loadGa4 function
-      name: 'development',
-      domains: [
-        'localhost',
-        '127.0.0.1',
-        '0.0.0.0',
-        'dev.gov.uk'
-      ],
-      initialiseGA4: true,
-      id: 'GTM-MG7HG5W',
-      auth: 'bRiZ-jiEHtw6hHpGd6dF9w',
-      preview: 'env-3',
-      gaProperty: 'UA-UNSET',
-      gaPropertyCrossDomain: 'UA-UNSET',
-      consentApiUrl: 'staging'
-    },
-    {
-      name: 'production',
-      domains: [
-        'www.gov.uk',
-        'www-origin.publishing.service.gov.uk',
-        'assets.publishing.service.gov.uk'
-      ],
-      initialiseGA4: true,
-      id: 'GTM-MG7HG5W',
-      gaProperty: 'UA-26179049-1',
-      gaPropertyCrossDomain: 'UA-145652997-1',
-      consentApiUrl: 'production'
-    },
-    {
-      name: 'staging',
-      domains: [
-        'www.staging.publishing.service.gov.uk',
-        'www-origin.staging.publishing.service.gov.uk',
-        'assets.staging.publishing.service.gov.uk'
-      ],
-      initialiseGA4: true,
-      id: 'GTM-MG7HG5W',
-      auth: 'oJWs562CxSIjZKn_GlB5Bw',
-      preview: 'env-5',
-      gaProperty: 'UA-26179049-20',
-      gaPropertyCrossDomain: 'UA-145652997-1',
-      consentApiUrl: 'staging'
-    },
-    {
-      name: 'integration',
-      domains: [
-        'www.integration.publishing.service.gov.uk',
-        'www-origin.integration.publishing.service.gov.uk',
-        'assets.integration.publishing.service.gov.uk'
-      ],
-      initialiseGA4: true,
-      id: 'GTM-MG7HG5W',
-      auth: 'C7iYdcsOlYgGmiUJjZKrHQ',
-      preview: 'env-4',
-      gaProperty: 'UA-26179049-22',
-      gaPropertyCrossDomain: 'UA-145652997-1',
-      consentApiUrl: 'staging'
-    },
-    {
-      name: 'devdocs',
-      domains: [
-        'docs.publishing.service.gov.uk'
-      ],
-      initialiseGA4: true,
-      id: 'GTM-TNKCK97',
-      consentApiUrl: 'production'
-    }
-  ],
-
   loadExtraDomains: function () {
-    if (Array.isArray(window.GOVUK.analyticsGa4Domains)) {
-      this.domains = this.domains.concat(window.GOVUK.analyticsGa4Domains)
+    if (Array.isArray(window.GOVUK.vars.extraDomains)) {
+      window.GOVUK.vars.domains = window.GOVUK.vars.domains.concat(window.GOVUK.vars.extraDomains)
     }
   },
 
@@ -94,8 +23,8 @@ window.GOVUK.loadAnalytics = {
     window.GOVUK.analyticsVars.gaProperty = 'UA-UNSET'
     window.GOVUK.analyticsVars.gaPropertyCrossDomain = 'UA-UNSET'
 
-    for (var i = 0; i < this.domains.length; i++) {
-      var current = this.domains[i]
+    for (var i = 0; i < window.GOVUK.vars.domains.length; i++) {
+      var current = window.GOVUK.vars.domains[i]
       if (this.arrayContains(currentDomain, current.domains)) {
         window.GOVUK.analyticsVars.gaProperty = current.gaProperty
         window.GOVUK.analyticsVars.gaPropertyCrossDomain = current.gaPropertyCrossDomain
@@ -140,11 +69,11 @@ window.GOVUK.loadAnalytics = {
   getEnvironment: function (currentDomain) {
     // lots of dev domains, so simplify the matching process
     if (currentDomain.match(/[a-zA-Z0-9.-]+dev\.gov\.uk/)) {
-      return this.domains[0]
+      return window.GOVUK.vars.domains[0]
     } else {
-      for (var i = 0; i < this.domains.length; i++) {
-        if (this.arrayContains(currentDomain, this.domains[i].domains)) {
-          return this.domains[i]
+      for (var i = 0; i < window.GOVUK.vars.domains.length; i++) {
+        if (this.arrayContains(currentDomain, window.GOVUK.vars.domains[i].domains)) {
+          return window.GOVUK.vars.domains[i]
         }
       }
     }

--- a/app/assets/javascripts/govuk_publishing_components/load-analytics.js
+++ b/app/assets/javascripts/govuk_publishing_components/load-analytics.js
@@ -18,7 +18,8 @@ window.GOVUK.loadAnalytics = {
       auth: 'bRiZ-jiEHtw6hHpGd6dF9w',
       preview: 'env-3',
       gaProperty: 'UA-UNSET',
-      gaPropertyCrossDomain: 'UA-UNSET'
+      gaPropertyCrossDomain: 'UA-UNSET',
+      consentApiUrl: 'staging'
     },
     {
       name: 'production',
@@ -30,7 +31,8 @@ window.GOVUK.loadAnalytics = {
       initialiseGA4: true,
       id: 'GTM-MG7HG5W',
       gaProperty: 'UA-26179049-1',
-      gaPropertyCrossDomain: 'UA-145652997-1'
+      gaPropertyCrossDomain: 'UA-145652997-1',
+      consentApiUrl: 'production'
     },
     {
       name: 'staging',
@@ -44,7 +46,8 @@ window.GOVUK.loadAnalytics = {
       auth: 'oJWs562CxSIjZKn_GlB5Bw',
       preview: 'env-5',
       gaProperty: 'UA-26179049-20',
-      gaPropertyCrossDomain: 'UA-145652997-1'
+      gaPropertyCrossDomain: 'UA-145652997-1',
+      consentApiUrl: 'staging'
     },
     {
       name: 'integration',
@@ -58,7 +61,8 @@ window.GOVUK.loadAnalytics = {
       auth: 'C7iYdcsOlYgGmiUJjZKrHQ',
       preview: 'env-4',
       gaProperty: 'UA-26179049-22',
-      gaPropertyCrossDomain: 'UA-145652997-1'
+      gaPropertyCrossDomain: 'UA-145652997-1',
+      consentApiUrl: 'staging'
     },
     {
       name: 'devdocs',
@@ -66,7 +70,8 @@ window.GOVUK.loadAnalytics = {
         'docs.publishing.service.gov.uk'
       ],
       initialiseGA4: true,
-      id: 'GTM-TNKCK97'
+      id: 'GTM-TNKCK97',
+      consentApiUrl: 'production'
     }
   ],
 

--- a/docs/load-analytics.md
+++ b/docs/load-analytics.md
@@ -18,11 +18,12 @@ The Google Analytics 4 environment variables are:
 
 ## Passing extra options
 
-If you wish to initialise the GA4 code on a new domain with different attributes, the code has been written to accept an array of additional values. Extra domains can be added before loading `dependencies.js` as below.
+If you wish to initialise the GA4 code on a new domain with different attributes, the code has been written to accept an array of additional values. Extra domains can be added at the end of your code as shown.
 
 ```JavaScript
 window.GOVUK = window.GOVUK || {}
-window.GOVUK.analyticsGa4Domains = [
+window.GOVUK.vars = window.GOVUK.vars || {}
+window.GOVUK.vars.extraDomains = [
   {
     name: 'my-domain',
     domains: ['not-a-real-domain.co.org.uk'],
@@ -34,6 +35,5 @@ window.GOVUK.analyticsGa4Domains = [
     gaProperty: 'gaProperty', // for UA
     gaPropertyCrossDomain: 'gaPropertyCrossDomain' // for UA (optional)
   }
-  // add further into the array as required
 ]
 ```

--- a/package.json
+++ b/package.json
@@ -24,7 +24,10 @@
     }
   },
   "stylelint": {
-    "extends": ["stylelint-config-gds/scss", "stylelint-stylistic/config"],
+    "extends": [
+      "stylelint-config-gds/scss",
+      "stylelint-stylistic/config"
+    ],
     "rules": {
       "stylistic/number-leading-zero": null,
       "stylistic/max-line-length": 160,
@@ -34,6 +37,7 @@
   "dependencies": {
     "axe-core": "^4.8.4",
     "govuk-frontend": "^4.8.0",
+    "govuk-single-consent": "^3.0.9",
     "sortablejs": "^1.15.2"
   },
   "devDependencies": {

--- a/spec/javascripts/components/cookie-banner-spec.js
+++ b/spec/javascripts/components/cookie-banner-spec.js
@@ -40,230 +40,343 @@ describe('Cookie banner', function () {
               '</div>' +
           '</div>' +
       '</div>'
-
     document.body.appendChild(container)
-    // set and store consent for all as a basis of comparison
-    window.GOVUK.setCookie('cookies_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true}')
-    ALL_COOKIE_CONSENT = GOVUK.getCookie('cookies_policy')
-
-    // set and store default cookie consent to use as basis of comparison
-    window.GOVUK.setDefaultConsentCookie()
-    DEFAULT_COOKIE_CONSENT = GOVUK.getCookie('cookies_policy')
   })
 
   afterEach(function () {
+    delete window.GOVUK.useSingleConsentApi
     document.body.removeChild(container)
   })
 
-  it('should show the cookie banner', function () {
-    var element = document.querySelector('[data-module="cookie-banner"]')
-    new GOVUK.Modules.CookieBanner(element).init()
+  describe('when the single consent api is not enabled', function () {
+    beforeEach(function () {
+      // set and store consent for all as a basis of comparison
+      window.GOVUK.setCookie('cookies_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true}')
+      ALL_COOKIE_CONSENT = GOVUK.getCookie('cookies_policy')
 
-    var cookieBannerMain = document.querySelector('.js-banner-wrapper')
-    var cookieBannerConfirmationAccept = document.querySelector('.gem-c-cookie-banner__confirmation-message--accepted')
-    var cookieBannerConfirmationReject = document.querySelector('.gem-c-cookie-banner__confirmation-message--rejected')
+      // set and store default cookie consent to use as basis of comparison
+      window.GOVUK.setDefaultConsentCookie()
+      DEFAULT_COOKIE_CONSENT = GOVUK.getCookie('cookies_policy')
+    })
 
-    expect(element).toBeVisible()
-    expect(cookieBannerMain).toBeVisible()
-    expect(cookieBannerConfirmationAccept).toBeHidden()
-    expect(cookieBannerConfirmationReject).toBeHidden()
-  })
+    it('should show the cookie banner', function () {
+      var element = document.querySelector('[data-module="cookie-banner"]')
+      new GOVUK.Modules.CookieBanner(element).init()
 
-  it('should show the cookie banner when preferences have not been actively set', function () {
-    GOVUK.setDefaultConsentCookie() // Set default cookies, which are set whether there is any interaction or not.
+      var cookieBannerMain = document.querySelector('.js-banner-wrapper')
+      var cookieBannerConfirmationAccept = document.querySelector('.gem-c-cookie-banner__confirmation-message--accepted')
+      var cookieBannerConfirmationReject = document.querySelector('.gem-c-cookie-banner__confirmation-message--rejected')
 
-    var element = document.querySelector('[data-module="cookie-banner"]')
-    new GOVUK.Modules.CookieBanner(element).init()
+      expect(element).toBeVisible()
+      expect(cookieBannerMain).toBeVisible()
+      expect(cookieBannerConfirmationAccept).toBeHidden()
+      expect(cookieBannerConfirmationReject).toBeHidden()
+    })
 
-    var cookieBannerMain = document.querySelector('.js-banner-wrapper')
-    var cookieBannerConfirmationAccept = document.querySelector('.gem-c-cookie-banner__confirmation-message--accepted')
-    var cookieBannerConfirmationReject = document.querySelector('.gem-c-cookie-banner__confirmation-message--rejected')
+    it('should show the cookie banner when preferences have not been actively set', function () {
+      GOVUK.setDefaultConsentCookie() // Set default cookies, which are set whether there is any interaction or not.
 
-    expect(element).toBeVisible()
-    expect(cookieBannerMain).toBeVisible()
-    expect(cookieBannerConfirmationAccept).toBeHidden()
-    expect(cookieBannerConfirmationReject).toBeHidden()
-  })
+      var element = document.querySelector('[data-module="cookie-banner"]')
+      new GOVUK.Modules.CookieBanner(element).init()
 
-  it('should hide the cookie banner when preferences have been actively set', function () {
-    GOVUK.cookie('cookies_preferences_set', 'true', { days: 365 })
+      var cookieBannerMain = document.querySelector('.js-banner-wrapper')
+      var cookieBannerConfirmationAccept = document.querySelector('.gem-c-cookie-banner__confirmation-message--accepted')
+      var cookieBannerConfirmationReject = document.querySelector('.gem-c-cookie-banner__confirmation-message--rejected')
 
-    var element = document.querySelector('[data-module="cookie-banner"]')
-    new GOVUK.Modules.CookieBanner(element).init()
+      expect(element).toBeVisible()
+      expect(cookieBannerMain).toBeVisible()
+      expect(cookieBannerConfirmationAccept).toBeHidden()
+      expect(cookieBannerConfirmationReject).toBeHidden()
+    })
 
-    expect(element).toBeHidden()
-  })
+    it('should hide the cookie banner when preferences have been actively set', function () {
+      GOVUK.cookie('cookies_preferences_set', 'true', { days: 365 })
 
-  it('should have the hidden attribute by default, and remove it once the JS loads when cookies are not set', function () {
-    var element = document.querySelector('[data-module="cookie-banner"]')
-    expect(element.hasAttribute('hidden')).toEqual(true)
-    expect(element.offsetParent).toEqual(null)
-    new GOVUK.Modules.CookieBanner(element).init()
-    expect(element.hasAttribute('hidden')).toEqual(false)
-    expect(!!element.offsetParent).toEqual(true)
-  })
+      var element = document.querySelector('[data-module="cookie-banner"]')
+      new GOVUK.Modules.CookieBanner(element).init()
 
-  it('should have the hidden attribute by default, and leave it when cookies are set', function () {
-    GOVUK.cookie('cookies_preferences_set', 'true', { days: 365 })
-    var element = document.querySelector('[data-module="cookie-banner"]')
-    expect(element.offsetParent).toEqual(null)
-    expect(element.hasAttribute('hidden')).toEqual(true)
-    new GOVUK.Modules.CookieBanner(element).init()
-    expect(element.offsetParent).toEqual(null)
-    expect(element.hasAttribute('hidden')).toEqual(true)
-  })
+      expect(element).toBeHidden()
+    })
 
-  it('sets a default consent cookie', function () {
-    var element = document.querySelector('[data-module="cookie-banner"]')
-    new GOVUK.Modules.CookieBanner(element).init()
+    it('should have the hidden attribute by default, and remove it once the JS loads when cookies are not set', function () {
+      var element = document.querySelector('[data-module="cookie-banner"]')
+      expect(element.hasAttribute('hidden')).toEqual(true)
+      expect(element.offsetParent).toEqual(null)
+      new GOVUK.Modules.CookieBanner(element).init()
+      expect(element.hasAttribute('hidden')).toEqual(false)
+      expect(!!element.offsetParent).toEqual(true)
+    })
 
-    expect(GOVUK.getCookie('cookies_preferences_set')).toEqual(null)
-    expect(GOVUK.getCookie('cookies_policy')).toEqual(DEFAULT_COOKIE_CONSENT)
-  })
+    it('should have the hidden attribute by default, and leave it when cookies are set', function () {
+      GOVUK.cookie('cookies_preferences_set', 'true', { days: 365 })
+      var element = document.querySelector('[data-module="cookie-banner"]')
+      expect(element.offsetParent).toEqual(null)
+      expect(element.hasAttribute('hidden')).toEqual(true)
+      new GOVUK.Modules.CookieBanner(element).init()
+      expect(element.offsetParent).toEqual(null)
+      expect(element.hasAttribute('hidden')).toEqual(true)
+    })
 
-  it('deletes unconsented cookies if cookie preferences not explicitly set', function () {
-    window.GOVUK.setCookie('_ga', 'this is not allowed!')
-    spyOn(GOVUK, 'deleteUnconsentedCookies').and.callThrough()
+    it('sets a default consent cookie', function () {
+      var element = document.querySelector('[data-module="cookie-banner"]')
+      new GOVUK.Modules.CookieBanner(element).init()
 
-    var element = document.querySelector('[data-module="cookie-banner"]')
-    new GOVUK.Modules.CookieBanner(element).init()
+      expect(GOVUK.getCookie('cookies_preferences_set')).toEqual(null)
+      expect(GOVUK.getCookie('cookies_policy')).toEqual(DEFAULT_COOKIE_CONSENT)
+    })
 
-    expect(GOVUK.getCookie('cookies_policy')).toEqual(DEFAULT_COOKIE_CONSENT)
-    expect(GOVUK.deleteUnconsentedCookies).toHaveBeenCalled()
-    expect(GOVUK.getCookie('_ga', null))
-  })
+    it('deletes unconsented cookies if cookie preferences not explicitly set', function () {
+      window.GOVUK.setCookie('_ga', 'this is not allowed!')
+      spyOn(GOVUK, 'deleteUnconsentedCookies').and.callThrough()
 
-  it('sets consent cookie when accepting cookies', function () {
-    spyOn(GOVUK, 'analyticsInit')
-    spyOn(GOVUK, 'setCookie').and.callThrough()
+      var element = document.querySelector('[data-module="cookie-banner"]')
+      new GOVUK.Modules.CookieBanner(element).init()
 
-    var element = document.querySelector('[data-module="cookie-banner"]')
-    new GOVUK.Modules.CookieBanner(element).init()
+      expect(GOVUK.getCookie('cookies_policy')).toEqual(DEFAULT_COOKIE_CONSENT)
+      expect(GOVUK.deleteUnconsentedCookies).toHaveBeenCalled()
+      expect(GOVUK.getCookie('_ga', null))
+    })
 
-    // Manually reset the consent cookie so we can check the accept button works as intended
-    expect(GOVUK.getCookie('cookies_policy')).toEqual(DEFAULT_COOKIE_CONSENT)
-    GOVUK.cookie('cookies_policy', null)
+    it('sets consent cookie when accepting cookies', function () {
+      spyOn(GOVUK, 'analyticsInit')
+      spyOn(GOVUK, 'setCookie').and.callThrough()
 
-    var acceptCookiesButton = document.querySelector('[data-accept-cookies]')
-    acceptCookiesButton.click()
+      var element = document.querySelector('[data-module="cookie-banner"]')
+      new GOVUK.Modules.CookieBanner(element).init()
 
-    expect(GOVUK.setCookie).toHaveBeenCalledWith('cookies_preferences_set', 'true', { days: 365 })
-    expect(GOVUK.getCookie('cookies_preferences_set')).toEqual('true')
-    expect(GOVUK.getCookie('cookies_policy')).toEqual(ALL_COOKIE_CONSENT)
-    expect(GOVUK.analyticsInit).toHaveBeenCalled()
-  })
+      // Manually reset the consent cookie so we can check the accept button works as intended
+      expect(GOVUK.getCookie('cookies_policy')).toEqual(DEFAULT_COOKIE_CONSENT)
+      GOVUK.cookie('cookies_policy', null)
 
-  it('sets global_bar_seen cookie when accepting cookies', function () {
-    if (typeof GOVUK.globalBarInit === 'undefined') {
-      GOVUK.globalBarInit = {
-        init: function () {}
+      var acceptCookiesButton = document.querySelector('[data-accept-cookies]')
+      acceptCookiesButton.click()
+
+      expect(GOVUK.setCookie).toHaveBeenCalledWith('cookies_preferences_set', 'true', { days: 365 })
+      expect(GOVUK.getCookie('cookies_preferences_set')).toEqual('true')
+      expect(GOVUK.getCookie('cookies_policy')).toEqual(ALL_COOKIE_CONSENT)
+      expect(GOVUK.analyticsInit).toHaveBeenCalled()
+    })
+
+    it('sets global_bar_seen cookie when accepting cookies', function () {
+      if (typeof GOVUK.globalBarInit === 'undefined') {
+        GOVUK.globalBarInit = {
+          init: function () {}
+        }
       }
+      spyOn(GOVUK.globalBarInit, 'init')
+      spyOn(GOVUK, 'setCookie').and.callThrough()
+
+      var element = document.querySelector('[data-module="cookie-banner"]')
+      new GOVUK.Modules.CookieBanner(element).init()
+
+      // Manually reset the consent cookie so we can check the accept button works as intended
+      expect(GOVUK.getCookie('cookies_policy')).toEqual(DEFAULT_COOKIE_CONSENT)
+      GOVUK.cookie('cookies_policy', null)
+
+      var acceptCookiesButton = document.querySelector('[data-accept-cookies]')
+      acceptCookiesButton.click()
+
+      expect(GOVUK.setCookie).toHaveBeenCalledWith('cookies_preferences_set', 'true', { days: 365 })
+      expect(GOVUK.getCookie('cookies_preferences_set')).toEqual('true')
+      expect(GOVUK.getCookie('cookies_policy')).toEqual(ALL_COOKIE_CONSENT)
+      expect(GOVUK.globalBarInit.init).toHaveBeenCalled()
+    })
+
+    it('shows a confirmation message when cookies have been accepted', function () {
+      var element = document.querySelector('[data-module="cookie-banner"]')
+      new GOVUK.Modules.CookieBanner(element).init()
+
+      var acceptCookiesButton = document.querySelector('[data-accept-cookies]')
+      var confirmationMessageAccepted = document.querySelector('.gem-c-cookie-banner__confirmation-message--accepted')
+
+      expect(confirmationMessageAccepted).toBeHidden()
+
+      acceptCookiesButton.click()
+
+      expect(confirmationMessageAccepted).toBeVisible()
+      expect(confirmationMessageAccepted.innerText).toContain('You have accepted additional cookies. You can change your cookie settings at any time.')
+    })
+
+    it('shows a confirmation message when cookies have been rejected', function () {
+      var element = document.querySelector('[data-module="cookie-banner"]')
+      new GOVUK.Modules.CookieBanner(element).init()
+
+      var rejectCookiesButton = document.querySelector('[data-reject-cookies]')
+      var confirmationMessageRejected = document.querySelector('.gem-c-cookie-banner__confirmation-message--rejected')
+
+      expect(confirmationMessageRejected).toBeHidden()
+
+      rejectCookiesButton.click()
+
+      expect(confirmationMessageRejected).toBeVisible()
+      expect(confirmationMessageRejected.innerText).toContain('You have rejected additional cookies. You can change your cookie settings at any time.')
+    })
+
+    it('set focus to the confirmation message after clicking button', function () {
+      var element = document.querySelector('[data-module="cookie-banner"]')
+      new GOVUK.Modules.CookieBanner(element).init()
+
+      var rejectCookiesButton = document.querySelector('[data-reject-cookies]')
+      var confirmationMessage = document.querySelector('.gem-c-cookie-banner__confirmation')
+
+      rejectCookiesButton.click()
+
+      var focusedElement = document.activeElement
+
+      expect(focusedElement.className).toBe(confirmationMessage.className)
+    })
+
+    it('set cookies_preferences_set cookie, and re-set cookies_policy expiration date when rejecting cookies', function () {
+      spyOn(GOVUK, 'setCookie').and.callThrough()
+      var element = document.querySelector('[data-module="cookie-banner"]')
+      new GOVUK.Modules.CookieBanner(element).init()
+
+      var rejectCookiesButton = document.querySelector('[data-reject-cookies]')
+
+      rejectCookiesButton.click()
+
+      expect(GOVUK.setCookie).toHaveBeenCalledWith('cookies_policy', DEFAULT_COOKIE_CONSENT, { days: 365 })
+      expect(GOVUK.setCookie).toHaveBeenCalledWith('cookies_preferences_set', 'true', { days: 365 })
+    })
+
+    it('should hide when pressing the "hide" link', function () {
+      spyOn(GOVUK, 'setCookie').and.callThrough()
+
+      var element = document.querySelector('[data-module="cookie-banner"]')
+      new GOVUK.Modules.CookieBanner(element).init()
+
+      var link = document.querySelector('button[data-hide-cookie-banner="true"]')
+      link.dispatchEvent(new window.Event('click'))
+
+      expect(element).toBeHidden()
+      expect(GOVUK.getCookie('cookies_preferences_set')).toBeTruthy()
+    })
+
+    describe('when rendered inside an iframe', function () {
+      var windowParent = window.parent
+      var mockWindowParent = {} // window.parent would be different than window when used inside an iframe
+
+      beforeEach(function () {
+        window.parent = mockWindowParent
+      })
+
+      afterEach(function () {
+        window.parent = windowParent
+      })
+
+      it('should hide the cookie banner', function () {
+        var element = document.querySelector('[data-module="cookie-banner"]')
+        new GOVUK.Modules.CookieBanner(element).init()
+        expect(element).toBeHidden()
+      })
+    })
+  })
+
+  describe('when the single consent api is enabled', function () {
+    var acceptAll = {
+      essential: true,
+      usage: true,
+      campaigns: true,
+      settings: true
     }
-    spyOn(GOVUK.globalBarInit, 'init')
-    spyOn(GOVUK, 'setCookie').and.callThrough()
-
-    var element = document.querySelector('[data-module="cookie-banner"]')
-    new GOVUK.Modules.CookieBanner(element).init()
-
-    // Manually reset the consent cookie so we can check the accept button works as intended
-    expect(GOVUK.getCookie('cookies_policy')).toEqual(DEFAULT_COOKIE_CONSENT)
-    GOVUK.cookie('cookies_policy', null)
-
-    var acceptCookiesButton = document.querySelector('[data-accept-cookies]')
-    acceptCookiesButton.click()
-
-    expect(GOVUK.setCookie).toHaveBeenCalledWith('cookies_preferences_set', 'true', { days: 365 })
-    expect(GOVUK.getCookie('cookies_preferences_set')).toEqual('true')
-    expect(GOVUK.getCookie('cookies_policy')).toEqual(ALL_COOKIE_CONSENT)
-    expect(GOVUK.globalBarInit.init).toHaveBeenCalled()
-  })
-
-  it('shows a confirmation message when cookies have been accepted', function () {
-    var element = document.querySelector('[data-module="cookie-banner"]')
-    new GOVUK.Modules.CookieBanner(element).init()
-
-    var acceptCookiesButton = document.querySelector('[data-accept-cookies]')
-    var confirmationMessageAccepted = document.querySelector('.gem-c-cookie-banner__confirmation-message--accepted')
-
-    expect(confirmationMessageAccepted).toBeHidden()
-
-    acceptCookiesButton.click()
-
-    expect(confirmationMessageAccepted).toBeVisible()
-    expect(confirmationMessageAccepted.innerText).toContain('You have accepted additional cookies. You can change your cookie settings at any time.')
-  })
-
-  it('shows a confirmation message when cookies have been rejected', function () {
-    var element = document.querySelector('[data-module="cookie-banner"]')
-    new GOVUK.Modules.CookieBanner(element).init()
-
-    var rejectCookiesButton = document.querySelector('[data-reject-cookies]')
-    var confirmationMessageRejected = document.querySelector('.gem-c-cookie-banner__confirmation-message--rejected')
-
-    expect(confirmationMessageRejected).toBeHidden()
-
-    rejectCookiesButton.click()
-
-    expect(confirmationMessageRejected).toBeVisible()
-    expect(confirmationMessageRejected.innerText).toContain('You have rejected additional cookies. You can change your cookie settings at any time.')
-  })
-
-  it('set focus to the confirmation message after clicking button', function () {
-    var element = document.querySelector('[data-module="cookie-banner"]')
-    new GOVUK.Modules.CookieBanner(element).init()
-
-    var rejectCookiesButton = document.querySelector('[data-reject-cookies]')
-    var confirmationMessage = document.querySelector('.gem-c-cookie-banner__confirmation')
-
-    rejectCookiesButton.click()
-
-    var focusedElement = document.activeElement
-
-    expect(focusedElement.className).toBe(confirmationMessage.className)
-  })
-
-  it('set cookies_preferences_set cookie, and re-set cookies_policy expiration date when rejecting cookies', function () {
-    spyOn(GOVUK, 'setCookie').and.callThrough()
-    var element = document.querySelector('[data-module="cookie-banner"]')
-    new GOVUK.Modules.CookieBanner(element).init()
-
-    var rejectCookiesButton = document.querySelector('[data-reject-cookies]')
-
-    rejectCookiesButton.click()
-
-    expect(GOVUK.setCookie).toHaveBeenCalledWith('cookies_policy', DEFAULT_COOKIE_CONSENT, { days: 365 })
-    expect(GOVUK.setCookie).toHaveBeenCalledWith('cookies_preferences_set', 'true', { days: 365 })
-  })
-
-  it('should hide when pressing the "hide" link', function () {
-    spyOn(GOVUK, 'setCookie').and.callThrough()
-
-    var element = document.querySelector('[data-module="cookie-banner"]')
-    new GOVUK.Modules.CookieBanner(element).init()
-
-    var link = document.querySelector('button[data-hide-cookie-banner="true"]')
-    link.dispatchEvent(new window.Event('click'))
-
-    expect(element).toBeHidden()
-    expect(GOVUK.getCookie('cookies_preferences_set')).toBeTruthy()
-  })
-
-  describe('when rendered inside an iframe', function () {
-    var windowParent = window.parent
-    var mockWindowParent = {} // window.parent would be different than window when used inside an iframe
+    var rejectAll = {
+      essential: true,
+      usage: false,
+      campaigns: false,
+      settings: false
+    }
+    var mix = {
+      essential: true,
+      usage: false,
+      campaigns: true,
+      settings: true
+    }
 
     beforeEach(function () {
-      window.parent = mockWindowParent
+      window.GOVUK.useSingleConsentApi = true
+      // delete consent cookies
+      window.GOVUK.cookie('cookies_policy')
+      window.GOVUK.cookie('cookies_preferences_set')
+      spyOn(window.GOVUK, 'setCookie')
+      spyOn(window.GOVUK.singleConsent, 'init').and.callThrough()
+      spyOn(window.GOVUK.singleConsent, 'apiCallback').and.callThrough()
     })
 
     afterEach(function () {
-      window.parent = windowParent
+      // delete consent cookies
+      window.GOVUK.cookie('cookies_policy')
+      window.GOVUK.cookie('cookies_preferences_set')
     })
 
-    it('should hide the cookie banner', function () {
+    it('initialises the single consent api on init', function () {
       var element = document.querySelector('[data-module="cookie-banner"]')
       new GOVUK.Modules.CookieBanner(element).init()
-      expect(element).toBeHidden()
+      expect(window.GOVUK.singleConsent.init).toHaveBeenCalled()
+      expect(window.GOVUK.singleConsent.apiCallback).toHaveBeenCalled()
+      expect(window.GOVUK.setCookie).not.toHaveBeenCalled()
+    })
+
+    it('should show the cookie banner', function () {
+      var element = document.querySelector('[data-module="cookie-banner"]')
+      new GOVUK.Modules.CookieBanner(element).init()
+      expect(element).toBeVisible()
+    })
+
+    describe('when a consent api UUID is passed in the URL', function () {
+      var existingUrl
+
+      beforeEach(function () {
+        jasmine.Ajax.install()
+        existingUrl = window.location.pathname + window.location.search
+        window.history.replaceState(null, null, '?gov_singleconsent_uid=1234')
+      })
+
+      afterEach(function () {
+        jasmine.Ajax.uninstall()
+        window.history.replaceState(null, null, existingUrl)
+      })
+
+      it('should hide the cookie banner and set cookies for consent', function () {
+        var element = document.querySelector('[data-module="cookie-banner"]')
+        new GOVUK.Modules.CookieBanner(element).init()
+        jasmine.Ajax.requests.mostRecent().respondWith({
+          status: 200,
+          contentType: 'text/plain',
+          responseText: '{ "uid": "1234", "status": ' + JSON.stringify(acceptAll) + '}'
+        })
+        expect(element).not.toBeVisible()
+        expect(window.GOVUK.cookie('cookies_preferences_set')).toEqual('true')
+        expect(window.GOVUK.cookie('cookies_policy')).toEqual(JSON.stringify(acceptAll))
+        expect(window.GOVUK.setCookie).not.toHaveBeenCalled()
+      })
+
+      it('should hide the cookie banner and set cookies for reject', function () {
+        var element = document.querySelector('[data-module="cookie-banner"]')
+        new GOVUK.Modules.CookieBanner(element).init()
+        jasmine.Ajax.requests.mostRecent().respondWith({
+          status: 200,
+          contentType: 'text/plain',
+          responseText: '{ "uid": "1234", "status": ' + JSON.stringify(rejectAll) + '}'
+        })
+        expect(element).not.toBeVisible()
+        expect(window.GOVUK.cookie('cookies_preferences_set')).toEqual('true')
+        expect(window.GOVUK.cookie('cookies_policy')).toEqual(JSON.stringify(rejectAll))
+        expect(window.GOVUK.setCookie).not.toHaveBeenCalled()
+      })
+
+      it('should hide the cookie banner and set cookies for a varied cookie consent', function () {
+        var element = document.querySelector('[data-module="cookie-banner"]')
+        new GOVUK.Modules.CookieBanner(element).init()
+        jasmine.Ajax.requests.mostRecent().respondWith({
+          status: 200,
+          contentType: 'text/plain',
+          responseText: '{ "uid": "1234", "status": ' + JSON.stringify(mix) + '}'
+        })
+        expect(element).not.toBeVisible()
+        expect(window.GOVUK.cookie('cookies_preferences_set')).toEqual('true')
+        expect(window.GOVUK.cookie('cookies_policy')).toEqual(JSON.stringify(mix))
+        expect(window.GOVUK.setCookie).not.toHaveBeenCalled()
+      })
     })
   })
 })

--- a/spec/javascripts/components/govspeak-spec.js
+++ b/spec/javascripts/components/govspeak-spec.js
@@ -9,6 +9,14 @@ describe('Govspeak', function () {
   })
 
   describe('youtube enhancement', function () {
+    beforeEach(function () {
+      window.GOVUK.cookie('cookies_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true}')
+    })
+
+    afterEach(function () {
+      window.GOVUK.cookie('cookies_policy', null)
+    })
+
     it('embeds youtube videos', function () {
       container = document.createElement('div')
       container.innerHTML =

--- a/spec/javascripts/govuk_publishing_components/lib/cookie-settings-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/cookie-settings-spec.js
@@ -8,6 +8,7 @@ describe('cookieSettings', function () {
     fakePreviousURL
 
   beforeEach(function () {
+    delete window.GOVUK.useSingleConsentApi
     GOVUK.Modules.CookieSettings.prototype.getReferrerLink = function () {
       return fakePreviousURL
     }
@@ -42,61 +43,183 @@ describe('cookieSettings', function () {
     document.body.removeChild(confirmationContainer)
   })
 
-  describe('setInitialFormValues', function () {
-    it('sets a consent cookie by default', function () {
+  describe('when the single consent api is not enabled', function () {
+    describe('setInitialFormValues', function () {
+      it('sets a consent cookie by default', function () {
+        GOVUK.cookie('cookies_policy', null)
+        spyOn(window.GOVUK, 'setDefaultConsentCookie').and.callThrough()
+
+        new GOVUK.Modules.CookieSettings(element).init()
+
+        expect(window.GOVUK.setDefaultConsentCookie).toHaveBeenCalled()
+      })
+
+      it('sets all radio buttons to the default values', function () {
+        new GOVUK.Modules.CookieSettings(element).init()
+
+        var radioButtons = element.querySelectorAll('input[value=on]')
+        var consentCookieJSON = JSON.parse(window.GOVUK.cookie('cookies_policy'))
+
+        for (var i = 0; i < radioButtons.length; i++) {
+          var name = radioButtons[i].name.replace('cookies-', '')
+
+          if (consentCookieJSON[name]) {
+            expect(radioButtons[i].checked).toBeTruthy()
+          } else {
+            expect(radioButtons[i].checked).not.toBeTruthy()
+          }
+        }
+      })
+
+      it('does not error if not all options are present', function () {
+        element.innerHTML =
+        '<form data-module="cookie-settings">' +
+          '<input type="radio" id="settings-on" name="cookies-settings" value="on">' +
+          '<input type="radio" id="settings-off" name="cookies-settings" value="off">' +
+          '<button id="submit-button" type="submit">Submit</button>' +
+        '</form>'
+
+        new GOVUK.Modules.CookieSettings(element).init()
+
+        var radioButtons = element.querySelectorAll('input[value=on]')
+        var consentCookieJSON = JSON.parse(window.GOVUK.cookie('cookies_policy'))
+
+        for (var i = 0; i < radioButtons.length; i++) {
+          var name = radioButtons[i].name.replace('cookies-', '')
+
+          if (consentCookieJSON[name]) {
+            expect(radioButtons[i].checked).toBeTruthy()
+          } else {
+            expect(radioButtons[i].checked).not.toBeTruthy()
+          }
+        }
+      })
+    })
+
+    describe('submitSettingsForm', function () {
+      it('updates consent cookie with any changes', function () {
+        spyOn(window.GOVUK, 'setConsentCookie').and.callThrough()
+
+        new GOVUK.Modules.CookieSettings(element).init()
+
+        element.querySelector('#settings-on').checked = false
+        element.querySelector('#settings-off').checked = true
+
+        var button = element.querySelector('#submit-button')
+        button.click()
+
+        var cookie = JSON.parse(GOVUK.cookie('cookies_policy'))
+
+        expect(window.GOVUK.setConsentCookie).toHaveBeenCalledWith({ settings: false, usage: false, campaigns: false })
+        expect(cookie.settings).toBeFalsy()
+      })
+
+      it('sets cookies_preferences_set cookie on form submit', function () {
+        spyOn(window.GOVUK, 'setCookie').and.callThrough()
+
+        new GOVUK.Modules.CookieSettings(element).init()
+
+        GOVUK.cookie('cookies_preferences_set', null)
+
+        expect(GOVUK.cookie('cookies_preferences_set')).toEqual(null)
+
+        var button = element.querySelector('#submit-button')
+        button.click()
+
+        expect(window.GOVUK.setCookie).toHaveBeenCalledWith('cookies_preferences_set', true, { days: 365 })
+        expect(GOVUK.cookie('cookies_preferences_set')).toBeTruthy()
+      })
+
+      it('fires a Google Analytics event', function () {
+        spyOn(GOVUK.analytics, 'trackEvent').and.callThrough()
+
+        new GOVUK.Modules.CookieSettings(element).init()
+
+        element.querySelector('#settings-on').checked = false
+        element.querySelector('#settings-off').checked = true
+
+        var button = element.querySelector('#submit-button')
+        button.click()
+
+        expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('cookieSettings', 'Save changes', { label: 'settings-no usage-no campaigns-no ' })
+      })
+    })
+
+    describe('showConfirmationMessage', function () {
+      it('sets the previous referrer link if one is present', function () {
+        fakePreviousURL = '/student-finance'
+
+        new GOVUK.Modules.CookieSettings(element).init()
+
+        var button = element.querySelector('#submit-button')
+        button.click()
+
+        var previousLink = document.querySelector('.cookie-settings__prev-page')
+
+        expect(previousLink.style.display).toEqual('inline')
+        expect(previousLink.href).toContain('/student-finance')
+      })
+
+      it('does not set a referrer if one is not present', function () {
+        fakePreviousURL = null
+
+        new GOVUK.Modules.CookieSettings(element).init()
+
+        var button = element.querySelector('#submit-button')
+        button.click()
+
+        var previousLink = document.querySelector('.cookie-settings__prev-page')
+
+        expect(previousLink.style.display).toEqual('none')
+      })
+
+      it('does not set a referrer if URL is the same as current page (cookies page)', function () {
+        fakePreviousURL = document.location.pathname
+
+        new GOVUK.Modules.CookieSettings(element).init()
+
+        var button = element.querySelector('#submit-button')
+        button.click()
+
+        var previousLink = document.querySelector('.cookie-settings__prev-page')
+
+        expect(previousLink.style.display).toEqual('none')
+      })
+
+      it('shows a confirmation message', function () {
+        var confirmationMessage = document.querySelector('[data-cookie-confirmation]')
+
+        new GOVUK.Modules.CookieSettings(element).init()
+
+        var button = element.querySelector('#submit-button')
+        button.click()
+
+        expect(confirmationMessage.style.display).toEqual('block')
+      })
+    })
+  })
+
+  describe('when the single consent api is enabled', function () {
+    beforeEach(function () {
+      window.GOVUK.useSingleConsentApi = true
+    })
+
+    afterEach(function () {
+      delete window.GOVUK.useSingleConsentApi
+    })
+
+    it('setInitialFormValues does not set a consent cookie by default', function () {
       GOVUK.cookie('cookies_policy', null)
       spyOn(window.GOVUK, 'setDefaultConsentCookie').and.callThrough()
 
       new GOVUK.Modules.CookieSettings(element).init()
 
-      expect(window.GOVUK.setDefaultConsentCookie).toHaveBeenCalled()
+      expect(window.GOVUK.setDefaultConsentCookie).not.toHaveBeenCalled()
     })
 
-    it('sets all radio buttons to the default values', function () {
-      new GOVUK.Modules.CookieSettings(element).init()
-
-      var radioButtons = element.querySelectorAll('input[value=on]')
-      var consentCookieJSON = JSON.parse(window.GOVUK.cookie('cookies_policy'))
-
-      for (var i = 0; i < radioButtons.length; i++) {
-        var name = radioButtons[i].name.replace('cookies-', '')
-
-        if (consentCookieJSON[name]) {
-          expect(radioButtons[i].checked).toBeTruthy()
-        } else {
-          expect(radioButtons[i].checked).not.toBeTruthy()
-        }
-      }
-    })
-
-    it('does not error if not all options are present', function () {
-      element.innerHTML =
-      '<form data-module="cookie-settings">' +
-        '<input type="radio" id="settings-on" name="cookies-settings" value="on">' +
-        '<input type="radio" id="settings-off" name="cookies-settings" value="off">' +
-        '<button id="submit-button" type="submit">Submit</button>' +
-      '</form>'
-
-      new GOVUK.Modules.CookieSettings(element).init()
-
-      var radioButtons = element.querySelectorAll('input[value=on]')
-      var consentCookieJSON = JSON.parse(window.GOVUK.cookie('cookies_policy'))
-
-      for (var i = 0; i < radioButtons.length; i++) {
-        var name = radioButtons[i].name.replace('cookies-', '')
-
-        if (consentCookieJSON[name]) {
-          expect(radioButtons[i].checked).toBeTruthy()
-        } else {
-          expect(radioButtons[i].checked).not.toBeTruthy()
-        }
-      }
-    })
-  })
-
-  describe('submitSettingsForm', function () {
-    it('updates consent cookie with any changes', function () {
-      spyOn(window.GOVUK, 'setConsentCookie').and.callThrough()
+    it('submitSettingsForm passes responsibility for handling consent to the single consent api', function () {
+      spyOn(window.GOVUK, 'setConsentCookie')
+      spyOn(window.GOVUK.singleConsent, 'init')
 
       new GOVUK.Modules.CookieSettings(element).init()
 
@@ -106,96 +229,8 @@ describe('cookieSettings', function () {
       var button = element.querySelector('#submit-button')
       button.click()
 
-      var cookie = JSON.parse(GOVUK.cookie('cookies_policy'))
-
-      expect(window.GOVUK.setConsentCookie).toHaveBeenCalledWith({ settings: false, usage: false, campaigns: false })
-      expect(cookie.settings).toBeFalsy()
-    })
-
-    it('sets cookies_preferences_set cookie on form submit', function () {
-      spyOn(window.GOVUK, 'setCookie').and.callThrough()
-
-      new GOVUK.Modules.CookieSettings(element).init()
-
-      GOVUK.cookie('cookies_preferences_set', null)
-
-      expect(GOVUK.cookie('cookies_preferences_set')).toEqual(null)
-
-      var button = element.querySelector('#submit-button')
-      button.click()
-
-      expect(window.GOVUK.setCookie).toHaveBeenCalledWith('cookies_preferences_set', true, { days: 365 })
-      expect(GOVUK.cookie('cookies_preferences_set')).toBeTruthy()
-    })
-
-    it('fires a Google Analytics event', function () {
-      spyOn(GOVUK.analytics, 'trackEvent').and.callThrough()
-
-      new GOVUK.Modules.CookieSettings(element).init()
-
-      element.querySelector('#settings-on').checked = false
-      element.querySelector('#settings-off').checked = true
-
-      element.querySelector('#usage-on').checked = true
-      element.querySelector('#usage-off').checked = false
-
-      var button = element.querySelector('#submit-button')
-      button.click()
-
-      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('cookieSettings', 'Save changes', { label: 'settings-no usage-yes campaigns-no ' })
-    })
-  })
-
-  describe('showConfirmationMessage', function () {
-    it('sets the previous referrer link if one is present', function () {
-      fakePreviousURL = '/student-finance'
-
-      new GOVUK.Modules.CookieSettings(element).init()
-
-      var button = element.querySelector('#submit-button')
-      button.click()
-
-      var previousLink = document.querySelector('.cookie-settings__prev-page')
-
-      expect(previousLink.style.display).toEqual('inline')
-      expect(previousLink.href).toContain('/student-finance')
-    })
-
-    it('does not set a referrer if one is not present', function () {
-      fakePreviousURL = null
-
-      new GOVUK.Modules.CookieSettings(element).init()
-
-      var button = element.querySelector('#submit-button')
-      button.click()
-
-      var previousLink = document.querySelector('.cookie-settings__prev-page')
-
-      expect(previousLink.style.display).toEqual('none')
-    })
-
-    it('does not set a referrer if URL is the same as current page (cookies page)', function () {
-      fakePreviousURL = document.location.pathname
-
-      new GOVUK.Modules.CookieSettings(element).init()
-
-      var button = element.querySelector('#submit-button')
-      button.click()
-
-      var previousLink = document.querySelector('.cookie-settings__prev-page')
-
-      expect(previousLink.style.display).toEqual('none')
-    })
-
-    it('shows a confirmation message', function () {
-      var confirmationMessage = document.querySelector('[data-cookie-confirmation]')
-
-      new GOVUK.Modules.CookieSettings(element).init()
-
-      var button = element.querySelector('#submit-button')
-      button.click()
-
-      expect(confirmationMessage.style.display).toEqual('block')
+      expect(window.GOVUK.setConsentCookie).not.toHaveBeenCalled()
+      expect(window.GOVUK.singleConsent.init).toHaveBeenCalled()
     })
   })
 

--- a/spec/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement-spec.js
@@ -6,14 +6,16 @@ describe('Youtube link enhancement', function () {
     var container
 
     beforeEach(function () {
+      window.GOVUK.cookie('cookies_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true}')
       container = document.createElement('div')
     })
 
     afterEach(function () {
+      window.GOVUK.cookie('cookies_policy', null)
       document.body.removeChild(container)
     })
 
-    it('replaces a link and it\'s container with a media-player embed', function () {
+    it('replaces a link and its container with a media-player embed', function () {
       container.innerHTML =
         '<div class="gem-c-govspeak govuk-govspeak" data-module="govspeak">' +
           '<p><a href="https://www.youtube.com/watch?v=0XpAtr24uUQ">Agile at GDS</a></p>' +
@@ -124,14 +126,16 @@ describe('Youtube link enhancement', function () {
     var container
 
     beforeEach(function () {
+      window.GOVUK.cookie('cookies_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true}')
       container = document.createElement('div')
     })
 
     afterEach(function () {
+      window.GOVUK.cookie('cookies_policy', null)
       document.body.removeChild(container)
     })
 
-    it('replaces a livestream link and it\'s container with a media-player embed', function () {
+    it('replaces a livestream link and its container with a media-player embed', function () {
       container.innerHTML =
         '<div class="gem-c-govspeak govuk-govspeak" data-module="govspeak">' +
           '<p><a href="https://www.youtube.com/embed/live_stream?channel=UCoMdktPbSTixAyNGwb-UYkQ">Livestream</a></p>' +

--- a/spec/javascripts/govuk_publishing_components/lib/single-consent-functions-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/single-consent-functions-spec.js
@@ -1,0 +1,227 @@
+/* eslint-env jasmine */
+
+describe('The single consent cookie code', function () {
+  var acceptAll = {
+    essential: true,
+    usage: true,
+    campaigns: true,
+    settings: true
+  }
+  var rejectAll = {
+    essential: true,
+    usage: false,
+    campaigns: false,
+    settings: false
+  }
+  var mix = {
+    essential: true,
+    usage: false,
+    campaigns: true,
+    settings: true
+  }
+
+  beforeEach(function () {
+    delete window.GOVUK.singleConsent.consentApiObj
+    delete window.GOVUK.singleConsent.url
+    delete window.GOVUK.useSingleConsentApi
+    spyOn(window.GOVUK, 'triggerEvent').and.callThrough()
+    spyOn(window.GOVUK.singleConsent, 'apiCallback').and.callThrough()
+    jasmine.Ajax.install()
+  })
+
+  afterEach(function () {
+    jasmine.Ajax.uninstall()
+    delete window.GOVUK.singleConsent.consentApiObj
+    delete window.GOVUK.singleConsent.url
+    delete window.GOVUK.useSingleConsentApi
+  })
+
+  describe('if the single consent API should not be used', function () {
+    beforeEach(function () {
+      delete window.GOVUK.useSingleConsentApi
+    })
+
+    it('will not initialise', function () {
+      window.GOVUK.singleConsent.init()
+      expect(window.GOVUK.singleConsent.consentApiObj).not.toBeDefined()
+    })
+  })
+
+  describe('if the single consent API should be used', function () {
+    beforeEach(function () {
+      window.GOVUK.useSingleConsentApi = true
+    })
+
+    afterEach(function () {
+      delete window.GOVUK.useSingleConsentApi
+    })
+
+    it('does nothing if there is no unique user id', function () {
+      window.GOVUK.singleConsent.init()
+      expect(window.GOVUK.singleConsent.consentApiObj).toBeDefined()
+      expect(jasmine.Ajax.requests.count()).toEqual(0)
+      expect(window.GOVUK.singleConsent.apiCallback).toHaveBeenCalledWith(null, false, null)
+    })
+
+    it('accepts a function for the callback', function () {
+      var test = {
+        testFunction: function () {}
+      }
+      spyOn(test, 'testFunction')
+      window.GOVUK.singleConsent.init(test.testFunction)
+      expect(test.testFunction).toHaveBeenCalled()
+    })
+
+    describe('when determining the environment', function () {
+      it('starts without a URL for the consent API', function () {
+        expect(window.GOVUK.singleConsent.url).toBeFalsy()
+      })
+
+      it('defaults to staging if the environment is not recognised', function () {
+        spyOn(window.GOVUK.analyticsGa4.core.trackFunctions, 'getHostname').and.returnValue('moo')
+        window.GOVUK.singleConsent.init()
+        expect(window.GOVUK.singleConsent.url).toEqual('staging')
+      })
+
+      it('switches to production when on production', function () {
+        spyOn(window.GOVUK.analyticsGa4.core.trackFunctions, 'getHostname').and.returnValue('www.gov.uk')
+        window.GOVUK.singleConsent.init()
+        expect(window.GOVUK.singleConsent.url).toEqual('production')
+      })
+    })
+
+    describe('when there is a user id', function () {
+      beforeEach(function () {
+        spyOn(window.GOVUK, 'checkConsentCookie').and.returnValue(true)
+        window.GOVUK.cookie('gov_singleconsent_uid', '1234')
+        window.GOVUK.singleConsent.init()
+      })
+
+      afterEach(function () {
+        window.GOVUK.cookie('gov_singleconsent_uid', null)
+      })
+
+      it('does everything expected when full consent is given', function () {
+        window.GOVUK.singleConsent.setPreferences('accept')
+        jasmine.Ajax.requests.mostRecent().respondWith({
+          status: 200,
+          contentType: 'text/plain',
+          responseText: '{ "uid": "1234", "status": ' + JSON.stringify(acceptAll) + '}'
+        })
+
+        expect(window.GOVUK.singleConsent.consentApiObj).toBeDefined()
+        expect(window.GOVUK.singleConsent.apiCallback).toHaveBeenCalledWith(acceptAll, true, null)
+        expect(window.GOVUK.triggerEvent).toHaveBeenCalledWith(window, 'cookie-consent')
+        expect(window.GOVUK.cookie('cookies_policy')).toEqual('{"essential":true,"usage":true,"campaigns":true,"settings":true}')
+      })
+
+      it('does everything expected when consent is rejected', function () {
+        window.GOVUK.singleConsent.setPreferences('reject')
+        jasmine.Ajax.requests.mostRecent().respondWith({
+          status: 200,
+          contentType: 'text/plain',
+          responseText: '{ "uid": "1234", "status": ' + JSON.stringify(rejectAll) + '}'
+        })
+
+        expect(window.GOVUK.singleConsent.consentApiObj).toBeDefined()
+        expect(window.GOVUK.singleConsent.apiCallback).toHaveBeenCalledWith(rejectAll, true, null)
+        expect(window.GOVUK.cookie('cookies_policy')).toEqual('{"essential":true,"usage":false,"campaigns":false,"settings":false}')
+      })
+
+      it('does everything expected when partial consent is given', function () {
+        window.GOVUK.singleConsent.setPreferences(false, mix)
+        jasmine.Ajax.requests.mostRecent().respondWith({
+          status: 200,
+          contentType: 'text/plain',
+          responseText: '{ "uid": "1234", "status": ' + JSON.stringify(mix) + '}'
+        })
+
+        expect(window.GOVUK.singleConsent.consentApiObj).toBeDefined()
+        expect(window.GOVUK.singleConsent.apiCallback).toHaveBeenCalledWith(mix, true, null)
+        expect(window.GOVUK.cookie('cookies_policy')).toEqual('{"essential":true,"usage":false,"campaigns":true,"settings":true}')
+      })
+    })
+  })
+
+  describe('when there is a problem with the consent api', function () {
+    beforeEach(function () {
+      spyOn(window.GOVUK, 'checkConsentCookie').and.returnValue(true)
+      window.GOVUK.cookie('gov_singleconsent_uid', '1234')
+      window.GOVUK.useSingleConsentApi = true
+      jasmine.clock().install()
+    })
+
+    afterEach(function () {
+      delete window.GOVUK.useSingleConsentApi
+      jasmine.clock().uninstall()
+      window.GOVUK.cookie('gov_singleconsent_uid', null)
+    })
+
+    it('handles a timeout gracefully', function () {
+      window.GOVUK.singleConsent.init()
+      window.GOVUK.singleConsent.setPreferences('accept')
+      jasmine.Ajax.requests.mostRecent().responseTimeout()
+      expect(window.GOVUK.singleConsent.consentApiObj).toBeDefined()
+      expect(window.GOVUK.cookie('cookies_policy')).toEqual('{"essential":true,"usage":false,"campaigns":false,"settings":false}')
+    })
+
+    it('fails gracefully if pointed at an incorrect endpoint URL', function () {
+      window.GOVUK.singleConsent.init()
+      window.GOVUK.singleConsent.setPreferences('accept')
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 404,
+        contentType: 'text/plain',
+        responseText: 'error not found'
+      })
+      expect(window.GOVUK.singleConsent.consentApiObj).toBeDefined()
+      expect(window.GOVUK.cookie('cookies_policy')).toEqual('{"essential":true,"usage":false,"campaigns":false,"settings":false}')
+    })
+
+    it('fails gracefully when the server errors', function () {
+      window.GOVUK.singleConsent.init()
+      window.GOVUK.singleConsent.setPreferences('accept')
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 500,
+        contentType: 'text/plain',
+        responseText: 'error not found'
+      })
+      expect(window.GOVUK.singleConsent.consentApiObj).toBeDefined()
+      expect(window.GOVUK.cookie('cookies_policy')).toEqual('{"essential":true,"usage":false,"campaigns":false,"settings":false}')
+    })
+
+    it('fails gracefully when the response is invalid', function () {
+      window.GOVUK.singleConsent.init()
+      window.GOVUK.singleConsent.setPreferences('accept')
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 200,
+        contentType: 'text/plain',
+        responseText: 'not valid json'
+      })
+      expect(window.GOVUK.singleConsent.consentApiObj).toBeDefined()
+      expect(window.GOVUK.cookie('cookies_policy')).toEqual('{"essential":true,"usage":false,"campaigns":false,"settings":false}')
+    })
+
+    it('fails gracefully when the response is not as expected', function () {
+      window.GOVUK.singleConsent.init()
+      window.GOVUK.singleConsent.setPreferences('accept')
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 200,
+        contentType: 'text/plain',
+        responseText: '{"valid json but not":"what should be returned by the api"}'
+      })
+      expect(window.GOVUK.singleConsent.consentApiObj).toBeDefined()
+      expect(window.GOVUK.cookie('cookies_policy')).toEqual('{"essential":true,"usage":false,"campaigns":false,"settings":false}')
+    })
+
+    it('restores correct cookie consent', function () {
+      window.GOVUK.cookie('cookies_policy', '{"essential":true,"usage":false,"campaigns":false,"settings":false}')
+      window.GOVUK.singleConsent.init()
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 200,
+        contentType: 'text/plain',
+        responseText: '{ "uid": "1234", "status": ' + JSON.stringify(acceptAll) + '}'
+      })
+      expect(window.GOVUK.cookie('cookies_policy')).toEqual('{"essential":true,"usage":true,"campaigns":true,"settings":true}')
+    })
+  })
+})

--- a/spec/javascripts/govuk_publishing_components/load-analytics.spec.js
+++ b/spec/javascripts/govuk_publishing_components/load-analytics.spec.js
@@ -133,41 +133,46 @@ describe('Analytics loading', function () {
     })
 
     it('doesnt load GA4 variables if initialiseGA4 is set to false', function () {
-      window.GOVUK.loadAnalytics.domains[0].initialiseGA4 = false
+      window.GOVUK.vars.domains[0].initialiseGA4 = false
       window.GOVUK.loadAnalytics.loadGa4('localhost')
       expect(window.GOVUK.analyticsGa4.vars).toEqual(null)
-      window.GOVUK.loadAnalytics.domains[0].initialiseGA4 = true
+      window.GOVUK.vars.domains[0].initialiseGA4 = true
     })
 
     describe('when additional domain details are needed', function () {
+      var saveDomains
+
+      beforeEach(function () {
+        // use slice to clone the array, otherwise this 'saving' doesn't work
+        saveDomains = window.GOVUK.vars.domains.slice()
+      })
+
       afterEach(function () {
-        delete window.GOVUK.analyticsGa4Domains
+        delete window.GOVUK.vars.extraDomains
+        window.GOVUK.vars.domains = saveDomains.slice()
       })
 
       it('defaults to the normal list when no extras are passed', function () {
-        var domains = window.GOVUK.loadAnalytics.domains
+        var expected = window.GOVUK.vars.domains.slice()
         window.GOVUK.loadAnalytics.loadExtraDomains()
         window.GOVUK.loadAnalytics.loadGa4()
-        expect(window.GOVUK.loadAnalytics.domains).toEqual(domains)
+        expect(window.GOVUK.vars.domains).toEqual(expected)
       })
 
       it('allows extra domains to be passed and appended to the existing list', function () {
-        var newDomain = {
+        var extra = {
           name: 'test-domain',
           domains: ['not-a-real-domain'],
           initialiseGA4: true,
           id: 'GTM-001'
         }
-        window.GOVUK.analyticsGa4Domains = [newDomain]
+        window.GOVUK.vars.extraDomains = [extra]
+        expected = window.GOVUK.vars.domains.slice()
+        expected.push(extra)
+
         window.GOVUK.loadAnalytics.loadExtraDomains()
-        expected = {
-          name: 'test-domain',
-          domains: ['not-a-real-domain'],
-          initialiseGA4: true,
-          id: 'GTM-001'
-        }
-        // the new domain gets appended to the end of the array
-        expect(window.GOVUK.loadAnalytics.domains[5]).toEqual(expected)
+        // the new domain should be appended to the end of the array
+        expect(window.GOVUK.vars.domains).toEqual(expected)
 
         window.GOVUK.loadAnalytics.loadGa4('not-a-real-domain')
         expect(window.GOVUK.analyticsGa4.vars.id).toEqual('GTM-001')

--- a/yarn.lock
+++ b/yarn.lock
@@ -1343,6 +1343,11 @@ govuk-frontend@^4.8.0:
   resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.8.0.tgz#df4e56c762e93aae74fed214bb6be08e13783772"
   integrity sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw==
 
+govuk-single-consent@^3.0.9:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/govuk-single-consent/-/govuk-single-consent-3.0.9.tgz#e197bba4011c11c613807fd3635a8e0a007d914b"
+  integrity sha512-QtWIck/1gnR6eY6J3jw6+LwLsQN6U5upjRH/xyHjy5elrZZ7LDCVmMju4yzDDHMgOTn+TwRBRS/0V3Lqn3c2ew==
+
 graceful-fs@^4.1.15, graceful-fs@^4.1.2:
   version "4.2.6"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"


### PR DESCRIPTION
## What / why
Adds code for the [single consent cookie API](https://github.com/alphagov/consent-api) to allow cookie preferences to be shared across GOV.UK.

Supersedes https://github.com/alphagov/govuk_publishing_components/pull/3829

### How this works
The single consent API should take control of the setting of cookies relating to cookie consent. Fortunately it sets exactly the same cookies as we do now:

- `cookies_preferences_set` indicating that a user preference has been made
- `cookies_policy` showing the preferences chosen (set by default to no consent)

### Testing scenarios
There are two main things to test - when the consent API is enabled, and when it is not. When it is not enabled (by default) everything should work as normal. This means:

- a users first visit should set the `cookies_policy` to reject all but essential cookies, and no other cookies
- when they choose a preference (accept/reject/custom), this should be reflected in the `cookies_policy` cookie, and the `cookies_preferences_set` cookie should also be set
- the page at `/help/cookies` should reflect the contents of the `cookies_policy` cookie, and allow it to be changed

When the consent API is enabled, the behaviour should be similar but the consent API code should set these cookies, not our code. Additionally:

- no cookies are set until the user makes a choice
- when the user chooses a cookie preference (accept/reject/custom), the consent API code makes an XMLHttpRequest to the consent API
- if this is successful, it sets a `gov_singleconsent_uid` cookie, containing the users randomly generated anonymous ID
- if this fails (e.g. timeout), this cookie is not set and the consent preferences are all set to `reject`
- on any following pages, the consent API code will not attempt to reconnect to the API, and leave user consent as rejected




### Testing locally

Check out this branch and run `yarn install` to get the single consent API code.

To make testing easier and keep the gem compatible with applications that do not need the single consent API, it is disabled by default. It is enabled by setting `window.GOVUK.useSingleConsentApi = true`. For the purposes of testing this can be set in your local `static`.

You'll need to run `frontend` (it renders the cookies page) running locally through docker with a local `static`, both pointed at this branch of the components gem. You'll need to modify `config/initializers/content_security_policy.rb` in `frontend` so that the CSP allows JS to make requests to the consent API. The staging URL has changed during development, is currently `https://gds-single-consent-staging.app/`.

```
GovukContentSecurityPolicy.configure do |policy|
  policy.connect_src(*policy.connect_src, "<staging url>")
end
```

You can test the scenario of arriving at GOV.UK having set cookie preferences on another site by either:

- using a URL of the form: `https://www.gov.uk?gov_singleconsent_uid=<id>`. You can get the value for `id` by from the `gov_singleconsent_uid` cookie (after it has been successfully set)
- accept cookies and let the consent api set the `gov_singleconsent_uid` cookie, then delete all other cookies (this wouldn't happen in real life, but it's an easy way of simulating the consent api already being initialised)

To test link decoration going from GOV.UK to a participating site you can use the consent API staging site https://gds-single-consent-staging.app/ (this is why the staging URL is both the API interface and an actual website). Do the following:

- modify a page in `frontend` to have a link to the staging site
- in the components gem code, open `node_modules/govuk-single-consent/dist/singleconsent.iife.js` and modify the `function (origins)` code around line 357 to include the following line before setting `addUIDtoCrossOriginLinks`:

```
origins.push('https://gds-single-consent-staging.app') // or whatever the staging URL is
```

- click on the link
- the link should be automatically decorated with a URL parameter, will immediately disappear when the page has loaded, so you can check it's worked by comparing the cookie settings on the staging site with what you set on your local site. You can also scroll to the bottom of the staging site and click on the `Cookies` link to change your preferences, then go back to your local site to confirm that changing preferences works both ways.


### Cumulative Layout Shift impact

Broadly - no impact. I suspect this is mostly due to recent changes to hide the banner by default and when JS is disabled.

All tests run locally to account for differences in local and production, however testable scores on production are the same. Testing carried out locally on frontend, homepage.

**Desktop**

Without consent api | With consent api
-- | --
accept all cookies - **0** | accept all cookies - **0**
reject all cookies - **0** | reject all cookies - **0**
no cookie preference made - **0.31** | no cookie preference made - **0.31**
(not available) | with only a valid govuk_consent_id cookie (to force the consent api call) - **0**

**Mobile**

Without consent api | With consent api
-- | --
accept all cookies - **0.003** | accept all cookies - **0.003**
reject all cookies - **0.003** | reject all cookies - **0.003**
no cookie preference made - **0.486** | no cookie preference made - **0.486**
(not available) | with only a valid govuk_consent_id cookie (to force the consent api call) - **0.003**




## Visual Changes
None.

Trello card: https://trello.com/c/dmlTAzKB/140-implement-single-consent-api