### PR TITLE
Update border colours on email/print buttons for greater contrast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Move the skip link after the cookie banner ([PR #3863](https://github.com/alphagov/govuk_publishing_components/pull/3863))
+* Update border colours on email/print buttons for greater contrast ([PR #3855](https://github.com/alphagov/govuk_publishing_components/pull/3855))
 
 ## 37.3.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_print-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_print-link.scss
@@ -34,7 +34,7 @@ $gem-c-print-link-background-height: 18px;
 }
 
 .gem-c-print-link__link {
-  box-shadow: inset 0 0 0 1px $govuk-border-colour;
+  box-shadow: inset 0 0 0 1px govuk-colour("dark-grey");
 
   &:focus {
     border: 0;
@@ -43,7 +43,7 @@ $gem-c-print-link-background-height: 18px;
 }
 
 .gem-c-print-link__button {
-  border: 1px solid $govuk-border-colour;
+  border: 1px solid govuk-colour("dark-grey");
   color: $govuk-link-colour;
   cursor: pointer;
   margin: govuk-spacing(0);

--- a/app/assets/stylesheets/govuk_publishing_components/components/_single-page-notification-button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_single-page-notification-button.scss
@@ -3,7 +3,7 @@
 .gem-c-single-page-notification-button__submit {
   padding: govuk-spacing(2);
   margin: govuk-spacing(0);
-  border: 1px solid $govuk-border-colour;
+  border: 1px solid govuk-colour("dark-grey");
   color: $govuk-link-colour;
   cursor: pointer;
   background: none;


### PR DESCRIPTION
## What
These changes update the colour of the border on the "Print link" and "Single page notification button" components. 
<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
The borders on these components have been reported in DAC's audit to be too faint: #b1b4b6 against white is only a contrast of 2.1:1. Although this will not affect functionality of the button, it means that lots of people won’t see the border.

See Trello card [103 | Some button's borders are too faint](https://trello.com/c/awwxbZSm/103-some-buttons-borders-are-too-faint)

## Visual Changes
||Print link|Single page notification button|
|-|-|-|
|**Before**|![Screenshot 2024-02-06 at 10 09 14](https://github.com/alphagov/govuk_publishing_components/assets/6080548/9e13255b-f6af-4de8-a3de-a1bd1be08e23)|![Screenshot 2024-02-06 at 10 07 33](https://github.com/alphagov/govuk_publishing_components/assets/6080548/1dba70c7-9140-4009-8180-7e9add6a2bd1)|
|**After**|![Screenshot 2024-02-06 at 10 08 59](https://github.com/alphagov/govuk_publishing_components/assets/6080548/99f82c11-2b15-49d4-b785-3a0402a8aef2)|![Screenshot 2024-02-06 at 10 07 54](https://github.com/alphagov/govuk_publishing_components/assets/6080548/f021a679-e63e-4787-ab1c-81d8c1337d5c)|

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->
