### PR TITLE
Version 37.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 37.3.0
 
 * Allow other applications to use GA4 code ([PR #3851](https://github.com/alphagov/govuk_publishing_components/pull/3851))
 * Update cookie event listeners ([PR #3849](https://github.com/alphagov/govuk_publishing_components/pull/3849))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (37.2.4)
+    govuk_publishing_components (37.3.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "37.2.4".freeze
+  VERSION = "37.3.0".freeze
 end


### PR DESCRIPTION
## 37.3.0

* Allow other applications to use GA4 code ([PR #3851](https://github.com/alphagov/govuk_publishing_components/pull/3851))
* Update cookie event listeners ([PR #3849](https://github.com/alphagov/govuk_publishing_components/pull/3849))
* Remove DI cookie consent code ([PR #3846](https://github.com/alphagov/govuk_publishing_components/pull/3846))
* Add tracking to back link ([PR #3840](https://github.com/alphagov/govuk_publishing_components/pull/3840))
* Allow attachment to pass tracking to details ([PR #3820](https://github.com/alphagov/govuk_publishing_components/pull/3820))
* Allow GA4 link tracker to track to multiple child classes ([PR #3835](https://github.com/alphagov/govuk_publishing_components/pull/3835))
* Add GA4 link tracking to govspeak callout links ([PR #3843](https://github.com/alphagov/govuk_publishing_components/pull/3843))
* Allow inputs to be exempt from GA4 form tracker [REDACT] code ([PR #3848](https://github.com/alphagov/govuk_publishing_components/pull/3848))
* Hide our cookie banner when JS is disabled ([PR #3830](https://github.com/alphagov/govuk_publishing_components/pull/3830))