### PR TITLE
Move the skip link after the cookie banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Move the skip link after the cookie banner ([PR #3863](https://github.com/alphagov/govuk_publishing_components/pull/3863))
+
 ## 37.3.0
 
 * Allow other applications to use GA4 code ([PR #3851](https://github.com/alphagov/govuk_publishing_components/pull/3851))

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -99,12 +99,10 @@
     <%= javascript_tag nonce: true do -%>
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     <% end -%>
+    <%= render "govuk_publishing_components/components/cookie_banner", layout_helper.cookie_banner_data %>
     <%= render "govuk_publishing_components/components/skip_link", {
       href: "#content"
     } %>
-
-    <%= render "govuk_publishing_components/components/cookie_banner", layout_helper.cookie_banner_data %>
-
     <% unless omit_header %>
       <% if show_explore_header %>
         <% if homepage %>

--- a/spec/components/layout_for_public_spec.rb
+++ b/spec/components/layout_for_public_spec.rb
@@ -295,4 +295,10 @@ describe "Layout for public", type: :view do
       expect(meta.first["content"]).to match(%r{^https?://})
     end
   end
+
+  it "has the skip link immediately after the cookie banner" do
+    render_component({})
+
+    assert_select ".gem-c-cookie-banner + .gem-c-skip-link"
+  end
 end


### PR DESCRIPTION
## What

Move the skip link after the cookie banner.

**Review URL**: https://components-gem-pr-3863.herokuapp.com/component-guide/layout_for_public/full_width/preview

https://trello.com/c/AGHUDMGb/76-skip-link-unexpectedly-before-cookie-banner

## Why

https://github.com/alphagov/govuk_publishing_components/issues/3860

## Visual Changes

### Before

![components publishing service gov uk_component-guide_layout_for_public_full_width_preview(Surface Pro 7) (1)](https://github.com/alphagov/govuk_publishing_components/assets/87758239/c99403e6-1358-4e74-b171-c43fa4a60f78)

### After

![0 0 0 0_3212_component-guide_layout_for_public_default_preview(Surface Pro 7) (1)](https://github.com/alphagov/govuk_publishing_components/assets/87758239/30802d50-2d2e-4785-8f33-e7efdc1a2391)