### PR TITLE
Add Breadcrumb Handling for Mainstream Browse Pages with no Parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   of the commit log.
 
 ## Unreleased
-
+* Ensure whitehall content tagged to mainstream browse and the topic taxonomy has a topic taxonomy breadcrumb ([PR #3871](https://github.com/alphagov/govuk_publishing_components/pull/3871))
 * Add GA4 tracking to the document list component ([PR #3874](https://github.com/alphagov/govuk_publishing_components/pull/3874))
 * Remove GA4 'action' from navigation content history events ([PR #3877](https://github.com/alphagov/govuk_publishing_components/pull/3877))
 

--- a/lib/govuk_publishing_components/presenters/breadcrumb_selector.rb
+++ b/lib/govuk_publishing_components/presenters/breadcrumb_selector.rb
@@ -45,7 +45,7 @@ module GovukPublishingComponents
             step_by_step: false,
             breadcrumbs: navigation.taxon_breadcrumbs,
           }
-        elsif navigation.content_tagged_to_mainstream_browse_pages?
+        elsif navigation.content_parent_is_mainstream_browse?
           {
             step_by_step: false,
             breadcrumbs: navigation.breadcrumbs,

--- a/lib/govuk_publishing_components/presenters/contextual_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/contextual_navigation.rb
@@ -68,6 +68,10 @@ module GovukPublishingComponents
         content_item.dig("links", "mainstream_browse_pages").present?
       end
 
+      def content_parent_is_mainstream_browse?
+        content_item.dig("links", "parent").present? && content_item.dig("links", "parent", 0, "document_type") == "mainstream_browse_page"
+      end
+
       def content_has_curated_related_items?
         content_item.dig("links", "ordered_related_items").present? && content_item.dig("links", "parent").present?
       end

--- a/spec/components/contextual_breadcrumbs_spec.rb
+++ b/spec/components/contextual_breadcrumbs_spec.rb
@@ -60,7 +60,7 @@ describe "ContextualBreadcrumbs", type: :view do
     assert_select "a", text: "Learn to drive a car: step by step"
   end
 
-  it "renders parent-based breadcrumbs if the content_item is tagged to mainstream browse" do
+  it "renders parent-based breadcrumbs if the content_item is tagged to mainstream browse and there is a parent" do
     render_component(content_item: example_document_for("place", "find-regional-passport-office"))
     assert_no_selector(".gem-c-step-nav-header")
     assert_select "a", text: "Home"
@@ -83,12 +83,10 @@ describe "ContextualBreadcrumbs", type: :view do
     assert_select "a", text: "Licences and licence applications"
   end
 
-  it "renders taxon breadcrumbs if there are some and no mainstream or curated_content" do
-    content_item = example_document_for("guide", "guide")
-    content_item = remove_mainstream_browse(content_item)
-    content_item = remove_curated_related_item(content_item)
+  it "renders taxon breadcrumbs if the content_item is tagged to mainstream browse but there is no mainstream browse parent" do
+    content_item = example_document_for("guide", "guide-with-no-parent")
     content_item = set_live_taxons(content_item)
-    content_item = remove_topics(content_item)
+    remove_topics(content_item)
     render_component(content_item:)
     assert_no_selector(".gem-c-step-nav-header")
     assert_select "a", text: "Home"


### PR DESCRIPTION
## What
This logic rewrite ensures that:

- In cases where specialist (Whitehall) content is tagged to a Mainstream Browse Page **and** its tagged parent is also a MSB, the breadcrumbs are set by ancestry (which was the original behaviour, minus the parent check).
- In cases where specialist (Whitehall) content is tagged to a MSB but there is no parent (or the parent is not an MSB), the breadcrumbs are set from the taxonomy.

## Why
When guidance pages were linked to mainstream browse pages after their related specialist topic was archived, the pages had no parent tag. They were tagged to taxonomy, but this was not reflected in the breadcrumb, only showing "Home."

https://trello.com/c/ls1MlMKC/2369-breadcrumb-disappears-when-whitehall-content-is-tagged-to-msb-m

## Visual Changes
### Before
Here is an example [MSB tagged guidance page without a parent](https://www.gov.uk/guidance/agricultural-relief-on-inheritance-tax), as it exists on Production right now:
![image](https://github.com/alphagov/govuk_publishing_components/assets/6087231/6ef22cc9-d3a1-4009-90b8-9e8c94024e7b)

### After
And here is it with this change:
![image](https://github.com/alphagov/govuk_publishing_components/assets/6087231/2e3567ee-bb8b-4d87-acc3-41f10cc499bf)






