### PR TITLE
Remove GA4 'action' from navigation content history events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add GA4 tracking to the document list component ([PR #3874](https://github.com/alphagov/govuk_publishing_components/pull/3874))
+* Remove GA4 'action' from navigation content history events ([PR #3877](https://github.com/alphagov/govuk_publishing_components/pull/3877))
 
 ## 37.4.0
 

--- a/app/views/govuk_publishing_components/components/_metadata.html.erb
+++ b/app/views/govuk_publishing_components/components/_metadata.html.erb
@@ -31,7 +31,6 @@
     event_name: "navigation",
     type: "content history",
     section: "Top",
-    action: "opened"
   }.to_json unless disable_ga4
 %>
 <%= content_tag :div, class: classes, data: { module: "gem-toggle metadata" } do %>

--- a/spec/components/metadata_spec.rb
+++ b/spec/components/metadata_spec.rb
@@ -220,7 +220,6 @@ describe "Metadata", type: :view do
       "event_name": "navigation",
       "type": "content history",
       "section": "Top",
-      "action": "opened",
     }.to_json
 
     assert_select ".gem-c-metadata__definition:nth-of-type(2)" do |alternate_see_all_updates_container|


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Removes the `action` value from `navigation` versions of the `content history` event

## Why
<!-- What are the reasons behind this change being made? -->
- We have a `select_content` version of this event which needs the `action`, but we forgot to remove it from the `navigation` version of the event
- https://trello.com/c/3WrRBUCk/787-remove-action-parameter-on-content-history-navigation-events

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None