### PR TITLE
Add GA4 tracking to the notice link component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Ensure whitehall content tagged to mainstream browse and the topic taxonomy has a topic taxonomy breadcrumb ([PR #3871](https://github.com/alphagov/govuk_publishing_components/pull/3871))
 * Add GA4 tracking to the document list component ([PR #3874](https://github.com/alphagov/govuk_publishing_components/pull/3874))
 * Remove GA4 'action' from navigation content history events ([PR #3877](https://github.com/alphagov/govuk_publishing_components/pull/3877))
+* Add GA4 tracking to the notice link component ([PR #3885](https://github.com/alphagov/govuk_publishing_components/pull/3885))
 
 ## 37.4.0
 

--- a/app/views/govuk_publishing_components/components/_notice.html.erb
+++ b/app/views/govuk_publishing_components/components/_notice.html.erb
@@ -25,9 +25,28 @@
   aria_attributes[:labelledby] = banner_title_id if show_banner_title
 
   description_present = description.present? || description_text.present? || description_govspeak.present?
+  disable_ga4 ||= false
+
+  if description_govspeak
+    govspeak_data_attributes = {
+      content: description_govspeak,
+      disable_ga4: true # Keep the govspeak component GA4 tracking disabled, otherwise tracking will be duplicated when tracking is enabled on this component.
+    }
+  end
+
+  unless disable_ga4
+    section_data_attributes = {
+      module: "ga4-link-tracker",
+      ga4_track_links_only: "",
+      ga4_link: {
+        event_name: "navigation",
+        type: "callout"
+      }.to_json
+    }
+  end
 %>
 <% if title || description_present %>
-  <%= tag.section class: css_classes, aria: aria_attributes, lang: lang, role: "region" do %>
+  <%= tag.section class: css_classes, aria: aria_attributes, lang: lang, role: "region", data: section_data_attributes do %>
     <%= tag.div class: "govuk-notification-banner__header" do %>
       <%= tag.h2 banner_title, class: "govuk-notification-banner__title", id: banner_title_id %>
     <% end if show_banner_title %>
@@ -37,8 +56,9 @@
       <%= tag.p description_text, class: "gem-c-notice__description" if description_text %>
 
       <%= description if description %>
-
-      <%= render 'govuk_publishing_components/components/govspeak', content: description_govspeak if description_govspeak %>
+      <% if govspeak_data_attributes %>
+        <%= render 'govuk_publishing_components/components/govspeak', govspeak_data_attributes %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/notice.yml
+++ b/app/views/govuk_publishing_components/components/docs/notice.yml
@@ -65,3 +65,13 @@ examples:
       description_govspeak: <p>This document is no longer current. We published a new version on 30 September 2015.</p>
       show_banner_title: true
       banner_title: "Information"
+  with_ga4_tracking_disabled:
+    description: |
+      Disables GA4 tracking on the component. Tracking on the component is enabled by default. Tracking on the nested govspeak component is always disabled to prevent duplication. When tracking is enabled on this component, a data module and data attributes are added to the parent element. See the [ga4-link-tracker documentation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-link-tracker.md) for more information.
+    data:
+      disable_ga4: true
+      title: 'This publication was withdrawn on 30 September 2015'
+      description_govspeak: <p>This document is no longer current. We published a new version on 30 September 2015.</p>
+      show_banner_title: true
+      banner_title: "Information"
+

--- a/spec/components/notice_spec.rb
+++ b/spec/components/notice_spec.rb
@@ -103,4 +103,30 @@ describe "Notice", type: :view do
     assert_select ".gem-c-notice h2.govuk-notification-banner__title", text: "Notice"
     assert_select "h3.gem-c-notice__title", text: "Your settings have been saved"
   end
+
+  it "has GA4 tracking enabled on the component, and disabled on the nested govspeak render" do
+    render_component(title: "Title", description_govspeak: "<marquee>It's 1998</marquee>".html_safe)
+
+    assert_select ".gem-c-notice[data-module='ga4-link-tracker']"
+    assert_select ".gem-c-notice[data-ga4-track-links-only]"
+    assert_select '.gem-c-notice[data-ga4-link="{\"event_name\":\"navigation\",\"type\":\"callout\"}"]'
+
+    assert_no_selector ".gem-c-govspeak[data-module='govspeak ga4-link-tracker']"
+    assert_no_selector ".gem-c-govspeak[data-ga4-track-links-only]"
+    assert_no_selector ".gem-c-govspeak[data-ga4-limit-to-element-class='call-to-action, info-notice, help-notice, advisory']"
+    assert_no_selector '.gem-c-govspeak[data-ga4-link="{\"event_name\":\"navigation\",\"type\":\"callout\"}"]'
+  end
+
+  it "can have GA4 tracking disabled" do
+    render_component(title: "Title", description_govspeak: "<marquee>It's 1998</marquee>".html_safe)
+
+    assert_no_selector ".gem-c-notice[data-module='ga4-link-tracker']"
+    assert_no_selector ".gem-c-notice[data-ga4-track-links-only]"
+    assert_no_selector '.gem-c-notice[data-ga4-link="{\"event_name\":\"navigation\",\"type\":\"callout\"}"]'
+
+    assert_no_selector ".gem-c-govspeak[data-module='govspeak ga4-link-tracker']"
+    assert_no_selector ".gem-c-govspeak[data-ga4-track-links-only]"
+    assert_no_selector ".gem-c-govspeak[data-ga4-limit-to-element-class='call-to-action, info-notice, help-notice, advisory']"
+    assert_no_selector '.gem-c-govspeak[data-ga4-link="{\"event_name\":\"navigation\",\"type\":\"callout\"}"]'
+  end
 end


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Add GA4 tracking to the notice link component
- This component contains a nested `govspeak` component, so we disable tracking on this component so that our tracking is not duplicated by possibly having two link trackers running.

## Why
<!-- What are the reasons behind this change being made? -->
https://trello.com/c/f4i7CKvO/791-add-tracking-notice-links

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

Component example updated with a `With ga4 tracking disabled` example