### PR TITLE
Version 37.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 37.5.0
 
 * Update LUX to 313 ([PR #3884](https://github.com/alphagov/govuk_publishing_components/pull/3884))
 * Ensure whitehall content tagged to mainstream browse and the topic taxonomy has a topic taxonomy breadcrumb ([PR #3871](https://github.com/alphagov/govuk_publishing_components/pull/3871))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (37.4.0)
+    govuk_publishing_components (37.5.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "37.4.0".freeze
+  VERSION = "37.5.0".freeze
 end


### PR DESCRIPTION
## 37.5.0

* Update LUX to 313 ([PR #3884](https://github.com/alphagov/govuk_publishing_components/pull/3884))
* Ensure whitehall content tagged to mainstream browse and the topic taxonomy has a topic taxonomy breadcrumb ([PR #3871](https://github.com/alphagov/govuk_publishing_components/pull/3871))
* Add GA4 tracking to the document list component ([PR #3874](https://github.com/alphagov/govuk_publishing_components/pull/3874))
* Remove GA4 'action' from navigation content history events ([PR #3877](https://github.com/alphagov/govuk_publishing_components/pull/3877))
* Add GA4 tracking to the notice link component ([PR #3885](https://github.com/alphagov/govuk_publishing_components/pull/3885))