### PR TITLE
Adjust keyboard functionality of dropdown menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Reintroduce GA4 callout tracking and fix link tracker compatibility ([PR #3905](https://github.com/alphagov/govuk_publishing_components/pull/3905))
+* Adjust keyboard functionality of dropdown menu ([PR #3888](https://github.com/alphagov/govuk_publishing_components/pull/3888))
 
 ## 37.6.1
 

--- a/app/assets/javascripts/govuk_publishing_components/components/layout-super-navigation-header.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/layout-super-navigation-header.js
@@ -93,6 +93,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.$module = $module
     this.$searchToggle = this.$module.querySelector('#super-search-menu-toggle')
     this.$searchMenu = this.$module.querySelector('#super-search-menu')
+    this.$navToggle = this.$module.querySelector('#super-navigation-menu-toggle')
+    this.$navMenu = this.$module.querySelector('#super-navigation-menu')
 
     // The menu toggler buttons need three attributes for this to work:
     //  - `aria-controls` contains the id of the menu to be toggled
@@ -126,7 +128,68 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     toggle($target, $targetMenu)
   }
 
+  SuperNavigationMegaMenu.prototype.handleKeyDown = function (event) {
+    var KEY_TAB = 9
+    var KEY_ESC = 27
+    var $navMenuLinks = this.$navMenu.querySelectorAll('li a')
+    var $firstNavLink = $navMenuLinks[0]
+    var $lastNavLink = $navMenuLinks[$navMenuLinks.length - 1]
+    var $searchMenuLinks = this.$searchMenu.querySelectorAll('li a')
+    var $lastSearchLink = $searchMenuLinks[$searchMenuLinks.length - 1]
+
+    if (event.keyCode === KEY_TAB) {
+      if (!this.$navMenu.hasAttribute('hidden')) {
+        switch (document.activeElement) {
+          case this.$navToggle:
+            if (!event.shiftKey) {
+              event.preventDefault()
+              $firstNavLink.focus()
+            }
+            break
+          case $lastNavLink:
+            if (!event.shiftKey) {
+              event.preventDefault()
+              this.$searchToggle.focus()
+              hide(this.$navToggle, this.$navMenu)
+            }
+            break
+          case $firstNavLink:
+            if (event.shiftKey) {
+              event.preventDefault()
+              this.$navToggle.focus()
+            }
+            break
+          case this.$searchToggle:
+            if (event.shiftKey) {
+              event.preventDefault()
+              $lastNavLink.focus()
+            }
+            break
+          default:
+            break
+        }
+      } else if (!this.$searchMenu.hasAttribute('hidden')) {
+        if (document.activeElement === $lastSearchLink) {
+          if (!event.shiftKey) {
+            hide(this.$searchToggle, this.$searchMenu)
+          }
+        }
+      }
+    } else if (event.keyCode === KEY_ESC) {
+      if (!this.$navMenu.hasAttribute('hidden')) {
+        hide(this.$navToggle, this.$navMenu)
+        this.$navToggle.focus()
+      } else if (!this.$searchMenu.hasAttribute('hidden')) {
+        hide(this.$searchToggle, this.$searchMenu)
+        this.$searchToggle.focus()
+      }
+    }
+  }
+
   SuperNavigationMegaMenu.prototype.init = function () {
+    // Handle key events for tab and escape keys
+    this.$module.addEventListener('keydown', this.handleKeyDown.bind(this))
+
     for (var j = 0; j < this.$buttons.length; j++) {
       var $button = this.$buttons[j]
       $button.addEventListener('click', this.buttonHandler.bind(this), true)

--- a/app/assets/javascripts/govuk_publishing_components/lib/trigger-event.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/trigger-event.js
@@ -27,6 +27,10 @@
       event.keyCode = keyCode
     }
 
+    if (params.shiftKey) {
+      event.shiftKey = true
+    }
+
     element.dispatchEvent(event)
   }
 }(window))

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -162,7 +162,6 @@
 
       <%
         link = t("components.layout_super_navigation_header.navigation_link")
-        unique_id = SecureRandom.hex(4)
         show_menu_text = show_navigation_menu_text
         hide_menu_text = hide_navigation_menu_text
         tracking_label = link[:label].downcase.gsub(/\s+/, "")
@@ -192,7 +191,7 @@
 
             <%= content_tag(:button, {
               aria: {
-                controls: "super-navigation-menu-#{unique_id}",
+                controls: "super-navigation-menu",
                 expanded: false,
                 label: show_menu_text,
               },
@@ -213,7 +212,7 @@
                 }
               },
               hidden: true,
-              id: "super-navigation-menu-#{unique_id}-toggle",
+              id: "super-navigation-menu-toggle",
               type: "button",
             }) do %>
               <%= tag.span link[:label], class: top_toggle_button_inner_classes %>
@@ -282,7 +281,7 @@
       </div>
 
       <%= content_tag(:div, {
-        id: "super-navigation-menu-#{unique_id}",
+        id: "super-navigation-menu",
         hidden: "",
         class: dropdown_menu_classes,
       }) do %>

--- a/app/views/govuk_publishing_components/components/docs/layout_super_navigation_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_super_navigation_header.yml
@@ -7,6 +7,8 @@ accessibility_criteria: |
   The component must:
 
   * have a text contrast ratio higher than 4.5:1 against the background colour to meet WCAG AA
+  * follow the expected tabbing border
+  * allow menus to be closed when the escape key is pressed
 
   Images in the super navigation header must:
 

--- a/spec/javascripts/components/layout-super-navigation-header-spec.js
+++ b/spec/javascripts/components/layout-super-navigation-header-spec.js
@@ -343,6 +343,118 @@ describe('The super header navigation', function () {
     })
   })
 
+  describe('tab key', function () {
+    var $navMenuButton
+    var $searchMenuButton
+    var $navMenu
+    var $navLinks
+    var $firstNavLink
+    var $lastNavLink
+    var $searchMenu
+    var $searchLinks
+    var $lastSearchLink
+
+    beforeEach(function () {
+      thisModule.init()
+      $navMenuButton = document.querySelector('#super-navigation-menu-toggle')
+      $searchMenuButton = document.querySelector('#super-search-menu-toggle')
+      $navMenu = document.querySelector('#super-navigation-menu')
+      $navLinks = $navMenu.querySelectorAll('li')
+      $firstNavLink = $navLinks[0].querySelector('a')
+      $lastNavLink = $navLinks[$navLinks.length - 1].querySelector('a')
+      $searchMenu = document.querySelector('#super-search-menu')
+      $searchLinks = $searchMenu.querySelectorAll('li a')
+      $lastSearchLink = $searchLinks[$searchLinks.length - 1]
+    })
+
+    it('when the Menu button is focussed, the nav menu is open and the tab key is pressed focus moves to the first nav menu link', function () {
+      $navMenu.removeAttribute('hidden')
+      $navMenuButton.focus()
+      window.GOVUK.triggerEvent($navMenuButton, 'keydown', { keyCode: 9, cancelable: true })
+
+      expect(document.activeElement).toEqual($navLinks[0].querySelector('a'))
+    })
+
+    it('when the last nav menu link is focussed and the tab key is pressed focus moves to the search button and the nav menu is closed', function () {
+      $navMenu.removeAttribute('hidden')
+      $lastNavLink.focus()
+      window.GOVUK.triggerEvent($lastNavLink, 'keydown', { keyCode: 9, cancelable: true })
+
+      expect(document.activeElement).toEqual($searchMenuButton)
+      expect($navMenu.hasAttribute('hidden')).toEqual(true)
+      expect($navMenuButton.getAttribute('aria-expanded')).toEqual('false')
+      expect($navMenuButton.getAttribute('aria-label')).toEqual('Show navigation menu')
+      expect($navMenuButton.classList).not.toContain('gem-c-layout-super-navigation-header__open-button')
+    })
+
+    it('when the first nav menu link is focussed, the nav menu is open and the shift and tab keys are pressed focus moves to the Menu button', function () {
+      $navMenu.removeAttribute('hidden')
+      $firstNavLink.focus()
+      window.GOVUK.triggerEvent($firstNavLink, 'keydown', { keyCode: 9, cancelable: true, shiftKey: true })
+
+      expect(document.activeElement).toEqual($navMenuButton)
+    })
+
+    it('when the search button is focussed, the nav menu is open and the shift and tab keys are pressed focus moves to the last nav menu link', function () {
+      $navMenu.removeAttribute('hidden')
+      $searchMenuButton.focus()
+      window.GOVUK.triggerEvent($searchMenuButton, 'keydown', { keyCode: 9, cancelable: true, shiftKey: true })
+
+      expect(document.activeElement).toEqual($lastNavLink)
+    })
+
+    it('when the last search menu link is focussed and the tab key is pressed the search menu is closed', function () {
+      $searchMenu.removeAttribute('hidden')
+      $lastSearchLink.focus()
+      window.GOVUK.triggerEvent($lastSearchLink, 'keydown', { keyCode: 9, cancelable: true })
+
+      expect($searchMenu.hasAttribute('hidden')).toEqual(true)
+      expect($searchMenuButton.getAttribute('aria-expanded')).toEqual('false')
+      expect($searchMenuButton.getAttribute('aria-label')).toEqual('Show search menu')
+      expect($searchMenuButton.classList).not.toContain('gem-c-layout-super-navigation-header__open-button')
+    })
+  })
+
+  describe('escape key', function () {
+    var $navMenu
+    var $navMenuButton
+    var $searchMenu
+    var $searchMenuButton
+
+    beforeEach(function () {
+      thisModule.init()
+      $navMenu = document.querySelector('#super-navigation-menu')
+      $navMenuButton = document.querySelector('#super-navigation-menu-toggle')
+      $searchMenu = document.querySelector('#super-search-menu')
+      $searchMenuButton = document.querySelector('#super-search-menu-toggle')
+    })
+
+    it('when the user presses the escape key and the nav menu is open the menu is closed and focus moves back to the Menu button', function () {
+      $navMenu.removeAttribute('hidden')
+      $navMenuButton.setAttribute('aria-expanded', 'true')
+      window.GOVUK.triggerEvent($navMenu, 'keydown', { keyCode: 27, cancelable: true })
+
+      expect($navMenu.hasAttribute('hidden')).toEqual(true)
+      expect(document.activeElement).toEqual($navMenuButton)
+      expect($navMenuButton.getAttribute('aria-expanded')).toEqual('false')
+      expect($navMenuButton.getAttribute('aria-label')).toEqual('Show navigation menu')
+      expect($navMenuButton.classList).not.toContain('gem-c-layout-super-navigation-header__open-button')
+    })
+
+    it('when the user presses the escape key and the search menu is open the menu is closed and focus moves back to the Search button', function () {
+      $searchMenu.removeAttribute('hidden')
+      $searchMenuButton.setAttribute('aria-expanded', 'true')
+      $searchMenuButton.classList.add('gem-c-layout-super-navigation-header__open-button')
+      window.GOVUK.triggerEvent($searchMenu, 'keydown', { keyCode: 27, cancelable: true })
+
+      expect($searchMenu.hasAttribute('hidden')).toEqual(true)
+      expect(document.activeElement).toEqual($searchMenuButton)
+      expect($searchMenuButton.getAttribute('aria-expanded')).toEqual('false')
+      expect($searchMenuButton.getAttribute('aria-label')).toEqual('Show search menu')
+      expect($searchMenuButton.classList).not.toContain('gem-c-layout-super-navigation-header__open-button')
+    })
+  })
+
   describe('search toggle button', function () {
     var $button
 


### PR DESCRIPTION
Trello cards: 
- [Adjust keyboard functionality of dropdown menu [L]](https://trello.com/c/ke3jvHve/2400-adjust-keyboard-functionality-of-dropdown-menu-l)
- [Unexpected focus order when activating menu button in header](https://trello.com/c/v6hdKvtj/11-unexpected-focus-order-when-activating-menu-button-in-header)

## What
These changes update the behaviour of some keyboard functionality on the header component: 
- Adds a `handleKeyDown` method to the `layout-super-navigation-header` component to handle 'tab' and 'escape' key events
- Adds tests for the new functionality
- Updates the trigger-event lib component to accept values for the shift key

## Why
<!-- What are the reasons behind this change being made? -->
There are a some accessibility failures on the header whereby
- a user navigating with the tab key traverses the elements in an unpredictable and confusing order, specifically
  - If the "Menu" button is focussed and the menu is open pressing the tab key moves focus to the "Search" button where expected behaviour is to move to the first link in the menu
  - If the last link of the menu is focused, pressing the tab key moves focus away from the header completely where expected behaviour is to move focus to the "Search" button
  - If the menu is closed, focus remains where it is where expected behaviour is that it should move to the "Search" button
- the escape key does not follow the expected behaviour of closing the navigation

## Visual Changes
|Action|Before|After|
|-|-|-|
|Nav menu open<br/>"Menu"focussed<br/>tab key pressed|![Screenshot 2024-02-28 at 15 00 47](https://github.com/alphagov/govuk_publishing_components/assets/6080548/6104e1b3-06e9-4bb2-a9e0-898e3b770410)|![Screenshot 2024-02-28 at 15 01 06](https://github.com/alphagov/govuk_publishing_components/assets/6080548/9e6be96f-2090-460d-8031-db9718a4ff41)|
|Nav&nbsp;menu&nbsp;open<br/>last&nbsp;link&nbsp;focussed<br/>tab&nbsp;key&nbsp;pressed|![Screenshot 2024-02-28 at 15 08 17](https://github.com/alphagov/govuk_publishing_components/assets/6080548/1345f239-f026-4183-be35-d1df7e69112a)|![Screenshot 2024-03-04 at 11 57 15](https://github.com/alphagov/govuk_publishing_components/assets/6080548/e0b4f7c3-85a2-4b44-ab3c-26ef1a428efe)|
|Nav&nbsp;menu&nbsp;open<br/>link&nbsp;focussed<br/>escape&nbsp;key&nbsp;pressed|![Screenshot 2024-02-28 at 15 09 52](https://github.com/alphagov/govuk_publishing_components/assets/6080548/53633d30-f905-44ed-a182-7f435e3b5e78)|![Screenshot 2024-03-04 at 11 55 47](https://github.com/alphagov/govuk_publishing_components/assets/6080548/ad15350e-9d27-4b38-bf56-893c2f50075f)|
|Search&nbsp;menu&nbsp;open<br />Last&nbsp;link&nbsp;focussed<br />Tab&nbsp;key&nbsp;pressed|![Screenshot 2024-03-04 at 15 29 08](https://github.com/alphagov/govuk_publishing_components/assets/6080548/b0251ef0-3a82-4a46-a121-e9731517cc60)|![Screenshot 2024-03-04 at 15 29 17](https://github.com/alphagov/govuk_publishing_components/assets/6080548/bd3dee06-93f7-445b-a3e3-c106f92c05a3)|
|Search&nbsp;menu&nbsp;open<br />Link&nbsp;focussed<br />Escape&nbsp;key&nbsp;pressed|![Screenshot 2024-03-04 at 15 01 23](https://github.com/alphagov/govuk_publishing_components/assets/6080548/0ba2d759-36b4-4882-a8e6-a357b29b8133)|![Screenshot 2024-03-04 at 15 01 34](https://github.com/alphagov/govuk_publishing_components/assets/6080548/4b8a4bfa-f915-44c6-81fb-bc89c352c485)|

<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

