### PR TITLE
Ensure analytics stops firing if a user disables usage cookies on our cookie settings page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Ensure analytics stops firing if a user disables usage cookies on our cookie settings page ([PR #3893](https://github.com/alphagov/govuk_publishing_components/pull/3893))
+
 ## 37.5.1
 
 * Remove GA4 callout tracking from govspeak component ([PR #3889](https://github.com/alphagov/govuk_publishing_components/pull/3889))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -39,6 +39,11 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
     },
 
     sendData: function (data) {
+      // Allows us to stop sending tracking at the moment a user sets their usage cookies to "false" on the cookie settings page.
+      if (window.GOVUK.stopSendingAnalytics) {
+        return false
+      }
+
       data.govuk_gem_version = this.getGemVersion()
       data.timestamp = this.getTimestamp()
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics/analytics.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/analytics.js
@@ -21,6 +21,11 @@
   Analytics.PIISafe = PIISafe
 
   Analytics.prototype.sendToTrackers = function (method, args) {
+    // Allows us to stop sending tracking at the moment a user sets their usage cookies to "false" on the cookie settings page.
+    if (window.GOVUK.stopSendingAnalytics) {
+      return false
+    }
+
     for (var i = 0, l = this.trackers.length; i < l; i++) {
       var tracker = this.trackers[i]
       var fn = tracker[method]
@@ -49,7 +54,7 @@
   Analytics.prototype.trackPageview = function (path, title, options) {
     arguments[0] = arguments[0] || this.defaultPathForTrackPageview(window.location)
     if (arguments.length === 0) { arguments.length = 1 }
-    this.sendToTrackers('trackPageview', this.pii.stripPII(arguments))
+    return this.sendToTrackers('trackPageview', this.pii.stripPII(arguments))
   }
 
   /*
@@ -59,11 +64,11 @@
     options.nonInteraction – Prevent event from impacting bounce rate
   */
   Analytics.prototype.trackEvent = function (category, action, options) {
-    this.sendToTrackers('trackEvent', this.pii.stripPII(arguments))
+    return this.sendToTrackers('trackEvent', this.pii.stripPII(arguments))
   }
 
   Analytics.prototype.trackShare = function (network, options) {
-    this.sendToTrackers('trackSocial', this.pii.stripPII([network, 'share', global.location.pathname, options]))
+    return this.sendToTrackers('trackSocial', this.pii.stripPII([network, 'share', global.location.pathname, options]))
   }
 
   /*
@@ -71,14 +76,14 @@
     Universal Analytics profile
    */
   Analytics.prototype.setDimension = function (index, value) {
-    this.sendToTrackers('setDimension', this.pii.stripPII(arguments))
+    return this.sendToTrackers('setDimension', this.pii.stripPII(arguments))
   }
 
   /*
    Add a beacon to track a page in another GA account on another domain.
    */
   Analytics.prototype.addLinkedTrackerDomain = function (trackerId, name, domain) {
-    this.sendToTrackers('addLinkedTrackerDomain', arguments)
+    return this.sendToTrackers('addLinkedTrackerDomain', arguments)
   }
 
   GOVUK.Analytics = Analytics

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-settings.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-settings.js
@@ -54,6 +54,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         var value = input.value === 'on'
 
         options[name] = value
+
+        if (name === 'usage' && !value) {
+          window.GOVUK.stopSendingAnalytics = true
+          window.GOVUK.LUX = {}
+        }
       }
     }
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
@@ -70,6 +70,13 @@ describe('GA4 core', function () {
     })
   })
 
+  it('does not push data to the dataLayer if window.GOVUK.stopSendingAnalytics is true', function () {
+    window.GOVUK.stopSendingAnalytics = true
+    GOVUK.analyticsGa4.core.sendData({})
+    expect(window.dataLayer[0]).toEqual(undefined)
+    expect(GOVUK.analyticsGa4.core.sendData()).toEqual(false)
+  })
+
   describe('query strings allow pushing to a fake dataLayer', function () {
     var data
 

--- a/spec/javascripts/govuk_publishing_components/analytics/analytics.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/analytics.spec.js
@@ -322,4 +322,22 @@ describe('GOVUK.Analytics', function () {
       expect(allArgs).toContain(['test3.send', 'pageview'])
     })
   })
+
+  describe('when window.GOVUK.stopSendingAnalytics is true', function () {
+    beforeEach(function () {
+      window.GOVUK.stopSendingAnalytics = true
+    })
+
+    it('disables pageview tracking', function () {
+      expect(analytics.trackPageview()).toEqual(false)
+    })
+
+    it('disables share tracking', function () {
+      expect(analytics.trackShare()).toEqual(false)
+    })
+
+    it('disables event tracking', function () {
+      expect(analytics.trackShare()).toEqual(false)
+    })
+  })
 })

--- a/spec/javascripts/govuk_publishing_components/lib/cookie-settings-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/cookie-settings-spec.js
@@ -17,8 +17,8 @@ describe('cookieSettings', function () {
       '<form data-module="cookie-settings">' +
         '<input type="radio" id="settings-on" name="cookies-settings" value="on">' +
         '<input type="radio" id="settings-off" name="cookies-settings" value="off">' +
-        '<input type="radio" name="cookies-usage" value="on">' +
-        '<input type="radio" name="cookies-usage" value="off">' +
+        '<input type="radio" id="usage-on" name="cookies-usage" value="on">' +
+        '<input type="radio" id="usage-off" name="cookies-usage" value="off">' +
         '<input type="radio" name="cookies-campaigns" value="on">' +
         '<input type="radio" name="cookies-campaigns" value="off">' +
         '<button id="submit-button" type="submit">Submit</button>' +
@@ -136,10 +136,13 @@ describe('cookieSettings', function () {
       element.querySelector('#settings-on').checked = false
       element.querySelector('#settings-off').checked = true
 
+      element.querySelector('#usage-on').checked = true
+      element.querySelector('#usage-off').checked = false
+
       var button = element.querySelector('#submit-button')
       button.click()
 
-      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('cookieSettings', 'Save changes', { label: 'settings-no usage-no campaigns-no ' })
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('cookieSettings', 'Save changes', { label: 'settings-no usage-yes campaigns-no ' })
     })
   })
 
@@ -193,6 +196,45 @@ describe('cookieSettings', function () {
       button.click()
 
       expect(confirmationMessage.style.display).toEqual('block')
+    })
+  })
+
+  describe('when setting usage cookies to false', function () {
+    beforeEach(function () {
+      spyOn(GOVUK.analyticsGa4.core, 'getGemVersion').and.returnValue('aVersion')
+    })
+    it('stops analytics tracking', function () {
+      var analytics = new GOVUK.Analytics({
+        universalId: 'universal-id',
+        cookieDomain: '.www.gov.uk',
+        siteSpeedSampleRate: 100
+      })
+      window.dataLayer = []
+
+      // Expect the default return value when you send an analytics event
+      expect(analytics.trackEvent()).toEqual(undefined)
+      expect(analytics.trackShare()).toEqual(undefined)
+      expect(analytics.trackPageview()).toEqual(undefined)
+      expect(GOVUK.analyticsGa4.core.sendData({})).toEqual(undefined)
+
+      new GOVUK.Modules.CookieSettings(element).init()
+
+      element.querySelector('#usage-on').checked = false
+      element.querySelector('#usage-off').checked = true
+
+      var button = element.querySelector('#submit-button')
+      button.click()
+
+      expect(window.GOVUK.stopSendingAnalytics).toEqual(true)
+
+      // Expect a false return value now when you send an analytics event
+
+      expect(analytics.trackEvent()).toEqual(false)
+      expect(analytics.trackShare()).toEqual(false)
+      expect(analytics.trackPageview()).toEqual(false)
+      expect(window.GOVUK.analyticsGa4.core.sendData()).toEqual(false)
+
+      expect(window.GOVUK.LUX).toEqual({})
     })
   })
 })

--- a/spec/javascripts/helpers/SpecHelper.js
+++ b/spec/javascripts/helpers/SpecHelper.js
@@ -32,6 +32,7 @@ beforeEach(function () {
 
 // load-analytics.js modifies the universal analytics vars, so we need to ensure they are reset each time.
   savedUaVars = window.GOVUK.extendObject(window.GOVUK.analyticsVars)
+  window.GOVUK.stopSendingAnalytics = false
 })
 
 afterEach(function () {


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Currently, if a user has `usage` cookies set to `true`, and then disables them on `/help/cookies`, our tracking still fires on the cookie settings page until they refresh/navigate away. (This doesn't affect other pages on GOV.UK as our JS will reinitialise every time they go to another page, which then checks their consent status.)
- I have fixed this by setting a boolean called `window.GOVUK.stopSendingAnalytics` to `true` when they disable usage cookies. This boolean is then checked in Universal Analytics and GA4 before they send tracking data.
- I've set `window.GOVUK.LUX` to an empty object (`{}`) when they disable the usage cookie as well, but I'm not sure how to test if this actually doing anything.
- I'm assuming the only tracking stuff we have on our site is UA, GA4, and LUX. I'm going by this page: https://www.gov.uk/help/cookie-details

## Why
<!-- What are the reasons behind this change being made? -->
- Fixes a bug that has existed or years on the cookie settings page.
- I'm not checking the consent cookie directly to stop sending analytics, (i.e. `if usage = false, dont send analytics`) because this caused 200+ of our tests to start failing.
    -  I assume this is because a lot of our tests send tracking data without worrying what our usage cookie is set to, and if I used the usage cookie as a guard at the time we send tracking data, those 200 tests would then stop working. Therefore, using this boolean was a lot simpler.
    -  I also assume using the consent cookie might have impact on the single consent work, as trying to get those 200 tests to work would probably cause a massive merge conflict for the consent PR.
    -  I also thought that since UA will be removed soon, it would be a lot of effort to try and fix all the tests if they'll just be removed eventually.
- I thought about just setting `window.GOVUK.analytics` and `window.GOVUK.analyticsGa4` to empty objects once the usage cookie is false as well, but this also caused issues with the tests - even when I tried to revert the UA/GA4 objects after the tests, the tests were acting strangely. Doing this would have also caused console errors on the cookie settings page, as the existing tracking event listeners would try and run tracking functions that no longer exist.
- Trello card: https://trello.com/c/vAI4kvX5/795-tracking-is-still-active-on-cookie-settings-page-after-rejecting-consent

## How to test
- Run `static` locally, pointing to this branch of the gem
- Run `frontend` locally, pointing to your local `static`, and this branch of the gem
- Go to the cookie settings page, `http://127.0.0.1:3005/help/cookies` with your usage cookie set to `true`.
- If you expand/collapse our header menu, you will see UA events in `Omnibug`, and GA4 events in the `dataLayer`
- If you then set the usage cookie to false via the cookie settings form, you will no longer get any additional `Omnibug` events or `dataLayer` events if you interact with the page, for example expanding the header menu again.



## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
