### PR TITLE
Fix cookie settings page crash in IE11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Allow custom text for GA4 scroll tracker ([PR #3896](https://github.com/alphagov/govuk_publishing_components/pull/3896))
 * Ensure analytics stops firing if a user disables usage cookies on our cookie settings page ([PR #3893](https://github.com/alphagov/govuk_publishing_components/pull/3893))
+* Fix cookie settings page crash in IE11 ([PR #3894](https://github.com/alphagov/govuk_publishing_components/pull/3894))
 
 ## 37.5.1
 

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-settings.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-settings.js
@@ -107,7 +107,13 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   }
 
   CookieSettings.prototype.getReferrerLink = function () {
-    return document.referrer ? new URL(document.referrer).pathname : false
+    var documentReferrer = false
+    try {
+      documentReferrer = document.referrer || new URL(document.referrer).pathname
+    } catch (e) {
+      console.error('Error grabbing referrer for cookie settings', window.location, e)
+    }
+    return documentReferrer
   }
 
   Modules.CookieSettings = CookieSettings


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- The cookie settings code has a line to grab the document referrer. It partly used the `URL` object for this.
- `URL` is unsupported in IE11, so it was crashing on save in IE11
-  Use try/catch to grab the referrer value instead
- It looks new URL(document.referrer).pathname has been in the code for 5 years https://github.com/alphagov/frontend/blame/1ee93d82ba4f33e95fd5e4136b656d32963d2489/app/assets/javascripts/modules/cookie-settings.js#L98

## Why
<!-- What are the reasons behind this change being made? -->
- /help/cookies is crashing when saving the form in production in IE11

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None