### PR TITLE
Rework search icon styles

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -17,7 +17,7 @@ $large-input-size: 50px;
     height: $large-input-size;
 
     .gem-c-search__icon {
-      @include icon-positioning($large-input-size);
+      transform: scale(.4);
     }
   }
 }
@@ -106,19 +106,6 @@ $large-input-size: 50px;
   }
 }
 
-@mixin icon-positioning($container-size) {
-  $icon-dimension: 20px;
-  $icon-position: calc(($container-size - $icon-dimension) / 2);
-
-  display: block;
-  pointer-events: none;
-  position: absolute;
-  height: $icon-dimension;
-  width: $icon-dimension;
-  top: $icon-position;
-  left: $icon-position;
-}
-
 .gem-c-search__submit {
   border: 0;
   cursor: pointer;
@@ -135,7 +122,13 @@ $large-input-size: 50px;
   overflow: hidden;
 
   .gem-c-search__icon {
-    @include icon-positioning($input-size);
+    pointer-events: none;
+    position: absolute;
+    height: 100%;
+    width: 100%;
+    top: 0;
+    left: 0;
+    transform: scale(.5);
   }
 
   &:focus {


### PR DESCRIPTION
## What
Rework the sass for the search component SVG icon, which used a mixin with a calc function to determine the correct `top` and `left` values based on a given container size. Instead use a simpler effect - set the icon to be the height and width of the parent, but scale it by half (origin defaults to the center). Since the button is 40px and the icon should be 20px this should result in no visual difference.

For the large icon, the search icon should remain the same size, despite the button being 10px larger at 50px. Instead we apply a scale of `.4`, which results in the same size.

## Why
Trying to use the search component in the govuk-dev-docs, which is running on an older version of Sass and doesn't interpret the `calc` part properly (it outputs it without calculating it, resulting in an invalid CSS value), which looks like this:

![Screenshot 2024-03-04 at 15 26 36](https://github.com/alphagov/govuk_publishing_components/assets/861310/56c15a39-b46c-4285-b0f9-010e6054cf38)
![Screenshot 2024-03-04 at 15 26 47](https://github.com/alphagov/govuk_publishing_components/assets/861310/65716ade-54c6-4f50-9cca-5b1129fead80)

This change fixes this.

## Visual Changes
Shouldn't be any, thought it might be different by a pixel or so compared to the original but the visual diff passes. I've tested this in a few browsers and it looks like it always did. Anything below IE10 doesn't work (because IE9 didn't support `transform`) but the result is that the icon is just a bit bigger than it should be. Since we don't support IE I think this falls into the acceptable category of 'looks a bit strange but still works'.
