### PR TITLE
Remove info-frontend refs

### DIFF
--- a/app/controllers/govuk_publishing_components/audit_controller.rb
+++ b/app/controllers/govuk_publishing_components/audit_controller.rb
@@ -13,7 +13,6 @@ module GovukPublishingComponents
         frontend
         government-frontend
         govspeak-preview
-        info-frontend
         release
         search-admin
         signon

--- a/app/models/govuk_publishing_components/audit_comparer.rb
+++ b/app/models/govuk_publishing_components/audit_comparer.rb
@@ -11,7 +11,6 @@ module GovukPublishingComponents
           finder-frontend
           frontend
           government-frontend
-          info-frontend
           service-manual-frontend
           smart-answers
         ]


### PR DESCRIPTION
info-frontend is now retired.

Trello:
https://trello.com/c/sWZM0a38/2387-archive-repo-in-github

## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
<!-- What are the reasons behind this change being made? -->

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

### Before


### After
