### PR TITLE
Update popular links in search header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   of the commit log.
 
 ## Unreleased
-
+* Update popular links in super navigation header ([PR #3904](https://github.com/alphagov/govuk_publishing_components/pull/3904))
 * Allow custom text for GA4 scroll tracker ([PR #3896](https://github.com/alphagov/govuk_publishing_components/pull/3896))
 * Ensure analytics stops firing if a user disables usage cookies on our cookie settings page ([PR #3893](https://github.com/alphagov/govuk_publishing_components/pull/3893))
 * Fix cookie settings page crash in IE11 ([PR #3894](https://github.com/alphagov/govuk_publishing_components/pull/3894))

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -234,8 +234,8 @@ en:
       popular_links:
       - label: Get support with the cost of living
         href: "/cost-of-living"
-      - label: Find out about the Energy Bills Support Scheme
-        href: "/guidance/getting-the-energy-bills-support-scheme-discount"
+      - label: Find out about help you can get with your energy bills
+        href: "/get-help-energy-bills"
       - label: Find a job
         href: "/find-a-job"
       - label: 'Universal Credit account: sign in'


### PR DESCRIPTION
## What
Update popular links in the search in the header to match those on the body of the page, as defined in  https://github.com/alphagov/frontend/blob/main/config/locales/en.yml#L572-L584

## Why
Both parts of the page should contain the same links. These were missed from https://github.com/alphagov/frontend/pull/3524

## Visual Changes

|Before|After|
|-|-|
|<img width="948" alt="Screenshot 2024-03-05 at 20 39 20" src="https://github.com/alphagov/govuk_publishing_components/assets/17908089/34fc7572-9781-40ac-88fc-7bb1a8c6c0a6">|<img width="999" alt="Screenshot 2024-03-05 at 21 25 56" src="https://github.com/alphagov/govuk_publishing_components/assets/17908089/772c1e5f-6c03-43ee-a58b-fff8320af806">|
