### PR TITLE
Reintroduce GA4 callout tracking and fix link tracker compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Reintroduce GA4 callout tracking and fix link tracker compatibility ([PR #3905](https://github.com/alphagov/govuk_publishing_components/pull/3905))
+
 ## 37.6.1
 
 * Include single consent api package ([PR #3908](https://github.com/alphagov/govuk_publishing_components/pull/3908))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.js
@@ -40,9 +40,31 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
         return
       }
 
-      // don't track this link if it's already being tracked by the another tracker (e.g. the link tracker or ecommerce tracker)
-      if (element.closest('[data-ga4-link]') || element.closest('[data-ga4-ecommerce-path]')) {
+      // Don't track this link if it's already being tracked by the ecommerce tracker
+      if (element.closest('[data-ga4-ecommerce-path]')) {
         return
+      }
+
+      // Code below ensures the tracker plays nicely with the other link tracker
+      var otherLinkTracker = element.closest('[data-ga4-link]')
+      if (otherLinkTracker) {
+        var limitToElementClass = otherLinkTracker.getAttribute('data-ga4-limit-to-element-class')
+
+        if (!limitToElementClass) {
+          // If this link is inside the other link tracker, and the other link tracker IS NOT limiting itself to specific classes,
+          // then stop this tracker from firing, as the other tracker is responsible for this link.
+          return
+        } else {
+          // If this link is inside the other link tracker, but the other link tracker IS limiting itself to specific classes,
+          // then track the link here only if it is not within the specified classes that the other tracker is looking for.
+          var classes = limitToElementClass.split(',')
+
+          for (var i = 0; i < classes.length; i++) {
+            if (element.closest('.' + classes[i].trim())) {
+              return
+            }
+          }
+        }
       }
 
       var href = element.getAttribute('href')

--- a/app/views/govuk_publishing_components/components/_govspeak.html.erb
+++ b/app/views/govuk_publishing_components/components/_govspeak.html.erb
@@ -10,8 +10,19 @@
   classes << "disable-youtube" if disable_youtube_expansions
   classes << "gem-c-govspeak--inverse" if inverse
 
+  disable_ga4 ||= false
+
   data_modules = "govspeak"
+  data_modules << " ga4-link-tracker" unless disable_ga4
   data_attributes = { module: data_modules }
+
+  unless disable_ga4
+    data_attributes.merge!({
+      ga4_track_links_only: "",
+      ga4_limit_to_element_class: "call-to-action, info-notice, help-notice, advisory",
+      ga4_link: { "event_name": "navigation", "type": "callout" }.to_json,
+    })
+  end
 
 %>
 

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -914,3 +914,12 @@ examples:
             <p>Deforested area. Credit: Blue Ventures-Garth Cripps</p>
           </figcaption>
         </figure>
+  without_ga4_tracking:
+    description: |
+      Disables GA4 tracking on the component. Tracking is enabled by default. This adds a data module and data-attributes with JSON data. See the [ga4-link-tracker documentation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-link-tracker.md) for more information.
+    data:
+      block: |
+        <p>
+          <a href='https://www.gov.uk'>Hello World</a>
+        </p>
+      disable_ga4: true

--- a/spec/components/govspeak_spec.rb
+++ b/spec/components/govspeak_spec.rb
@@ -46,4 +46,27 @@ describe "Govspeak", type: :view do
 
     expect(rendered).to include("content-via-block")
   end
+
+  it "adds GA4 tracking" do
+    render_component(
+      content: "<h1>content</h1>".html_safe,
+    )
+
+    assert_select ".gem-c-govspeak[data-module='govspeak ga4-link-tracker']"
+    assert_select ".gem-c-govspeak[data-ga4-track-links-only]"
+    assert_select ".gem-c-govspeak[data-ga4-limit-to-element-class='call-to-action, info-notice, help-notice, advisory']"
+    assert_select '.gem-c-govspeak[data-ga4-link="{\"event_name\":\"navigation\",\"type\":\"callout\"}"]'
+  end
+
+  it "can disable GA4 tracking" do
+    render_component(
+      content: "<h1>content</h1>".html_safe,
+      disable_ga4: true,
+    )
+
+    assert_no_selector ".gem-c-govspeak[data-module='govspeak ga4-link-tracker']"
+    assert_no_selector ".gem-c-govspeak[data-ga4-track-links-only]"
+    assert_no_selector ".gem-c-govspeak[data-ga4-limit-to-element-class]"
+    assert_no_selector ".gem-c-govspeak[data-ga4-link]"
+  end
 end

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.spec.js
@@ -91,7 +91,6 @@ describe('A specialist link tracker', function () {
     afterEach(function () {
       body.removeEventListener('click', preventDefault)
       links.remove()
-      linkTracker.stopTracking()
     })
 
     it('detects external click events on well structured external links', function () {
@@ -357,7 +356,6 @@ describe('A specialist link tracker', function () {
     afterEach(function () {
       body.removeEventListener('click', preventDefault)
       links.remove()
-      linkTracker.stopTracking()
     })
 
     it('detects download clicks on fully structured gov.uk download links', function () {
@@ -543,7 +541,6 @@ describe('A specialist link tracker', function () {
     afterEach(function () {
       body.removeEventListener('click', preventDefault)
       links.remove()
-      linkTracker.stopTracking()
     })
 
     it('detects email events on mailto links', function () {
@@ -584,7 +581,6 @@ describe('A specialist link tracker', function () {
     afterEach(function () {
       body.removeEventListener('click', preventDefault)
       links.remove()
-      linkTracker.stopTracking()
     })
 
     it('removes _ga and _gl from href query parameters', function () {
@@ -660,7 +656,6 @@ describe('A specialist link tracker', function () {
     afterEach(function () {
       body.removeEventListener('click', preventDefault)
       links.remove()
-      linkTracker.stopTracking()
     })
 
     it('redacts postcodes and dates from the URL', function () {
@@ -702,7 +697,6 @@ describe('A specialist link tracker', function () {
     afterEach(function () {
       body.removeEventListener('click', preventDefault)
       links.remove()
-      linkTracker.stopTracking()
     })
 
     it('sets the text property to image', function () {
@@ -713,6 +707,76 @@ describe('A specialist link tracker', function () {
         GOVUK.triggerEvent(links[i], 'click')
         expect(window.dataLayer[0].event_data.text).toEqual('image')
       }
+    })
+  })
+
+  describe('when data-ga4-link and data-ga4-limit-to-element-class are on the parent', function () {
+    var specialistLinkTracker
+
+    beforeEach(function () {
+      window.dataLayer = []
+      links = document.createElement('div')
+      links.setAttribute('data-module', 'ga4-link-tracker')
+      links.setAttribute('data-ga4-track-links-only', '')
+      links.setAttribute('data-ga4-limit-to-element-class', 'hello')
+      links.setAttribute('data-ga4-link', JSON.stringify({ event_name: 'navigation', type: 'callout' }))
+
+      links.innerHTML = '<div class="hello"><a class="otherLink" href="https://example.com">GA4 Link Tracker</a></div>' +
+      '<a class="specialistLink" href="https://example.co.uk">Specialist Link Tracker</a>'
+
+      body.appendChild(links)
+      body.addEventListener('click', preventDefault)
+
+      GOVUK.setCookie('cookies_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true}')
+
+      var otherLinkTracker = new GOVUK.Modules.Ga4LinkTracker(links)
+      otherLinkTracker.init()
+
+      specialistLinkTracker = GOVUK.analyticsGa4.analyticsModules.Ga4SpecialistLinkTracker
+      specialistLinkTracker.init()
+    })
+
+    afterEach(function () {
+      body.removeEventListener('click', preventDefault)
+      links.remove()
+    })
+
+    it('does not fire the specialist tracker if the link should be tracked by the other link tracker', function () {
+      var otherLink = document.querySelector('.otherLink')
+      otherLink.click()
+
+      expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
+      expected.event = 'event_data'
+      expected.event_data.event_name = 'navigation'
+      expected.event_data.type = 'callout'
+      expected.event_data.method = 'primary click'
+      expected.event_data.external = 'true'
+      expected.govuk_gem_version = 'aVersion'
+      expected.event_data.url = 'https://example.com'
+      expected.event_data.text = 'GA4 Link Tracker'
+      expected.event_data.link_domain = 'https://example.com'
+      expected.timestamp = '123456'
+      expect(window.dataLayer[0]).toEqual(expected)
+      expect(window.dataLayer.length).toEqual(1)
+    })
+
+    it('still fires the specialist tracker if the link is within the other tracker, but outside the classes it is looking for', function () {
+      var specialistLink = document.querySelector('.specialistLink')
+      specialistLink.click()
+
+      expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
+      expected.event = 'event_data'
+      expected.event_data.event_name = 'navigation'
+      expected.event_data.type = 'generic link'
+      expected.event_data.method = 'primary click'
+      expected.event_data.external = 'true'
+      expected.govuk_gem_version = 'aVersion'
+      expected.event_data.url = 'https://example.co.uk'
+      expected.event_data.text = 'Specialist Link Tracker'
+      expected.event_data.link_domain = 'https://example.co.uk'
+      expected.timestamp = '123456'
+      expect(window.dataLayer[0]).toEqual(expected)
+      expect(window.dataLayer.length).toEqual(1)
     })
   })
 })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.spec.js
@@ -721,8 +721,11 @@ describe('A specialist link tracker', function () {
       links.setAttribute('data-ga4-limit-to-element-class', 'hello')
       links.setAttribute('data-ga4-link', JSON.stringify({ event_name: 'navigation', type: 'callout' }))
 
-      links.innerHTML = '<div class="hello"><a class="otherLink" href="https://example.com">GA4 Link Tracker</a></div>' +
-      '<a class="specialistLink" href="https://example.co.uk">Specialist Link Tracker</a>'
+      links.innerHTML =
+        '<div class="hello">' +
+          '<a class="otherLink" href="https://example.com">GA4 Link Tracker</a>' +
+        '</div>' +
+        '<a class="specialistLink" href="https://example.co.uk">Specialist Link Tracker</a>'
 
       body.appendChild(links)
       body.addEventListener('click', preventDefault)
@@ -737,6 +740,7 @@ describe('A specialist link tracker', function () {
     })
 
     afterEach(function () {
+      GOVUK.cookie('cookies_policy', null)
       body.removeEventListener('click', preventDefault)
       links.remove()
     })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/init-ga4.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/init-ga4.spec.js
@@ -4,7 +4,6 @@ describe('Initialising GA4', function () {
   var GOVUK = window.GOVUK
 
   afterEach(function () {
-    GOVUK.analyticsGa4.analyticsModules.Ga4SpecialistLinkTracker.stopTracking()
     window.dataLayer = []
     window.removeEventListener('cookie-consent', window.GOVUK.analyticsGa4.init)
   })

--- a/spec/javascripts/helpers/SpecHelper.js
+++ b/spec/javascripts/helpers/SpecHelper.js
@@ -36,6 +36,7 @@ beforeEach(function () {
 })
 
 afterEach(function () {
+  GOVUK.analyticsGa4.analyticsModules.Ga4SpecialistLinkTracker.stopTracking()
   resetCookies()
   window.GOVUK.analyticsVars = savedUaVars
 })


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Reintroduces the `callout` tracking and fixes an issue with it we discovered on production. The fix is detailed in the below bullet points.
- There are two link trackers in our GA4 tracking - the `ga4-link-tracker` and the `ga4-specialist-link-tracker`
- The `ga4-link-tracker` is more specific, so it usually overrides the specialist link tracker when it exists on an element. The hierarchy for link tracking is this:
    - If the `ga4-link-tracker` is on an element, the `ga4-link-tracker` should track the clicked link
    - If the `ga4-link-tracker` is on an element with `data-ga4-limit-to-element-class`, and the clicked link is within the right class, the `ga4-link-tracker` should track the link
    - If the `ga4-link-tracker` is on an element with `data-ga4-limit-to-element-class`, and the clicked link is not within the right class, then the `ga4-specialist-link-tracker` should track the link -  **this was broken before, and is fixed in this PR**
    - If no `ga4-link-tracker` exists on the element, then the `ga4-specialist-link-tracker` will track it 
    - Note the specialist link tracker will only track the link if the link is external, a file_download, or an email address.

- Currently, if a link is inside a parent element containing `ga4-link-tracker` with `data-ga4-limit-to-element-class`, but the link itself is outside the child classes that are being tracked by the parent, then the `ga4-specialist-link-tracker` was not taking over to track the link. This caused external/file_download/email link tracking to break within `govspeak` when we added the `callout` tracking.


## Why
<!-- What are the reasons behind this change being made? -->
- Fixes a bug with external link tracking when we had tracking on the `govspeak` component
- https://trello.com/c/j8JYsjCu/799-fix-govspeak-tracking-disabling-the-specialist-link-tracker


## Testing

- I have tested this by running this gem in `static`, and then rendering a `govspeak` component with multiple types of links, like so:

```ERB
<%= render "govuk_publishing_components/components/govspeak", {} do %>
  <div class="call-to-action">
    <p><a href="https://google.com">This callout link should be tracked by the regular link tracker</a></p>
    <section class="gem-c-attachment govuk-!-display-none-print govuk-!-margin-bottom-6" data-module="ga4-link-tracker">
        <div class="gem-c-attachment__details">
          <h2 class="gem-c-attachment__title">
              <a class="govuk-link gem-c-attachment__link" target="_self" data-ga4-link="{&quot;event_name&quot;:&quot;navigation&quot;,&quot;type&quot;:&quot;attachment&quot;}" href="/government/publications/equality-act-guidance/individuals-a-summary-guide-to-your-rights-html">This attachment link should be tracked by the regular link tracker</a>
          </h2>
        </div>
    </section>
  </div>
  <section class="gem-c-attachment govuk-!-display-none-print govuk-!-margin-bottom-6" data-module="ga4-link-tracker">
    <div class="gem-c-attachment__details">
        <h2 class="gem-c-attachment__title">
          <a class="govuk-link gem-c-attachment__link" target="_self" data-ga4-link="{&quot;event_name&quot;:&quot;navigation&quot;,&quot;type&quot;:&quot;attachment&quot;}" href="/government/publications/equality-act-guidance/individuals-a-summary-guide-to-your-rights-html">This attachment link should also be tracked by the regular link tracker</a>
        </h2>
    </div>
  </section>
  <p><a href="https://google.com">This generic link should be tracked by the specialist link tracker</a></p>
  <p><a href="https://assets.publishing.service.gov.uk/media/5a78ff28ed915d0422066fb6/individual-rights1.pdf">This file download should be tracked by the specialist link tracker</a></p>
  <p><a href="mailto:email@example.com">This email should be tracked by the specialist link tracker</a></p>
<% end %>
```
- If you click or right click the links, they should all be tracked correctly


## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->


- Reintroduces how to disable GA4 in the `govspeak` docs