### PR TITLE
Fix accessibility issue in contents list component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix accessibility issue in contents list component ([PR #3907](https://github.com/alphagov/govuk_publishing_components/pull/3907))
+
 ## 37.6.0
 
 * Add single cookie consent API ([PR #3854](https://github.com/alphagov/govuk_publishing_components/pull/3854))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_contents-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_contents-list.scss
@@ -50,7 +50,7 @@
   padding-left: $contents-spacing;
   padding-right: $contents-spacing;
 
-  &::before {
+  & span::before {
     content: "—";
     position: absolute;
     left: 0;

--- a/app/views/govuk_publishing_components/components/_contents_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_contents_list.html.erb
@@ -41,6 +41,7 @@
       <% index_link = 1 unless disable_ga4 %>
       <% contents.each.with_index(1) do |contents_item, position| %>
         <li class="<%= cl_helper.list_item_classes(contents_item, false) %>" <%= "aria-current=true" if contents_item[:active] %>>
+          <span aria-hidden="true"></span>
           <% link_text = format_numbers ? cl_helper.wrap_numbers_with_spans(contents_item[:text]) : contents_item[:text]
             unless disable_ga4
               ga4_data[:event_name] = cl_helper.get_ga4_event_name(contents_item[:href]) if contents_item[:href]
@@ -64,6 +65,7 @@
             <ol class="gem-c-contents-list__nested-list">
               <% contents_item[:items].each.with_index(1) do |nested_contents_item, nested_position| %>
                 <li class="<%= cl_helper.list_item_classes(nested_contents_item, true) %>" <%= "aria-current=true" if nested_contents_item[:active] %>>
+                  <span aria-hidden="true"></span>
                   <%
                     unless disable_ga4
                       ga4_data[:event_name] = cl_helper.get_ga4_event_name(nested_contents_item[:href]) if nested_contents_item[:href]

--- a/app/views/govuk_publishing_components/components/docs/contents_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/contents_list.yml
@@ -18,6 +18,7 @@ accessibility_criteria: |
   - convey the content structure
   - indicate the current page when contents span different pages, and not link to itself
   - include an aria-label to contextualise the list
+  - ensure dashes before each list item are hidden from screen readers
 
   Links with formatted numbers must separate the number and text with a space for correct screen reader pronunciation. This changes pronunciation from "1 dot Item" to "1 Item".
 shared_accessibility_criteria:

--- a/spec/components/contents_list_spec.rb
+++ b/spec/components/contents_list_spec.rb
@@ -48,6 +48,11 @@ describe "Contents list", type: :view do
     assert_select ".gem-c-contents-list__link.govuk-link--no-underline[href='#two']", text: "2. Two"
   end
 
+  it "renders with dashes hidden from screen readers" do
+    render_component(contents: contents_list)
+    assert_select ".gem-c-contents-list__list-item.gem-c-contents-list__list-item--dashed span[aria-hidden='true']"
+  end
+
   it "renders with the underline option" do
     render_component(contents: contents_list, underline_links: true)
     assert_select ".gem-c-contents-list"


### PR DESCRIPTION
## What
Stop dashes before each 'Contents' list item being read by screen readers

## Why
Nearly every screen reader (except NVDA of the major ones) reads out the “em dash“ before each item/link in the “Contents“ list. Screen reader users found that frustrating to read through.

[Trello card](https://trello.com/c/MajjZ6ds/2414-dashes-before-each-contents-list-item-read-by-screen-readers-m-l)

## Accessibility testing

| Screen Reader | Browser | Issue fixed |
| --- | --- | --- |
| NVDA - 2023.3.3 | Firefox - 123 | fixed :white_check_mark: |
| Narrator - 21H2 | Edge 122 | fixed :white_check_mark: |
| JAWS 2022 | Chrome | fixed :white_check_mark: |
| JAWS 2023 | Chrome|  fixed :white_check_mark: |
| VoiceOver 10 | Safari 17.3.1 | fixed :white_check_mark: |
| VoiceOver 10 | Safari 17.3.1 | fixed :white_check_mark: |
| VoiceOver 10 | Firefox 123 | fixed :white_check_mark: |

## VoiceOver example

## VoiceOver Before

https://github.com/alphagov/govuk_publishing_components/assets/28779939/54e964e0-c1bc-4f17-afe3-c924294cedc8

## VoiceOver After

https://github.com/alphagov/govuk_publishing_components/assets/28779939/122f55d3-3607-4c1b-afb9-f158b0be4a09

## Further info

### Using `list-style-type`

We considered using [list-style-type](https://github.com/alphagov/govuk_publishing_components/pull/3907), however this did present us with 2 issues.

1. The dash style currently used it not available as a list style, we would have to choose something else such as “circle” or “disc” for example.
2. When testing in VoiceOver the list item style is still read out as “You are currently on a AXListMarker”

###  Using `speak`

We also explored other options, such as using the CSS speak property to turn off voice output for screen readers. On top of this, browser support is very limited currently, so this is not an option - ["speak" | Can I use... Support tables for HTML5, CSS3, etc](https://caniuse.com/?search=speak)