### PR TITLE
Fix failing test

### DIFF
--- a/spec/javascripts/govuk_publishing_components/lib/cookie-functions-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/cookie-functions-spec.js
@@ -5,6 +5,22 @@ var GOVUK = window.GOVUK || {}
 describe('Cookie helper functions', function () {
   'use strict'
 
+  beforeEach(function () {
+    GOVUK.cookie('cookies_policy', null)
+    GOVUK.cookie('cookies_preferences_set', null)
+    GOVUK.cookie('_ga_VBLT2V3FZR', null)
+    GOVUK.cookie('_ga_P1DGM6TVYF', null)
+    GOVUK.cookie('_ga_S5RQ7FTGVR', null)
+  })
+
+  afterEach(function () {
+    GOVUK.cookie('cookies_policy', null)
+    GOVUK.cookie('cookies_preferences_set', null)
+    GOVUK.cookie('_ga_VBLT2V3FZR', null)
+    GOVUK.cookie('_ga_P1DGM6TVYF', null)
+    GOVUK.cookie('_ga_S5RQ7FTGVR', null)
+  })
+
   describe('GOVUK.cookie', function () {
     it('returns the cookie value if not provided with a value to set', function () {
       GOVUK.cookie('cookies_preferences_set', 'testing fetching cookie value')


### PR DESCRIPTION
## What / why
Fix intermittently failing tests in the cookie functions.

- some of the tests in this file were intermittently failing (even only using specific seeds 51181 and 04195)
- no cleanup was present for these tests, which now run alongside a lot more tests involving the single consent API, so it seems likely that uncleared cookies were causing this problem

## Visual changes
None.
