### PR TITLE
Disable the single consent cookie API code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Disable the single consent cookie API code ([PR #3916](https://github.com/alphagov/govuk_publishing_components/pull/3916))
+
 ## 37.7.1
 
 * Move the single consent code ([PR #3913](https://github.com/alphagov/govuk_publishing_components/pull/3913))

--- a/app/assets/javascripts/govuk_publishing_components/dependencies.js
+++ b/app/assets/javascripts/govuk_publishing_components/dependencies.js
@@ -3,7 +3,6 @@
 // This adds in javascript that initialises components and dependencies
 // that are provided by Slimmer in public frontend applications.
 // = require ./modules.js
-// = require ./single-consent-functions.js
 
 document.addEventListener('DOMContentLoaded', function () {
   window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}

--- a/spec/javascripts/components/cookie-banner-spec.js
+++ b/spec/javascripts/components/cookie-banner-spec.js
@@ -272,7 +272,7 @@ describe('Cookie banner', function () {
     })
   })
 
-  describe('when the single consent api is enabled', function () {
+  xdescribe('when the single consent api is enabled', function () {
     var acceptAll = {
       essential: true,
       usage: true,

--- a/spec/javascripts/govuk_publishing_components/lib/cookie-settings-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/cookie-settings-spec.js
@@ -199,7 +199,7 @@ describe('cookieSettings', function () {
     })
   })
 
-  describe('when the single consent api is enabled', function () {
+  xdescribe('when the single consent api is enabled', function () {
     beforeEach(function () {
       window.GOVUK.useSingleConsentApi = true
     })

--- a/spec/javascripts/govuk_publishing_components/single-consent-functions-spec.js
+++ b/spec/javascripts/govuk_publishing_components/single-consent-functions-spec.js
@@ -1,6 +1,6 @@
 /* eslint-env jasmine */
 
-describe('The single consent cookie code', function () {
+xdescribe('The single consent cookie code', function () {
   var acceptAll = {
     essential: true,
     usage: true,


### PR DESCRIPTION
## What
Disable the single cookie consent code. This disables the code and prevents it being included in the public facing page weight, but leaves it the gem repo for now if we want to reinstate it.

- removes the inclusion of the single consent functions (which pulls in the single consent API code) from dependencies, preventing the single consent code from operating at all
- also disables a number of tests reliant on this code

## Why
Pausing the work.

## Visual Changes
None.

Trello card: https://trello.com/c/dmlTAzKB/140-implement-single-consent-api