### PR TITLE
Remove "Popular" links from super navigation header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Disable the single consent cookie API code ([PR #3916](https://github.com/alphagov/govuk_publishing_components/pull/3916))
+* Remove "Popular" links from super navigation header ([PR #3918](https://github.com/alphagov/govuk_publishing_components/pull/3918))
 
 ## 37.7.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -884,7 +884,11 @@ $after-button-padding-left: govuk-spacing(4);
 }
 
 .gem-c-layout-super-navigation-header__search-form {
-  padding: 0 0 govuk-spacing(8) 0;
+  padding: 0;
+
+  @include govuk-media-query($from: "desktop") {
+    padding-bottom: govuk-spacing(2);
+  }
 }
 
 // Popular links.

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -893,17 +893,6 @@ $after-button-padding-left: govuk-spacing(4);
   padding: govuk-spacing(1) 0;
 }
 
-.gem-c-layout-super-navigation-header__popular-link {
-  display: inline-block;
-  font-size: 16px;
-  font-size: govuk-px-to-rem(16px);
-  padding: 0;
-
-  &::after {
-    @include make-selectable-area-bigger;
-  }
-}
-
 .gem-c-layout-super-navigation-header__width-container {
   @include govuk-media-query($until: "desktop") {
     margin: 0;
@@ -988,11 +977,6 @@ $after-button-padding-left: govuk-spacing(4);
 }
 
 @include govuk-media-query($until: tablet) {
-  .gem-c-layout-super-navigation-header__popular-links-heading--large-navbar {
-    font-size: 24px;
-    font-size: govuk-px-to-rem(24px);
-  }
-
   // can't disable responsive styling because using override classes
   // from govuk-frontend which are all responsive so have to supply
   // custom class to the label of the search component to turn off

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -15,8 +15,6 @@
   navigation_menu_heading = t("components.layout_super_navigation_header.navigation_menu_heading")
   navigation_search_heading = t("components.layout_super_navigation_header.navigation_search_heading")
   navigation_search_subheading = t("components.layout_super_navigation_header.navigation_search_subheading")
-  popular_links = t("components.layout_super_navigation_header.popular_links")
-  popular_links_heading = t("components.layout_super_navigation_header.popular_links_heading")
   search_text = t("components.layout_super_navigation_header.search_text")
 
   hide_search_menu_text = t("components.layout_super_navigation_header.menu_toggle_label.hide", :label => "search")
@@ -67,9 +65,6 @@
 
   dropdown_menu_classes = %w(gem-c-layout-super-navigation-header__navigation-dropdown-menu)
   dropdown_menu_classes << "gem-c-layout-super-navigation-header__navigation-dropdown-menu--large-navbar" if large_navbar
-
-  popular_links_heading_classes = %w(govuk-heading-m)
-  popular_links_heading_classes << "gem-c-layout-super-navigation-header__popular-links-heading--large-navbar" if large_navbar
 
   absolute_links_helper = GovukPublishingComponents::Presenters::AbsoluteLinksHelper.new()
 %>
@@ -383,45 +378,6 @@
                   },
                 } %>
               </form>
-            </div>
-          </div>
-          <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
-              <%= content_tag(:h3, {
-                class: popular_links_heading_classes
-              }) do %>
-                <%= popular_links_heading %>
-              <% end %>
-              <ul class="govuk-list">
-                <% index_total = popular_links.length %>
-                <% popular_links.each_with_index do | popular_link, index | %>
-                  <li class="gem-c-layout-super-navigation-header__popular-item">
-                    <% link_href = absolute_links_helper.make_url_absolute(popular_link[:href]) %>
-                    <%= link_to popular_link[:label], link_href, {
-                      class: [
-                        "govuk-link",
-                        "gem-c-layout-super-navigation-header__popular-link",
-                      ],
-                      data: {
-                        track_action: "popularLink",
-                        track_category: "headerClicked",
-                        track_label: popular_link[:href],
-                        track_dimension: popular_link[:label],
-                        track_dimension_index: "29",
-                        ga4_link: {
-                          "event_name": "navigation",
-                          "type": "header menu bar",
-                          "index_section": 4,
-                          "index_link": index + 1,
-                          "index_section_count": 4,
-                          "index_total": index_total,
-                          "section": popular_links_heading,
-                        }
-                      }
-                    } %>
-                  </li>
-                <% end %>
-              </ul>
             </div>
           </div>
         </div>

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -127,8 +127,6 @@ ar:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: من

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -124,8 +124,6 @@ az:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: "...dan (dən)"

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -130,8 +130,6 @@ be:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: З

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -128,8 +128,6 @@ bg:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: От

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -125,8 +125,6 @@ bn:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: থেকে

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -129,8 +129,6 @@ cs:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: 'Komu I:'

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -128,8 +128,6 @@ cy:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: Gan

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -125,8 +125,6 @@ da:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: Fra

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -128,8 +128,6 @@ de:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: Von

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -126,8 +126,6 @@ dr:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: از

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -124,8 +124,6 @@ el:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: Από

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -231,20 +231,6 @@ en:
       navigation_menu_heading: Navigation menu
       navigation_search_heading: Search and popular pages
       navigation_search_subheading: Search
-      popular_links:
-      - label: Get support with the cost of living
-        href: "/cost-of-living"
-      - label: Find out about help you can get with your energy bills
-        href: "/get-help-energy-bills"
-      - label: Find a job
-        href: "/find-a-job"
-      - label: 'Universal Credit account: sign in'
-        href: "/sign-in-universal-credit"
-      - label: Check your National Insurance record
-        href: "/check-national-insurance-record"
-      - label: 'Check MOT history of a vehicle'
-        href: /check-mot-history
-      popular_links_heading: Popular on GOV.UK
       search_text: Search GOV.UK
     metadata:
       from: From

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -124,8 +124,6 @@ es-419:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: Desde

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -124,8 +124,6 @@ es:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: Desde

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -127,8 +127,6 @@ et:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: Alates

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -123,8 +123,6 @@ fa:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: از

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -126,8 +126,6 @@ fi:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: Alkaen

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -124,8 +124,6 @@ fr:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: De

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -126,8 +126,6 @@ gd:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: De

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -124,8 +124,6 @@ gu:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: થી

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -124,8 +124,6 @@ he:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: מ-

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -124,8 +124,6 @@ hi:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: से

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -125,8 +125,6 @@ hr:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: Iz

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -127,8 +127,6 @@ hu:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: Feladó

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -128,8 +128,6 @@ hy:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: Ումից՝

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -124,8 +124,6 @@ id:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: Dari

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -124,8 +124,6 @@ is:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: Frá

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -124,8 +124,6 @@ it:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: Da

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -120,8 +120,6 @@ ja:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: から

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -127,8 +127,6 @@ ka:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: დან

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -124,8 +124,6 @@ kk:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: Кімнен

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -119,8 +119,6 @@ ko:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -129,8 +129,6 @@ lt:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: Nuo

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -128,8 +128,6 @@ lv:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: 'No'

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -123,8 +123,6 @@ ms:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: Daripada

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -126,8 +126,6 @@ mt:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: Minn

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -124,8 +124,6 @@ nl:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: Van

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -124,8 +124,6 @@
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: Fra

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -120,8 +120,6 @@ pa-pk:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: ایتھوں

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -124,8 +124,6 @@ pa:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: ਤੋਂ

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -128,8 +128,6 @@ pl:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: Od

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -121,8 +121,6 @@ ps:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: له

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -124,8 +124,6 @@ pt:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: De

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -125,8 +125,6 @@ ro:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: De la

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -128,8 +128,6 @@ ru:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: Из

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -124,8 +124,6 @@ si:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: සිට

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -129,8 +129,6 @@ sk:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: Od

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -131,8 +131,6 @@ sl:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: Od

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -124,8 +124,6 @@ so:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: Laga bilaabo

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -124,8 +124,6 @@ sq:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: Nga

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -125,8 +125,6 @@ sr:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: Od

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -124,8 +124,6 @@ sv:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: Från

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -124,8 +124,6 @@ sw:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: Kuanzia

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -125,8 +125,6 @@ ta:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: இதிலிருந்து

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -122,8 +122,6 @@ th:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: จาก

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -125,8 +125,6 @@ tk:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: "-dan"

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -125,8 +125,6 @@ tr:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: Şuradan

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -131,8 +131,6 @@ uk:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: Від

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -121,8 +121,6 @@ ur:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: از

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -126,8 +126,6 @@ uz:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: дан

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -123,8 +123,6 @@ vi:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: Từ

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -122,8 +122,6 @@ zh-hk:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: 來自

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -122,8 +122,6 @@ zh-tw:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: 從

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -122,8 +122,6 @@ zh:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:
-      popular_links:
-      popular_links_heading:
       search_text:
     metadata:
       from: 从

--- a/spec/components/layout_super_navigation_header_spec.rb
+++ b/spec/components/layout_super_navigation_header_spec.rb
@@ -166,13 +166,11 @@ describe "Super navigation header", type: :view do
     render_component({ ga4_tracking: true })
 
     assert_select "header[data-module='gem-track-click ga4-event-tracker ga4-link-tracker']"
-    assert_select "a[data-ga4-link]", count: 29
+    assert_select "a[data-ga4-link]", count: 23
     assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","external":"false","text":"GOV.UK","section":"Logo","index_link":1,"index_section":0,"index_section_count":2,"index_total":1}\']'
     assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index_section":1,"index_link":1,"index_section_count":4,"index_total":16,"section":"Services and information"}\']'
     assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index_section":1,"index_link":16,"index_section_count":4,"index_total":16,"section":"Services and information"}\']'
     assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index_section":2,"index_link":1,"index_section_count":4,"index_total":6,"section":"Government activity"}\']'
     assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index_section":2,"index_link":6,"index_section_count":4,"index_total":6,"section":"Government activity"}\']'
-    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index_section":4,"index_link":1,"index_section_count":4,"index_total":6,"section":"Popular on GOV.UK"}\']'
-    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index_section":4,"index_link":5,"index_section_count":4,"index_total":6,"section":"Popular on GOV.UK"}\']'
   end
 end

--- a/spec/javascripts/components/layout-super-navigation-header-spec.js
+++ b/spec/javascripts/components/layout-super-navigation-header-spec.js
@@ -171,28 +171,6 @@ describe('The super header navigation', function () {
                           '</form>' +
                       '</div>' +
                   '</div>' +
-                  '<div class="govuk-grid-row">' +
-                      '<div class="govuk-grid-column-full">' +
-                          '<h3 class="govuk-heading-m">Popular on GOV.UK</h3>' +
-                          '<ul class="govuk-list">' +
-                              '<li class="gem-c-layout-super-navigation-header__popular-item">' +
-                                  '<a class="govuk-link gem-c-layout-super-navigation-header__popular-link" data-track-action="popularLink" data-track-category="headerClicked" data-track-label="/check-benefits-financial-support" data-track-dimension="Check benefits and financial support you can get" data-track-dimension-index="29" data-ga4-link="{&quot;event_name&quot;:&quot;navigation&quot;,&quot;type&quot;:&quot;header menu bar&quot;,&quot;index&quot;:&quot;2.2.1&quot;,&quot;index_total&quot;:29,&quot;section&quot;:&quot;Popular on GOV.UK&quot;}" href="/check-benefits-financial-support">Check benefits and financial support you can get</a>' +
-                              '</li>' +
-                              '<li class="gem-c-layout-super-navigation-header__popular-item">' +
-                                  '<a class="govuk-link gem-c-layout-super-navigation-header__popular-link" data-track-action="popularLink" data-track-category="headerClicked" data-track-label="/guidance/getting-the-energy-bills-support-scheme-discount" data-track-dimension="Find out about the Energy Bills Support Scheme" data-track-dimension-index="29" data-ga4-link="{&quot;event_name&quot;:&quot;navigation&quot;,&quot;type&quot;:&quot;header menu bar&quot;,&quot;index&quot;:&quot;2.2.2&quot;,&quot;index_total&quot;:29,&quot;section&quot;:&quot;Popular on GOV.UK&quot;}" href="/guidance/getting-the-energy-bills-support-scheme-discount">Find out about the Energy Bills Support Scheme</a>' +
-                              '</li>' +
-                              '<li class="gem-c-layout-super-navigation-header__popular-item">' +
-                                  '<a class="govuk-link gem-c-layout-super-navigation-header__popular-link" data-track-action="popularLink" data-track-category="headerClicked" data-track-label="/find-a-job" data-track-dimension="Find a job" data-track-dimension-index="29" data-ga4-link="{&quot;event_name&quot;:&quot;navigation&quot;,&quot;type&quot;:&quot;header menu bar&quot;,&quot;index&quot;:&quot;2.2.3&quot;,&quot;index_total&quot;:29,&quot;section&quot;:&quot;Popular on GOV.UK&quot;}" href="/find-a-job">Find a job</a>' +
-                              '</li>' +
-                              '<li class="gem-c-layout-super-navigation-header__popular-item">' +
-                                  '<a class="govuk-link gem-c-layout-super-navigation-header__popular-link" data-track-action="popularLink" data-track-category="headerClicked" data-track-label="/coronavirus" data-track-dimension="Coronavirus (COVID-19)" data-track-dimension-index="29" data-ga4-link="{&quot;event_name&quot;:&quot;navigation&quot;,&quot;type&quot;:&quot;header menu bar&quot;,&quot;index&quot;:&quot;2.2.4&quot;,&quot;index_total&quot;:29,&quot;section&quot;:&quot;Popular on GOV.UK&quot;}" href="/coronavirus">Coronavirus (COVID-19)</a>' +
-                              '</li>' +
-                              '<li class="gem-c-layout-super-navigation-header__popular-item">' +
-                                  '<a class="govuk-link gem-c-layout-super-navigation-header__popular-link" data-track-action="popularLink" data-track-category="headerClicked" data-track-label="/sign-in-universal-credit" data-track-dimension="Universal Credit account: sign in" data-track-dimension-index="29" data-ga4-link="{&quot;event_name&quot;:&quot;navigation&quot;,&quot;type&quot;:&quot;header menu bar&quot;,&quot;index&quot;:&quot;2.2.5&quot;,&quot;index_total&quot;:29,&quot;section&quot;:&quot;Popular on GOV.UK&quot;}" href="/sign-in-universal-credit">Universal Credit account: sign in</a>' +
-                              '</li>' +
-                          '</ul>' +
-                      '</div>' +
-                  '</div>' +
               '</div>' +
           '</div>' +
       '</nav>'
@@ -350,9 +328,6 @@ describe('The super header navigation', function () {
     var $navLinks
     var $firstNavLink
     var $lastNavLink
-    var $searchMenu
-    var $searchLinks
-    var $lastSearchLink
 
     beforeEach(function () {
       thisModule.init()
@@ -362,9 +337,6 @@ describe('The super header navigation', function () {
       $navLinks = $navMenu.querySelectorAll('li')
       $firstNavLink = $navLinks[0].querySelector('a')
       $lastNavLink = $navLinks[$navLinks.length - 1].querySelector('a')
-      $searchMenu = document.querySelector('#super-search-menu')
-      $searchLinks = $searchMenu.querySelectorAll('li a')
-      $lastSearchLink = $searchLinks[$searchLinks.length - 1]
     })
 
     it('when the Menu button is focussed, the nav menu is open and the tab key is pressed focus moves to the first nav menu link', function () {
@@ -401,17 +373,6 @@ describe('The super header navigation', function () {
       window.GOVUK.triggerEvent($searchMenuButton, 'keydown', { keyCode: 9, cancelable: true, shiftKey: true })
 
       expect(document.activeElement).toEqual($lastNavLink)
-    })
-
-    it('when the last search menu link is focussed and the tab key is pressed the search menu is closed', function () {
-      $searchMenu.removeAttribute('hidden')
-      $lastSearchLink.focus()
-      window.GOVUK.triggerEvent($lastSearchLink, 'keydown', { keyCode: 9, cancelable: true })
-
-      expect($searchMenu.hasAttribute('hidden')).toEqual(true)
-      expect($searchMenuButton.getAttribute('aria-expanded')).toEqual('false')
-      expect($searchMenuButton.getAttribute('aria-label')).toEqual('Show search menu')
-      expect($searchMenuButton.classList).not.toContain('gem-c-layout-super-navigation-header__open-button')
     })
   })
 


### PR DESCRIPTION
## What
We have decided to remove the Popular links from the super navigation component. We already host Popular links on the GOV.UK homepage.

<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
The Popular links inside the search menu of the super navigation component get relatively little engagement from our users. Removing them will also simplify 2nd line and documentation.

## Visual Changes

### Before
<img width="854" alt="Screenshot 2024-03-14 at 12 59 24" src="https://github.com/alphagov/govuk_publishing_components/assets/5007934/f2c0d37d-0e14-4326-884f-d694aea9bec7">

### After
<img width="853" alt="Screenshot 2024-03-14 at 13 09 02" src="https://github.com/alphagov/govuk_publishing_components/assets/5007934/f6546311-e5bc-4fd0-9a59-7ecdeb747593">



