### PR TITLE
Change navigation header GA4 indexes

### DIFF
--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -323,7 +323,7 @@
                               "type": "header menu bar",
                               "index_section": column_index + 1,
                               "index_link": index + 1,
-                              "index_section_count": 4,
+                              "index_section_count": 3,
                               "index_total": index_total,
                               "section": column[:label],
                             }
@@ -343,7 +343,7 @@
         id: "super-search-menu",
         hidden: "",
         class: dropdown_menu_classes,
-      }) do %>        
+      }) do %>
         <div class="govuk-width-container gem-c-layout-super-navigation-header__search-container gem-c-layout-super-navigation-header__search-items">
           <h3 class="govuk-visually-hidden">
             <%= navigation_search_subheading %>

--- a/spec/components/layout_super_navigation_header_spec.rb
+++ b/spec/components/layout_super_navigation_header_spec.rb
@@ -168,9 +168,9 @@ describe "Super navigation header", type: :view do
     assert_select "header[data-module='gem-track-click ga4-event-tracker ga4-link-tracker']"
     assert_select "a[data-ga4-link]", count: 23
     assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","external":"false","text":"GOV.UK","section":"Logo","index_link":1,"index_section":0,"index_section_count":2,"index_total":1}\']'
-    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index_section":1,"index_link":1,"index_section_count":4,"index_total":16,"section":"Services and information"}\']'
-    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index_section":1,"index_link":16,"index_section_count":4,"index_total":16,"section":"Services and information"}\']'
-    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index_section":2,"index_link":1,"index_section_count":4,"index_total":6,"section":"Government activity"}\']'
-    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index_section":2,"index_link":6,"index_section_count":4,"index_total":6,"section":"Government activity"}\']'
+    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index_section":1,"index_link":1,"index_section_count":3,"index_total":16,"section":"Services and information"}\']'
+    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index_section":1,"index_link":16,"index_section_count":3,"index_total":16,"section":"Services and information"}\']'
+    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index_section":2,"index_link":1,"index_section_count":3,"index_total":6,"section":"Government activity"}\']'
+    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index_section":2,"index_link":6,"index_section_count":3,"index_total":6,"section":"Government activity"}\']'
   end
 end


### PR DESCRIPTION
## What / why
- recent removal of the 'popular links' section means that the `index_section_count` of the other links in the header should be reduced from 4 to 3

## Visual Changes
None.
