### PR TITLE
Fix accessibility issue in option select component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add a new GA4 'focus loss' tracker ([PR #3920](https://github.com/alphagov/govuk_publishing_components/pull/3920))
+* Fix accessibility issue in option select component ([PR #3926](https://github.com/alphagov/govuk_publishing_components/pull/3926))
 
 ## 37.8.1
 

--- a/app/views/govuk_publishing_components/components/_option_select.html.erb
+++ b/app/views/govuk_publishing_components/components/_option_select.html.erb
@@ -50,7 +50,7 @@
     <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" width="0" height="0" class="gem-c-option-select__icon gem-c-option-select__icon--down" aria-hidden="true" focusable="false"><path d="m225.84 414.16l256 256c16.683 16.683 43.691 16.683 60.331 0l256-256c16.683-16.683 16.683-43.691 0-60.331s-43.691-16.683-60.331 0l-225.84 225.84-225.84-225.84c-16.683-16.683-43.691-16.683-60.331 0s-16.683 43.691 0 60.331z"/></svg>
   </h3>
 
-  <%= content_tag(:div, role: "group", aria: { labelledby: title_id }, class: options_container_classes, id: options_container_id, tabindex: "-1") do %>
+  <%= content_tag(:div, class: options_container_classes, id: options_container_id, tabindex: "-1") do %>
     <div class="gem-c-option-select__container-inner js-auto-height-inner">
       <% if show_filter %>
         <span id="<%= checkboxes_count_id %>"


### PR DESCRIPTION
## What
This PR removes `role='group'` and `aria-labelledby` from the parent `div` of the [option select component](https://github.com/alphagov/govuk_publishing_components/blob/main/app/views/govuk_publishing_components/components/_option_select.html.erb). This was causing issues with screen readers because the [checkboxes component](https://github.com/alphagov/govuk_publishing_components/blob/main/app/views/govuk_publishing_components/components/_checkboxes.html.erb), which is what [this component ultimately renders](https://github.com/alphagov/govuk_publishing_components/blob/a2aba9d0222e67171c53cc3ff425c0990861d319/app/views/govuk_publishing_components/components/_option_select.html.erb#L63), contains a `fieldset` element with the same text as the parent `div`'s `aria-labelledby` attribute. This meant that the label text of the parent `div` and `fieldset` were both being announced (in a nutshell, the same text was being announced twice).

I'm fairly confident that removing `role='group'` and `aria-labelledby` won't have any adverse effects - my understanding is that in [earlier implementations of the option select component](https://github.com/alphagov/finder-frontend/blame/f89b8dafe0b43afd28d9f9b0caa34df6342d1278/app/views/components/_option-select.html.erb), a `fieldset` for checkboxes wasn't featured and instead `role='group'` and `aria-labelledby` was used. [When a move was made use the checkboxes component in the components gem](https://github.com/alphagov/finder-frontend/commit/242c79a5d811e9ef19cc88f8ae31c15bc9ad9265#diff-8bde8b9e948d88ef5d03de11ab41b637a26bdba8c58367a98c3a9e18a56161b8), `fieldset` elements were used and therefore `role='group'` and `aria-labelledby` were made redundant.

## Why
Fixes an issue identified as part of a WCAG audit - [trello card](https://trello.com/c/yGryNtR9/75-duplicate-group-and-label-in-option-select-component)

## Visual Changes
N/A
