### PR TITLE
Feedback component accessibility fix

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/components/feedback.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/feedback.js
@@ -10,7 +10,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.prompt = this.$module.querySelector('.js-prompt')
     this.forms = this.$module.querySelectorAll('.js-feedback-form')
     this.toggleForms = this.$module.querySelectorAll('.js-toggle-form')
-    this.closeForms = this.$module.querySelectorAll('.js-close-form')
     this.activeForm = false
     this.pageIsUsefulButton = this.$module.querySelector('.js-page-is-useful')
     this.pageIsNotUsefulButton = this.$module.querySelector('.js-page-is-not-useful')
@@ -40,21 +39,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         this.toggleForm(el.getAttribute('aria-controls'))
         this.trackEvent(this.getTrackEventParams(el))
         this.updateAriaAttributes(el)
-      }.bind(this))
-    }
-
-    for (var i = 0; i < this.closeForms.length; i++) {
-      this.closeForms[i].hidden = false
-      this.closeForms[i].addEventListener('click', function (e) {
-        e.preventDefault()
-        var el = e.target
-        var formToToggle = el.getAttribute('aria-controls')
-        this.toggleForm(formToToggle)
-        this.trackEvent(this.getTrackEventParams(el))
-        this.setInitialAriaAttributes()
-        this.revealInitialPrompt()
-        var refocusClass = '.js-' + formToToggle
-        this.$module.querySelector(refocusClass).focus()
       }.bind(this))
     }
 

--- a/app/assets/javascripts/govuk_publishing_components/components/feedback.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/feedback.js
@@ -43,6 +43,13 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         this.toggleForm(el.getAttribute('aria-controls'), el)
         this.trackEvent(this.getTrackEventParams(el))
         this.updateAriaAttributes(el)
+
+        // if closing the form, shift focus back to the button that controls it
+        if(!this.activeForm) {
+          var formToToggle = el.getAttribute('aria-controls')
+          var refocusClass = '.js-' + formToToggle
+          this.$module.querySelector(refocusClass).focus()
+        }
       }.bind(this))
     }
 

--- a/app/assets/javascripts/govuk_publishing_components/components/feedback.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/feedback.js
@@ -20,6 +20,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.jshiddenClass = 'js-hidden'
     this.whatDoingInput = this.$module.querySelector('[name=what_doing]')
     this.whatWrongInput = this.$module.querySelector('[name=what_wrong]')
+    this.pageIsUsefulHeading = this.$module.querySelector('.js-prompt-question')
+    this.pageIsUsefulYesButton = this.$module.querySelector('.js-page-is-useful')
+    this.pageIsUsefulNoButton = this.$module.querySelector('.js-page-is-not-useful')
+    this.feedbackPrompt = this.$module.querySelector('.gem-c-feedback__prompt-content')
   }
 
   Feedback.prototype.init = function () {
@@ -36,7 +40,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       this.toggleForms[j].addEventListener('click', function (e) {
         e.preventDefault()
         var el = e.target.closest('button')
-        this.toggleForm(el.getAttribute('aria-controls'))
+        this.toggleForm(el.getAttribute('aria-controls'), el)
         this.trackEvent(this.getTrackEventParams(el))
         this.updateAriaAttributes(el)
       }.bind(this))
@@ -184,17 +188,71 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     }
   }
 
-  Feedback.prototype.toggleForm = function (formId) {
+  Feedback.prototype.toggleForm = function (formId, el) {
     this.activeForm = this.$module.querySelector('#' + formId)
     this.activeForm.hidden ? this.activeForm.hidden = false : this.activeForm.hidden = true
 
     if (!this.activeForm.hidden) {
+      var elementsToHide = [this.promptQuestions[1], this.pageIsUsefulHeading, this.pageIsUsefulYesButton]
+
+      el.querySelector('.js-prompt-button-text').textContent = el.dataset.feedbackCloseTranslation
+      this.hidePrompts(el, elementsToHide)
       this.activeForm.querySelectorAll('.gem-c-textarea .govuk-textarea, .gem-c-input.govuk-input')[0]
         .focus()
     } else {
+      var buttonText = this.isSomethingIsWrongButton(el) ? el.dataset.feedbackSomethingWrongTranslation : el.dataset.feedbackNoTranslation
+      var elementsToShow = [this.promptQuestions[0], this.promptQuestions[1], this.pageIsUsefulHeading, this.pageIsUsefulYesButton]
+      
+      el.querySelector('.js-prompt-button-text').textContent = buttonText
+      this.showPrompts(elementsToShow)
       this.activeForm = false
       clearInterval(this.timerInterval)
     }
+  }
+
+  Feedback.prototype.hidePrompts = function(el, elementsToHide) {
+    this.feedbackPrompt.classList.add('js-prompt-content')
+
+    if(this.isSomethingIsWrongButton(el)) {
+      this.promptQuestions[0].setAttribute('hidden', true)
+      this.somethingIsWrongButton.parentElement.classList.add('js-no-border-top')
+    }
+    else if (this.isPageIsNotUsefulButton(el)) {
+      for(var i = 0; i < elementsToHide.length; i++) {
+        elementsToHide[i].setAttribute('hidden', true)
+      }
+      this.toggleStyling(true)
+    }
+  }
+
+  Feedback.prototype.showPrompts = function(elementsToShow) {
+    this.feedbackPrompt.classList.remove('js-prompt-content')
+
+    for(var i = 0; i < elementsToShow.length; i++) {
+      elementsToShow[i].removeAttribute('hidden')
+    }
+    
+    this.toggleStyling(false)
+  }
+
+  Feedback.prototype.toggleStyling = function(addStyling) {
+    if(addStyling) {
+      this.pageIsUsefulNoButton.parentElement.classList.add('govuk-!-margin-0')
+      this.pageIsUsefulNoButton.parentElement.classList.add('govuk-!-width-full')
+    }
+    else {
+      this.somethingIsWrongButton.parentElement.classList.remove('js-no-border-top')
+      this.pageIsUsefulNoButton.parentElement.classList.remove('govuk-!-margin-0')
+      this.pageIsUsefulNoButton.parentElement.classList.remove('govuk-!-width-full')
+    }
+  }
+
+  Feedback.prototype.isSomethingIsWrongButton = function(el) {
+    return el.classList.contains('js-something-is-wrong')
+  }
+
+  Feedback.prototype.isPageIsNotUsefulButton = function(el) {
+    return el.classList.contains('js-page-is-not-useful')
   }
 
   Feedback.prototype.getTrackEventParams = function ($node) {

--- a/app/assets/javascripts/govuk_publishing_components/components/feedback.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/feedback.js
@@ -174,13 +174,19 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   }
 
   Feedback.prototype.updateAriaAttributes = function (linkClicked) {
-    linkClicked.setAttribute('aria-expanded', true)
+    this.ariaExpanded = linkClicked.getAttribute('aria-expanded')
+
+    if(this.ariaExpanded === 'false') {
+      linkClicked.setAttribute('aria-expanded', true)
+    }
+    else {
+      linkClicked.setAttribute('aria-expanded', false)
+    }
   }
 
   Feedback.prototype.toggleForm = function (formId) {
     this.activeForm = this.$module.querySelector('#' + formId)
     this.activeForm.hidden ? this.activeForm.hidden = false : this.activeForm.hidden = true
-    this.prompt.hidden ? this.prompt.hidden = false : this.prompt.hidden = true
 
     if (!this.activeForm.hidden) {
       this.activeForm.querySelectorAll('.gem-c-textarea .govuk-textarea, .gem-c-input.govuk-input')[0]

--- a/app/assets/javascripts/govuk_publishing_components/components/feedback.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/feedback.js
@@ -41,8 +41,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       this.toggleForms[j].addEventListener('click', function (e) {
         e.preventDefault()
         var el = e.target.closest('button')
-        this.toggleForm(el.getAttribute('aria-controls'), el)
         this.trackEvent(this.getTrackEventParams(el))
+        this.toggleForm(el.getAttribute('aria-controls'), el)
         this.updateAriaAttributes(el)
 
         // if closing the form, shift focus back to the button that controls it

--- a/app/assets/javascripts/govuk_publishing_components/components/feedback.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/feedback.js
@@ -24,6 +24,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.pageIsUsefulYesButton = this.$module.querySelector('.js-page-is-useful')
     this.pageIsUsefulNoButton = this.$module.querySelector('.js-page-is-not-useful')
     this.feedbackPrompt = this.$module.querySelector('.gem-c-feedback__prompt-content')
+    this.feedbackTrackingData = this.initialiseFeedbackTrackingData()
   }
 
   Feedback.prototype.init = function () {
@@ -204,6 +205,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
       el.querySelector('.js-prompt-button-text').textContent = el.dataset.feedbackCloseTranslation
       this.hidePrompts(el, elementsToHide)
+      this.toggleFeedbackTrackingDataAttributes(el)
       this.activeForm.querySelectorAll('.gem-c-textarea .govuk-textarea, .gem-c-input.govuk-input')[0]
         .focus()
     } else {
@@ -212,6 +214,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       
       el.querySelector('.js-prompt-button-text').textContent = buttonText
       this.showPrompts(elementsToShow)
+      this.toggleFeedbackTrackingDataAttributes(el)
       this.activeForm = false
       clearInterval(this.timerInterval)
     }
@@ -260,6 +263,65 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   Feedback.prototype.isPageIsNotUsefulButton = function(el) {
     return el.classList.contains('js-page-is-not-useful')
+  }
+
+  Feedback.prototype.toggleFeedbackTrackingDataAttributes = function(el) {
+    this.clearFeedbackTrackingDataAttributes(el)
+    var data;
+
+    if(this.isSomethingIsWrongButton(el)) {
+      data = this.feedbackTrackingData.somethingWrongTrackingData
+    }
+    else if(this.isPageIsNotUsefulButton(el)) {
+      data = this.feedbackTrackingData.pageIsNotUsefulTrackingData
+    }
+
+    this.setFeedbackTrackingDataAttributes(el, data)
+  }
+
+  Feedback.prototype.clearFeedbackTrackingDataAttributes = function(el) {
+    if(el) {
+      for(var prop in el.dataset){
+        delete el.dataset[prop]
+      }
+    }
+  }
+
+  Feedback.prototype.setFeedbackTrackingDataAttributes = function(el, data){
+    if(el && data) {
+      var data = !this.activeForm.hidden ? data.collapsedDataAttributes : data.expandedDataAttributes
+      for(var prop in data) {
+        el.dataset[prop] = data[prop]
+      }
+    }
+  }
+
+  Feedback.prototype.initialiseFeedbackTrackingData = function() {
+    var initialSomethingWrongTrackingData = this.somethingIsWrongButton.dataset
+    var initialPageIsNotUsefulTrackingData = this.pageIsNotUsefulButton.dataset
+
+    return {
+      somethingWrongTrackingData: {
+        // Convert expandedDataAttributes from a DOMStringMap to an object. This makes it easier to toggle the data attributes.
+        expandedDataAttributes: window.GOVUK.extendObject({}, initialSomethingWrongTrackingData),
+        collapsedDataAttributes: {
+          trackCategory: "Onsite Feedback",
+          trackAction: "GOV.UK Close Form",
+          feedbackSomethingWrongTranslation: initialSomethingWrongTrackingData.feedbackSomethingWrongTranslation,
+          feedbackCloseTranslation: initialSomethingWrongTrackingData.feedbackCloseTranslation
+        }
+      },
+      pageIsNotUsefulTrackingData: {
+        // Convert expandedDataAttributes from a DOMStringMap to an object. This makes it easier to toggle the data attributes.
+        expandedDataAttributes: window.GOVUK.extendObject({}, initialPageIsNotUsefulTrackingData),
+        collapsedDataAttributes: {
+          trackCategory: "yesNoFeedbackForm",
+          trackAction: "ffFormClose",
+          feedbackNoTranslation: initialPageIsNotUsefulTrackingData.feedbackNoTranslation,
+          feedbackCloseTranslation: initialPageIsNotUsefulTrackingData.feedbackCloseTranslation
+        }
+      }
+    }
   }
 
   Feedback.prototype.getTrackEventParams = function ($node) {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -3,6 +3,7 @@
 .gem-c-feedback {
   background: govuk-colour("white");
   margin-top: govuk-spacing(6);
+  position: relative;
 
   @include govuk-media-query($from: desktop) {
     margin-top: govuk-spacing(9);
@@ -137,6 +138,14 @@
   list-style-type: none;
   margin: 0;
   padding: 0;
+
+  @include govuk-media-query($until: tablet) {
+    width: 100%;
+  }
+
+  @include govuk-media-query($until: 320px) {
+    justify-content: center;
+  }
 }
 
 .gem-c-feedback__option-list-item {
@@ -200,10 +209,13 @@
 
 .gem-c-feedback__form {
   padding: govuk-spacing(3);
-  border-top: 1px solid $govuk-border-colour;
 
   @include govuk-media-query($from: tablet) {
     padding: govuk-spacing(6);
+  }
+
+  @include govuk-media-query($from: mobile, $until: tablet) {
+    border-top: none;
   }
 }
 
@@ -231,6 +243,11 @@
 
   @include govuk-media-query($from: desktop) {
     margin-top: govuk-spacing(2);
+    margin-left: govuk-spacing(3);
+  }
+
+  @include govuk-media-query($until: desktop) {
+    display: block;
   }
 
   &:focus,
@@ -249,5 +266,23 @@
 
   &:focus {
     outline: $govuk-focus-width solid $govuk-focus-colour;
+  }
+}
+
+.js-prompt-content {
+  position: absolute;
+  right: 0;
+  @include govuk-media-query($until: tablet) {
+    position: static;
+  }
+
+  @include govuk-media-query($until: tablet) {
+    background-color: govuk-colour("white");
+  }
+}
+
+.js-no-border-top {
+  @include govuk-media-query($until: tablet) {
+    border-top: none;
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -225,13 +225,6 @@
   padding-bottom: govuk-spacing(3);
 }
 
-.gem-c-feedback__close {
-  margin: 0 govuk-spacing(2);
-  @include govuk-media-query($until: tablet) {
-    margin: govuk-spacing(4) 0 0;
-  }
-}
-
 .gem-c-feedback__email-link {
   display: inline-block;
   margin-top: govuk-spacing(4);

--- a/app/views/govuk_publishing_components/components/feedback/_problem_form.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_problem_form.html.erb
@@ -60,14 +60,6 @@
         }
       } %>
 
-      <button
-        class="govuk-button govuk-button--secondary gem-c-feedback__close gem-c-feedback__js-show js-close-form"
-        data-track-category="Onsite Feedback"
-        data-track-action="GOV.UK Close Form"
-        aria-controls="something-is-wrong"
-        aria-expanded="true">
-        <%= t("components.feedback.close") %>
-      </button>
     </div>
   </div>
 </form>

--- a/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
@@ -47,16 +47,6 @@
         }
       } %>
 
-      <button
-        class="govuk-button govuk-button--secondary gem-c-feedback__close js-close-form"
-        data-track-category="yesNoFeedbackForm"
-        data-track-action="ffFormClose"
-        aria-controls="page-is-not-useful"
-        aria-expanded="true"
-        hidden>
-        <%= t("components.feedback.close") %>
-      </button>
-
     </div>
   </div>
 </form>

--- a/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
@@ -27,7 +27,7 @@
   <div class="gem-c-feedback__prompt-content">
     <div class="gem-c-feedback__prompt-questions js-prompt-questions" hidden>
       <div class="gem-c-feedback__prompt-question-answer">
-        <h2 class="gem-c-feedback__prompt-question"><%= t("components.feedback.is_this_page_useful") %></h2>
+        <h2 class="gem-c-feedback__prompt-question js-prompt-question"><%= t("components.feedback.is_this_page_useful") %></h2>
         <ul class="gem-c-feedback__option-list">
           <li class="gem-c-feedback__option-list-item govuk-visually-hidden" hidden>
             <% # Maybe button exists only to try and capture clicks by bots %>
@@ -67,8 +67,10 @@
                 track_category: "yesNoFeedbackForm",
                 track_action: "ffNoClick",
                 ga4_event: ga4_no_button_event,
+                feedback_no_translation: t("components.feedback.no"),
+                feedback_close_translation: t("components.feedback.close"),
               }) do %>
-              <%= t("components.feedback.no") %> <span class="govuk-visually-hidden"><%= t("components.feedback.is_not_useful") %></span>
+                <span class="js-prompt-button-text" aria-hidden="true"><%= t("components.feedback.no") %></span><span class="govuk-visually-hidden"><%= t("components.feedback.no") %> <%= t("components.feedback.is_not_useful") %></span>
             <% end %>
           </li>
         </ul>
@@ -90,8 +92,10 @@
           track_category: "Onsite Feedback",
           track_action: "GOV-UK Open Form",
           ga4_event: ga4_problem_button_event,
+          feedback_something_wrong_translation: t("components.feedback.something_wrong"),
+          feedback_close_translation: t("components.feedback.close"),
         }) do %>
-        <%= t("components.feedback.something_wrong") %>
+        <span class="js-prompt-button-text" aria-hidden="true"><%= t("components.feedback.something_wrong") %></span><span class="govuk-visually-hidden"><%= t("components.feedback.something_wrong") %></span>
       <% end %>
     </div>
   </div>

--- a/spec/javascripts/components/feedback-spec.js
+++ b/spec/javascripts/components/feedback-spec.js
@@ -68,10 +68,6 @@ describe('Feedback component', function () {
 
           '<button class="gem-c-button govuk-button" type="submit">Send</button>' +
 
-          '<button class="govuk-button govuk-button--secondary gem-c-feedback__close gem-c-feedback__js-show js-close-form" data-track-category="Onsite Feedback" data-track-action="GOV.UK Close Form" aria-controls="something-is-wrong" aria-expanded="true">' +
-            'Cancel' +
-          '</button>' +
-
         '</div>' +
       '</div>' +
     '</form>' +
@@ -92,10 +88,6 @@ describe('Feedback component', function () {
           '</div>' +
 
           '<button class="gem-c-button govuk-button" type="submit">Send me the survey</button>' +
-
-          '<button class="govuk-button govuk-button--secondary gem-c-feedback__close js-close-form" data-track-category="yesNoFeedbackForm" data-track-action="ffFormClose" aria-controls="page-is-not-useful" aria-expanded="true" hidden>' +
-            'Cancel' +
-          '</button>' +
 
         '</div>' +
       '</div>' +
@@ -274,7 +266,6 @@ describe('Feedback component', function () {
     beforeEach(function () {
       loadFeedbackComponent()
       $('.js-something-is-wrong')[0].click()
-      $('#something-is-wrong .js-close-form')[0].click()
     })
 
     it('hides the form', function () {
@@ -294,7 +285,6 @@ describe('Feedback component', function () {
     })
 
     it('triggers a Google Analytics event', function () {
-      $('#something-is-wrong .js-close-form')[0].click()
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('Onsite Feedback', 'GOV.UK Close Form')
     })
@@ -304,7 +294,6 @@ describe('Feedback component', function () {
     beforeEach(function () {
       loadFeedbackComponent()
       $('.js-page-is-not-useful')[0].click()
-      $('#page-is-not-useful .js-close-form')[0].click()
     })
 
     it('hides the form', function () {
@@ -324,7 +313,6 @@ describe('Feedback component', function () {
     })
 
     it('triggers a Google Analytics event', function () {
-      $('#page-is-not-useful .js-close-form')[0].click()
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('yesNoFeedbackForm', 'ffFormClose')
     })

--- a/spec/javascripts/components/feedback-spec.js
+++ b/spec/javascripts/components/feedback-spec.js
@@ -9,7 +9,7 @@ describe('Feedback component', function () {
       '<div class="gem-c-feedback__prompt-content">' +
         '<div class="gem-c-feedback__prompt-questions js-prompt-questions" hidden>' +
           '<div class="gem-c-feedback__prompt-question-answer">' +
-            '<h2 class="gem-c-feedback__prompt-question">Is this page useful?</h2>' +
+            '<h2 class="gem-c-feedback__prompt-question js-prompt-question">Is this page useful?</h2>' +
             '<ul class="gem-c-feedback__option-list">' +
               '<li class="gem-c-feedback__option-list-item govuk-visually-hidden" style="display: none" hidden>' +
                 '<a class="gem-c-feedback__prompt-link" data-track-category="yesNoFeedbackForm" data-track-action="ffMaybeClick" role="button" style="display: none" hidden="hidden" aria-hidden="true" href="/contact/govuk">' +
@@ -22,8 +22,13 @@ describe('Feedback component', function () {
                 '</button>' +
               '</li>' +
               '<li class="gem-c-feedback__option-list-item">' +
-                '<button class="govuk-button gem-c-feedback__prompt-link js-toggle-form js-page-is-not-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffNoClick" aria-controls="page-is-not-useful" aria-expanded="false">' +
-                  'No <span class="govuk-visually-hidden">this page is not useful</span>' +
+                '<button class="govuk-button gem-c-feedback__prompt-link js-toggle-form js-page-is-not-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffNoClick" data-feedback-no-translation="No" data-feedback-close-translation="Cancel" aria-controls="page-is-not-useful" aria-expanded="false">' +
+                  '<span class="js-prompt-button-text" aria-hidden="true">' +
+                    'No' +
+                  '</span>' +
+                  '<span span class="govuk-visually-hidden">' +
+                    'No this page is not useful' +
+                  '</span>' +
                 '</button>' +
               '</li>' +
             '</ul>' +
@@ -33,8 +38,13 @@ describe('Feedback component', function () {
           'Thank you for your feedback' +
         '</div>' +
         '<div class="gem-c-feedback__prompt-questions gem-c-feedback__prompt-questions--something-is-wrong js-prompt-questions" hidden>' +
-          '<button class="govuk-button gem-c-feedback__prompt-link js-toggle-form js-something-is-wrong" data-track-category="Onsite Feedback" data-track-action="GOV.UK Open Form" aria-controls="something-is-wrong" aria-expanded="false">' +
-            'Report a problem with this page' +
+          '<button class="govuk-button gem-c-feedback__prompt-link js-toggle-form js-something-is-wrong" data-track-category="Onsite Feedback" data-track-action="GOV.UK Open Form" aria-controls="something-is-wrong" data-feedback-something-wrong-translation="Report a problem with this page" data-feedback-close-translation="Cancel" aria-expanded="false">' +
+            '<span class="js-prompt-button-text" aria-hidden="true">' +
+              'Report a problem with this page' +
+            '</span>' +
+            '<span span class="govuk-visually-hidden">' +
+              'Report a problem with this page' +
+            '</span>' +
           '</button>' +
         '</div>' +
       '</div>' +
@@ -183,6 +193,13 @@ describe('Feedback component', function () {
   })
 
   describe('clicking the "page was not useful" link', function () {
+    it('sets the text of the link to Cancel', function () {
+      loadFeedbackComponent()
+      $('.js-page-is-not-useful')[0].click()
+      
+      expect($('.js-page-is-not-useful .js-prompt-button-text')).toHaveText("Cancel")
+    })
+
     it('shows the feedback form', function () {
       loadFeedbackComponent()
       $('.js-page-is-not-useful')[0].click()
@@ -190,11 +207,13 @@ describe('Feedback component', function () {
       expect($('.gem-c-feedback .js-feedback-form#page-is-not-useful').prop('hidden')).toBe(false)
     })
 
-    it('hides the prompt', function () {
+    it('hides the prompts', function () {
       loadFeedbackComponent()
       $('.js-page-is-not-useful')[0].click()
 
-      expect($('.gem-c-feedback .js-prompt').prop('hidden')).toBe(true)
+      expect($('.js-prompt-question').prop('hidden')).toBe(true)
+      expect($('.js-page-is-useful').prop('hidden')).toBe(true)
+      expect($('.gem-c-feedback__prompt-questions--something-is-wrong').prop('hidden')).toBe(true)
     })
 
     it('conveys that the form is now expanded', function () {
@@ -220,9 +239,25 @@ describe('Feedback component', function () {
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('yesNoFeedbackForm', 'ffNoClick')
     })
+
+    it('adds the appropriate CSS classes', function () {
+      loadFeedbackComponent()
+      $('.js-page-is-not-useful')[0].click()
+
+      expect($('.gem-c-feedback__prompt-content')[0]).toHaveClass('js-prompt-content')
+      expect($('.js-page-is-not-useful')[0].parentElement).toHaveClass('govuk-!-margin-0')
+      expect($('.js-page-is-not-useful')[0].parentElement).toHaveClass('govuk-!-width-full')
+    })
   })
 
   describe('Clicking the "is there anything wrong with this page" link', function () {
+    it('sets the text of the link to Cancel', function () {
+      loadFeedbackComponent()
+      $('.js-something-is-wrong')[0].click()
+
+      expect($('.js-something-is-wrong .js-prompt-button-text')).toHaveText("Cancel")
+    })
+
     it('shows the form', function () {
       loadFeedbackComponent()
       $('.js-something-is-wrong')[0].click()
@@ -230,11 +265,11 @@ describe('Feedback component', function () {
       expect($('.gem-c-feedback .js-feedback-form#something-is-wrong').prop('hidden')).toBe(false)
     })
 
-    it('hides the prompt', function () {
+    it('hides the prompts', function () {
       loadFeedbackComponent()
       $('.js-something-is-wrong')[0].click()
 
-      expect($('.gem-c-feedback .js-prompt').prop('hidden')).toBe(true)
+      expect($('.js-prompt-questions')[0].hidden).toBe(true)
     })
 
     it('conveys that the form is now expanded', function () {
@@ -260,64 +295,90 @@ describe('Feedback component', function () {
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('Onsite Feedback', 'GOV.UK Open Form')
     })
+
+    it('adds the appropriate CSS classes', function () {
+      loadFeedbackComponent()
+      $('.js-something-is-wrong')[0].click()
+
+      expect($('.gem-c-feedback__prompt-content')[0]).toHaveClass('js-prompt-content')
+      expect($('.js-something-is-wrong')[0].parentElement).toHaveClass('js-no-border-top')
+    })
   })
 
   describe('Clicking the close link in the "something is wrong" form', function () {
     beforeEach(function () {
       loadFeedbackComponent()
       $('.js-something-is-wrong')[0].click()
+      $('.js-something-is-wrong')[0].click()
+    })
+
+    it('sets the text of the link to Report a problem with this page', function () {
+      expect($('.js-something-is-wrong .js-prompt-button-text')).toHaveText("Report a problem with this page")
     })
 
     it('hides the form', function () {
       expect($('.gem-c-feedback #something-is-wrong').prop('hidden')).toBe(true)
     })
 
-    it('shows the prompt', function () {
-      expect($('.gem-c-feedback .js-prompt').prop('hidden')).toBe(false)
+    it('shows the prompts', function () {
+      expect($('.js-prompt-questions')[0].hidden).toBe(false)
+      expect($('.js-prompt-questions')[1].hidden).toBe(false)
       expect(document.activeElement).toBe($('.js-something-is-wrong').get(0))
     })
 
     it('conveys that the form is not expanded', function () {
-      loadFeedbackComponent()
-
       expect($('.js-page-is-not-useful').attr('aria-expanded')).toBe('false')
       expect($('.js-something-is-wrong').attr('aria-expanded')).toBe('false')
     })
 
     it('triggers a Google Analytics event', function () {
-
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('Onsite Feedback', 'GOV.UK Close Form')
     })
-  })
 
+    it('remove the appropriate CSS classes', function () {
+      expect($('.gem-c-feedback__prompt-content')[0]).not.toHaveClass('js-prompt-content')
+      expect($('.js-something-is-wrong')[0].parentElement).not.toHaveClass('js-no-border-top')
+    })
+  })
+  
   describe('Clicking the close link in the "not useful" form', function () {
     beforeEach(function () {
       loadFeedbackComponent()
       $('.js-page-is-not-useful')[0].click()
+      $('.js-page-is-not-useful')[0].click()
+    })
+
+    it('sets the text of the link to No', function () {
+      expect($('.js-page-is-not-useful .js-prompt-button-text')).toHaveText("No")
     })
 
     it('hides the form', function () {
       expect($('.gem-c-feedback #page-is-not-useful').prop('hidden')).toBe(true)
     })
 
-    it('shows the prompt', function () {
-      expect($('.gem-c-feedback .js-prompt').prop('hidden')).toBe(false)
+    it('shows the prompts', function () {
+      expect($('.js-prompt-question').prop('hidden')).toBe(false)
+      expect($('.js-page-is-useful').prop('hidden')).toBe(false)
+      expect($('.gem-c-feedback__prompt-questions--something-is-wrong').prop('hidden')).toBe(false)
       expect(document.activeElement).toBe($('.js-page-is-not-useful').get(0))
     })
 
     it('conveys that the form is not expanded', function () {
-      loadFeedbackComponent()
-
       expect($('.js-page-is-not-useful').attr('aria-expanded')).toBe('false')
       expect($('.js-something-is-wrong').attr('aria-expanded')).toBe('false')
     })
 
     it('triggers a Google Analytics event', function () {
-
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('yesNoFeedbackForm', 'ffFormClose')
     })
-  })
 
+    it('removes the appropriate CSS classes', function () {
+      expect($('.gem-c-feedback__prompt-content')[0]).not.toHaveClass('js-prompt-content')
+      expect($('.js-page-is-not-useful')[0].parentElement).not.toHaveClass('govuk-!-margin-0')
+      expect($('.js-page-is-not-useful')[0].parentElement).not.toHaveClass('govuk-!-width-full')
+    })
+  })
+ 
   // this check prevents these tests being run if in IE11 or below
   // because the JS doesn't work for form submissions on IE
   if (typeof window.URLSearchParams === 'function') {


### PR DESCRIPTION
## What
This PR fixes an accessibility issue with the buttons on the feedback component and how `aria-expanded` is working. In essence, the `No` and `Report a problem with this page` buttons that open the feedback forms and the `Cancel` buttons that close them work in unexpected ways.

For example, the `aria-expanded` attributes on the `No` and `Report a problem with this page` do toggle correctly however the buttons disappear on click i.e. they only handle expanding the forms, not collapsing them. A separate `Cancel` button handles collapsing the forms, which also disappears on click and its `aria-expanded` is only ever set to `true`.

Ideally, expanding and collapsing the feedback forms would be handled by a single button that shows at all times.

Therefore, this PR proposes to remove the `Cancel` button and moves towards using a single button. This change does mean that some of the visual updates introduced in [this PR](https://github.com/alphagov/govuk_publishing_components/pull/2894) (specifically the position of the buttons) will be reverted to how they were before. This has been discussed with and approved by the interaction designer that worked on the feedback component at the time.

## Why
Fixes an accessibility issue identified as part of a WCAG audit - [trello card](https://trello.com/c/MT27SXD9/28-unexpected-show-hide-behaviour-in-feedback-component)

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

### Before

Clicking the `No` button (desktop):

![image](https://github.com/alphagov/govuk_publishing_components/assets/110391449/94a261eb-eb59-4ae1-9c04-6003a8a5b32c)

Clicking the `No` button (mobile):

![image](https://github.com/alphagov/govuk_publishing_components/assets/110391449/507cd982-abe6-4c4e-ad47-b42dff78adfa)

Clicking the `Report a problem with this page` button (desktop):

![image](https://github.com/alphagov/govuk_publishing_components/assets/110391449/75095862-8ea7-4666-b9dc-f95d89bb1cf5)

Clicking the `Report a problem with this page` button (mobile):

![image](https://github.com/alphagov/govuk_publishing_components/assets/110391449/00f6e6b4-7728-437e-903a-c53d2d6f6f9d)

### After

Clicking the `No` button (desktop):

![image](https://github.com/alphagov/govuk_publishing_components/assets/110391449/04aa8dde-c147-4421-a1ea-5d42ca5bdadc)

Clicking the `No` button (mobile):

![image](https://github.com/alphagov/govuk_publishing_components/assets/110391449/eefdf8ed-fa71-4d5b-a0fe-407d418a873f)

Clicking the `Report a problem with this page` button (desktop):

![image](https://github.com/alphagov/govuk_publishing_components/assets/110391449/bdf4679b-d9ea-489b-a155-206429e19b25)

Clicking the `Report a problem with this page` button (mobile):

![image](https://github.com/alphagov/govuk_publishing_components/assets/110391449/285e0887-8c32-4e63-ad60-379ba9c187a8)