### PR TITLE
Version 37.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 37.9.0
 
 * Add a new GA4 'focus loss' tracker ([PR #3920](https://github.com/alphagov/govuk_publishing_components/pull/3920))
 * Fix accessibility issue in option select component ([PR #3926](https://github.com/alphagov/govuk_publishing_components/pull/3926))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (37.8.1)
+    govuk_publishing_components (37.9.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "37.8.1".freeze
+  VERSION = "37.9.0".freeze
 end


### PR DESCRIPTION
## 37.9.0

* Add a new GA4 'focus loss' tracker ([PR #3920](https://github.com/alphagov/govuk_publishing_components/pull/3920))
* Fix accessibility issue in option select component ([PR #3926](https://github.com/alphagov/govuk_publishing_components/pull/3926))