### PR TITLE
Track 'Start now' buttons with a specific GA4 type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Track 'Start now' buttons with a specific GA4 type ([PR #3935](https://github.com/alphagov/govuk_publishing_components/pull/3935))
 * Use component wrapper in document list component ([PR #3933](https://github.com/alphagov/govuk_publishing_components/pull/3933))
 
 ## 37.9.0

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.js
@@ -72,7 +72,22 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
       if (!href) {
         return
       }
+
       var data = {}
+      var extraAttributes = element.getAttribute('data-ga4-attributes')
+      if (extraAttributes) {
+        try {
+          extraAttributes = JSON.parse(extraAttributes)
+          // make sure the data object remains an object - JSON.parse can return a string
+          for (var attrname in extraAttributes) {
+            data[attrname] = extraAttributes[attrname]
+          }
+        } catch (e) {
+          // fall back to the empty data object if something goes wrong
+          console.error('GA4 configuration error: ' + e.message, window.location)
+        }
+      }
+
       var mailToLink = false
       if (window.GOVUK.analyticsGa4.core.trackFunctions.isMailToLink(href)) {
         data.event_name = 'navigation'
@@ -85,7 +100,7 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
         data.external = window.GOVUK.analyticsGa4.core.trackFunctions.isExternalLink(href) ? 'true' : 'false'
       } else if (window.GOVUK.analyticsGa4.core.trackFunctions.isExternalLink(href)) {
         data.event_name = 'navigation'
-        data.type = 'generic link'
+        data.type = data.type || 'generic link'
         data.external = 'true'
       }
 

--- a/app/views/govuk_publishing_components/components/_button.html.erb
+++ b/app/views/govuk_publishing_components/components/_button.html.erb
@@ -1,5 +1,6 @@
 <%
   add_gem_component_stylesheet("button")
+  disable_ga4 ||= false
 
   # button_helper.css_classes generates "gem-c-button"
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)

--- a/app/views/govuk_publishing_components/components/docs/button.yml
+++ b/app/views/govuk_publishing_components/components/docs/button.yml
@@ -44,6 +44,14 @@ examples:
       href: '#'
       start: true
       rel: external
+  start_now_button_without_ga4_attributes:
+    description: By default the start now button version of this component includes a `data-ga4-attributes` attribute that is used by the specialist (external) link tracker to uniquely identify start now buttons. This attribute can be removed using the `disable_ga4` option.
+    data:
+      text: Start now
+      disable_ga4: true
+      href: '#'
+      start: true
+      rel: external
   secondary_button:
     data:
       text: Secondary button

--- a/docs/analytics-ga4/ga4-specialist-link-tracker.md
+++ b/docs/analytics-ga4/ga4-specialist-link-tracker.md
@@ -72,7 +72,7 @@ In the example above, on a left click of the link, the following would be pushed
 
 Preview links would turn `type` to `preview`.
 
-External links would turn `event_name` to `navigation` and `type` to `generic link`.
+External links would turn `event_name` to `navigation` and `type` to `generic link`. `type` can be overridden by putting a `data-ga4-attributes` attribute on a link, containing a JSON snippet with an alternative `type`. This is done on 'Start now' buttons to uniquely identify them.
 
 Mailto links would turn turn `event_name` to `navigation` and `type` to `email`.
 

--- a/lib/govuk_publishing_components/presenters/button_helper.rb
+++ b/lib/govuk_publishing_components/presenters/button_helper.rb
@@ -28,6 +28,7 @@ module GovukPublishingComponents
                   :aria_describedby
 
       def initialize(local_assigns)
+        @disable_ga4 = local_assigns[:disable_ga4]
         @href = local_assigns[:href]
         @text = local_assigns[:text]
         @title = local_assigns[:title]
@@ -45,6 +46,7 @@ module GovukPublishingComponents
         @target = local_assigns[:target]
         @type = local_assigns[:type]
         @start = local_assigns[:start]
+        @data_attributes[:ga4_attributes] = ga4_attribute if start
         @secondary = local_assigns[:secondary]
         @secondary_quiet = local_assigns[:secondary_quiet]
         @secondary_solid = local_assigns[:secondary_solid]
@@ -128,6 +130,10 @@ module GovukPublishingComponents
         legacy_class = "gem-c-button__info-text--bottom-margin" if info_text
 
         [*0..9].include?(margin) ? "govuk-!-margin-bottom-#{margin}" : legacy_class
+      end
+
+      def ga4_attribute
+        { type: "start button" }.to_json unless @disable_ga4
       end
     end
   end

--- a/spec/components/button_spec.rb
+++ b/spec/components/button_spec.rb
@@ -15,6 +15,7 @@ describe "Button", type: :view do
     assert_select ".govuk-button[type=submit]", text: "Submit"
     assert_select ".govuk-button--start", false
     assert_select ".gem-c-button__info-text", false
+    assert_select "[data-ga4-attributes]", false
   end
 
   it "renders text correctly" do
@@ -46,6 +47,14 @@ describe "Button", type: :view do
     render_component(text: "Start now", href: "#", start: true)
     assert_select ".govuk-button[href='#'] span", text: /Start now/
     assert_select ".govuk-button--start"
+    assert_select ".govuk-button--start[data-ga4-attributes='{\"type\":\"start button\"}']"
+  end
+
+  it "renders start now button with GA4 attributes disabled" do
+    render_component(text: "Start now", href: "#", start: true, disable_ga4: true)
+    assert_select ".govuk-button[href='#'] span", text: /Start now/
+    assert_select ".govuk-button--start"
+    assert_select ".govuk-button--start[data-ga4-attributes='{\"type\":\"start button\"}']", false
   end
 
   it "renders secondary button" do

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.spec.js
@@ -49,6 +49,10 @@ describe('A specialist link tracker', function () {
               '<a href="https://www.nationalarchives.gov.uk/2" link_domain="https://www.nationalarchives.gov.uk" path="/2"></a>' +
               '<a href="https://www.nationalarchives.gov.uk/3.pdf" link_domain="https://www.nationalarchives.gov.uk" path="/3.pdf">National Archives PDF</a>' +
             '</div>' +
+            '<div class="external-links-with-data-attributes">' +
+              '<a href="http://www.nationalarchives.gov.uk/1" link_domain="http://www.nationalarchives.gov.uk" path="/1"> National Archives </a>' +
+              '<a href="http://www.nationalarchives.gov.uk/2" link_domain="http://www.nationalarchives.gov.uk" path="/2"> National Archives </a>' +
+            '</div>' +
             '<div class="www-less-external-links">' +
               '<a href="http://nationalarchives.gov.uk/1" path="/1" link_domain="http://nationalarchives.gov.uk"> National Archives </a>' +
               '<a href="https://nationalarchives.gov.uk/2" path="/2" link_domain="https://nationalarchives.gov.uk"></a>' +
@@ -103,6 +107,33 @@ describe('A specialist link tracker', function () {
         expected.event_data.link_domain = link.getAttribute('link_domain')
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.text = link.innerText.trim()
+
+        expect(window.dataLayer[0]).toEqual(expected)
+      }
+    })
+
+    it('reads type from data-ga4-link attributes on external links', function () {
+      var linksToTest = document.querySelectorAll('.external-links-with-data-attributes a')
+      var attributes = [
+        {
+          type: 'specific type'
+        },
+        'invalid JSON'
+      ]
+      var types = [
+        'specific type',
+        'generic link'
+      ]
+
+      for (var i = 0; i < linksToTest.length; i++) {
+        var link = linksToTest[i]
+        link.setAttribute('data-ga4-attributes', JSON.stringify(attributes[i]))
+        window.dataLayer = []
+        GOVUK.triggerEvent(link, 'click')
+        expected.event_data.link_domain = link.getAttribute('link_domain')
+        expected.event_data.url = link.getAttribute('href')
+        expected.event_data.text = link.innerText.trim()
+        expected.event_data.type = types[i]
 
         expect(window.dataLayer[0]).toEqual(expected)
       }


### PR DESCRIPTION
## What
Modifies the button component and the specialist link tracker to allow for a `data-ga4-link` attribute to be read, containing an alternative `type` for the GA4 data.

This includes a change to the button component, where 'Start now' buttons automatically include this attribute (which can also be removed using a `disable_ga4` option if required). And a change to the specialist link tracker, to check for the presence of a `data-ga4-link` attribute and read it if found.

This could probably be made more generic to allow more attributes than just `type` to be overridden, but this is the current requirement.

## Why
Tracking of 'Start now' buttons (on pages like https://www.gov.uk/log-in-register-hmrc-online-services) is done automatically by the specialist link tracker, as an external link. We want to be able to uniquely identify these buttons from other external link tracking, by changing the `type` from `generic link` to `start button`.

## Visual Changes
None.

Trello card: https://trello.com/c/DqWUObIj/803-add-tracking-start-buttons
