### PR TITLE
Update breadcrumb tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Improve test coverage of contextual breadcrumb logic ([PR #3944](https://github.com/alphagov/govuk_publishing_components/pull/3944))
+
 ## 37.9.1
 
 * Track 'Start now' buttons with a specific GA4 type ([PR #3935](https://github.com/alphagov/govuk_publishing_components/pull/3935))

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -22,8 +22,8 @@ describe "Contextual navigation" do
     and_i_see_the_other_step_by_step_as_an_also_part_of_list
   end
 
-  scenario "There's a mainstream browse page tagged" do
-    given_theres_a_browse_page
+  scenario "The page is tagged to browse and has a browse parent" do
+    given_theres_a_page_tagged_to_browse_with_a_browse_parent
     and_i_visit_that_page
     then_i_see_the_browse_page_in_the_footer
     and_the_default_breadcrumbs
@@ -254,7 +254,7 @@ describe "Contextual navigation" do
     })
   end
 
-  def given_theres_a_browse_page
+  def given_theres_a_page_tagged_to_browse_with_a_browse_parent
     content_store_has_random_item(
       links: {
         "parent" => [top_level_mainstream_browse_page],

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -29,6 +29,13 @@ describe "Contextual navigation" do
     and_the_default_breadcrumbs
   end
 
+  scenario "The page is tagged to browse and does not have a browse parent" do
+    given_theres_a_page_tagged_to_browse_without_a_browse_parent
+    and_i_visit_that_page
+    then_i_see_the_browse_page_in_the_footer
+    then_i_see_the_topic_breadcrumb
+  end
+
   scenario "Foreign travel advice content" do
     given_theres_a_travel_advice_page
     and_i_visit_that_page
@@ -258,6 +265,15 @@ describe "Contextual navigation" do
     content_store_has_random_item(
       links: {
         "parent" => [top_level_mainstream_browse_page],
+        "mainstream_browse_pages" => [example_item("mainstream_browse_page", "root_page")],
+      },
+    )
+  end
+
+  def given_theres_a_page_tagged_to_browse_without_a_browse_parent
+    content_store_has_random_item(
+      links: {
+        "topics" => [topic_item],
         "mainstream_browse_pages" => [example_item("mainstream_browse_page", "root_page")],
       },
     )


### PR DESCRIPTION
## What
Minor update to contextual breadcrumb tests to better represent live behaviour

## Why
To improve our confidence when we retire specialist topics in future work.