### PR TITLE
Remove GA4 callout tracking from the govspeak component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Improve test coverage of contextual breadcrumb logic ([PR #3944](https://github.com/alphagov/govuk_publishing_components/pull/3944) and [PR #3945](https://github.com/alphagov/govuk_publishing_components/pull/3945))
+* Remove GA4 callout tracking from the govspeak component ([PR #3946](https://github.com/alphagov/govuk_publishing_components/pull/3946))
 
 ## 37.9.1
 

--- a/app/views/govuk_publishing_components/components/_govspeak.html.erb
+++ b/app/views/govuk_publishing_components/components/_govspeak.html.erb
@@ -10,19 +10,8 @@
   classes << "disable-youtube" if disable_youtube_expansions
   classes << "gem-c-govspeak--inverse" if inverse
 
-  disable_ga4 ||= false
-
   data_modules = "govspeak"
-  data_modules << " ga4-link-tracker" unless disable_ga4
   data_attributes = { module: data_modules }
-
-  unless disable_ga4
-    data_attributes.merge!({
-      ga4_track_links_only: "",
-      ga4_limit_to_element_class: "call-to-action, info-notice, help-notice, advisory",
-      ga4_link: { "event_name": "navigation", "type": "callout" }.to_json,
-    })
-  end
 
 %>
 

--- a/app/views/govuk_publishing_components/components/_notice.html.erb
+++ b/app/views/govuk_publishing_components/components/_notice.html.erb
@@ -30,7 +30,6 @@
   if description_govspeak
     govspeak_data_attributes = {
       content: description_govspeak,
-      disable_ga4: true # Keep the govspeak component GA4 tracking disabled, otherwise tracking will be duplicated when tracking is enabled on this component.
     }
   end
 

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -914,12 +914,3 @@ examples:
             <p>Deforested area. Credit: Blue Ventures-Garth Cripps</p>
           </figcaption>
         </figure>
-  without_ga4_tracking:
-    description: |
-      Disables GA4 tracking on the component. Tracking is enabled by default. This adds a data module and data-attributes with JSON data. See the [ga4-link-tracker documentation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-link-tracker.md) for more information.
-    data:
-      block: |
-        <p>
-          <a href='https://www.gov.uk'>Hello World</a>
-        </p>
-      disable_ga4: true

--- a/spec/components/govspeak_spec.rb
+++ b/spec/components/govspeak_spec.rb
@@ -46,27 +46,4 @@ describe "Govspeak", type: :view do
 
     expect(rendered).to include("content-via-block")
   end
-
-  it "adds GA4 tracking" do
-    render_component(
-      content: "<h1>content</h1>".html_safe,
-    )
-
-    assert_select ".gem-c-govspeak[data-module='govspeak ga4-link-tracker']"
-    assert_select ".gem-c-govspeak[data-ga4-track-links-only]"
-    assert_select ".gem-c-govspeak[data-ga4-limit-to-element-class='call-to-action, info-notice, help-notice, advisory']"
-    assert_select '.gem-c-govspeak[data-ga4-link="{\"event_name\":\"navigation\",\"type\":\"callout\"}"]'
-  end
-
-  it "can disable GA4 tracking" do
-    render_component(
-      content: "<h1>content</h1>".html_safe,
-      disable_ga4: true,
-    )
-
-    assert_no_selector ".gem-c-govspeak[data-module='govspeak ga4-link-tracker']"
-    assert_no_selector ".gem-c-govspeak[data-ga4-track-links-only]"
-    assert_no_selector ".gem-c-govspeak[data-ga4-limit-to-element-class]"
-    assert_no_selector ".gem-c-govspeak[data-ga4-link]"
-  end
 end


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Remove the `callout` tracking from the `govspeak` component (again)

## Why
<!-- What are the reasons behind this change being made? -->
- We have deemed this too fiddly to keep in
- https://trello.com/c/P20AYeRP/810-remove-callout-link-tracking

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
