### PR TITLE
Remove GA4 callout tracking from notice & warning text components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Improve test coverage of contextual breadcrumb logic ([PR #3944](https://github.com/alphagov/govuk_publishing_components/pull/3944) and [PR #3945](https://github.com/alphagov/govuk_publishing_components/pull/3945))
 * Remove GA4 callout tracking from the govspeak component ([PR #3946](https://github.com/alphagov/govuk_publishing_components/pull/3946))
+* Remove GA4 callout tracking from notice & warning text components ([PR #3947](https://github.com/alphagov/govuk_publishing_components/pull/3947))
 
 ## 37.9.1
 

--- a/app/views/govuk_publishing_components/components/_notice.html.erb
+++ b/app/views/govuk_publishing_components/components/_notice.html.erb
@@ -25,27 +25,15 @@
   aria_attributes[:labelledby] = banner_title_id if show_banner_title
 
   description_present = description.present? || description_text.present? || description_govspeak.present?
-  disable_ga4 ||= false
 
   if description_govspeak
     govspeak_data_attributes = {
       content: description_govspeak,
     }
   end
-
-  unless disable_ga4
-    section_data_attributes = {
-      module: "ga4-link-tracker",
-      ga4_track_links_only: "",
-      ga4_link: {
-        event_name: "navigation",
-        type: "callout"
-      }.to_json
-    }
-  end
 %>
 <% if title || description_present %>
-  <%= tag.section class: css_classes, aria: aria_attributes, lang: lang, role: "region", data: section_data_attributes do %>
+  <%= tag.section class: css_classes, aria: aria_attributes, lang: lang, role: "region" do %>
     <%= tag.div class: "govuk-notification-banner__header" do %>
       <%= tag.h2 banner_title, class: "govuk-notification-banner__title", id: banner_title_id %>
     <% end if show_banner_title %>

--- a/app/views/govuk_publishing_components/components/_warning_text.html.erb
+++ b/app/views/govuk_publishing_components/components/_warning_text.html.erb
@@ -14,18 +14,9 @@
   text_classes << "gem-c-warning-text__text--no-indent" if text_icon.empty?
   text_classes << "gem-c-warning-text__text--large" if large_font
   text_classes << "gem-c-warning-text__text--highlight" if highlight_text
-
-  disable_ga4 ||= false
-
-  ga4_data_attributes = {
-    "module": "ga4-link-tracker",
-    "ga4-track-links-only": "",
-    "ga4-link": { "event_name": "navigation", "type": "callout" }.to_json
-  } unless disable_ga4
-
 %>
 
-<%= tag.div id: id, class: "gem-c-warning-text govuk-warning-text", data: ga4_data_attributes do %>
+<%= tag.div id: id, class: "gem-c-warning-text govuk-warning-text" do %>
   <% unless text_icon.empty? %>
     <%= tag.span text_icon, class: "govuk-warning-text__icon", "aria-hidden": "true" %>
   <% end %>

--- a/app/views/govuk_publishing_components/components/docs/notice.yml
+++ b/app/views/govuk_publishing_components/components/docs/notice.yml
@@ -65,13 +65,3 @@ examples:
       description_govspeak: <p>This document is no longer current. We published a new version on 30 September 2015.</p>
       show_banner_title: true
       banner_title: "Information"
-  with_ga4_tracking_disabled:
-    description: |
-      Disables GA4 tracking on the component. Tracking on the component is enabled by default. Tracking on the nested govspeak component is always disabled to prevent duplication. When tracking is enabled on this component, a data module and data attributes are added to the parent element. See the [ga4-link-tracker documentation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-link-tracker.md) for more information.
-    data:
-      disable_ga4: true
-      title: 'This publication was withdrawn on 30 September 2015'
-      description_govspeak: <p>This document is no longer current. We published a new version on 30 September 2015.</p>
-      show_banner_title: true
-      banner_title: "Information"
-

--- a/app/views/govuk_publishing_components/components/docs/warning_text.yml
+++ b/app/views/govuk_publishing_components/components/docs/warning_text.yml
@@ -33,10 +33,3 @@ examples:
     data:
       text: "This is a heading 3"
       heading_level: 3
-  without_ga4_tracking:
-    description: |
-      Disables GA4 tracking on warning text links. Tracking is enabled by default, which adds a data module and data attributes to the component. See the [ga4-link-tracker documentation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-link-tracker.md) for more information.
-    data:
-      disable_ga4: true
-      text: "This is a heading 3"
-      heading_level: 3

--- a/spec/components/notice_spec.rb
+++ b/spec/components/notice_spec.rb
@@ -103,30 +103,4 @@ describe "Notice", type: :view do
     assert_select ".gem-c-notice h2.govuk-notification-banner__title", text: "Notice"
     assert_select "h3.gem-c-notice__title", text: "Your settings have been saved"
   end
-
-  it "has GA4 tracking enabled on the component, and disabled on the nested govspeak render" do
-    render_component(title: "Title", description_govspeak: "<marquee>It's 1998</marquee>".html_safe)
-
-    assert_select ".gem-c-notice[data-module='ga4-link-tracker']"
-    assert_select ".gem-c-notice[data-ga4-track-links-only]"
-    assert_select '.gem-c-notice[data-ga4-link="{\"event_name\":\"navigation\",\"type\":\"callout\"}"]'
-
-    assert_no_selector ".gem-c-govspeak[data-module='govspeak ga4-link-tracker']"
-    assert_no_selector ".gem-c-govspeak[data-ga4-track-links-only]"
-    assert_no_selector ".gem-c-govspeak[data-ga4-limit-to-element-class='call-to-action, info-notice, help-notice, advisory']"
-    assert_no_selector '.gem-c-govspeak[data-ga4-link="{\"event_name\":\"navigation\",\"type\":\"callout\"}"]'
-  end
-
-  it "can have GA4 tracking disabled" do
-    render_component(title: "Title", description_govspeak: "<marquee>It's 1998</marquee>".html_safe)
-
-    assert_no_selector ".gem-c-notice[data-module='ga4-link-tracker']"
-    assert_no_selector ".gem-c-notice[data-ga4-track-links-only]"
-    assert_no_selector '.gem-c-notice[data-ga4-link="{\"event_name\":\"navigation\",\"type\":\"callout\"}"]'
-
-    assert_no_selector ".gem-c-govspeak[data-module='govspeak ga4-link-tracker']"
-    assert_no_selector ".gem-c-govspeak[data-ga4-track-links-only]"
-    assert_no_selector ".gem-c-govspeak[data-ga4-limit-to-element-class='call-to-action, info-notice, help-notice, advisory']"
-    assert_no_selector '.gem-c-govspeak[data-ga4-link="{\"event_name\":\"navigation\",\"type\":\"callout\"}"]'
-  end
 end

--- a/spec/components/warning_text_spec.rb
+++ b/spec/components/warning_text_spec.rb
@@ -48,18 +48,4 @@ describe "warning text", type: :view do
     assert_select("h1.govuk-warning-text__text", text: /Because/i)
     assert_select("h1.govuk-warning-text__text .govuk-warning-text__assistive", text: /Warning/i)
   end
-
-  it "has GA4 link tracking" do
-    render_component(text: "Because", heading_level: 1)
-    assert_select("[data-module='ga4-link-tracker']")
-    assert_select('[data-ga4-link="{\"event_name\":\"navigation\",\"type\":\"callout\"}"]')
-    assert_select("[data-ga4-track-links-only]")
-  end
-
-  it "can disable GA4 link tracking" do
-    render_component(disable_ga4: true, text: "Because", heading_level: 1)
-    assert_select("[data-module='ga4-link-tracker']", false)
-    assert_select('[data-ga4-link="{\"event_name\":\"navigation\",\"type\":\"callout\"}"]', false)
-    assert_select("[data-ga4-track-links-only]", false)
-  end
 end

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.spec.js
@@ -750,7 +750,7 @@ describe('A specialist link tracker', function () {
       links.setAttribute('data-module', 'ga4-link-tracker')
       links.setAttribute('data-ga4-track-links-only', '')
       links.setAttribute('data-ga4-limit-to-element-class', 'hello')
-      links.setAttribute('data-ga4-link', JSON.stringify({ event_name: 'navigation', type: 'callout' }))
+      links.setAttribute('data-ga4-link', JSON.stringify({ event_name: 'navigation', type: 'something' }))
 
       links.innerHTML =
         '<div class="hello">' +
@@ -783,7 +783,7 @@ describe('A specialist link tracker', function () {
       expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
       expected.event = 'event_data'
       expected.event_data.event_name = 'navigation'
-      expected.event_data.type = 'callout'
+      expected.event_data.type = 'something'
       expected.event_data.method = 'primary click'
       expected.event_data.external = 'true'
       expected.govuk_gem_version = 'aVersion'


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Removes the `callout` tracking from the non-govspeak components that had the `callout` tracking on them

## Why
<!-- What are the reasons behind this change being made? -->
- I thought we were only removing the `callout` tracking from `govspeak` as that was causing the issues, but after asking the PAs this tracking is being removed entirely instead
- https://trello.com/c/P20AYeRP/810-remove-callout-link-tracking

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

Removes the examples with GA4 tracking disabled from the yml files