### PR TITLE
Update JavaScript test file convention docs

### DIFF
--- a/docs/component_conventions.md
+++ b/docs/component_conventions.md
@@ -25,7 +25,7 @@ The namespace indicates where a component lives. A single page on GOV.UK could r
 | Images | `app/assets/images/govuk_publishing_components` | `my-comp.png` | [Images](#images) |
 | Scripts | `app/assets/javascripts/components` | `my-comp.js` | [JavaScript enhancements](#javascript) |
 | Tests | `test/components` | `my_comp_test.rb` | [Unit tests](#tests) |
-| JavaScript tests | `spec/components` | `my_comp_spec.rb` | [Unit tests](#tests) |
+| JavaScript tests | `spec/javascripts/components` | `my-comp-spec.js` | [Unit tests](#tests) |
 | Helpers | `lib/govuk_publishing_components/presenters` | `my_comp_helper.rb` | [Helpers](#helpers) |
 
 ## Template


### PR DESCRIPTION
## What
I was going through the docs on [component conventions](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/component_conventions.md) and noticed the JavaScript test file conventions needed updating. I've changed:

- The suggested test file location from `spec/components` to `spec/javascripts/components`
- The suggested test file name from `my_comp_spec.rb` to `my-comp-spec.js`

## Why
Docs needed a minor update.

## Visual Changes
N/A
