### PR TITLE
Remove support for specialist topics from footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Remove support for specialist topics from contextual footer ([#3950](https://github.com/alphagov/govuk_publishing_components/pull/3950))
+
 ## 37.10.0
 
 * Add discovery_engine_attribution_token to GA4 pageview ([PR #3951](https://github.com/alphagov/govuk_publishing_components/pull/3951))

--- a/app/views/govuk_publishing_components/components/docs/contextual_footer.yml
+++ b/app/views/govuk_publishing_components/components/docs/contextual_footer.yml
@@ -22,16 +22,13 @@ examples:
       content_item:
         title: "A content item"
         links:
-          topics:
+          mainstream_browse_pages:
           - title: Apprenticeships, 14 to 19 education and training for work
             base_path: /browse/education/find-course
-            document_type: topic
+            document_type: mainstream_browse_page
           - title: Finding a job
             base_path: /browse/working/finding-job
-            document_type: topic
-          - title: Apprenticeships
-            base_path: /topic/further-education-skills/apprenticeships
-            document_type: topic
+            document_type: mainstream_browse_page
           topical_events:
           - title: UK-China High-Level People to People Dialogue 2017
             base_path: /government/topical-events/uk-china-high-level-people-to-people-dialogue-2017
@@ -76,16 +73,13 @@ examples:
       content_item:
         title: "A content item"
         links:
-          topics:
+          mainstream_browse_pages:
           - title: Apprenticeships, 14 to 19 education and training for work
             base_path: /browse/education/find-course
-            document_type: topic
+            document_type: mainstream_browse_page
           - title: Finding a job
             base_path: /browse/working/finding-job
-            document_type: topic
-          - title: Apprenticeships
-            base_path: /topic/further-education-skills/apprenticeships
-            document_type: topic
+            document_type: mainstream_browse_page
           topical_events:
           - title: UK-China High-Level People to People Dialogue 2017
             base_path: /government/topical-events/uk-china-high-level-people-to-people-dialogue-2017

--- a/app/views/govuk_publishing_components/components/docs/related_navigation.yml
+++ b/app/views/govuk_publishing_components/components/docs/related_navigation.yml
@@ -19,20 +19,6 @@ examples:
               base_path: /training-study-work-your-rights
             - title: Careers helpline for teenagers
               base_path: /careers-helpline-for-teenagers
-  with_curated_topics:
-    data:
-      content_item:
-        links:
-          topics:
-            - title: Apprenticeships, 14 to 19 education and training for work
-              base_path: /browse/education/find-course
-              document_type: topic
-            - title: Finding a job
-              base_path: /browse/working/finding-job
-              document_type: topic
-            - title: Apprenticeships
-              base_path: /topic/further-education-skills/apprenticeships
-              document_type: topic
   with_mainstream_browse_pages:
     data:
       content_item:
@@ -53,24 +39,8 @@ examples:
             base_path: /transport/driving-instruction-and-driving-lessons
             phase: live
             document_type: taxon
-  with_curated_topics_and_mainstream_browse_pages:
-    description: Currated topics and mainstream browse pages are combined.
-    data:
-      content_item:
-        links:
-          mainstream_browse_pages:
-          - title: Driving licences
-            base_path: /browse/driving/driving-licences
-            document_type: mainstream_browse_page
-          - title: Driving tests and learning to drive or ride
-            base_path: /browse/driving/learning-to-drive
-            document_type: mainstream_browse_page
-          topics:
-          - title: Cars
-            base_path: /topic/driving-tests-and-learning-to-drive/car
-            document_type: topic
-  with_curated_topics_and_mainstream_browse_pages_and_taxons:
-    description: Currated topics and mainstream browse pages take precedence over the sidewide topic taxonomy.
+  with_mainstream_browse_pages_and_taxons:
+    description: Mainstream browse pages take precedence over the sidewide topic taxonomy.
     data:
       content_item:
         links:
@@ -86,10 +56,6 @@ examples:
             base_path: /transport/driving-instruction-and-driving-lessons
             phase: live
             document_type: taxon
-          topics:
-          - title: Cars
-            base_path: /topic/driving-tests-and-learning-to-drive/car
-            document_type: topic
   with_collections:
     data:
       content_item:
@@ -218,7 +184,7 @@ examples:
             - title: Find an apprenticeship (French)
               base_path: /apply-apprenticeship.fr
               locale: fr
-          topics:
+          mainstream_browse_pages:
             - title: Apprenticeships, 14 to 19 education and training for work (Korean)
               base_path: /browse/education/find-course.ko
               document_type: topic
@@ -263,16 +229,13 @@ examples:
               base_path: /training-study-work-your-rights
             - title: Careers helpline for teenagers
               base_path: /careers-helpline-for-teenagers
-          topics:
+          mainstream_browse_pages:
             - title: Apprenticeships, 14 to 19 education and training for work
               base_path: /browse/education/find-course
-              document_type: topic
+              document_type: mainstream_browse_page
             - title: Finding a job
               base_path: /browse/working/finding-job
-              document_type: topic
-            - title: Apprenticeships
-              base_path: /topic/further-education-skills/apprenticeships
-              document_type: topic
+              document_type: mainstream_browse_page
           topical_events:
             - title: UK-China High-Level People to People Dialogue 2017
               base_path: /government/topical-events/uk-china-high-level-people-to-people-dialogue-2017
@@ -319,16 +282,13 @@ examples:
               base_path: /training-study-work-your-rights
             - title: Careers helpline for teenagers
               base_path: /careers-helpline-for-teenagers
-          topics:
+          mainstream_browse_pages:
             - title: Apprenticeships, 14 to 19 education and training for work
               base_path: /browse/education/find-course
-              document_type: topic
+              document_type: mainstream_browse_page
             - title: Finding a job
               base_path: /browse/working/finding-job
-              document_type: topic
-            - title: Apprenticeships
-              base_path: /topic/further-education-skills/apprenticeships
-              document_type: topic
+              document_type: mainstream_browse_page
           topical_events:
             - title: UK-China High-Level People to People Dialogue 2017
               base_path: /government/topical-events/uk-china-high-level-people-to-people-dialogue-2017

--- a/lib/govuk_publishing_components/presenters/related_navigation_helper.rb
+++ b/lib/govuk_publishing_components/presenters/related_navigation_helper.rb
@@ -32,7 +32,7 @@ module GovukPublishingComponents
           }
         when :footer
           {
-            "topics" => related_topics_or_taxons,
+            "topics" => related_browse_topics_or_taxons,
             "topical_events" => related_topical_events,
             "world_locations" => related_world_locations,
             "statistical_data_sets" => related_statistical_data_sets,
@@ -44,7 +44,7 @@ module GovukPublishingComponents
             "related_items" => related_items,
             "related_guides" => related_guides,
             "collections" => related_document_collections,
-            "topics" => related_topics_or_taxons,
+            "topics" => related_browse_topics_or_taxons,
             "topical_events" => related_topical_events,
             "world_locations" => related_world_locations,
             "statistical_data_sets" => related_statistical_data_sets,
@@ -142,26 +142,12 @@ module GovukPublishingComponents
         @related_taxons ||= content_item_links_for("taxons", only: "taxon")
       end
 
-      def related_topics_or_taxons
-        return related_topics if related_topics.any?
-        return related_taxons if related_taxons.any?
-
-        []
+      def related_browse_topics_or_taxons
+        related_browse_topics.presence || related_taxons.presence || []
       end
 
-      def related_topics
-        @related_topics ||= begin
-          mainstream_browse_page_links = content_item_links_for("mainstream_browse_pages", only: "mainstream_browse_page")
-          topic_links = content_item_links_for("topics", only: "topic")
-
-          return topic_links if topic_links.present? && mainstream_browse_page_links.empty?
-
-          mainstream_browse_page_links + topic_links.find_all do |topic_link|
-            mainstream_browse_page_links.none? do |mainstream_browse_page_link|
-              mainstream_browse_page_link[:text] == topic_link[:text]
-            end
-          end
-        end
+      def related_browse_topics
+        @related_browse_topics ||= content_item_links_for("mainstream_browse_pages", only: "mainstream_browse_page")
       end
 
       def related_topical_events

--- a/spec/components/contextual_footer_spec.rb
+++ b/spec/components/contextual_footer_spec.rb
@@ -31,20 +31,21 @@ RSpec.describe "Contextual footer", type: :view do
   it "sets the GA4 type to \"contextual footer\"" do
     content_item = {}
     content_item["links"] = {
-      "topics" => [
+      "taxons" => [
         {
           "base_path" => "/skating",
           "title" => "Skating",
-          "document_type" => "topic",
+          "document_type" => "taxon",
+          "phase" => "live",
         },
         {
           "base_path" => "/paragliding",
           "title" => "Paragliding",
-          "document_type" => "topic",
+          "document_type" => "taxon",
+          "phase" => "live",
         },
       ],
     }
-
     render_component(content_item:)
 
     assert_select ".gem-c-related-navigation[data-module='gem-track-click ga4-link-tracker']"
@@ -55,22 +56,23 @@ RSpec.describe "Contextual footer", type: :view do
   it "allows GA4 to be disabled" do
     content_item = {}
     content_item["links"] = {
-      "topics" => [
+      "taxons" => [
         {
           "base_path" => "/skating",
           "title" => "Skating",
-          "document_type" => "topic",
+          "document_type" => "taxon",
+          "phase" => "live",
         },
         {
           "base_path" => "/paragliding",
           "title" => "Paragliding",
-          "document_type" => "topic",
+          "document_type" => "taxon",
+          "phase" => "live",
         },
       ],
     }
 
     render_component(content_item:, disable_ga4: true)
-
     assert_select ".gem-c-related-navigation[data-module='gem-track-click']"
     assert_select ".gem-c-related-navigation[data-module='gem-track-click ga4-link-tracker']", false
     assert_select ".gem-c-related-navigation__section-link[data-ga4-link]", false

--- a/spec/components/related_navigation_spec.rb
+++ b/spec/components/related_navigation_spec.rb
@@ -44,17 +44,6 @@ describe "Related navigation", type: :view do
     assert_select ".gem-c-related-navigation__section-link[href=\"/something-a-bit-like-this\"]", text: "Some other guidance"
   end
 
-  it "renders topics section when passed topic items" do
-    content_item = {}
-    content_item["links"] = construct_links(
-      "topics", "/finding-a-job", "Finding a job", "topic"
-    )
-    render_component(content_item:)
-
-    assert_select ".gem-c-related-navigation__sub-heading", text: "Explore the topic"
-    assert_select ".gem-c-related-navigation__section-link[href=\"/finding-a-job\"]", text: "Finding a job"
-  end
-
   it "renders statistical data set section when passed statistical data set items" do
     content_item = {}
     content_item["links"] = construct_links(
@@ -148,10 +137,10 @@ describe "Related navigation", type: :view do
   it "adds aria labelledby to navigation sections" do
     content_item = {}
     content_item["links"] = construct_links(
-      "topics",
-      "/apprenticeships",
-      "Apprenticeships",
-      "topic",
+      "topical_events",
+      "/government/topical-events/uk-china-high-level-people-to-people-dialogue-2017",
+      "UK-China High-Level People to People Dialogue 2017",
+      "topical_event",
     )
     render_component(content_item:)
 
@@ -197,15 +186,22 @@ describe "Related navigation", type: :view do
 
   it "link tracking is enabled" do
     content_item = {}
-    content_item["links"] = construct_links(
-      "topics", "/apprenticeships", "Apprenticeships", "topic"
-    )
+    content_item["links"] = {
+      "taxons" => [
+        {
+          "base_path" => "/skating",
+          "title" => "Skating",
+          "document_type" => "taxon",
+          "phase" => "live",
+        },
+      ],
+    }
     render_component(content_item:)
 
     assert_select ".gem-c-related-navigation[data-module='gem-track-click ga4-link-tracker']"
     assert_select ".gem-c-related-navigation__section-link[data-track-category='relatedLinkClicked']"
     assert_select ".gem-c-related-navigation__section-link[data-track-action='1.1 Explore the topic']"
-    assert_select ".gem-c-related-navigation__section-link[data-track-label='/apprenticeships']"
+    assert_select ".gem-c-related-navigation__section-link[data-track-label='/skating']"
   end
 
   it "tracks links with GA4" do
@@ -221,21 +217,24 @@ describe "Related navigation", type: :view do
           "title" => "Surfing",
         },
       ],
-      "topics" => [
+      "taxons" => [
         {
           "base_path" => "/skating",
           "title" => "Skating",
-          "document_type" => "topic",
+          "document_type" => "taxon",
+          "phase" => "live",
         },
         {
           "base_path" => "/paragliding",
           "title" => "Paragliding",
-          "document_type" => "topic",
+          "document_type" => "taxon",
+          "phase" => "live",
         },
         {
           "base_path" => "/knitting",
           "title" => "Knitting",
-          "document_type" => "topic",
+          "document_type" => "taxon",
+          "phase" => "live",
         },
       ],
       "world_locations" => [],
@@ -243,7 +242,6 @@ describe "Related navigation", type: :view do
     %w[USA Wales Fiji Iceland Sweden Mauritius Brazil].each do |country|
       content_item["links"]["world_locations"] << { "title" => country }
     end
-
     render_component(content_item:)
 
     assert_select ".gem-c-related-navigation[data-module='gem-track-click ga4-link-tracker']"
@@ -271,21 +269,18 @@ describe "Related navigation", type: :view do
           "title" => "Surfing",
         },
       ],
-      "topics" => [
+      "taxons" => [
         {
           "base_path" => "/skating",
           "title" => "Skating",
-          "document_type" => "topic",
+          "document_type" => "taxon",
+          "phase" => "live",
         },
         {
           "base_path" => "/paragliding",
           "title" => "Paragliding",
-          "document_type" => "topic",
-        },
-        {
-          "base_path" => "/knitting",
-          "title" => "Knitting",
-          "document_type" => "topic",
+          "document_type" => "taxon",
+          "phase" => "live",
         },
       ],
       "world_locations" => [],
@@ -305,9 +300,17 @@ describe "Related navigation", type: :view do
 
   it "uses lang when locale is set" do
     content_item = {}
-    content_item["links"] = construct_links(
-      "topics", "/apprenticeships", "Apprenticeships", "topic", "ko"
-    )
+    content_item["links"] = {
+      "taxons" => [
+        {
+          "base_path" => "/apprenticeships",
+          "title" => "Apprenticeships",
+          "document_type" => "taxon",
+          "phase" => "live",
+          "locale" => "ko",
+        },
+      ],
+    }
     render_component(content_item:)
 
     assert_select ".gem-c-related-navigation__section-link[lang='ko']"
@@ -315,9 +318,18 @@ describe "Related navigation", type: :view do
 
   it "lang is not used when the same as the app's locale" do
     content_item = {}
-    content_item["links"] = construct_links(
-      "topics", "/apprenticeships", "Apprenticeships", "topic", I18n.locale
-    )
+    content_item["links"] = {
+      "taxons" => [
+        {
+          "base_path" => "/apprenticeships",
+          "title" => "Apprenticeships",
+          "document_type" => "taxon",
+          "phase" => "live",
+          "locale" => I18n.locale,
+        },
+      ],
+
+    }
     render_component(content_item:)
 
     assert_select ".gem-c-related-navigation__section-link[lang='#{I18n.locale}']", false
@@ -325,9 +337,16 @@ describe "Related navigation", type: :view do
 
   it "lang is not used when no locale is set" do
     content_item = {}
-    content_item["links"] = construct_links(
-      "topics", "/apprenticeships", "Apprenticeships", "topic"
-    )
+    content_item["links"] = {
+      "taxons" => [
+        {
+          "base_path" => "/apprenticeships",
+          "title" => "Apprenticeships",
+          "document_type" => "taxon",
+          "phase" => "live",
+        },
+      ],
+    }
     render_component(content_item:)
 
     assert_select ".gem-c-related-navigation__section-link[lang]", false

--- a/spec/lib/govuk_publishing_components/presenters/related_navigation_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/related_navigation_helper_spec.rb
@@ -68,15 +68,6 @@ RSpec.describe GovukPublishingComponents::Presenters::RelatedNavigationHelper do
               "document_type" => "document_collection",
             },
           ],
-          "topics" => [
-            {
-              "content_id" => "32c1b93d-2553-47c9-bc3c-fc5b513ecc32",
-              "locale" => "en",
-              "base_path" => "/related-topic",
-              "title" => "related topic",
-              "document_type" => "topic",
-            },
-          ],
           "topical_events" => [
             {
               "content_id" => "32c1b93d-2553-47c9-bc3c-fc5b513ecc32",
@@ -120,7 +111,6 @@ RSpec.describe GovukPublishingComponents::Presenters::RelatedNavigationHelper do
         "collections" => [{ locale: "en", path: "/related-collection", text: "related collection" }],
         "topics" => [
           { locale: "en", path: "/browse/something", text: "A mainstream browse page" },
-          { locale: "en", path: "/related-topic", text: "related topic" },
         ],
         "related_contacts" => [],
         "related_external_links" => [],
@@ -164,7 +154,7 @@ RSpec.describe GovukPublishingComponents::Presenters::RelatedNavigationHelper do
       )
     end
 
-    it "deduplicates topics for mainstream content" do
+    it "returns mainstream content over taxonomy pages, if both are present" do
       payload = payload_for(
         "answer",
         "details" => {
@@ -189,13 +179,14 @@ RSpec.describe GovukPublishingComponents::Presenters::RelatedNavigationHelper do
               "document_type" => "guide",
             },
           ],
-          "topics" => [
+          "taxons" => [
             {
-              "content_id" => "7beb97b6-75c9-4aa7-86be-a733ab3a21aa",
+              "content_id" => "32c1b93d-2553-47c9-bc3c-fc5b513ecc32",
               "locale" => "en",
-              "base_path" => "/topic/personal-tax/self-assessment",
-              "title" => "Self Assessment",
-              "document_type" => "topic",
+              "base_path" => "/related-taxonomy-topic",
+              "title" => "related taxonomy topic",
+              "document_type" => "taxon",
+              "phase" => "live",
             },
           ],
         },
@@ -212,7 +203,6 @@ RSpec.describe GovukPublishingComponents::Presenters::RelatedNavigationHelper do
       expected = [
         { locale: "en", text: "Travel abroad", path: "/browse/abroad/travel-abroad" },
         { locale: "en", text: "Arriving in the UK", path: "/browse/visas-immigration/arriving-in-the-uk" },
-        { locale: "en", text: "Pets", path: "/topic/animal-welfare/pets" },
       ]
       expect(payload["topics"]).to eql(expected)
     end


### PR DESCRIPTION
## What
Remove specialist topics from the contextual footer

## Why
Specialist topics have been retired
[Trello](https://trello.com/c/lUE1xqoF/2423-remove-specialist-topic-code-from-govukpublishingcomponents-m-l)

## Visual Changes
None
