### PR TITLE
Add discovery_engine_attribution_token to GA4 pageview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   of the commit log.
 
 ## Unreleased
+
+* Add discovery_engine_attribution_token to GA4 pageview ([PR #3951](https://github.com/alphagov/govuk_publishing_components/pull/3951))
 * Remove support for specialist topics from contextual navigation ie breadcrumbs ([#3927](https://github.com/alphagov/govuk_publishing_components/pull/3927))
 * Improve test coverage of contextual breadcrumb logic ([PR #3944](https://github.com/alphagov/govuk_publishing_components/pull/3944) and [PR #3945](https://github.com/alphagov/govuk_publishing_components/pull/3945))
 * Remove GA4 callout tracking from the govspeak component ([PR #3946](https://github.com/alphagov/govuk_publishing_components/pull/3946))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
@@ -62,7 +62,8 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
             intervention: this.getBannerPresence('[data-ga4-intervention-banner]'),
             query_string: this.getQueryString(),
             search_term: this.getSearchTerm(),
-            spelling_suggestion: this.getMetaContent('spelling-suggestion')
+            spelling_suggestion: this.getMetaContent('spelling-suggestion'),
+            discovery_engine_attribution_token: this.getMetaContent('discovery-engine-attribution-token')
           }
         }
         window.GOVUK.analyticsGa4.core.sendData(data)

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
@@ -60,7 +60,8 @@ describe('Google Tag Manager page view tracking', function () {
         intervention: undefined,
         query_string: undefined,
         search_term: undefined,
-        spelling_suggestion: undefined
+        spelling_suggestion: undefined,
+        discovery_engine_attribution_token: undefined
       }
     }
     spyOn(GOVUK.analyticsGa4.core, 'getTimestamp').and.returnValue('123456')
@@ -641,6 +642,13 @@ describe('Google Tag Manager page view tracking', function () {
   it('correctly sets the spelling_suggestion parameter', function () {
     createMetaTags('spelling-suggestion', 'tax')
     expected.page_view.spelling_suggestion = 'tax'
+    GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
+    expect(window.dataLayer[0]).toEqual(expected)
+  })
+
+  it('correctly sets the discovery_engine_attribution_token parameter', function () {
+    createMetaTags('discovery-engine-attribution-token', 'searchyMcSearch')
+    expected.page_view.discovery_engine_attribution_token = 'searchyMcSearch'
     GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
     expect(window.dataLayer[0]).toEqual(expected)
   })


### PR DESCRIPTION
## What / why
Adds a new parameter to the GA4 page view, `discovery_engine_attribution_token`. This is a unique token generated by each search result, used for debugging purposes in search. Additional work will be done in `finder-frontend` to add this token as a meta tag so this code can read it - on all non-search pages this attribute will be undefined in the page view.

## Visual Changes
None.

