### PR TITLE
docs: Fix test instructions and generally spruce up the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,28 @@
 [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
 [![Stylelint Style Guide](https://img.shields.io/badge/code_style-stylelint-brightgreen.svg)](https://github.com/alphagov/stylelint-config-gds/)
 
-A Ruby gem to document and distribute components for GOV.UK applications. It provides:
+govuk_publishing_components is a Ruby gem to document and distribute components for GOV.UK applications. It provides:
 
 - a shared library of components
 - helpers to generate component payloads
 - an application to preview components and provide guidance
 - [GOV.UK Design System](https://design-system.service.gov.uk/) styles and components (via [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend))
 
-Components should be added to this gem if they are required in more than one application, otherwise they should be added to that application. All components should meet the same standards of browser and assistive technology support described in [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend#browser-and-assistive-technology-support).
+Only add a component to this gem if it is required in more than one application. Please do not add application-specific components to govuk_publishing_components.
+
+All components should meet the accessibility standards for browser and assistive technology support described in [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend#browser-and-assistive-technology-support).
 
 ## Technical documentation
 
-You can use the [GOV.UK Docker environment](https://github.com/alphagov/govuk-docker) or the local `startup.sh` script to run the app. Read the [guidance on local frontend development](https://docs.publishing.service.gov.uk/manual/local-frontend-development.html) to find out more about each approach, before you get started.
+### Run the application
 
-If you are using GOV.UK Docker, remember to combine it with the commands that follow. See the [GOV.UK Docker usage instructions](https://github.com/alphagov/govuk-docker#usage) for examples.
+```sh
+./startup.sh
+```
 
-### Running the test suite
+See also [Local frontend development](https://docs.publishing.service.gov.uk/manual/local-frontend-development.html).
+
+### Run the test suite
 
 ```sh
 bundle install
@@ -27,29 +33,33 @@ yarn install
 bundle exec rake
 ```
 
-To run JavaScript tests (only):
+### Run the JavaScript tests alone
+
+In browser:
 
 ```sh
-# run JS tests in browser
 yarn run jasmine:browser
+```
 
-# run JS tests on command line
+On command line:
+
+```sh
 yarn run jasmine:ci
 ```
 
-### Using the gem
+### Use the gem
 
 - [Install and use this gem](docs/install-and-use.md)
 - [Use a component in your application](docs/use-components.md)
 - [Test a branch of the gem](docs/test-a-branch-of-the-gem.md)
 
-### Managing the gem
+### Manage the gem
 
 - [Publish/release a new version of the gem](docs/publishing-to-rubygems.md)
 - [Keep this gem in sync with the Design System](docs/upgrade-govuk-frontend.md)
 - [Move a component from an application to the gem](docs/moving-components-upstream-into-this-gem.md)
 
-### Making components
+### Make a new component
 
 - [Generate a new component](docs/generate-a-new-component.md)
 - [Component conventions](docs/component_conventions.md)
@@ -57,12 +67,12 @@ yarn run jasmine:ci
 
 ### Further documentation
 
-- [Testing a component](docs/testing-components.md)
+- [Test a component](docs/testing-components.md)
 - [Component auditing](docs/auditing.md)
 - [Code documentation on rubydoc.info](http://www.rubydoc.info/gems/govuk_publishing_components)
 - [Our analytics approach](docs/analytics-ga4/analytics.md)
 
-More documentation can be found in the [docs directory](docs/).
+There is more documentation in the [docs directory](docs/).
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ If you are using GOV.UK Docker, remember to combine it with the commands that fo
 ### Running the test suite
 
 ```sh
+bundle install
+yarn install
 bundle exec rake
 ```
 

--- a/README.md
+++ b/README.md
@@ -35,17 +35,19 @@ bundle exec rake
 
 ### Run the JavaScript tests alone
 
-In browser:
+With text-only output to the terminal:
+
+```sh
+yarn run jasmine:ci
+```
+
+With output viewable in a browser at <http://localhost:8888/>:
 
 ```sh
 yarn run jasmine:browser
 ```
 
-On command line:
-
-```sh
-yarn run jasmine:ci
-```
+You need to restart the `jasmine:browser` test server for it to pick up any changes to JavaScript code.
 
 ### Use the gem
 


### PR DESCRIPTION
The 'Run the test suite' instructions didn't work without a couple of build steps which weren't mentioned anywhere in the README. Add them to the example so that it works for new contributors.

Also remove some confusing information about GOV.UK Docker and generally tidy up the README to bring it in line with GDS tech writing style.

No changes to the gem itself apart from the README.