### PR TITLE
Fix unnecessary use of YAML.unsafe_load.

### DIFF
--- a/app/models/govuk_publishing_components/component_docs.rb
+++ b/app/models/govuk_publishing_components/component_docs.rb
@@ -45,9 +45,7 @@ module GovukPublishingComponents
     end
 
     def parse_documentation(file)
-      # Psych 4's YAML.unsafe_load_file === Psych 3's YAML.load_file
-      # but until we drop support for Ruby 2.7 and Ruby 3.0, we need to support both major versions of Psych
-      yaml = YAML.respond_to?(:unsafe_load_file) ? YAML.unsafe_load_file(file) : YAML.load_file(file)
+      yaml = YAML.load_file(file, aliases: true, permitted_classes: [Symbol, Time])
       { id: File.basename(file, ".yml") }.merge(yaml).with_indifferent_access
     end
 

--- a/spec/components/all_components_spec.rb
+++ b/spec/components/all_components_spec.rb
@@ -13,9 +13,7 @@ describe "All components" do
       end
 
       it "has the correct documentation" do
-        # Psych 4's YAML.unsafe_load_file === Psych 3's YAML.load_file
-        # but until we drop support for Ruby 2.7 and Ruby 3.0, we need to support both major versions of Psych
-        yaml = YAML.respond_to?(:unsafe_load_file) ? YAML.unsafe_load_file(yaml_file) : YAML.load_file(yaml_file)
+        yaml = YAML.load_file(yaml_file, aliases: true, permitted_classes: [Symbol, Time])
 
         expect(yaml["name"]).not_to be_nil
         expect(yaml["description"]).not_to be_nil


### PR DESCRIPTION
## What

There's no need for us to call `YAML.unsafe_load_file` when parsing the documentation sources.

## Why

Fixes https://github.com/alphagov/govuk_publishing_components/security/code-scanning/7.

No visual changes or changes to functionality.