### PR TITLE
Version 37.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 37.10.0
 
 * Add discovery_engine_attribution_token to GA4 pageview ([PR #3951](https://github.com/alphagov/govuk_publishing_components/pull/3951))
 * Remove support for specialist topics from contextual navigation ie breadcrumbs ([#3927](https://github.com/alphagov/govuk_publishing_components/pull/3927))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (37.9.1)
+    govuk_publishing_components (37.10.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "37.9.1".freeze
+  VERSION = "37.10.0".freeze
 end


### PR DESCRIPTION
## 37.10.0

* Add discovery_engine_attribution_token to GA4 pageview ([PR #3951](https://github.com/alphagov/govuk_publishing_components/pull/3951))
* Remove support for specialist topics from contextual navigation ie breadcrumbs ([#3927](https://github.com/alphagov/govuk_publishing_components/pull/3927))
* Improve test coverage of contextual breadcrumb logic ([PR #3944](https://github.com/alphagov/govuk_publishing_components/pull/3944) and [PR #3945](https://github.com/alphagov/govuk_publishing_components/pull/3945))
* Remove GA4 callout tracking from the govspeak component ([PR #3946](https://github.com/alphagov/govuk_publishing_components/pull/3946))
* Remove GA4 callout tracking from notice & warning text components ([PR #3947](https://github.com/alphagov/govuk_publishing_components/pull/3947))
* Restores test and refactors component and test for layout-super-navigation-header ([PR #3939](https://github.com/alphagov/govuk_publishing_components/pull/3939))