### PR TITLE
Fix anchoring in ID validation regex.

### DIFF
--- a/lib/govuk_publishing_components/presenters/component_wrapper_helper.rb
+++ b/lib/govuk_publishing_components/presenters/component_wrapper_helper.rb
@@ -60,7 +60,7 @@ module GovukPublishingComponents
       def check_id_is_valid(id)
         return if id.blank?
 
-        raise(ArgumentError, "Id (#{id}) cannot start with a number or contain whitespace and can only contain letters, digits, `_` and `-`") unless /^[a-zA-Z][\w:-]*$/.match?(id)
+        raise(ArgumentError, "Id (#{id}) cannot start with a number or contain whitespace and can only contain letters, digits, `_` and `-`") unless /\A[a-zA-Z][\w:-]*\z/.match?(id)
       end
 
       def check_data_attributes_are_valid(attributes)

--- a/spec/lib/govuk_publishing_components/components/component_wrapper_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/components/component_wrapper_helper_spec.rb
@@ -49,22 +49,18 @@ RSpec.describe GovukPublishingComponents::Presenters::ComponentWrapperHelper do
     end
 
     it "does not accept invalid ids" do
-      ["2idstartingwithanumber", "id containing spaces", "idwitha.character"].each do |id|
-        error = "Id (#{id}) cannot start with a number or contain whitespace and can only contain letters, digits, `_` and `-`"
+      ["1dstartingwithnumber", "id with spaces", "idwith.dot", "id\nwithnewline"].each do |id|
         expect {
           GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(id:)
-        }.to raise_error(ArgumentError, error)
+        }.to raise_error(ArgumentError, / contain/)
       end
     end
 
     it "does not accept invalid ids when passed" do
-      ["2idstartingwithanumber", "id containing spaces", "idwitha.character"].each do |id|
-        error = "Id (#{id}) cannot start with a number or contain whitespace and can only contain letters, digits, `_` and `-`"
-        expect {
-          helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(id: "original")
-          helper.set_id(id)
-        }.to raise_error(ArgumentError, error)
-      end
+      expect {
+        helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(id: "valid")
+        helper.set_id("not. a. valid. id")
+      }.to raise_error(ArgumentError)
     end
 
     it "can add a class to already passed classes" do


### PR DESCRIPTION
Ruby regexes are — bizarrely — multiline by default, so `ComponentWrapperHelper::check_id_is_valid` would have erroneously accepted an ID string that contained newlines.

Fixes https://github.com/alphagov/govuk_publishing_components/security/code-scanning/8.

No visual changes. Should also be no functional change for normal usage.