### PR TITLE
Fix incomplete regex for detecting external links.

### DIFF
--- a/lib/govuk_publishing_components/presenters/intervention_helper.rb
+++ b/lib/govuk_publishing_components/presenters/intervention_helper.rb
@@ -27,10 +27,12 @@ module GovukPublishingComponents
       end
 
       def security_attr
-        rel = "noopener noreferrer"
-        rel << " external" unless @suggestion_link_url.start_with?("/", "https://gov.uk", "https://www.gov.uk")
-
-        rel
+        # Link is external unless it begins with "/" (but not "//") or it's on gov.uk.
+        if %r{\A(/[^/]|https://(www\.)?gov\.uk(/|\z))}.match?(@suggestion_link_url)
+          "noopener noreferrer"
+        else
+          "noopener noreferrer external"
+        end
       end
 
       def show?

--- a/spec/lib/govuk_publishing_components/components/intervention_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/components/intervention_helper_spec.rb
@@ -66,10 +66,14 @@ RSpec.describe GovukPublishingComponents::Presenters::InterventionHelper do
       end
 
       it "returns appends external attribute for new tab external links" do
-        intervention_helper = GovukPublishingComponents::Presenters::InterventionHelper.new({ suggestion_link_text: "Text", suggestion_link_url: "https://www.nationalarchives.gov.uk", params: {} })
-        security_attrs = intervention_helper.security_attr
+        external_urls = %w[https://www.nationalarchives.gov.uk //external.com https://www.gov.uk.example.com].freeze
 
-        expect(security_attrs).to eql("noopener noreferrer external")
+        external_urls.each do |url|
+          intervention_helper = GovukPublishingComponents::Presenters::InterventionHelper.new({ suggestion_link_text: "Text", suggestion_link_url: url, params: {} })
+          security_attrs = intervention_helper.security_attr
+
+          expect(security_attrs).to eql("noopener noreferrer external")
+        end
       end
     end
 


### PR DESCRIPTION
`InterventionHelper::security_attr` was erroneously classifying some external URLs as same-site, including:

- URLs with domains starting with `gov.uk` or `www.gov.uk`, such as `https://gov.uk.example.com/`
- protocol-relative URLs like `//external.example.com/`

Fixes https://github.com/alphagov/govuk_publishing_components/security/code-scanning/9.

No visual change and should be no functional change in normal use.