### PR TITLE
Fix intermittently failing test

### DIFF
--- a/spec/javascripts/govuk_publishing_components/lib/cookie-settings-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/cookie-settings-spec.js
@@ -72,6 +72,7 @@ describe('cookieSettings', function () {
       })
 
       it('does not error if not all options are present', function () {
+        window.GOVUK.setDefaultConsentCookie()
         element.innerHTML =
         '<form data-module="cookie-settings">' +
           '<input type="radio" id="settings-on" name="cookies-settings" value="on">' +


### PR DESCRIPTION
## What / why
This test has been failing intermittently for a while now and needed fixing. 

Was failing with seed 62445 because the consent cookie wasn't being set as expected in this order of tests.

## Visual Changes
None.
