### PR TITLE
Add GA4 indexes to header search form

### DIFF
--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -350,11 +350,22 @@
           </h3>
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
+              <%
+                form_attributes = {
+                  event_name: "search",
+                  type: "header menu bar",
+                  section: "Search GOV.UK",
+                  action: "search",
+                  url: "/search/all",
+                  index_section: 3,
+                  index_section_count: 3,
+                }.to_json
+              %>
               <form
                 class="gem-c-layout-super-navigation-header__search-form"
                 id="search"
                 data-module="ga4-form-tracker"
-                data-ga4-form='{ "event_name": "search", "type": "header menu bar", "section": "Search GOV.UK", "action": "search", "url": "/search/all" }'
+                data-ga4-form="<%= form_attributes %>"
                 data-ga4-form-include-text
                 data-ga4-form-no-answer-undefined
                 action="<%= absolute_links_helper.make_url_absolute('/search') %>"

--- a/spec/components/layout_super_navigation_header_spec.rb
+++ b/spec/components/layout_super_navigation_header_spec.rb
@@ -172,5 +172,15 @@ describe "Super navigation header", type: :view do
     assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index_section":1,"index_link":16,"index_section_count":3,"index_total":16,"section":"Services and information"}\']'
     assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index_section":2,"index_link":1,"index_section_count":3,"index_total":6,"section":"Government activity"}\']'
     assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index_section":2,"index_link":6,"index_section_count":3,"index_total":6,"section":"Government activity"}\']'
+    form_attributes = {
+      event_name: "search",
+      type: "header menu bar",
+      section: "Search GOV.UK",
+      action: "search",
+      url: "/search/all",
+      index_section: 3,
+      index_section_count: 3,
+    }.to_json
+    assert_select "form[data-ga4-form=\'#{form_attributes}\']"
   end
 end


### PR DESCRIPTION
## What / why
Update the layout header to add `index_section` and `index_section_count` of `3` to the GA4 search form tracking data, to make it in line with other elements in these drop down menus

## Visual Changes
None.

Trello card: https://trello.com/c/PXOGIDpO/806-add-indexsection-and-indexsection-count-values-to-header-menu-bar-search
