### PR TITLE
Version 38.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 38.0.0
 
-* Remove show password component ([PR #3973](https://github.com/alphagov/govuk_publishing_components/pull/3973))
-* Complete the removal of specialist topic code from the gem [PR #3955](https://github.com/alphagov/govuk_publishing_components/pull/3955)
-* Remove support for specialist topics from contextual footer ([#3950](https://github.com/alphagov/govuk_publishing_components/pull/3950))
+* **BREAKING:** Remove show password component ([PR #3973](https://github.com/alphagov/govuk_publishing_components/pull/3973))
+* Complete the removal of specialist topic code from the gem ([PR #3955](https://github.com/alphagov/govuk_publishing_components/pull/3955))
+* Remove support for specialist topics from contextual footer ([PR #3950](https://github.com/alphagov/govuk_publishing_components/pull/3950))
 * Update HMRC organisation logos ([PR #3962](https://github.com/alphagov/govuk_publishing_components/pull/3962))
 
 ## 37.10.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (37.10.0)
+    govuk_publishing_components (38.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "37.10.0".freeze
+  VERSION = "38.0.0".freeze
 end


### PR DESCRIPTION
## 38.0.0

* **BREAKING:** Remove show password component ([PR #3973](https://github.com/alphagov/govuk_publishing_components/pull/3973))
* Complete the removal of specialist topic code from the gem ([PR #3955](https://github.com/alphagov/govuk_publishing_components/pull/3955))
* Remove support for specialist topics from contextual footer ([PR #3950](https://github.com/alphagov/govuk_publishing_components/pull/3950))
* Update HMRC organisation logos ([PR #3962](https://github.com/alphagov/govuk_publishing_components/pull/3962))