### PR TITLE
Add the hidden attribute to mobile menu button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add the hidden attribute to mobile menu button ([PR #3975](https://github.com/alphagov/govuk_publishing_components/pull/3975))
+
 ## 38.0.1
 
 * Explicitly require ostruct ([PR #3976](https://github.com/alphagov/govuk_publishing_components/pull/3976))

--- a/app/views/govuk_publishing_components/components/layout_header/_navigation_items.html.erb
+++ b/app/views/govuk_publishing_components/components/layout_header/_navigation_items.html.erb
@@ -8,6 +8,7 @@
       class="govuk-header__menu-button govuk-js-header-toggle gem-c-header__menu-button govuk-!-display-none-print"
       type="button"
       data-button-name="menu"
+      hidden
     >
       <%= t("components.layout_header.menu") %>
     </button>

--- a/spec/components/layout_header_spec.rb
+++ b/spec/components/layout_header_spec.rb
@@ -63,6 +63,7 @@ describe "Layout header", type: :view do
     assert_select ".govuk-header__navigation-item", text: "Bar"
     assert_select ".govuk-header__navigation-item.govuk-header__navigation-item--collapsed-menu-only", text: "Hello"
     assert_select ".gem-c-header__nav[aria-label='Top level']"
+    assert_select ".govuk-header__menu-button[hidden]"
   end
 
   it "renders the header navigation items with custom aria-label when navigation_aria_label is specified" do


### PR DESCRIPTION
## What
Add the `hidden` attribute to the mobile menu button in the layout_header component

## Why
In preparation for upgrading to version 5 of govuk-frontend.

Adding the `hidden` attribute to the mobile menu button was a recommend change in the release of 4.3 of govuk-frontend - https://github.com/alphagov/govuk-frontend/releases/tag/v4.3.0

In version 5 of govuk-frontend, the `hidden` attribute is required to ensure that the menu button remains hidden when JavaScript is disabled:

- https://github.com/alphagov/govuk-frontend/pull/3596
- https://github.com/alphagov/govuk-frontend/blob/main/CHANGELOG.md

[Trello card](https://trello.com/c/6LsKqHIO/2231-prepare-govukpublishingcomponents-to-run-v51-of-govuk-frontend-l)