### PR TITLE
Add tool_name to GA4 feedback component tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add the hidden attribute to mobile menu button ([PR #3975](https://github.com/alphagov/govuk_publishing_components/pull/3975))
+* Add tool_name to GA4 feedback component tracking ([PR #3984](https://github.com/alphagov/govuk_publishing_components/pull/3984))
 
 ## 38.0.1
 

--- a/app/views/govuk_publishing_components/components/feedback/_problem_form.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_problem_form.html.erb
@@ -44,11 +44,13 @@
 
       <%
         unless disable_ga4 
+          heading_text = t("components.feedback.help_us_improve_govuk", locale: :en)
           ga4_submit_button_event = {
             event_name: "form_submit",
             type: "feedback",
             text: t("components.feedback.send", locale: :en),
-            section: t("components.feedback.help_us_improve_govuk", locale: :en),
+            section: heading_text,
+            tool_name: heading_text
           }.to_json
         end
       %>

--- a/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
@@ -31,11 +31,13 @@
 
       <%
         unless disable_ga4
+          heading_text = t("components.feedback.help_us_improve_govuk", locale: :en)
           ga4_send_button_event = {
             event_name: "form_submit",
             type: "feedback",
             text: t("components.feedback.send_me_survey", locale: :en),
-            section: t("components.feedback.help_us_improve_govuk", locale: :en),
+            section: heading_text,
+            tool_name: heading_text
           }.to_json
         end
       %>

--- a/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
@@ -1,24 +1,28 @@
 <%
   unless disable_ga4
+    heading_text = t("components.feedback.is_this_page_useful", locale: :en)
     ga4_yes_button_event = {
       "event_name": "form_submit",
       "type": "feedback",
-      "text": t("components.feedback.yes", locale: :en), 
-      "section": t("components.feedback.is_this_page_useful", locale: :en),
+      "text": t("components.feedback.yes", locale: :en),
+      "section": heading_text,
+      "tool_name": heading_text,
       }.to_json
 
     ga4_no_button_event = {
       "event_name": "form_submit",
       "type": "feedback",
       "text": t("components.feedback.no", locale: :en),
-      "section": t("components.feedback.is_this_page_useful", locale: :en)
+      "section": heading_text,
+      "tool_name": heading_text,
       }.to_json
 
     ga4_problem_button_event = {
       "event_name": "form_submit",
       "type": "feedback",
       "text": t("components.feedback.something_wrong", locale: :en),
-      "section": t("components.feedback.is_this_page_useful", locale: :en)
+      "section": heading_text,
+      "tool_name": heading_text,
     }.to_json
   end
 %>

--- a/spec/components/feedback_spec.rb
+++ b/spec/components/feedback_spec.rb
@@ -40,4 +40,43 @@ describe "Feedback", type: :view do
       expect(response.body).to include(utf8_url)
     end
   end
+
+  it "has GA4 tracking" do
+    render_component({})
+
+    assert_select ".gem-c-feedback[data-module='feedback ga4-event-tracker']"
+
+    # Yes button
+    assert_select ".js-page-is-useful[data-ga4-event='{\"event_name\":\"form_submit\",\"type\":\"feedback\",\"text\":\"Yes\",\"section\":\"Is this page useful?\",\"tool_name\":\"Is this page useful?\"}']"
+
+    # No button
+    assert_select ".js-page-is-not-useful[data-ga4-event='{\"event_name\":\"form_submit\",\"type\":\"feedback\",\"text\":\"No\",\"section\":\"Is this page useful?\",\"tool_name\":\"Is this page useful?\"}']"
+
+    # Report a problem button
+    assert_select ".js-something-is-wrong[data-ga4-event='{\"event_name\":\"form_submit\",\"type\":\"feedback\",\"text\":\"Report a problem with this page\",\"section\":\"Is this page useful?\",\"tool_name\":\"Is this page useful?\"}']"
+
+    # Report a problem submit
+    assert_select ".govuk-button[data-ga4-event='{\"event_name\":\"form_submit\",\"type\":\"feedback\",\"text\":\"Send\",\"section\":\"Help us improve GOV.UK\",\"tool_name\":\"Help us improve GOV.UK\"}']"
+
+    # Send me the survey submit
+    assert_select ".govuk-button[data-ga4-event='{\"event_name\":\"form_submit\",\"type\":\"feedback\",\"text\":\"Send me the survey\",\"section\":\"Help us improve GOV.UK\",\"tool_name\":\"Help us improve GOV.UK\"}']"
+  end
+
+  it "can have its GA4 tracking disabled" do
+    render_component({ disable_ga4: true })
+
+    assert_select ".gem-c-feedback[data-module='feedback ga4-event-tracker']", false
+
+    # Yes button
+    assert_select ".js-page-is-useful[data-ga4-event]", false
+
+    # No button
+    assert_select ".js-page-is-not-useful[data-ga4-event]", false
+
+    # Report a problem button
+    assert_select ".js-something-is-wrong[data-ga4-event]", false
+
+    # Report a problem submit / Send me the survey submit
+    assert_select ".govuk-button[data-ga4-event]", false
+  end
 end


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Adds `tool_name` to the GA4 feedback component tracking
- Adds tests to the component - for context this tracking was added early on in the GA4 project, so I don't think we had our spec test process set up at that time.

## Why
<!-- What are the reasons behind this change being made? -->
- https://trello.com/c/fLwaDGY3/793-feedback-form-tool-name

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.