### PR TITLE
Update script snippet in view templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add PDF specific icon to attachment component ([PR #3985](https://github.com/alphagov/govuk_publishing_components/pull/3985))
 * Add the hidden attribute to mobile menu button ([PR #3975](https://github.com/alphagov/govuk_publishing_components/pull/3975))
 * Add tool_name to GA4 feedback component tracking ([PR #3984](https://github.com/alphagov/govuk_publishing_components/pull/3984))
+* Update script snippet in view templates ([PR #3986](https://github.com/alphagov/govuk_publishing_components/pull/3986))
 
 ## 38.0.1
 

--- a/app/views/govuk_publishing_components/components/_layout_for_admin.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_admin.html.erb
@@ -19,7 +19,7 @@
   </head>
   <body class="gem-c-layout-for-admin govuk-template__body">
     <%= javascript_tag nonce: true do -%>
-      document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+      document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');
     <% end -%>
     <%= yield %>
     <%= javascript_include_tag "application" %>

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -97,7 +97,7 @@
   </head>
   <%= tag.body class: body_css_classes do %>
     <%= javascript_tag nonce: true do -%>
-      document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+      document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');
     <% end -%>
     <%= render "govuk_publishing_components/components/cookie_banner", layout_helper.cookie_banner_data %>
     <%= render "govuk_publishing_components/components/skip_link", {

--- a/app/views/layouts/govuk_publishing_components/application.html.erb
+++ b/app/views/layouts/govuk_publishing_components/application.html.erb
@@ -47,7 +47,7 @@
   </head>
   <body class="gem-c-layout-for-admin govuk-template__body <%= 'hide-header-and-footer' if @preview %>">
     <%= javascript_tag nonce: true do -%>
-      document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+      document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');
     <% end -%>
     <%= yield :body %>
 


### PR DESCRIPTION
## What

Update the <script> snippet in view templates

## Why

For govuk-frontend v5, there now needs to be additional class added to the `body` tag to indicate that the components are supported.

This class is `govuk-frontend-supported` and is added if the browser supports JS of type `module` (which is the new browser target for govuk-frontend).

The script tag is directly taken from the documentation, see "Update the `<script>` snippet at the top of your `<body>` tag" in the [release notes for govuk-frontend 5.0.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.0.0)

We can safely move to the new snippet in advance of upgrading to V5 of govuk-frontend, this will also give us a bit more flexibility in how we release the changes in our frontend rendering apps and `static`.

For example, if we couple this change with the upgrade to v5 in the gem, and we upgrade a frontend rendering application before `static`, components that rely on govuk-frontend will not be initliased.

[Trello card](https://trello.com/c/FLCXEcTQ/937-prep-for-51-update-the-script-snippet-in-view-templates-in-govuk-publishing-components-gem)