### PR TITLE
Fix rendering of unnumbered papers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Fix rendering of unnumbered papers ([PR #3988](https://github.com/alphagov/govuk_publishing_components/pull/3988))
 * Add PDF specific icon to attachment component ([PR #3985](https://github.com/alphagov/govuk_publishing_components/pull/3985))
 * Add the hidden attribute to mobile menu button ([PR #3975](https://github.com/alphagov/govuk_publishing_components/pull/3975))
 * Add tool_name to GA4 feedback component tracking ([PR #3984](https://github.com/alphagov/govuk_publishing_components/pull/3984))

--- a/lib/govuk_publishing_components/presenters/attachment_helper.rb
+++ b/lib/govuk_publishing_components/presenters/attachment_helper.rb
@@ -78,8 +78,8 @@ module GovukPublishingComponents
       end
 
       def unnumbered_reference
-        unnumbered_reference = "Unnumbered command paper" if attachment_data[:unnumbered_command_paper].eql?(true) && !attachment_data[:command_paper_number]
-        unnumbered_reference = "Unnumbered act paper" if attachment_data[:unnumbered_hoc_paper].eql?(true) && !attachment_data[:hoc_paper_number]
+        unnumbered_reference = "Unnumbered command paper" if attachment_data[:unnumbered_command_paper].eql?(true) && attachment_data[:command_paper_number].blank?
+        unnumbered_reference = "Unnumbered act paper" if attachment_data[:unnumbered_hoc_paper].eql?(true) && attachment_data[:hoc_paper_number].blank?
         unnumbered_reference
       end
 

--- a/spec/lib/govuk_publishing_components/presenters/attachment_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/attachment_spec.rb
@@ -175,6 +175,7 @@ RSpec.describe GovukPublishingComponents::Presenters::AttachmentHelper do
         title: "test",
         url: "test",
         content_type: "text/csv",
+        command_paper_number: "",
         unnumbered_command_paper: true,
       )
       expect(attachment.unnumbered_reference).to eq("Unnumbered command paper")
@@ -185,6 +186,7 @@ RSpec.describe GovukPublishingComponents::Presenters::AttachmentHelper do
         title: "test",
         url: "test",
         content_type: "text/csv",
+        hoc_paper_number: "",
         unnumbered_hoc_paper: true,
       )
       expect(attachment.unnumbered_reference).to eq("Unnumbered act paper")


### PR DESCRIPTION
## What
Fix rendering of unnumbered papers so that "Unnumbered..." is displayed

## Why
The "false" check in the unnumbered command and act papers was failing because the component is passed an empty string rather than nil for the number, which does not evaluate to false:

e.g.

```bash
a = false
!a
=> true
b = nil
!b
=> true
c = ""
!c
=> false
```

Therefore the check was returning `nil` rather than the "Unnumbered..." text.

## Visual Changes
### Before
![Screenshot 2024-04-19 at 16 38 17](https://github.com/alphagov/govuk_publishing_components/assets/5793815/dcb1f99f-0247-4775-bae7-575c120b3755)

### After
![Screenshot 2024-04-19 at 16 38 04](https://github.com/alphagov/govuk_publishing_components/assets/5793815/9ff4a3bc-93a4-4a1b-863c-0bb57c714297)

