### PR TITLE
Version 38.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 38.1.0
 
 * Fix rendering of unnumbered papers ([PR #3988](https://github.com/alphagov/govuk_publishing_components/pull/3988))
 * Add PDF specific icon to attachment component ([PR #3985](https://github.com/alphagov/govuk_publishing_components/pull/3985))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (38.0.1)
+    govuk_publishing_components (38.1.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "38.0.1".freeze
+  VERSION = "38.1.0".freeze
 end


### PR DESCRIPTION
## 38.1.0

* Fix rendering of unnumbered papers ([PR #3988](https://github.com/alphagov/govuk_publishing_components/pull/3988))
* Add PDF specific icon to attachment component ([PR #3985](https://github.com/alphagov/govuk_publishing_components/pull/3985))
* Add the hidden attribute to mobile menu button ([PR #3975](https://github.com/alphagov/govuk_publishing_components/pull/3975))
* Add tool_name to GA4 feedback component tracking ([PR #3984](https://github.com/alphagov/govuk_publishing_components/pull/3984))
* Update script snippet in view templates ([PR #3986](https://github.com/alphagov/govuk_publishing_components/pull/3986))
* Font changes ahead of apps being made compatible with govuk-frontend v5 ([PR #3981](https://github.com/alphagov/govuk_publishing_components/pull/3981))