### PR TITLE
Use Terser instead of Uglifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Update Twitter logo ([PR #4011](https://github.com/alphagov/govuk_publishing_components/pull/4011))
+* Use Terser instead of Uglifier ([PR #3990](https://github.com/alphagov/govuk_publishing_components/pull/3990))
 
 ## 38.2.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,7 +128,7 @@ GEM
     domain_name (0.6.20240107)
     drb (2.2.1)
     erubi (1.12.0)
-    execjs (2.8.1)
+    execjs (2.9.1)
     faker (3.3.1)
       i18n (>= 1.8.11, < 2)
     gds-api-adapters (95.1.0)
@@ -599,12 +599,12 @@ GEM
     stringio (3.1.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
+    terser (1.2.0)
+      execjs (>= 0.3.0, < 3)
     thor (1.3.1)
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uglifier (4.2.0)
-      execjs (>= 0.3.0, < 3)
     unicode-display_width (2.5.0)
     webmock (3.23.0)
       addressable (>= 2.8.0)
@@ -638,7 +638,7 @@ DEPENDENCIES
   rake
   rspec-rails
   rubocop-govuk
-  uglifier
+  terser
   webmock
   yard
 

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec-rails"
   s.add_development_dependency "rubocop-govuk"
-  s.add_development_dependency "uglifier"
+  s.add_development_dependency "terser"
   s.add_development_dependency "webmock"
   s.add_development_dependency "yard"
 end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -4,6 +4,7 @@ require "action_controller/railtie"
 require "action_view/railtie"
 require "action_mailer/railtie"
 require "sprockets/railtie"
+require "terser"
 require "dartsass-rails"
 
 # In a heroku environment we don't have chrome and chromedriver available

--- a/spec/dummy/config/environments/production.rb
+++ b/spec/dummy/config/environments/production.rb
@@ -19,7 +19,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = :terser
   config.assets.css_compressor = false
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
## What

Use Terser instead of Uglifier to compile JavaScript.

## Why

govuk-frontend v5 now targets browsers that support ES6. This means that the UMD modules used in govuk_publishing_components from govuk-frontend use features of ES6 and so it means that Uglifier can't be used anymore because it only supports ES5.

[Trello card](https://trello.com/c/lnPFryyC/2562-prep-for-51-move-fe-applications-from-uglifier-to-terser-l)

## Changes

### JS Size
Overall the minified JS has increased slightly, by 1KB in the example below, however the overall GZIP size has decreased by 2KB.

| minifier | file | minified JS | minified JS (gzip) |
| --- | --- | --- | --- |
| uglifer | component_guide/application.js | 611KB | 162KB |
| terser | component_guide/application.js | 612KB | 160KB |

## Testing

### Component Guide
The component-guide still works as expected in the gem, I've also tested the component-guide in `government-frontend` and `collections`, which both work OK.

The component-guide is not currently working in the `frontend` app due to the error below:

```
Psych::DisallowedClass at /
Tried to load unspecified class: Date
```

This appears to be an existing issue unrelated to this change, for example, all component guide previews work on this link, https://docs.publishing.service.gov.uk/manual/components.html#component-guides, `frontend` being the exception.

### Heroku

`require "terser"` has been added to [spec/dummy/config/application.rb](https://github.com/alphagov/govuk_publishing_components/pull/3990/files#diff-ad366e89306810a068ae008a627d8fe6c27f88bf77bee35cd828f784bc6de062R7), this avoids the error below when deploying to Heroku:

```sh
rake aborted!
Sprockets::Error: unknown compressor: terser (Sprockets::Error)
```