### PR TITLE
Fix misaligned button and input on search component

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -68,8 +68,8 @@ $large-input-size: 50px;
   @include govuk-font($size: 19, $line-height: (28 / 19));
   margin: 0;
   width: 100%;
-  height: govuk-em(40, 16);
-  padding: govuk-em(6, 16);
+  height: govuk-em(40, 19);
+  padding: govuk-em(6, 19);
   border: $govuk-border-width-form-element solid $govuk-input-border-colour;
   background: govuk-colour("white");
   border-radius: 0; // otherwise iphones apply an automatic border radius
@@ -77,10 +77,6 @@ $large-input-size: 50px;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  @include govuk-media-query($from: tablet) {
-    height: govuk-em(40, 19);
-    padding: govuk-em(6, 19);
-  }
 
   // the .focus class is added by JS and ensures that the input remains above the label once clicked/filled in
   &:focus,


### PR DESCRIPTION
## What
Make the search input field and button the same height after applying type scale changes in design system v5.

## Why
These two elements became misaligned when the input field font-size was increased as part of the design system typography improvements. We no longer need adjusted padding for the tablet+ view as the font size is now the same 19px at all screen sizes.

## Visual Changes

1) Original site with 16px fonts
2) Updated typescale with 19px font and broken search field
3) Updated typescale with 19px font and fixed search field (this PR)

![image](https://github.com/alphagov/govuk_publishing_components/assets/2166204/33f42c22-8fed-450d-af55-cdb8f063871f)

