### PR TITLE
Update `module.js` ready for v5 of govuk-frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Update module.js ready for v5 of govuk-frontend ([PR #3992](https://github.com/alphagov/govuk_publishing_components/pull/3992))
+
 ## 38.3.2
 
 * Reintroduce feedback survey path and new tab functionality ([PR #4024](https://github.com/alphagov/govuk_publishing_components/pull/4024))

--- a/app/assets/javascripts/govuk_publishing_components/modules.js
+++ b/app/assets/javascripts/govuk_publishing_components/modules.js
@@ -36,15 +36,20 @@
           var moduleName = camelCaseAndCapitalise(moduleNames[j])
           var started = element.getAttribute('data-' + moduleNames[j] + '-module-started')
           if (typeof GOVUK.Modules[moduleName] === 'function' && !started) {
-            // Vanilla JavaScript GOV.UK Modules and GOV.UK Frontend Modules
-            if (GOVUK.Modules[moduleName].prototype.init) {
-              try {
+            try {
+              if (GOVUK.Modules[moduleName].prototype.init) {
+                // Vanilla JavaScript GOV.UK Modules and GOV.UK Frontend V4 Modules
                 new GOVUK.Modules[moduleName](element).init()
-                element.setAttribute('data-' + moduleNames[j] + '-module-started', true)
-              } catch (e) {
-                // if there's a problem with the module, catch the error to allow other modules to start
-                console.error('Error starting ' + moduleName + ' component JS: ', e, window.location)
+              } else {
+                // GOV.UK Frontend V5 Modules - removed component init() methods and initialise in constructor
+                // https://github.com/alphagov/govuk-design-system-architecture/blob/main/decision-records/010-remove-init-method.md
+                /* eslint-disable no-new */
+                new GOVUK.Modules[moduleName](element)
               }
+              element.setAttribute('data-' + moduleNames[j] + '-module-started', true)
+            } catch (e) {
+              // if there's a problem with the module, catch the error to allow other modules to start
+              console.error('Error starting ' + moduleName + ' component JS: ', e, window.location)
             }
           }
         }

--- a/spec/javascripts/govuk_publishing_components/modules.spec.js
+++ b/spec/javascripts/govuk_publishing_components/modules.spec.js
@@ -74,10 +74,12 @@ describe('GOVUK Modules', function () {
   describe('when modules exist', function () {
     var container
     var callbackFrontendModule
+    var callbackFrontendModuleVersionFive
     var callbackGemFrontendModule
 
     beforeEach(function () {
       callbackFrontendModule = jasmine.createSpy()
+      callbackFrontendModuleVersionFive = jasmine.createSpy()
       callbackGemFrontendModule = jasmine.createSpy()
 
       // GOV.UK Frontend Modules
@@ -88,6 +90,16 @@ describe('GOVUK Modules', function () {
         callbackFrontendModule(this.element)
       }
       GOVUK.Modules.TestAlertFrontendModule = TestAlertFrontendModule
+
+      // GOV.UK Frontend Modules - V5
+      function TestAlertFrontendModuleVersionFive (element) {
+        this.element = element
+        this.initControls()
+      }
+      TestAlertFrontendModuleVersionFive.prototype.initControls = function () {
+        callbackFrontendModuleVersionFive(this.element)
+      }
+      GOVUK.Modules.TestAlertFrontendModuleVersionFive = TestAlertFrontendModuleVersionFive
 
       // GOV.UK Gem Frontend Modules
       function GemTestAlertFrontendModule (element) {
@@ -136,6 +148,7 @@ describe('GOVUK Modules', function () {
 
     afterEach(function () {
       delete GOVUK.Modules.TestAlertFrontendModule
+      delete GOVUK.Modules.TestAlertFrontendModuleVersionFive
       delete GOVUK.Modules.GemTestAlertFrontendModule
       delete GOVUK.Modules.TestAlertPublishingAndFrontendModule
       delete GOVUK.Modules.TestCookieDependencyModule
@@ -154,12 +167,19 @@ describe('GOVUK Modules', function () {
     })
 
     it('does not start modules that are already started', function () {
-      var module = $('<div data-module="test-alert-frontend-module"></div>')
-      container.append(module)
+      var modules = $(
+        '<div data-module="test-alert-frontend-module"></div>' +
+        '<div data-module="test-alert-frontend-module-version-five"></div>' +
+        '<div data-module="gem-test-alert-frontend-module"></div>'
+      )
 
-      GOVUK.modules.start(module[0])
-      GOVUK.modules.start(module[0])
+      $('body').append(modules)
+      GOVUK.modules.start()
+      GOVUK.modules.start()
       expect(callbackFrontendModule.calls.count()).toBe(1)
+      expect(callbackFrontendModuleVersionFive.calls.count()).toBe(1)
+      expect(callbackGemFrontendModule.calls.count()).toBe(1)
+      modules.remove()
     })
 
     it('passes the HTML element to the module’s start method', function () {
@@ -176,12 +196,17 @@ describe('GOVUK Modules', function () {
       var modules = $(
         '<div data-module="test-alert-frontend-module"></div>' +
         '<strong data-module="test-alert-frontend-module"></strong>' +
-        '<span data-module="test-alert-frontend-module"></span>'
+        '<span data-module="test-alert-frontend-module"></span>' +
+        '<div data-module="test-alert-frontend-module-version-five"></div>' +
+        '<strong data-module="test-alert-frontend-module-version-five"></strong>' +
+        '<div data-module="gem-test-alert-frontend-module"></div>'
       )
 
       $('body').append(modules)
       GOVUK.modules.start()
       expect(callbackFrontendModule.calls.count()).toBe(3)
+      expect(callbackFrontendModuleVersionFive.calls.count()).toBe(2)
+      expect(callbackGemFrontendModule.calls.count()).toBe(1)
       modules.remove()
     })
 
@@ -194,6 +219,18 @@ describe('GOVUK Modules', function () {
       GOVUK.modules.start()
       expect(callbackGemFrontendModule.calls.count()).toBe(1)
       expect(callbackFrontendModule.calls.count()).toBe(1)
+      modules.remove()
+    })
+
+    it('starts govuk-frontend v5 and gem modules on a single element', function () {
+      var modules = $(
+        '<div data-module="test-alert-frontend-module-version-five gem-test-alert-frontend-module"></div>'
+      )
+
+      $('body').append(modules)
+      GOVUK.modules.start()
+      expect(callbackGemFrontendModule.calls.count()).toBe(1)
+      expect(callbackFrontendModuleVersionFive.calls.count()).toBe(1)
       modules.remove()
     })
 


### PR DESCRIPTION
## What

- Update the start function in `module.js` to support how JS modules are initialisted in govuk-frontend v5 as initialisation now happens automatically
  - see "Remove calls to component init methods from your JavaScript" in the release notes of [GOV.UK Frontend v5.0.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.0.0)
- Add tests to `modules.spec.js` to check modules are initialised as expected when the `init` method is not on the modules prototype

## Why

[Trello card](https://trello.com/c/Vm74rv2e/938-prep-for-51-update-modulejs-in-govuk-publishing-components-to-support-multiple-initialisation-approaches-m)

These changes are required to support v5 of govuk-frontend, by making these changes in advance of the release of v5 of govuk-frontend we can help avoid any potentially breaking changes when migrating to the new version of the gem that upgrades govuk-frontend to v5.

The main challenge here is when using static and frontend rendering applications. Modules are found and started in [dependencies.js](https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/dependencies.js) by including ./modules.js, this is called by [static](https://github.com/alphagov/static/blob/main/app/assets/javascripts/application.js#L1) once for all applications on GOV.UK. If we were to include the changes made to `modules.js` as part of the upgrade to v5, this could cause some breaking changes in certain scenarios, further examples below.

### Accordion Component

**Scenario**
- `collections` is running v5 of govuk-frontend
- `static` is running an old version of the gem that does not support both initialisation approaches in `modules.js`

**Outcome**
As the `init` method is removed from the accordion component in v5 of govuk-frontend, the accordion component from govuk-frontend will not be initialised in `modules.js`

**Impact**
The content will not be accessible as shown in the screenshots below. This is a known issue and further details are included in https://github.com/alphagov/govuk-frontend/issues/999

| initialised | not initialised |
| --- | --- |
| <img width="999" alt="accordion-working" src="https://github.com/alphagov/govuk_publishing_components/assets/28779939/ee741c86-432d-42d6-899d-53c1be35a7f6"> | <img width="992" alt="accordion-component-not-working" src="https://github.com/alphagov/govuk_publishing_components/assets/28779939/bd74a567-8ce0-470d-b239-e6523385f33a"> |

### Tabs Component

**Scenario**
- `frontend` is running v5 of govuk-frontend
- `static` is running an old version of the gem that does not support both initialisation approaches in `modules.js`
- the init method is removed from the tabs component in v5 of govuk-frontend

**Outcome**
As the `init` method is removed from the tabs component in v5 of govuk-frontend, the tabs component from govuk-frontend will not be initialised in `modules.js`

**Impact**
- tabs are still styled as expected
- tab content is accessible
- all tab content will appear on the page
- clicking a tab will scroll a user to the related section of the page

| initialised | not initialised |
| --- | --- |
| <img width="671" alt="tabs-component-working" src="https://github.com/alphagov/govuk_publishing_components/assets/28779939/28368a4d-b0f2-4c70-a91f-2bf309c9d255"> | <img width="710" alt="tabs-component-not-initialised" src="https://github.com/alphagov/govuk_publishing_components/assets/28779939/f53083e8-4682-429d-8b05-8bdf1808bac1"> |

## Further information

- GOV.UK Design System Architecture decision record - [Remove init() method from JavaScript components](https://github.com/alphagov/govuk-design-system-architecture/blob/main/decision-records/010-remove-init-method.md)
- [Remove component init() methods and initialise in constructor](https://github.com/alphagov/govuk-frontend/pull/4011)
- [govuk publishing components - JavaScript Modules](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/javascript-modules.md)
