### PR TITLE
Update layout_for_admin component to take custom asset filenames 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+- Update layout_for_admin component to take custom asset filenames ([PR #3993](https://github.com/alphagov/govuk_publishing_components/pull/3993))
+
 ## 38.1.0
 
 * Fix rendering of unnumbered papers ([PR #3988](https://github.com/alphagov/govuk_publishing_components/pull/3988))

--- a/app/views/govuk_publishing_components/components/_layout_for_admin.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_admin.html.erb
@@ -1,5 +1,7 @@
 <%
   add_gem_component_stylesheet("layout-for-admin")
+  js_filename ||= "application"
+  css_filename ||= "application"
 
   product_name ||= "Publishing"
 %>
@@ -13,7 +15,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <%= csrf_meta_tags %>
     <%= favicon_link_tag "govuk_publishing_components/favicon-#{environment}.png" %>
-    <%= stylesheet_link_tag "application", media: "all" %>
+    <%= stylesheet_link_tag css_filename, media: "all" %>
     <%= javascript_include_tag "govuk_publishing_components/vendor/modernizr" %>
     <%= yield :head %>
   </head>
@@ -22,6 +24,6 @@
       document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');
     <% end -%>
     <%= yield %>
-    <%= javascript_include_tag "application" %>
+    <%= javascript_include_tag js_filename %>
   </body>
 </html>

--- a/app/views/govuk_publishing_components/components/docs/layout_for_admin.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_for_admin.yml
@@ -23,3 +23,21 @@ examples:
       browser_title: 'A page title'
       block: |
         <!-- You probably want to use the header, main & footer components here -->
+  with_custom_js_filename:
+    description: An alternative JS filename can be used in place of the default `application.js` if required (note that this cannot easily be demonstrated here).
+    data:
+      environment: production
+      product_name: Publishing
+      browser_title: 'A page title'
+      js_filename: "application"
+      block: |
+        <!-- You probably want to use the header, main & footer components here -->
+  with_custom_css_filename:
+    description: An alternative JS filename can be used in place of the default `application.scss` if required (note that this cannot easily be demonstrated here).
+    data:
+      environment: production
+      product_name: Publishing
+      browser_title: 'A page title'
+      css_filename: "application"
+      block: |
+        <!-- You probably want to use the header, main & footer components here -->

--- a/spec/components/layout_for_admin_spec.rb
+++ b/spec/components/layout_for_admin_spec.rb
@@ -16,4 +16,25 @@ describe "Layout for admin", type: :view do
 
     assert_select 'meta[name="robots"][content="noindex,nofollow,noimageindex"]', visible: false
   end
+
+  it "can receive a custom js filename" do
+    allow_any_instance_of(ActionView::Base).to receive(:javascript_include_tag).with("govuk_publishing_components/vendor/modernizr")
+    expect_any_instance_of(ActionView::Base).to receive(:javascript_include_tag).with("admin").once
+
+    render_component(
+      browser_title: "Hello, admin page",
+      environment: "production",
+      js_filename: "admin",
+    )
+  end
+
+  it "can receive a custom css filename" do
+    expect_any_instance_of(ActionView::Base).to receive(:stylesheet_link_tag).with("admin", media: "all")
+
+    render_component(
+      browser_title: "Hello, admin page",
+      environment: "production",
+      css_filename: "admin",
+    )
+  end
 end


### PR DESCRIPTION
## What

Allow custom JS and CSS filenames to be passed to the layout_for_admin component.

## Why

We're adding an admin interface to our application and want to use retain application.js & application.scss for the public interface.

This will allow us to pass admin.js and admin.scss in as args so we can retain only loading the required components for each so the page load time is fast.


## Visual Changes

N/A

## Testing

It was a bit awkward to test this as passing it a filename that doesn't exist causes exceptions. Using any_instance_of is a bit of a smell, but it's probs okay(ish) here to avoid additional complexity.

## Trello card

https://trello.com/c/r6uafy2D/1354-basic-admin-area