### PR TITLE
Limit GA4 view_item_list arrays to 15,000 UTF-16 code units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Limit GA4 view_item_list arrays to 15,000 UTF-16 code units ([PR #3994](https://github.com/alphagov/govuk_publishing_components/pull/3994))
+
 ## 38.1.1
 
-- Update layout_for_admin component to take custom asset filenames ([PR #3993](https://github.com/alphagov/govuk_publishing_components/pull/3993))
+* Update layout_for_admin component to take custom asset filenames ([PR #3993](https://github.com/alphagov/govuk_publishing_components/pull/3993))
 
 ## 38.1.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -371,11 +371,6 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
           }
         } else {
           for (var i = 0; i < items.length; i++) {
-            // GA4 limits us to 200 items, so we should limit the array to this size.
-            if (i === 200) {
-              break
-            }
-
             var item = items[i]
             var path = item.getAttribute('data-ga4-ecommerce-path')
 
@@ -385,16 +380,28 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
               item.setAttribute('data-ga4-ecommerce-index', i + 1)
             }
 
-            ecommerceSchema.search_results.ecommerce.items.push({
+            var nextItem = {
               item_id: path,
               item_content_id: item.getAttribute('data-ga4-ecommerce-content-id') || undefined,
               item_list_name: listTitle,
               index: window.GOVUK.analyticsGa4.core.ecommerceHelperFunctions.getIndex(item, startPosition)
-            })
+            }
+
+            // GA4 has a max payload, so ensure this array doesn't exceed 15,000 UTF-16 code units.
+            if ((this.getArraySize(ecommerceSchema.search_results.ecommerce.items) + this.getArraySize(nextItem)) >= 15000) {
+              break
+            }
+
+            ecommerceSchema.search_results.ecommerce.items.push(nextItem)
           }
         }
 
         return ecommerceSchema
+      },
+
+      getArraySize: function (array) {
+        // .length represents the number of UTF-16 code units in a string, so we can stringify the array then grab the length of the string to get an 'accurate enough' number representing the size.
+        return JSON.stringify(array).length
       }
     }
   }

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
@@ -629,36 +629,31 @@ describe('GA4 core', function () {
         expect(builtEcommerceObject).toEqual(expectedEcommerceObject)
       })
 
-      it('the ecommerce items array is limited to 200 items', function () {
+      it('the ecommerce items array is limited to a maximum of 15,000 UTF-16 code units', function () {
         var innerHTML = ''
         var ecommerceItems = []
 
-        // Adds 500 search results to the DOM, but only adds 200 to our expected ecommerce object array
-        for (var i = 0; i < 500; i++) {
+        for (var i = 0; i < 4000; i++) {
           innerHTML = innerHTML + '<a data-ga4-ecommerce-path="https://www.gov.uk/the-warm-home-discount-scheme" href="https://www.gov.uk/the-warm-home-discount-scheme" data-ga4-ecommerce-index="' + (i + 1) + '">Check if you’re eligible for the Warm Home Discount scheme</a>'
 
-          if (i < 200) {
-            ecommerceItems.push({
-              item_id: 'https://www.gov.uk/the-warm-home-discount-scheme',
-              item_content_id: undefined,
-              item_list_name: 'Smart answer results',
-              index: i + 1
-            })
-          }
+          ecommerceItems.push({
+            a: 'b'
+          })
         }
 
-        resultsCount.innerHTML = '500 results'
         results.innerHTML = innerHTML
-        expectedEcommerceObject.search_results.results = 500
-        expectedEcommerceObject.search_results.ecommerce.items = ecommerceItems
 
         var builtEcommerceObject = GOVUK.analyticsGa4.core.ecommerceHelperFunctions.populateEcommerceSchema({
           element: resultsParentEl,
           resultsId: 'result-count'
         })
 
-        expect(builtEcommerceObject).toEqual(expectedEcommerceObject)
-        expect(builtEcommerceObject.search_results.ecommerce.items.length).toEqual(200)
+        // Check our test data is above 15,000 UTF-16 code units
+        expect(GOVUK.analyticsGa4.core.ecommerceHelperFunctions.getArraySize(ecommerceItems) === 40001).toEqual(true)
+        // Check that the array GA4 is given is less than/equal to 15,000 UTF-16 code units
+        expect(GOVUK.analyticsGa4.core.ecommerceHelperFunctions.getArraySize(builtEcommerceObject.search_results.ecommerce.items) <= 15000).toEqual(true)
+        // Ensure it's going as close to 15,000 as possible (as the above assertion would still pass if someone reduced the limit)
+        expect(GOVUK.analyticsGa4.core.ecommerceHelperFunctions.getArraySize(builtEcommerceObject.search_results.ecommerce.items) === 14958).toEqual(true)
       })
     })
   })


### PR DESCRIPTION
## What
- On the following pages, GA4 is throwing a 413 HTTP error, as we're sending too much data:
    - https://www.gov.uk/world/organisations
    - https://www.gov.uk/government/groups
    - https://www.gov.uk/government/organisations/hm-revenue-customs/contact
- This is because the ecommerce arrays we were sending were too large (20,000 - 40,000+ bytes)
- I've done some investigation and it looks like GTM errors if a request exceeds 16,000 bytes (16KB)
- I've also discovered that each push to the dataLayer also seems to push the Pageview data with it as well. Therefore, when sending the ecommerce array we must leave some room for the pageview data as well in the request.
- Therefore I've limited the eCommerce arrays to 15,000 UTF-16 code units, which should give about 1384 bytes of room for the pageview data.
- We can't really solve this by limiting the array to a certain amount of items, because an array with 50 items could be 100,000 bytes depending on what it's storing, and an array with 1000 items in it could be 10,000 bytes. Therefore we need to limit it by it's size in some way.
- The code to limit the ecommerce array works by:
    - Turning the array into a string using `JSON.stringify` 
    - Grabbing the `.length` of this string
    - The length of this string gives us a good-enough estimation of the array size in UTF-16 code units.
    - We can then use this byte number to stop the array from exceeding 15,000 UTF-16 code units. Every time a new item wants to be added to the array, we check if adding that item will cause the array to exceed 15,000 UTF-16 code units. If adding that item will cause the array to become too large, we stop adding items to the array.
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
<!-- What are the reasons behind this change being made? -->
https://trello.com/c/i3XBl4Hh/815-fix-viewitemlist-events-on-contact-hm-revenue-customs-page

## Testing
- I have tested this is working by taking the new `dataLayer` object that is output locally on the offending pages, and pushing that object to the `dataLayer` via our homepage on `integration`. There is no error from GTM about the payload being too large.

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.