### PR TITLE
Fix minor format string vuln in log message.

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/vendor/lux/lux-measurer.js
+++ b/app/assets/javascripts/govuk_publishing_components/vendor/lux/lux-measurer.js
@@ -192,5 +192,5 @@ try {
     }
   }
 } catch (e) {
-  console.error('Error in LUX reporting the HTTP protocol (' + window.location + '):', e)
+  console.error('Error in LUX reporting the HTTP protocol (%s):', window.location, e)
 }


### PR DESCRIPTION
Resolves https://github.com/alphagov/govuk_publishing_components/security/code-scanning/6.

This source file appears to be forked from some closed upstream. I couldn't find the upstream source, but it looks like this isn't the first change we've made to it so I'm guessing it's reasonable to make this fix here.

(slightly off-topic: I also couldn't find any licence info about this source file, so that may or may not be a pre-existing problem there.)

No visual or functional changes.