### PR TITLE
Add custom_header and a custom_layout options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Limit GA4 view_item_list arrays to 15,000 UTF-16 code units ([PR #3994](https://github.com/alphagov/govuk_publishing_components/pull/3994))
+* Add custom_header and a custom_layout options ([PR #4004](https://github.com/alphagov/govuk_publishing_components/pull/4004))
 
 ## 38.1.1
 

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -17,6 +17,7 @@
   omit_footer_navigation ||= false
   omit_footer_border ||= false
   omit_header ||= false
+  custom_layout ||= false
   product_name ||= nil
   show_explore_header ||= false
   show_cross_service_header ||= false
@@ -120,6 +121,8 @@
           service_navigation_items: service_navigation_items,
           product_name: product_name,
         } %>
+      <% elsif content_for?(:custom_header) %>
+        <%= yield :custom_header %>
       <% else %>
         <%= render "govuk_publishing_components/components/layout_header", {
           search: show_search,
@@ -159,6 +162,8 @@
         <%= yield :before_content %>
         <%= yield %>
       <% end %>
+    <% elsif custom_layout %>
+      <%= yield %>
     <% else %>
       <div id="wrapper" class="<%= "govuk-width-container" unless full_width %>">
         <%= yield :before_content %>

--- a/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
@@ -123,3 +123,19 @@ examples:
           cookie_preferences:
             text: How GOV.UK accounts use cookies
             href: https://www.gov.uk/government/publications/govuk-accounts-trial-full-privacy-notice-and-accessibility-statement
+  with_custom_layout:
+    description: Yields a custom layout for the content.
+    data:
+      custom_layout: true
+      block: |
+        <main id="custom-layout">
+          <h1>This is a custom layout</h1>
+        </main>
+  with_custom_header:
+    description: Allows the header to be replaced with HTML injected by the calling application in a `content_for` tag named `:custom_header`.
+    embed: |
+      <% content_for(:custom_header) do %>
+        <header id="custom-header">I'm a custom header</header>
+      <% end %>
+      <%= render "govuk_publishing_components/components/layout_for_public", {
+      } %>

--- a/spec/components/layout_for_public_spec.rb
+++ b/spec/components/layout_for_public_spec.rb
@@ -301,4 +301,22 @@ describe "Layout for public", type: :view do
 
     assert_select ".gem-c-cookie-banner + .gem-c-skip-link"
   end
+
+  it "can render a custom header instead of the default one" do
+    view.content_for(:custom_header) { content_tag(:header, "GOV.UK with a custom header", id: "custom-header") }
+    render_component({})
+
+    assert_select "header#custom-header"
+    assert page.has_no_selector?(".gem-c-layout-header")
+  end
+
+  it "it can render a custom layout instead of the default one" do
+    render_component({ custom_layout: true }) do
+      content_tag(:main, "GOV.UK with a custom layout", id: "custom-layout")
+    end
+
+    assert_select "main#custom-layout"
+    assert page.has_no_selector?("div#wrapper")
+    assert page.has_no_selector?("main.govuk-main-wrapper")
+  end
 end


### PR DESCRIPTION
## What
This PR modifies the `layout_for_public` template to accept a custom header and a custom layout. This is to accommodate a custom layout for GOV.UK Chat but still bring in all the other HTML that `layout_for_public` provides.

We've opted for generic variable names e.g. `custom_header` and `custom_layout` in case another product has this need in future.

## Why
To achieve the custom layout of GOV.UK Chat - [Trello card](https://trello.com/c/PFfhPhjK/1350-fix-ui-layout)

## Visual Changes
None.
