### PR TITLE
Add blue option

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_button.scss
@@ -8,6 +8,14 @@
   margin-bottom: 0;
 }
 
+.gem-c-button--blue {
+  background-color: govuk-colour("blue");
+
+  &:hover {
+    background-color: govuk-shade(govuk-colour("blue"), 20%);
+  }
+}
+
 // this will be moved and extended into a model for general component spacing
 // once this has been decided upon and other work completed, see:
 // https://trello.com/c/KEkNsxG3/142-3-implement-customisable-spacing-for-components

--- a/app/views/govuk_publishing_components/components/docs/button.yml
+++ b/app/views/govuk_publishing_components/components/docs/button.yml
@@ -52,6 +52,10 @@ examples:
       href: '#'
       start: true
       rel: external
+  blue_button:
+    data:
+      text: Blue button
+      blue: true
   secondary_button:
     data:
       text: Secondary button

--- a/lib/govuk_publishing_components/presenters/button_helper.rb
+++ b/lib/govuk_publishing_components/presenters/button_helper.rb
@@ -16,6 +16,7 @@ module GovukPublishingComponents
                   :target,
                   :type,
                   :start,
+                  :blue,
                   :secondary,
                   :secondary_quiet,
                   :secondary_solid,
@@ -47,6 +48,7 @@ module GovukPublishingComponents
         @type = local_assigns[:type]
         @start = local_assigns[:start]
         @data_attributes[:ga4_attributes] = ga4_attribute if start
+        @blue = local_assigns[:blue]
         @secondary = local_assigns[:secondary]
         @secondary_quiet = local_assigns[:secondary_quiet]
         @secondary_solid = local_assigns[:secondary_solid]
@@ -112,6 +114,7 @@ module GovukPublishingComponents
       def css_classes
         css_classes = %w[gem-c-button govuk-button]
         css_classes << "govuk-button--start" if start
+        css_classes << "gem-c-button--blue" if blue
         css_classes << "gem-c-button--secondary" if secondary
         css_classes << "gem-c-button--secondary-quiet" if secondary_quiet
         css_classes << "govuk-button--secondary" if secondary_solid

--- a/spec/components/button_spec.rb
+++ b/spec/components/button_spec.rb
@@ -57,6 +57,11 @@ describe "Button", type: :view do
     assert_select ".govuk-button--start[data-ga4-attributes='{\"type\":\"start button\"}']", false
   end
 
+  it "renders blue button" do
+    render_component(text: "I am a blue button", blue: true)
+    assert_select ".gem-c-button--blue", text: "I am a blue button"
+  end
+
   it "renders secondary button" do
     render_component(text: "Secondary", href: "#", secondary: true)
     assert_select ".gem-c-button--secondary[href='#']", text: "Secondary"


### PR DESCRIPTION
## What
This PR extends the [button component](https://github.com/alphagov/govuk_publishing_components/blob/main/app/views/govuk_publishing_components/components/_button.html.erb) to accept a `blue` option so it has a blue background.

## Why
The landing page for GOV.UK Chat uses a blue button and I thought the cleanest solution would be to extend the gem's button component to also accept a blue background colour as opposed to creating a duplicate application component with the only difference being the background colour - [trello card](https://trello.com/c/cf8aTngw/1407-build-landing-page).

## Visual Changes

When the `blue` option is not passed/set to `false`:

![image](https://github.com/alphagov/govuk_publishing_components/assets/110391449/469017ef-12aa-4a91-8cce-761f0466f530)

When the `blue` option is passed and set to `true`:

![image](https://github.com/alphagov/govuk_publishing_components/assets/110391449/06b4b395-7d1f-4df9-a91c-19f8bf0cdcfe)