### PR TITLE
Remove Oxford comma from metadata component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Unreleased
 
+* Remove Oxford comma from metadata component ([PR #4012](https://github.com/alphagov/govuk_publishing_components/pull/4012))
+
 ## 38.3.0
 
 * Remove email from survey ([PR #4017](https://github.com/alphagov/govuk_publishing_components/pull/4017))

--- a/app/views/govuk_publishing_components/components/metadata/_sentence.html.erb
+++ b/app/views/govuk_publishing_components/components/metadata/_sentence.html.erb
@@ -7,7 +7,7 @@
   end
 %>
 <% if remaining.any? %>
-  <%= items.to_sentence(last_word_connector: ', ').html_safe %>
+  <%= items.to_sentence(last_word_connector: ' and ').html_safe %>
   <div class="gem-c-metadata__toggle-wrap govuk-!-display-none-print">
     <a href="#"
        class="gem-c-metadata__definition-link govuk-!-display-none-print"
@@ -21,5 +21,5 @@
   </div>
   <span id="toggle-<%= toggle_id %>" class="gem-c-metadata__toggle-items js-hidden"><%= remaining.to_sentence.html_safe %></span>
 <% else %>
-  <%= items.to_sentence.html_safe %>
+  <%= items.to_sentence(last_word_connector: ' and ').html_safe %>
 <% end %>

--- a/spec/components/metadata_spec.rb
+++ b/spec/components/metadata_spec.rb
@@ -59,7 +59,7 @@ describe "Metadata", type: :view do
 
     assert_definition("From:", "one and another")
     assert_definition("Part of:", "this and that")
-    assert_definition("Related topics:", "a, b, and c")
+    assert_definition("Related topics:", "a, b and c")
   end
 
   it "long lists of metadata are truncated and the remainder hidden behind a toggle for from" do


### PR DESCRIPTION
## What
Removes the Oxford comma from the metadata component. The output changes from:

`item1, item2, and item3`

to

`item1, item2 and item3`

This also adds the word `and` into some parts of this component where it was previously missing, see screenshots below, specifically the `Industry` line.

## Why
Done as part of the work around this zendesk ticket: https://govuk.zendesk.com/agent/tickets/5820104

## Visual Changes
Before:

![Screenshot 2024-05-10 at 12 34 54](https://github.com/alphagov/govuk_publishing_components/assets/861310/0f28d1ea-80e2-4102-aef7-b9cedf328c0d)

After:

![Screenshot 2024-05-10 at 12 34 29](https://github.com/alphagov/govuk_publishing_components/assets/861310/9341131a-26dd-4478-9f84-72af5410e80a)
