### PR TITLE
Prevent error if input field is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Remove Oxford comma from metadata component ([PR #4012](https://github.com/alphagov/govuk_publishing_components/pull/4012))
+* Add null check for input element ([PR #4022](https://github.com/alphagov/govuk_publishing_components/pull/4022))
 
 ## 38.3.0
 

--- a/app/assets/javascripts/govuk_publishing_components/components/feedback.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/feedback.js
@@ -161,8 +161,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.prompt.hidden ? this.prompt.hidden = false : this.prompt.hidden = true
 
     if (!this.activeForm.hidden) {
-      this.activeForm.querySelectorAll('.gem-c-textarea .govuk-textarea, .gem-c-input.govuk-input')[0]
-        .focus()
+      var input = this.activeForm.querySelectorAll('.gem-c-textarea .govuk-textarea, .gem-c-input.govuk-input')
+      if (input.length > 0) {
+        input[0].focus()
+      }
     } else {
       this.activeForm = false
       clearInterval(this.timerInterval)


### PR DESCRIPTION
## What
Prevent errors if input field is missing from the feedback form, by adding a null check. 
This is currently causing smokey to [fail](https://argo.eks.integration.govuk.digital/applications/cluster-services/smokey?node=%2FPod%2Fapps%2Fsmokey-28595090-rh8qb&tab=logs&orphaned=false&resource=). There will be work in this area around cleaning up the feedback, but this is just to quickly fix smokey.


## Why
Due to recent changes that removed the email address from the survey form, there is no input element available to focus on when the feedback form loads.

