### PR TITLE
Reintroduce feedback survey path and new tab functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Unreleased
 
+* Reintroduce feedback survey path and new tab functionality ([PR #4024](https://github.com/alphagov/govuk_publishing_components/pull/4024))
+
 ## 38.3.1
 
 * Remove Oxford comma from metadata component ([PR #4012](https://github.com/alphagov/govuk_publishing_components/pull/4012))

--- a/app/assets/javascripts/govuk_publishing_components/components/feedback.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/feedback.js
@@ -26,7 +26,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   Feedback.prototype.init = function () {
     this.setInitialAriaAttributes()
     this.setHiddenValues()
-
+    this.setSurveyPath()
     this.prompt.hidden = false
     for (var k = 0; k < this.promptQuestions.length; k++) {
       this.promptQuestions[k].hidden = false
@@ -149,6 +149,21 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.timerHoneyPot.setAttribute('name', 'timer')
     this.timerHoneyPot.setAttribute('value', this.timer)
     this.somethingIsWrongForm.appendChild(this.timerHoneyPot)
+  }
+
+  // This getter is needed for spyOn in tests
+  Feedback.prototype.getPagePath = function () {
+    return window.location.pathname
+  }
+
+  Feedback.prototype.setSurveyPath = function () {
+    var surveyLink = this.$module.querySelector('#survey_explanation a')
+
+    if (surveyLink) {
+      var pathWithoutEmailPII = this.getPagePath().replace(/[^\s=?&]+(?:@|%40)[^\s=?&]+/, '[email]')
+      var encodedPath = encodeURI(pathWithoutEmailPII)
+      surveyLink.setAttribute('href', 'https://www.smartsurvey.co.uk/s/gov-uk-banner/?c=' + encodedPath)
+    }
   }
 
   Feedback.prototype.updateAriaAttributes = function (linkClicked) {

--- a/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
@@ -10,7 +10,7 @@
       <h3 class="gem-c-feedback__form-heading"><%= t("components.feedback.help_us_improve_govuk") %></h3>
       <p id="survey_explanation" class="gem-c-feedback__form-paragraph">
         <%= t("components.feedback.more_about_visit") %>
-        <a href="https://www.smartsurvey.co.uk/s/gov-uk-banner/?c=no-js" class="govuk-link">Please fill in this survey</a>.
+        <a href="https://www.smartsurvey.co.uk/s/gov-uk-banner/?c=no-js" class="govuk-link" target="_blank" rel="noopener noreferrer external">Please fill in this survey (opens in a new tab)</a>.
       </p>
       <button
         class="govuk-button govuk-button--secondary js-close-form"

--- a/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
@@ -10,7 +10,7 @@
       <h3 class="gem-c-feedback__form-heading"><%= t("components.feedback.help_us_improve_govuk") %></h3>
       <p id="survey_explanation" class="gem-c-feedback__form-paragraph">
         <%= t("components.feedback.more_about_visit") %>
-        <a href="https://www.smartsurvey.co.uk/s/gov-uk-banner/?c=<%= path_without_pii %>" class="govuk-link">Please fill in this survey</a>.
+        <a href="https://www.smartsurvey.co.uk/s/gov-uk-banner/?c=no-js" class="govuk-link">Please fill in this survey</a>.
       </p>
       <button
         class="govuk-button govuk-button--secondary js-close-form"

--- a/spec/components/feedback_spec.rb
+++ b/spec/components/feedback_spec.rb
@@ -74,4 +74,10 @@ describe "Feedback", type: :view do
     # Report a problem submit / Send me the survey submit
     assert_select ".govuk-button[data-ga4-event]", false
   end
+
+  it "The survey link exists, with c=no-js on the link by default" do
+    render_component({})
+
+    assert_select "#survey_explanation a[href='https://www.smartsurvey.co.uk/s/gov-uk-banner/?c=no-js']"
+  end
 end

--- a/spec/components/feedback_spec.rb
+++ b/spec/components/feedback_spec.rb
@@ -80,4 +80,10 @@ describe "Feedback", type: :view do
 
     assert_select "#survey_explanation a[href='https://www.smartsurvey.co.uk/s/gov-uk-banner/?c=no-js']"
   end
+
+  it "The survey link opens in a new tab, with rel='noopener noreferrer external' and the new tab guidance text" do
+    render_component({})
+
+    assert_select "#survey_explanation a[target='_blank'][rel='noopener noreferrer external']", text: "Please fill in this survey (opens in a new tab)"
+  end
 end

--- a/spec/javascripts/components/feedback-spec.js
+++ b/spec/javascripts/components/feedback-spec.js
@@ -2,6 +2,7 @@
 /* global GOVUK */
 
 describe('Feedback component', function () {
+  var feedbackComponent
   var FIXTURE =
   '<div class="gem-c-feedback govuk-!-display-none-print" data-module="feedback">' +
 
@@ -84,7 +85,7 @@ describe('Feedback component', function () {
           '<input name="email_survey_signup[survey_source]" type="hidden" value="a_source">' +
 
           '<h3 class="gem-c-feedback__form-heading">Help us improve GOV.UK</h3>' +
-          '<p id="survey_explanation" class="gem-c-feedback__form-paragraph">To help us improve GOV.UK, we\'d like to know more about your visit today. We\'ll send you a link to a feedback form. It will take only 2 minutes to fill in. Don\'t worry we won\'t send you spam or share your email address with anyone.</p>' +
+          '<p id="survey_explanation" class="gem-c-feedback__form-paragraph">To help us improve GOV.UK, we\'d like to know more about your visit today. We\'ll send you a link to a feedback form. It will take only 2 minutes to fill in. Don\'t worry we won\'t send you spam or share your email address with anyone. <a href="https://www.smartsurvey.co.uk/s/gov-uk-banner/?c=no-js" class="govuk-link">Please fill in this survey</a>.</p>' +
 
           '<div class="govuk-form-group">' +
             '<label for="input-11111111" class="gem-c-label govuk-label">Email address</label>' +
@@ -206,6 +207,30 @@ describe('Feedback component', function () {
       $('.js-page-is-not-useful')[0].click()
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('yesNoFeedbackForm', 'ffNoClick')
+    })
+
+    it('has the page path in the survey', function () {
+      var testPath = '/government/organisations/government-digital-service'
+      var expectedUrl = 'https://www.smartsurvey.co.uk/s/gov-uk-banner/?c=' + testPath
+
+      loadFeedbackComponent(function () {
+        spyOn(feedbackComponent, 'getPagePath').and.returnValue(testPath)
+      })
+
+      document.querySelector('.js-page-is-not-useful').click()
+      expect(document.querySelector('#survey_explanation a').getAttribute('href')).toBe(expectedUrl)
+    })
+
+    it('hides the path in the survey link if it contains an @ symbol', function () {
+      var testPath = '/contact/email@example.com'
+      var expectedUrl = 'https://www.smartsurvey.co.uk/s/gov-uk-banner/?c=' + '%5Bemail%5D'
+
+      loadFeedbackComponent(function () {
+        spyOn(feedbackComponent, 'getPagePath').and.returnValue(testPath)
+      })
+
+      document.querySelector('.js-page-is-not-useful').click()
+      expect(document.querySelector('#survey_explanation a').getAttribute('href')).toBe(expectedUrl)
     })
   })
 
@@ -742,8 +767,13 @@ describe('Feedback component', function () {
     })
   })
 
-  function loadFeedbackComponent () {
-    new GOVUK.Modules.Feedback($('.gem-c-feedback')[0]).init()
+  function loadFeedbackComponent (feedbackSpies) {
+    feedbackComponent = new GOVUK.Modules.Feedback($('.gem-c-feedback')[0])
+    // Allows spies to be added before .init() is run
+    if (feedbackSpies) {
+      feedbackSpies()
+    }
+    feedbackComponent.init()
   }
 
   function fillAndSubmitSomethingIsWrongForm () {


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Reintroduces adding the current page path to the smart survey `c=` query string parameter
- By default, the query string parameter is `c=no-js`
- It uses the same PII that was removed in #4017 
- Makes the survey link open in a new tab. I added `(opens in a new tab)` in the link text, as I'm 95% sure this is good practice for accessibility but can remove it if there's disagreement.

## Why
<!-- What are the reasons behind this change being made? -->
- The page path functionality was unintentionally removed in #4017
- The survey link should open in a new tab
- https://trello.com/c/rvDFQeEc/127-correctly-pass-page-path-to-govuk-intents-survey

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
