### PR TITLE
Add missing Welsh translation to the devolved nations component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add missing Welsh translation to the devolved nations component ([PR #4036](https://github.com/alphagov/govuk_publishing_components/pull/4036))
+
 ## 38.4.0
 
 * Update module.js ready for v5 of govuk-frontend ([PR #3992](https://github.com/alphagov/govuk_publishing_components/pull/3992))

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -60,7 +60,7 @@ cy:
       - Rydyn ni hefyd yn defnyddio cwcis sy'n cael eu gosod gan wefannau eraill i'n helpu i gyflwyno cynnwys o'u gwasanaethau nhw.
       title: Cwcis ar GOV.UK
     devolved_nations:
-      applies_to:
+      applies_to: Yn berthnasol i
       connectors:
         last_word:
         two_words:
@@ -72,7 +72,7 @@ cy:
         detailed_guide:
         guidance:
         publication:
-      wales:
+      wales: Gymru
     feedback:
       close: Cau
       dont_include_personal_info: Peidiwch â chynnwys gwybodaeth bersonol neu ariannol fel eich rhif Yswiriant Gwladol neu rif cerdyn credyd.


### PR DESCRIPTION
## What
The devolved nations component didn't include a Welsh translation for the text 'Applies to Wales'. When a page containing the component was rendered in Welsh, the component would display the text in English ('Applies to Wales').

The translated text in this PR was provided to us by the DWP Welsh Unit.

## Why
The component should include the Welsh translation.

[Trello ticket](https://trello.com/c/4mr2fnsq/2578-welsh-translation-needed-on-hmrc-corporate-report-page-m)

## Visual Changes

### Before

<img width="872" alt="Screenshot 2024-05-23 at 16 34 56" src="https://github.com/alphagov/govuk_publishing_components/assets/5007934/c38348aa-ac6c-4ddc-8d0c-38edf750f21d">

### After

<img width="849" alt="Screenshot 2024-05-23 at 16 25 06" src="https://github.com/alphagov/govuk_publishing_components/assets/5007934/9f81cbd9-f7a8-44d8-bf27-904d35bce75f">

