### PR TITLE
Add a class to the page body when our global bar is present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ tmp/failures.txt
 node_modules
 yarn-error.log
 coverage
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Allow Date in YAML.load_file ([PR #4050](https://github.com/alphagov/govuk_publishing_components/pull/4050))
 * Add global bar to GA4 page view tracking ([PR #4051](https://github.com/alphagov/govuk_publishing_components/pull/4051))
+* Add a class to the page body when our global bar is present ([PR #4047](https://github.com/alphagov/govuk_publishing_components/pull/4047))
 
 ## 38.4.1
 

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -51,6 +51,7 @@
   blue_bar_dedupe = !full_width && global_bar.present?
   body_css_classes = %w(gem-c-layout-for-public govuk-template__body)
   body_css_classes << "draft" if draft_watermark
+  body_css_classes << "global-bar-present" if global_bar.present?
 
   blue_bar_wrapper_classes = %w()
   blue_bar_wrapper_classes << "gem-c-layout-for-public__blue-bar-wrapper--#{blue_bar_background_colour}" if blue_bar_background_colour

--- a/spec/components/layout_for_public_spec.rb
+++ b/spec/components/layout_for_public_spec.rb
@@ -288,6 +288,18 @@ describe "Layout for public", type: :view do
     assert_select ".gem-c-layout-for-public.govuk-template__body.draft"
   end
 
+  it "contains a global-bar-present class when the global bar is present" do
+    render_component({ global_bar: { present: true } })
+
+    assert_select ".gem-c-layout-for-public.govuk-template__body.global-bar-present"
+  end
+
+  it "does not contains a global-bar-present class when the global bar is not present" do
+    render_component({ global_bar: {} })
+
+    assert_select ".gem-c-layout-for-public.govuk-template__body.global-bar-present", false
+  end
+
   it "has an Open Graph image with an absolute URL" do
     render_component({})
 


### PR DESCRIPTION
## What/Why
<!-- What are the reasons behind this change being made? -->
- When the global bar is present, add a `global-bar-present` class to the `<body>`
- This will allow us to conditionally style two pages in `collections` based on the presence of this class. A draft PR exists for this to demonstrate: https://github.com/alphagov/collections/pull/3644
-  This will prevent us from having to create temporary PRs such as https://github.com/alphagov/collections/pull/3637
- https://trello.com/c/T4tonmaz/166-global-bar-border-issues

## Visual Changes

None.