### PR TITLE
Allow Date in YAML.load_file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Allow Date in YAML.load_file ([PR #4050](https://github.com/alphagov/govuk_publishing_components/pull/4050))
+
 ## 38.4.1
 
 * Add missing Welsh translation to the devolved nations component ([PR #4036](https://github.com/alphagov/govuk_publishing_components/pull/4036))

--- a/app/models/govuk_publishing_components/component_docs.rb
+++ b/app/models/govuk_publishing_components/component_docs.rb
@@ -45,7 +45,7 @@ module GovukPublishingComponents
     end
 
     def parse_documentation(file)
-      yaml = YAML.load_file(file, aliases: true, permitted_classes: [Symbol, Time])
+      yaml = YAML.load_file(file, aliases: true, permitted_classes: [Symbol, Time, Date])
       { id: File.basename(file, ".yml") }.merge(yaml).with_indifferent_access
     end
 


### PR DESCRIPTION
## What
Modify the call to `YAML.load_file` in the component guide code to include `Date` in the list of permitted classes.

## Why
Turns out that the component guide in `frontend` uses `Date`, and without this change completely fails to load (`Tried to load unspecified class: Date`). Looks like this is the only application where `Date` is needed in a component (I think it's related to the calendar component in `frontend`).

Have tested this change locally in a locally running `frontend` and it fixes the problem.

Thanks to @KludgeKML for the fix!

## Visual Changes
None.

Trello card: https://trello.com/c/N3eQJZlU/168-fix-application-component-tests
