### PR TITLE
Add global bar to GA4 page view tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Allow Date in YAML.load_file ([PR #4050](https://github.com/alphagov/govuk_publishing_components/pull/4050))
+* Add global bar to GA4 page view tracking ([PR #4051](https://github.com/alphagov/govuk_publishing_components/pull/4051))
 
 ## 38.4.1
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
@@ -60,6 +60,7 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
             devolved_nations_banner: this.getElementAttribute('data-ga4-devolved-nations-banner') || undefined,
             cookie_banner: this.getBannerPresence('[data-ga4-cookie-banner]'),
             intervention: this.getBannerPresence('[data-ga4-intervention-banner]'),
+            global_bar: this.getBannerPresence('[data-ga4-global-bar]'),
             query_string: this.getQueryString(),
             search_term: this.getSearchTerm(),
             spelling_suggestion: this.getMetaContent('spelling-suggestion'),

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
@@ -58,6 +58,7 @@ describe('Google Tag Manager page view tracking', function () {
         devolved_nations_banner: undefined,
         cookie_banner: undefined,
         intervention: undefined,
+        global_bar: undefined,
         query_string: undefined,
         search_term: undefined,
         spelling_suggestion: undefined,
@@ -538,6 +539,16 @@ describe('Google Tag Manager page view tracking', function () {
       expect(window.dataLayer[0]).toEqual(expected)
       window.GOVUK.setCookie('intervention_campaign', '')
     })
+  })
+
+  it('correctly sets the global_bar parameter', function () {
+    var div = document.createElement('div')
+    div.setAttribute('data-ga4-global-bar', '')
+    document.body.appendChild(div)
+    expected.page_view.global_bar = 'true'
+    GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
+    expect(window.dataLayer[0]).toEqual(expected)
+    document.body.removeChild(div)
   })
 
   it('correctly sets the query_string parameter with PII and _ga/_gl values redacted', function () {


### PR DESCRIPTION
## What/Why
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Adds `global_bar` to GA4 page view tracking
- Uses the `data-ga4-global-bar` data attribute that was added onto the global bar when GA4 tracking was added to it last week
- https://trello.com/c/XtbvfDSo/826-global-bar-tracking

## Visual Changes
None.