### PR TITLE
Add "event_name: navigation" to start button tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Allow Date in YAML.load_file ([PR #4050](https://github.com/alphagov/govuk_publishing_components/pull/4050))
 * Add global bar to GA4 page view tracking ([PR #4051](https://github.com/alphagov/govuk_publishing_components/pull/4051))
 * Add a class to the page body when our global bar is present ([PR #4047](https://github.com/alphagov/govuk_publishing_components/pull/4047))
+* Add "event_name: navigation" to start button tracking ([PR #4052](https://github.com/alphagov/govuk_publishing_components/pull/4052))
 
 ## 38.4.1
 

--- a/lib/govuk_publishing_components/presenters/button_helper.rb
+++ b/lib/govuk_publishing_components/presenters/button_helper.rb
@@ -133,7 +133,7 @@ module GovukPublishingComponents
       end
 
       def ga4_attribute
-        { type: "start button" }.to_json unless @disable_ga4
+        { event_name: "navigation", type: "start button" }.to_json unless @disable_ga4
       end
     end
   end

--- a/spec/components/button_spec.rb
+++ b/spec/components/button_spec.rb
@@ -47,14 +47,14 @@ describe "Button", type: :view do
     render_component(text: "Start now", href: "#", start: true)
     assert_select ".govuk-button[href='#'] span", text: /Start now/
     assert_select ".govuk-button--start"
-    assert_select ".govuk-button--start[data-ga4-attributes='{\"type\":\"start button\"}']"
+    assert_select ".govuk-button--start[data-ga4-attributes='{\"event_name\":\"navigation\",\"type\":\"start button\"}']"
   end
 
   it "renders start now button with GA4 attributes disabled" do
     render_component(text: "Start now", href: "#", start: true, disable_ga4: true)
     assert_select ".govuk-button[href='#'] span", text: /Start now/
     assert_select ".govuk-button--start"
-    assert_select ".govuk-button--start[data-ga4-attributes='{\"type\":\"start button\"}']", false
+    assert_select ".govuk-button--start[data-ga4-attributes='{\"event_name\":\"navigation\",\"type\":\"start button\"}']", false
   end
 
   it "renders secondary button" do


### PR DESCRIPTION
## What / Why

- `event_name: "navigation"` had not been added to some GA4 data for start buttons
- This PR adds that data to the start buttons
- https://trello.com/c/C6l6mC9B/830-fix-start-button-navigation-events-coming-through-with-eventname-undefined

## Visual Changes

none.