### PR TITLE
Add guard to accordion component init method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add guard to accordion component init method ([PR #4069](https://github.com/alphagov/govuk_publishing_components/pull/4069))
 * Prevent screen readers from announcing document list child/parts items dashes ([PR #4066](https://github.com/alphagov/govuk_publishing_components/pull/4066))
 * Align checkboxes component more toward Design System ([PR #4061](https://github.com/alphagov/govuk_publishing_components/pull/4061))
 * Add govuk-frontend checking to the component auditing ([PR #4058](https://github.com/alphagov/govuk_publishing_components/pull/4058))

--- a/app/assets/javascripts/govuk_publishing_components/components/accordion.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/accordion.js
@@ -24,6 +24,11 @@ window.GOVUK.Modules.GovukAccordion = window.GOVUKFrontend.Accordion;
   }
 
   GemAccordion.prototype.init = function () {
+    // Do not initialise if the accordion component from govuk-frontend has not initialised
+    if (this.$module.querySelector(this.showAllControls) === null) {
+      return
+    }
+
     // Indicate that JavaScript has worked
     this.$module.querySelector(this.showAllControls).classList.add('gem-c-accordion__show-all')
 

--- a/spec/javascripts/components/accordion-spec.js
+++ b/spec/javascripts/components/accordion-spec.js
@@ -10,7 +10,7 @@ describe('Accordion component', function () {
   var html =
     '<div class="gem-c-accordion" data-show-text="Show" data-hide-text="Hide" data-show-all-text="Show all sections" data-hide-all-text="Hide all sections" data-this-section-visually-hidden=" this section">' +
       '<div class="govuk-accordion__controls">' +
-        '<button type="button" class="govuk-accordion__show-all gem-c-accordion__show-all" aria-expanded="false">' +
+        '<button type="button" class="govuk-accordion__show-all" aria-expanded="false">' +
           '<span class="govuk-accordion__show-all-text">Show all sections</span>' +
         '</button>' +
       '</div>' +
@@ -65,6 +65,14 @@ describe('Accordion component', function () {
     if (GOVUK.analytics.trackEvent.calls) {
       GOVUK.analytics.trackEvent.calls.reset()
     }
+  })
+
+  it('does not initialise if the accordion from govuk-frontend has not initialised', function () {
+    var accordionShowAllButton = accordion.querySelector('.govuk-accordion__show-all')
+    accordionShowAllButton.classList.remove('govuk-accordion__show-all')
+    startAccordion()
+
+    expect(accordion.querySelector('.govuk-accordion__controls button')).not.toHaveClass('gem-c-accordion__show-all')
   })
 
   it('applies custom attributes to click event if specified in section', function () {


### PR DESCRIPTION
## What

- Add guard to accordion component init method
- Add new test and update fixture

## Why

When the accordion component from govuk-frontend is initialised, the `govuk-accordion__show-all` class is added to the button element.

It is possible that the accordion component from govuk-frontend does not get initialised, but we have no checks in place to guard against this when initialising the accordion component from the gem.

Example error when using the accordion component with V5 govuk-frontend in Safari 10.1
<img width="1185" alt="Screenshot 2024-06-20 at 13 57 38" src="https://github.com/alphagov/govuk_publishing_components/assets/28779939/c95962fb-7398-4766-a10f-4181ce9b1c14">

This change checks if the accordion component from govuk-frontend has initialised before trying to initialise the accordion component from the publishing components gem.

A new test has been added to check it does not initialise, if the accordion from govuk-frontend has not initialised. `gem-c-accordion__show-all` was removed from the fixture as this is added by the JS from the publishing-components accordion.