### PR TITLE
Update and/or add component print styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fix some layout_header search visual bugs ([PR #4156](https://github.com/alphagov/govuk_publishing_components/pull/4156))
 * Fix issue with using special characters in content-list ([PR #4157](https://github.com/alphagov/govuk_publishing_components/pull/4157))
 * Add 'Chat entry' component ([PR #4151](https://github.com/alphagov/govuk_publishing_components/pull/4151))
+* Update and/or add component print styles ([PR #4073](https://github.com/alphagov/govuk_publishing_components/pull/4073))
 
 ## 42.0.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_accordion.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_accordion.scss
@@ -11,10 +11,15 @@
 //
 // TODO: Replace with the print styles that will come from GOV.UK Frontend.
 
+// stylelint-disable declaration-no-important
 @include govuk-media-query($media-type: print) {
   // Open all of the accordion sections.
   .govuk-accordion__section-content {
-    display: block !important; // stylelint-disable-line declaration-no-important
+    display: block !important;
+
+    > :last-child {
+      margin-bottom: 20px;
+    }
   }
 
   .govuk-frontend-supported .govuk-accordion__section-content[hidden] {
@@ -25,7 +30,9 @@
 
   // Change the colour from the blue link colour to black.
   .govuk-accordion__section-button {
-    color: govuk-colour("black") !important; // stylelint-disable-line declaration-no-important
+    color: govuk-colour("black") !important;
+    padding: 20px 0 0 !important;
+    border-bottom: 0 !important;
   }
 
   // Change the summary subheading size.
@@ -37,6 +44,14 @@
   // Hide the unusable "Show all" and "Show" sections.
   .govuk-accordion__show-all,
   .govuk-accordion__section-toggle {
-    display: none !important; // stylelint-disable-line declaration-no-important
+    display: none !important;
+  }
+
+  // Remove extra space for expanded accordions, not needed on a printout
+  .govuk-accordion__section--expanded {
+    .govuk-accordion__section-content {
+      padding: 0 !important;
+    }
   }
 }
+// stylelint-enable declaration-no-important

--- a/app/assets/stylesheets/govuk_publishing_components/components/_attachment-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_attachment-link.scss
@@ -1,4 +1,19 @@
+@import "govuk_publishing_components/individual_component_support";
+
 .gem-c-attachment-link__abbr {
   text-decoration: none;
   cursor: help;
 }
+
+// stylelint-disable declaration-no-important
+@include govuk-media-query($media-type: print) {
+  .gem-c-attachment-link .govuk-link {
+    color: $govuk-print-text-colour !important;
+
+    &::after {
+      font-size: inherit;
+      color: inherit;
+    }
+  }
+}
+// stylelint-enable declaration-no-important

--- a/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
@@ -84,3 +84,23 @@ $thumbnail-icon-border-colour: govuk-colour("mid-grey");
   text-decoration: none;
   cursor: help;
 }
+
+@include govuk-media-query($media-type: print) {
+  .gem-c-attachment__details {
+    padding: 0;
+  }
+
+  .gem-c-attachment__metadata,
+  .gem-c-attachment__metadata .govuk-link::after {
+    font-size: 12pt;
+  }
+
+  .gem-c-attachment__link.govuk-link {
+    word-break: break-word;
+
+    &::after {
+      font-size: 12pt;
+      line-height: 1 !important; // stylelint-disable-line declaration-no-important
+    }
+  }
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/_breadcrumbs.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_breadcrumbs.scss
@@ -54,3 +54,23 @@
     }
   }
 }
+
+@include govuk-media-query($media-type: print) {
+  .gem-c-breadcrumbs {
+    font-size: 12pt;
+  }
+
+  .gem-c-breadcrumbs,
+  .govuk-breadcrumbs {
+    .govuk-breadcrumbs__list-item {
+      .govuk-breadcrumbs__link:link,
+      .govuk-breadcrumbs__link:visited {
+        color: $govuk-print-text-colour;
+      }
+
+      &::before {
+        border-color: $govuk-print-text-colour;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
@@ -143,21 +143,42 @@
   }
 }
 
+// stylelint-disable declaration-no-important
 @include govuk-media-query($media-type: print) {
   .gem-c-cards__list {
     display: block;
   }
 
   .gem-c-cards__list-item {
-    padding-bottom: 0;
+    padding: 0;
   }
 
-  .gem-c-cards__sub-heading {
-    margin-top: govuk-spacing(4);
-    margin-bottom: govuk-spacing(1);
+  .gem-c-cards__list-item-wrapper {
+    padding: 5mm 0;
   }
 
-  .gem-c-cards__link::before {
-    display: none;
+  .gem-c-cards__description {
+    margin: 0;
+  }
+
+  .gem-c-cards__link {
+    &,
+    &:link,
+    &:link:visited {
+      color: $govuk-print-text-colour !important;
+    }
+
+    &::before {
+      display: none;
+    }
+
+    &::after {
+      position: static;
+      display: block;
+      margin: 1mm auto;
+      font-size: 12pt !important;
+      color: $govuk-print-text-colour;
+    }
   }
 }
+// stylelint-enable declaration-no-important

--- a/app/assets/stylesheets/govuk_publishing_components/components/_contents-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_contents-list.scss
@@ -84,14 +84,14 @@
     margin-left: 0;
   }
 
-  // Put indentation back where we use list style types
-  .gem-c-contents-list__list-item--dashed {
-    margin-left: govuk-spacing(3);
-    list-style-type: disc;
-  }
-
   .gem-c-contents-list__list-item--numbered,
   .gem-c-contents-list__list-item--parent {
     list-style-type: none;
+  }
+
+  .gem-c-contents-list__link {
+    &.govuk-link {
+      color: $govuk-print-text-colour;
+    }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cross-service-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cross-service-header.scss
@@ -436,3 +436,32 @@ $govuk-header-link-underline-thickness: 3px;
   }
 }
 // end service navigation styles
+
+@include govuk-media-query($media-type: print) {
+  .gem-c-cross-service-header {
+    margin-bottom: 5mm;
+  }
+
+  .gem-c-one-login-header {
+    background-color: initial;
+    border-bottom: 2pt solid $govuk-print-text-colour;
+
+    * {
+      color: $govuk-print-text-colour;
+    }
+
+    .govuk-width-container {
+      margin: 0;
+    }
+  }
+
+  .gem-c-service-header {
+    .govuk-width-container {
+      margin: 0;
+    }
+
+    .gem-c-service-header__container {
+      padding: 0;
+    }
+  }
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/_devolved-nations.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_devolved-nations.scss
@@ -10,3 +10,26 @@
     padding: govuk-spacing(4) govuk-spacing(6);
   }
 }
+
+// stylelint-disable declaration-no-important
+@include govuk-media-query($media-type: print) {
+  .gem-c-devolved-nations {
+    border: 2pt solid $govuk-print-text-colour;
+    margin: 0 0 5mm;
+
+    * {
+      color: $govuk-print-text-colour !important;
+    }
+
+    .govuk-list li {
+      margin-bottom: 2mm;
+    }
+
+    .govuk-link::after {
+      display: block;
+      margin: 1mm auto;
+      font-size: 12pt;
+    }
+  }
+}
+// stylelint-enable declaration-no-important

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -183,3 +183,22 @@
     display: none;
   }
 }
+
+// stylelint-disable declaration-no-important
+@include govuk-media-query($media-type: print) {
+  .gem-c-document-list__item {
+    break-inside: avoid;
+  }
+
+  .gem-c-document-list__item-title {
+    .govuk-link {
+      color: $govuk-print-text-colour !important;
+    }
+
+    .govuk-link::after {
+      display: block;
+      margin: 1mm auto;
+    }
+  }
+}
+// stylelint-enable declaration-no-important

--- a/app/assets/stylesheets/govuk_publishing_components/components/_heading.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_heading.scss
@@ -45,3 +45,19 @@
 .gem-c-heading--inverse {
   color: govuk-colour("white");
 }
+
+// stylelint-disable declaration-no-important
+@include govuk-media-query($media-type: print) {
+  // Override margins and colors
+  .gem-c-heading {
+    margin: 0 !important;
+    color: $govuk-print-text-colour !important;
+    border-color: $govuk-print-text-colour !important;
+    padding: 0;
+  }
+
+  .gem-c-heading--padding[class*="--border-top"] {
+    padding-top: govuk-spacing(3);
+  }
+}
+// stylelint-enable declaration-no-important

--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -347,3 +347,22 @@
     }
   }
 }
+
+// stylelint-disable declaration-no-important
+@include govuk-media-query($media-type: print) {
+  .gem-c-image-card__title[class*="govuk-heading-"] {
+    font-size: 16pt;
+  }
+
+  .gem-c-image-card__title-link {
+    color: $govuk-print-text-colour !important;
+
+    &::after {
+      display: block;
+      position: static;
+      margin-top: 2mm;
+      font-size: 12pt !important;
+    }
+  }
+}
+// stylelint-enable declaration-no-important

--- a/app/assets/stylesheets/govuk_publishing_components/components/_inset-text.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_inset-text.scss
@@ -1,2 +1,25 @@
 @import "govuk_publishing_components/individual_component_support";
 @import "govuk/components/inset-text/inset-text";
+
+// stylelint-disable declaration-no-important
+@include govuk-media-query($media-type: print) {
+  .gem-c-inset-text {
+    break-inside: avoid;
+  }
+
+  .gem-c-inset-text .govuk-link {
+    &,
+    &:link,
+    &:link:visited {
+      color: $govuk-print-text-colour !important;
+    }
+
+    &::after {
+      display: block;
+      margin: 1mm auto;
+      font-size: 12pt !important;
+      color: $govuk-print-text-colour;
+    }
+  }
+}
+// stylelint-enable declaration-no-important

--- a/app/assets/stylesheets/govuk_publishing_components/components/_intervention.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_intervention.scss
@@ -21,3 +21,32 @@
   height: 1em;
   margin-bottom: -2px;
 }
+
+// stylelint-disable declaration-no-important
+@include govuk-media-query($media-type: print) {
+  .gem-c-intervention {
+    break-inside: avoid;
+    background-color: transparent;
+    border-color: $govuk-print-text-colour;
+
+    .govuk-body {
+      margin: 0;
+    }
+  }
+
+  .gem-c-intervention .govuk-link {
+    &,
+    &:link,
+    &:link:visited {
+      color: $govuk-print-text-colour !important;
+    }
+
+    &::after {
+      display: block;
+      margin: 1mm auto;
+      font-size: 12pt !important;
+      color: $govuk-print-text-colour;
+    }
+  }
+}
+// stylelint-enable declaration-no-important

--- a/app/assets/stylesheets/govuk_publishing_components/components/_lead-paragraph.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_lead-paragraph.scss
@@ -12,3 +12,9 @@
 .gem-c-lead-paragraph--inverse {
   color: govuk-colour("white");
 }
+
+@include govuk-media-query($media-type: print) {
+  .gem-c-lead-paragraph {
+    color: $govuk-print-text-colour;
+  }
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/_metadata.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_metadata.scss
@@ -94,3 +94,19 @@
 .govuk-frontend-supported .gem-c-metadata__toggle-items.js-hidden {
   display: none;
 }
+
+// stylelint-disable declaration-no-important
+@include govuk-media-query($media-type: print) {
+  .gem-c-metadata {
+    break-inside: avoid;
+    color: $govuk-print-text-colour !important;
+    background-color: unset;
+    margin-bottom: 5mm;
+
+    a,
+    a:visited {
+      color: $govuk-print-text-colour !important;
+    }
+  }
+}
+// stylelint-enable declaration-no-important

--- a/app/assets/stylesheets/govuk_publishing_components/components/_phase-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_phase-banner.scss
@@ -26,3 +26,24 @@
     }
   }
 }
+
+// stylelint-disable declaration-no-important
+@include govuk-media-query($media-type: print) {
+  .gem-c-phase-banner {
+    &,
+    & * {
+      background-color: unset !important;
+      color: $govuk-print-text-colour !important;
+    }
+
+    .govuk-tag {
+      border: 1pt solid $govuk-print-text-colour;
+    }
+  }
+
+  .govuk-phase-banner__content__app-name {
+    margin-bottom: 1mm;
+    font-size: 12pt;
+  }
+}
+// stylelint-enable declaration-no-important

--- a/app/assets/stylesheets/govuk_publishing_components/components/_previous-and-next-navigation.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_previous-and-next-navigation.scss
@@ -1,2 +1,10 @@
 @import "govuk_publishing_components/individual_component_support";
 @import "govuk/components/pagination/pagination";
+
+// stylelint-disable declaration-no-important
+@include govuk-media-query($media-type: print) {
+  .govuk-pagination * {
+    color: $govuk-print-text-colour !important;
+  }
+}
+// stylelint-enable declaration-no-important

--- a/app/assets/stylesheets/govuk_publishing_components/components/_success-alert.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_success-alert.scss
@@ -4,3 +4,25 @@
 .gem-c-success-alert__message {
   @include govuk-font(19, $weight: bold);
 }
+
+// stylelint-disable declaration-no-important
+@include govuk-media-query($media-type: print) {
+  .gem-c-success-alert {
+    break-inside: avoid;
+    background-color: initial;
+    border-color: $govuk-print-text-colour;
+
+    * {
+      color: $govuk-print-text-colour !important;
+    }
+
+    .govuk-notification-banner__header {
+      border-bottom: 1pt solid $govuk-print-text-colour;
+    }
+
+    .govuk-notification-banner__title {
+      padding: 2mm 0;
+    }
+  }
+}
+// stylelint-enable declaration-no-important

--- a/app/assets/stylesheets/govuk_publishing_components/components/_title.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_title.scss
@@ -32,11 +32,19 @@
 }
 
 @include govuk-media-query($media-type: print) {
+  .gem-c-title {
+    margin: 5mm 0 10mm !important; // stylelint-disable-line declaration-no-important
+  }
+
   .gem-c-title__context {
     margin: 0;
   }
 
   .gem-c-title__text {
     margin-top: 0;
+  }
+
+  .gem-c-title--inverse {
+    color: $govuk-print-text-colour;
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_warning-text.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_warning-text.scss
@@ -21,3 +21,14 @@
 .gem-c-warning-text__text--highlight {
   color: $govuk-error-colour;
 }
+
+@include govuk-media-query($media-type: print) {
+  .gem-c-warning-text * {
+    color: $govuk-print-text-colour;
+  }
+
+  .govuk-warning-text__icon {
+    background-color: transparent;
+    color: $govuk-print-text-colour;
+  }
+}

--- a/app/views/govuk_publishing_components/components/_action_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_action_link.html.erb
@@ -17,7 +17,7 @@
   dark_large_icon ||= false
   light_icon ||= false
 
-  css_classes = %w(gem-c-action-link)
+  css_classes = %w(gem-c-action-link govuk-!-display-none-print)
   css_classes << "gem-c-action-link--light-text" if light_text
   css_classes << "gem-c-action-link--dark-icon" if dark_icon
   css_classes << "gem-c-action-link--dark-large-icon" if dark_large_icon

--- a/app/views/govuk_publishing_components/components/_attachment.html.erb
+++ b/app/views/govuk_publishing_components/components/_attachment.html.erb
@@ -10,7 +10,7 @@
   details_ga4_attributes ||= {}
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
 
-  container_class_names = %w[gem-c-attachment govuk-!-display-none-print]
+  container_class_names = %w[gem-c-attachment]
   container_class_names << shared_helper.get_margin_bottom if local_assigns.key?(:margin_bottom)
   ga4_link = { 'event_name': 'navigation', 'type': 'attachment' }
 
@@ -58,7 +58,7 @@
   data_attributes[:ga4_link] = ga4_link
 %>
 <%= tag.section class: class_names(container_class_names), data: { module: "ga4-link-tracker" } do %>
-  <%= tag.div class: "gem-c-attachment__thumbnail" do %>
+  <%= tag.div class: "gem-c-attachment__thumbnail govuk-!-display-none-print" do %>
     <%= link_to attachment.url,
                 class: "govuk-link",
                 target: target,

--- a/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
@@ -10,9 +10,11 @@
   <% if breadcrumb_selector.step_by_step %>
     <%= render 'govuk_publishing_components/components/step_by_step_nav_header', breadcrumb_selector.breadcrumbs %>
   <% elsif breadcrumb_selector.breadcrumbs %>
-    <%= render 'govuk_publishing_components/components/breadcrumbs',
-               breadcrumbs: breadcrumb_selector.breadcrumbs,
-               inverse: inverse,
-               collapse_on_mobile: collapse_on_mobile %>
+    <div class="govuk-!-display-none-print">
+      <%= render 'govuk_publishing_components/components/breadcrumbs',
+                 breadcrumbs: breadcrumb_selector.breadcrumbs,
+                 inverse: inverse,
+                 collapse_on_mobile: collapse_on_mobile %>
+    </div>
   <% end %>
 </div>

--- a/app/views/govuk_publishing_components/components/_contextual_footer.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_footer.html.erb
@@ -2,7 +2,7 @@
 <% disable_ga4 ||= false %>
 
 <% unless navigation.content_tagged_to_current_step_by_step? %>
-  <div class="gem-c-contextual-footer">
+  <div class="gem-c-contextual-footer govuk-!-display-none-print">
     <%# Rendering related navigation because no step by step list %>
     <%= render 'govuk_publishing_components/components/related_navigation',
                content_item: content_item,

--- a/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
@@ -10,7 +10,7 @@
   ga4_tracking_counts.index_section_count = 1 if show_ukraine_cta
 %>
 
-<div class="gem-c-contextual-sidebar">
+<div class="gem-c-contextual-sidebar govuk-!-display-none-print">
   <% if navigation.content_tagged_to_a_reasonable_number_of_step_by_steps? %>
     <%# Rendering step by step related items because there are a few but not too many of them %>
     <%= render 'govuk_publishing_components/components/step_by_step_nav_related', links: navigation.step_nav_helper.related_links, disable_ga4: disable_ga4 %>

--- a/app/views/govuk_publishing_components/components/_error_alert.html.erb
+++ b/app/views/govuk_publishing_components/components/_error_alert.html.erb
@@ -6,7 +6,7 @@
   data_attributes ||= {}
 %>
 
-<%= tag.div id: id, class: "gem-c-error-alert", data: { module: "initial-focus" }.merge(data_attributes), role: "alert", tabindex: "-1" do %>
+<%= tag.div id: id, class: "gem-c-error-alert govuk-!-display-none-print", data: { module: "initial-focus" }.merge(data_attributes), role: "alert", tabindex: "-1" do %>
   <% if description.present? %>
     <%= tag.h2 message, class: "gem-c-error-summary__title" %>
     <%= tag.div description, class: "gem-c-error-summary__body" %>

--- a/app/views/govuk_publishing_components/components/_intervention.html.erb
+++ b/app/views/govuk_publishing_components/components/_intervention.html.erb
@@ -72,7 +72,7 @@
     </p>
 
     <% if dismiss_text %>
-      <%= tag.p class: "govuk-body", data: dismiss_data_attributes do %>
+      <%= tag.p class: "govuk-body govuk-!-display-none-print", data: dismiss_data_attributes do %>
         <%= tag.a class: "govuk-link js-dismiss-link", href: dismiss_href, data: dismiss_link_data_attributes do %>
           <svg class="gem-c-intervention__dismiss-icon"
             width="19" height="19" viewBox="0 0 19 19"

--- a/app/views/govuk_publishing_components/components/_related_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_related_navigation.html.erb
@@ -12,7 +12,7 @@
 %>
 <% if related_nav_helper.related_navigation? %>
   <% random = SecureRandom.hex(4) %>
-  <%= tag.div(class: "gem-c-related-navigation", data: data) do %>
+  <%= tag.div(class: "gem-c-related-navigation govuk-!-display-none-print", data: data) do %>
     <% if local_assigns[:context] != :footer %>
       <h2 id="related-nav-related_items-<%= random %>"
           class="gem-c-related-navigation__main-heading"

--- a/app/views/govuk_publishing_components/components/cross_service_header/_one_login_header.html.erb
+++ b/app/views/govuk_publishing_components/components/cross_service_header/_one_login_header.html.erb
@@ -52,7 +52,7 @@
         <!--<![endif]-->
       </button>
 
-      <nav aria-label="GOV.UK One Login menu" class="gem-c-one-login-header__nav" data-open-class="gem-c-one-login-header__nav--open" id="one-login-header__nav">
+      <nav aria-label="GOV.UK One Login menu" class="gem-c-one-login-header__nav govuk-!-display-none-print" data-open-class="gem-c-one-login-header__nav--open" id="one-login-header__nav">
         <ul class="gem-c-one-login-header__nav__list">
           <li class="gem-c-one-login-header__nav__list-item">
             <%= link_to one_login_home[:href], class: "gem-c-one-login-header__nav__link gem-c-one-login-header__nav__link--one-login", data: one_login_home[:data] do %>

--- a/app/views/govuk_publishing_components/components/cross_service_header/_service_header.html.erb
+++ b/app/views/govuk_publishing_components/components/cross_service_header/_service_header.html.erb
@@ -17,12 +17,12 @@
             data-text-for-show="Menu" 
             data-text-for-hide="Close" 
             aria-expanded="false" 
-            class="gem-c-cross-service-header__button gem-c-cross-service-header__button--gem-c-service-header js-x-header-toggle">
+            class="gem-c-cross-service-header__button gem-c-cross-service-header__button--gem-c-service-header js-x-header-toggle govuk-!-display-none-print">
             <span class="gem-c-service-header__button-content">Menu</span>
           </button>
           <!-- Important! Label your navigation appropriately! When there are multiple navigation landmarks on a page, additional labelling is required to provide support for screen reader users -->
           <nav aria-label="<%= service_navigation_aria_label %>">
-            <ul class="gem-c-service-header__nav-list gem-c-service-header__nav" id="service-header__nav" data-open-class="gem-c-service-header__nav--open">
+            <ul class="gem-c-service-header__nav-list gem-c-service-header__nav govuk-!-display-none-print" id="service-header__nav" data-open-class="gem-c-service-header__nav--open">
               <% service_navigation_items.each_with_index do |item, index| %>
                 <%
                   li_classes = %w(gem-c-service-header__nav-list-item)


### PR DESCRIPTION
## What
This PR updates the print styles for any public-facing components. The changes broadly fall into these categories:

- hiding/removing components that should never be printed
- improving components that already have print styles 
- creating print styles for components that don't already have them

[Trello card](https://trello.com/c/irMHNKBd/186-review-and-fix-component-print-styles)

## Why
People still print a lot of pages from [GOV.UK](http://gov.uk/). And recent discussions have highlighted potential problems, or at least a perception that HTML pages when printed aren't as good as PDFs. We're trying to move away from/discourage the use of PDFs on [GOV.UK](http://gov.uk/), so improving the print experience could help.

## Visual Changes
There are too many differences to include all before/after shots here. Changes will be reviewed with a designer before deployment.

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->
