### PR TITLE
Add open attribute to component wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add open attribute to component wrapper ([PR #4074](https://github.com/alphagov/govuk_publishing_components/pull/4074))
 * Add guard to accordion component init method ([PR #4069](https://github.com/alphagov/govuk_publishing_components/pull/4069))
 * Prevent screen readers from announcing document list child/parts items dashes ([PR #4066](https://github.com/alphagov/govuk_publishing_components/pull/4066))
 * Align checkboxes component more toward Design System ([PR #4061](https://github.com/alphagov/govuk_publishing_components/pull/4061))

--- a/app/models/govuk_publishing_components/component_wrapper_helper_options.rb
+++ b/app/models/govuk_publishing_components/component_wrapper_helper_options.rb
@@ -10,6 +10,7 @@ This component uses the component wrapper helper. It accepts the following optio
 - `classes` - accepts a space separated string of classes, these should not be used for styling and must be prefixed with `js-`
 - `role` - accepts a space separated string of roles
 - `lang` - accepts a language attribute value
+- `open` - accepts an open attribute value (true or false)
       "
     end
   end

--- a/docs/component-wrapper-helper.md
+++ b/docs/component-wrapper-helper.md
@@ -31,6 +31,7 @@ These options can be passed to any component that uses the component wrapper.
 - `classes` - accepts a space separated string of classes, these should not be used for styling and must be prefixed with `js-`
 - `role` - accepts a space separated string of roles
 - `lang` - accepts a language attribute value
+- `open` - accepts an open attribute value (true or false)
 
 To prevent breaking [component isolation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/component_principles.md#a-component-is-isolated-when), passed classes should only be used for JavaScript hooks and not styling. All component styling should be included only in the component itself. Any passed classes should be prefixed with `js-`. To allow for extending this option, classes prefixed with `gem-c-`, `app-c-` or `govuk-` are also permitted, but should only be used within the component and not passed to it.
 
@@ -71,6 +72,7 @@ The component wrapper includes several methods to make managing options easier, 
   component_helper.add_aria_attribute({ label: "my-label" }) # works like 'add_data_attribute'
   component_helper.add_role("button") # works like 'add_class'
   component_helper.set_lang("en") # works like 'set_id' (can only have one lang)
+  component_helper.set_open(true) # can pass true or false
 %>
 <%= tag.div(**component_helper.all_attributes) do %>
   component content

--- a/lib/govuk_publishing_components/presenters/component_wrapper_helper.rb
+++ b/lib/govuk_publishing_components/presenters/component_wrapper_helper.rb
@@ -10,6 +10,7 @@ module GovukPublishingComponents
         check_aria_is_valid(@options[:aria]) if @options.include?(:aria)
         check_role_is_valid(@options[:role]) if @options.include?(:role)
         check_lang_is_valid(@options[:lang]) if @options.include?(:lang)
+        check_open_is_valid(@options[:open]) if @options.include?(:open)
       end
 
       def all_attributes
@@ -21,6 +22,7 @@ module GovukPublishingComponents
         attributes[:class] = @options[:classes] unless @options[:classes].blank?
         attributes[:role] = @options[:role] unless @options[:role].blank?
         attributes[:lang] = @options[:lang] unless @options[:lang].blank?
+        attributes[:open] = @options[:open] unless @options[:open].blank?
 
         attributes
       end
@@ -53,6 +55,11 @@ module GovukPublishingComponents
       def set_lang(lang)
         check_lang_is_valid(lang)
         @options[:lang] = lang
+      end
+
+      def set_open(open_attribute)
+        check_open_is_valid(open_attribute)
+        @options[:open] = open_attribute
       end
 
     private
@@ -111,6 +118,15 @@ module GovukPublishingComponents
         langs = %w[ab aa af ak sq am ar an hy as av ae ay az bm ba eu be bn bh bi bs br bg my ca ch ce ny zh zh-Hans zh-Hant cv kw co cr hr cs da dv nl dz en eo et ee fo fj fi fr ff gl gd gv ka de el kl gn gu ht ha he hz hi ho hu is io ig id in ia ie iu ik ga it ja jv kl kn kr ks kk km ki rw rn ky kv kg ko ku kj lo la lv li ln lt lu lg lb gv mk mg ms ml mt mi mr mh mo mn na nv ng nd ne no nb nn ii oc oj cu or om os pi ps fa pl pt pa qu rm ro ru se sm sg sa sr sh st tn sn ii sd si ss sk sl so nr es su sw ss sv tl ty tg ta tt te th bo ti to ts tr tk tw ug uk ur uz ve vi vo wa cy wo fy xh yi ji yo za zu]
         unless langs.include? lang
           raise(ArgumentError, "lang attribute (#{lang}) is not recognised")
+        end
+      end
+
+      def check_open_is_valid(open_attribute)
+        return if open_attribute.blank?
+
+        options = [true, false]
+        unless options.include? open_attribute
+          raise(ArgumentError, "open attribute (#{open_attribute}) is not recognised")
         end
       end
 

--- a/spec/lib/govuk_publishing_components/components/component_wrapper_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/components/component_wrapper_helper_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe GovukPublishingComponents::Presenters::ComponentWrapperHelper do
         },
         role: "navigation",
         lang: "en",
+        open: true,
       }
       component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(args)
       expected = {
@@ -23,6 +24,7 @@ RSpec.describe GovukPublishingComponents::Presenters::ComponentWrapperHelper do
         },
         role: "navigation",
         lang: "en",
+        open: true,
       }
       expect(component_helper.all_attributes).to eql(expected)
     end
@@ -165,6 +167,32 @@ RSpec.describe GovukPublishingComponents::Presenters::ComponentWrapperHelper do
       error = "lang attribute (klingon) is not recognised"
       expect {
         GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(lang: "klingon")
+      }.to raise_error(ArgumentError, error)
+    end
+
+    it "accepts valid open attribute value" do
+      component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(open: true)
+      expected = {
+        open: true,
+      }
+      expect(component_helper.all_attributes).to eql(expected)
+    end
+
+    it "can set an open attribute, overriding a passed value" do
+      helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(open: true)
+      helper.set_open(false)
+      expect(helper.all_attributes[:open]).to eql(nil)
+    end
+
+    it "does not include an open attribute if the option is false" do
+      component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(open: false)
+      expect(component_helper.all_attributes).to eql({})
+    end
+
+    it "does not accept an invalid open value" do
+      error = "open attribute (false) is not recognised"
+      expect {
+        GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(open: "false")
       }.to raise_error(ArgumentError, error)
     end
   end


### PR DESCRIPTION
## What
- adds the ability to pass an open attribute to the component wrapper helper
- needed for the details component, where open can be passed as true to have the details component expanded by default

## Why
Originally done as part of https://github.com/alphagov/govuk_publishing_components/pull/4068 but that PR is huge enough without this additional change, so I'm separating them out.

## Visual Changes
None.

Trello card: https://trello.com/c/rNPqwDIr/188-remove-ua-code-from-components-gem
