### PR TITLE
Disable Universal Analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Disable Universal Analytics ([PR #4083](https://github.com/alphagov/govuk_publishing_components/pull/4083))
+
 ## 39.1.0
 
 * Add open attribute to component wrapper ([PR #4074](https://github.com/alphagov/govuk_publishing_components/pull/4074))

--- a/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
@@ -95,9 +95,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.$module.showConfirmationMessage()
     this.$module.cookieBannerConfirmationMessage.focus()
 
-    if (window.GOVUK.analyticsInit) {
-      window.GOVUK.analyticsInit()
-    }
     if (window.GOVUK.globalBarInit) {
       window.GOVUK.globalBarInit.init()
     }

--- a/app/assets/javascripts/govuk_publishing_components/load-analytics.js
+++ b/app/assets/javascripts/govuk_publishing_components/load-analytics.js
@@ -31,10 +31,6 @@ window.GOVUK.loadAnalytics = {
         break
       }
     }
-    // Load universal analytics
-    if (typeof window.GOVUK.analyticsInit !== 'undefined') {
-      window.GOVUK.analyticsInit()
-    }
   },
 
   loadGa4: function (currentDomain) {

--- a/spec/javascripts/components/cookie-banner-spec.js
+++ b/spec/javascripts/components/cookie-banner-spec.js
@@ -138,7 +138,6 @@ describe('Cookie banner', function () {
     })
 
     it('sets consent cookie when accepting cookies', function () {
-      spyOn(GOVUK, 'analyticsInit')
       spyOn(GOVUK, 'setCookie').and.callThrough()
 
       var element = document.querySelector('[data-module="cookie-banner"]')
@@ -154,7 +153,6 @@ describe('Cookie banner', function () {
       expect(GOVUK.setCookie).toHaveBeenCalledWith('cookies_preferences_set', 'true', { days: 365 })
       expect(GOVUK.getCookie('cookies_preferences_set')).toEqual('true')
       expect(GOVUK.getCookie('cookies_policy')).toEqual(ALL_COOKIE_CONSENT)
-      expect(GOVUK.analyticsInit).toHaveBeenCalled()
     })
 
     it('sets global_bar_seen cookie when accepting cookies', function () {


### PR DESCRIPTION
## What / why

- UA is going to be switched off at some point on July 1st
- we're concerned that requesting anything from or sending any data to UA might cause some kind of error or timeout, and we'd rather be safe than sorry
- this change disables our UA code without removing it or causing any tests to fail
- have tested this through a local app running a local static both running this code, and no problems occur (most importantly GA4 still functions)

The `initAnalytics` script has been left intact, but not called. It seems to be called [from a few other places](https://github.com/search?q=org%3Aalphagov+analyticsInit&type=code&p=1), the only one that looks current is DGU.

## Visual Changes
None.

Trello card: https://trello.com/c/3p2DpogG/199-disable-universal-analytics
