### PR TITLE
Fix missing number formatting in contents list component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix missing number formatting in contents list component ([PR #4084](https://github.com/alphagov/govuk_publishing_components/pull/4084))
+
 ## 39.2.0
 
 * Disable Universal Analytics ([PR #4083](https://github.com/alphagov/govuk_publishing_components/pull/4083))

--- a/app/views/govuk_publishing_components/components/_contents_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_contents_list.html.erb
@@ -42,7 +42,7 @@
       <% contents.each.with_index(1) do |contents_item, position| %>
         <li class="<%= cl_helper.list_item_classes(contents_item, false) %>" <%= "aria-current=true" if contents_item[:active] %>>
           <span aria-hidden="true"></span>
-          <% link_text = format_numbers ? cl_helper.wrap_numbers_with_spans(contents_item[:text]) : contents_item[:text]
+          <% link_text = format_numbers ? cl_helper.wrap_numbers_with_spans(contents_item[:text]) : cl_helper.clean_string(contents_item[:text])
             unless disable_ga4
               ga4_data[:event_name] = cl_helper.get_ga4_event_name(contents_item[:href]) if contents_item[:href]
               ga4_data[:index_link] = index_link

--- a/app/views/govuk_publishing_components/components/docs/contents_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/contents_list.yml
@@ -88,7 +88,7 @@ examples:
       format_numbers: true
       contents:
         - href: "#first-thing"
-          text: 1. First thing
+          text: 1.&nbsp;First thing
         - href: "#two"
           active: true
           text: 2. Second thing

--- a/lib/govuk_publishing_components/presenters/contents_list_helper.rb
+++ b/lib/govuk_publishing_components/presenters/contents_list_helper.rb
@@ -22,22 +22,29 @@ module GovukPublishingComponents
         list_item_classes
       end
 
-      def wrap_numbers_with_spans(content_item_link)
-        content_item_text = strip_tags(content_item_link) # just the text of the link
-        content_item_text_stripped = content_item_text.strip # strip trailing spaces for the regex. Keep original content_item_text for the string replacement.
+      def wrap_numbers_with_spans(link_text)
+        output = clean_string(link_text)
         # Must start with a number
         # Number must be between 1 and 999 (ie not 2014)
         # Must be followed by a space
         # May contain a period `1.`
         # May be a decimal `1.2`
-        number = /^\d{1,3}(\.?|\.\d{1,2})(?=\s)/.match(content_item_text_stripped)
+        number = /^\d{1,3}(\.?|\.\d{1,2})(?=\s)/.match(output)
 
         if number
-          words = content_item_text.sub(number.to_s, "").strip # remove the number from the text
-          content_item_link.sub(content_item_text, "<span class=\"gem-c-contents-list__number\">#{number} </span><span class=\"gem-c-contents-list__numbered-text\">#{words}</span>").squish.html_safe
+          words = output.sub(number.to_s, "").strip # remove the number from the text
+          # the space in the first span is needed for screen readers
+          "<span class=\"gem-c-contents-list__number\">#{number} </span><span class=\"gem-c-contents-list__numbered-text\">#{words}</span>".squish.html_safe
         else
-          content_item_link
+          output
         end
+      end
+
+      def clean_string(text)
+        text = text.gsub(/&nbsp;/, " ")
+        text = text.gsub("/\u00a0/", " ")
+        text = text.gsub(160.chr("UTF-8"), " ")
+        strip_tags(text.tr("\n", "")).strip
       end
 
       def get_index_total

--- a/spec/lib/govuk_publishing_components/components/contents_list_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/components/contents_list_helper_spec.rb
@@ -36,49 +36,41 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentsListHelper do
 
     it "does nothing if no number is found" do
       cl = GovukPublishingComponents::Presenters::ContentsListHelper.new({})
-      input = '<a href="#vision">Vision</a>'
-      expected = '<a href="#vision">Vision</a>'
-      expect(cl.wrap_numbers_with_spans(input)).to eql(expected)
+      input = "Vision"
+      expect(cl.wrap_numbers_with_spans(input)).to eql(input)
     end
 
     it "does nothing if it's just a number" do
       cl = GovukPublishingComponents::Presenters::ContentsListHelper.new({})
-      input = '<a href="#first">1</a>'
-      expected = '<a href="#first">1</a>'
-      expect(cl.wrap_numbers_with_spans(input)).to eql(expected)
+      input = "1"
+      expect(cl.wrap_numbers_with_spans(input)).to eql(input)
     end
 
     it "does nothing if the number is part of the word" do
       cl = GovukPublishingComponents::Presenters::ContentsListHelper.new({})
-      input = '<a href="#vision">1Vision</a>'
-      expected = '<a href="#vision">1Vision</a>'
-      expect(cl.wrap_numbers_with_spans(input)).to eql(expected)
+      input = "1Vision"
+      expect(cl.wrap_numbers_with_spans(input)).to eql(input)
 
-      input = '<a href="#vision">1.Vision</a>'
-      expected = '<a href="#vision">1.Vision</a>'
-      expect(cl.wrap_numbers_with_spans(input)).to eql(expected)
+      input = "1.Vision"
+      expect(cl.wrap_numbers_with_spans(input)).to eql(input)
     end
 
     it "does nothing if it starts with a number longer than 3 digits" do
       cl = GovukPublishingComponents::Presenters::ContentsListHelper.new({})
-      input = '<a href="#vision">2014 Vision</a>'
-      expected = '<a href="#vision">2014 Vision</a>'
-      expect(cl.wrap_numbers_with_spans(input)).to eql(expected)
+      input = "2014 Vision"
+      expect(cl.wrap_numbers_with_spans(input)).to eql(input)
 
-      input = '<a href="#vision">2014. Vision</a>'
-      expected = '<a href="#vision">2014. Vision</a>'
-      expect(cl.wrap_numbers_with_spans(input)).to eql(expected)
+      input = "2014. Vision"
+      expect(cl.wrap_numbers_with_spans(input)).to eql(input)
 
-      input = '<a href="#vision">10001. Vision</a>'
-      expected = '<a href="#vision">10001. Vision</a>'
-      expect(cl.wrap_numbers_with_spans(input)).to eql(expected)
+      input = "10001. Vision"
+      expect(cl.wrap_numbers_with_spans(input)).to eql(input)
     end
 
     it "does nothing if a number is present but not at the start" do
       cl = GovukPublishingComponents::Presenters::ContentsListHelper.new({})
-      input = '<a href="#run-an-effective-welfare-system">Run an effective welfare system part 1. Social Care</a>'
-      expected = '<a href="#run-an-effective-welfare-system">Run an effective welfare system part 1. Social Care</a>'
-      expect(cl.wrap_numbers_with_spans(input)).to eql(expected)
+      input = "Run an effective welfare system part 1. Social Care"
+      expect(cl.wrap_numbers_with_spans(input)).to eql(input)
     end
 
     it "counts the number of links in the component" do
@@ -115,8 +107,7 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentsListHelper do
     number_class = "gem-c-contents-list__number"
     numbered_text_class = "gem-c-contents-list__numbered-text"
 
-    input = "<a href=\"#link\">#{number_and_text}</a>"
-    expected = "<a href=\"#link\"><span class=\"#{number_class}\">#{number} </span><span class=\"#{numbered_text_class}\">#{text}</span></a>"
-    expect(cl.wrap_numbers_with_spans(input)).to eql(expected)
+    expected = "<span class=\"#{number_class}\">#{number} </span><span class=\"#{numbered_text_class}\">#{text}</span>"
+    expect(cl.wrap_numbers_with_spans(number_and_text)).to eql(expected)
   end
 end


### PR DESCRIPTION
## What
- the contents list component does clever stuff when you pass the `format_numbers` option, where it identifies numbers at the start of the link text, splits the string into two, and wraps the number and text in separate spans so that the spacing between them can be controlled with CSS (otherwise 1. is misaligned with 10.)
- in some circumstances the content arriving at the component has a non-breaking space instead of an actual space, i.e. `1.&nbsp;Text of link`, which the component doesn't recognise and fails to split and wrap with spans for nice formatting, e.g. https://www.gov.uk/government/publications/financial-sanctions-guidance-for-russia/financial-sanctions-guidance-for-russia
- this change allows for this situation and converts the non-breaking space into a regular space prior to formatted number checking
- it also changes how the wrapped spans are returned (by now simply extracting the number and remaining text, wrapping them in spans and returning them) instead of a slightly more complex string replacing approach designed to preserve anything outside of the string
- this includes refactoring the code and tests to simplify the code and limit the method to assume that the string passed to it should only be text, not markup, by stripping any HTML from the input
- the helper spec in particular implied that markup (including a wrapping link) should be accepted by the method, but this is unrealistic - the output from the method is always wrapped in a parent (either a link or a span) and should not contain markup, as this is the text of the link, not a free area to inject HTML
- this was being done in one place (to include an abbreviation tag inside the link) but has been corrected, see https://github.com/alphagov/government-frontend/pull/3241

## Why
Formatting was incorrect in some circumstances.

## Visual Changes
Before | After
------ | ------
![Screenshot 2024-06-28 at 14 37 57](https://github.com/alphagov/govuk_publishing_components/assets/861310/581edc61-8e9a-4c5c-934e-1045849766b2) | ![Screenshot 2024-06-28 at 14 38 10](https://github.com/alphagov/govuk_publishing_components/assets/861310/757a9faf-4a3b-45d8-8842-42f6e8a1b4a5)

Trello card: https://trello.com/c/S5QIYLRx/9-mis-aligned-sub-headings