### PR TITLE
Version 39.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 39.2.1
 
 * Update to LUX 4.0.20 ([PR #4089](https://github.com/alphagov/govuk_publishing_components/pull/4089))
 * Fix missing number formatting in contents list component ([PR #4084](https://github.com/alphagov/govuk_publishing_components/pull/4084))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (39.2.0)
+    govuk_publishing_components (39.2.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "39.2.0".freeze
+  VERSION = "39.2.1".freeze
 end


### PR DESCRIPTION
## 39.2.1

* Update to LUX 4.0.20 ([PR #4089](https://github.com/alphagov/govuk_publishing_components/pull/4089))
* Fix missing number formatting in contents list component ([PR #4084](https://github.com/alphagov/govuk_publishing_components/pull/4084))
