### PR TITLE
Add more applications to component audit

### DIFF
--- a/app/controllers/govuk_publishing_components/audit_controller.rb
+++ b/app/controllers/govuk_publishing_components/audit_controller.rb
@@ -2,22 +2,38 @@ module GovukPublishingComponents
   class AuditController < GovukPublishingComponents::ApplicationController
     def show
       application_dirs = %w[
+        account-api
         collections
         collections-publisher
+        contacts-admin
         content-data-admin
         content-publisher
+        content-tagger
         datagovuk_find
         email-alert-frontend
         feedback
         finder-frontend
         frontend
         government-frontend
+        govspeak
         govspeak-preview
+        govuk-developer-docs
+        local-links-manager
+        manuals-publisher
+        maslow
+        places-manager
+        publisher
         release
         search-admin
+        search-v2-evaluator
+        service-manual-publisher
+        short-url-manager
         signon
         smart-answers
+        specialist-publisher
         static
+        support
+        transition
         travel-advice-publisher
         whitehall
       ]

--- a/app/views/govuk_publishing_components/audit/_applications.html.erb
+++ b/app/views/govuk_publishing_components/audit/_applications.html.erb
@@ -1,5 +1,5 @@
 <%
-  title = "Applications"
+  title = "Applications (" + @applications.length.to_s + ")"
   title = "This application" unless ENV["MAIN_COMPONENT_GUIDE"]
 %>
 <%= render "govuk_publishing_components/components/heading", {
@@ -77,7 +77,7 @@
               None
             <% end %>
           <% end %>
-          <% 
+          <%
             items << {
               field: "#{item[:name]} (#{item[:value].length})",
               value: content
@@ -134,7 +134,7 @@
           } %>
           <p class="govuk-body">This is a list of components found in this application. Note that some components may appear to be missing files due to inconsistencies in directory structure and naming conventions.</p>
           <%= render "component_contents", passed_components: application_components, show_application_name: false %>
-        <% end %>        
+        <% end %>
       <% else %>
         <p class="govuk-body">This application was not found. This could be because you do not have this repository checked out locally.</p>
       <% end %>


### PR DESCRIPTION
## What
Adds some more applications that use `govuk_publishing_components` to the component auditing tools.

## Why
The app consistency sheet was recently updated and there were a number of applications using the gem on there that weren't in here.

## Visual Changes
Only that I put the number of applications in at the top.

![Screenshot 2024-07-03 at 14 29 38](https://github.com/alphagov/govuk_publishing_components/assets/861310/4c3cfaea-b046-4484-93fd-9708f75a3177)

