### PR TITLE
Fix status icon in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # GOV.UK Publishing Components
-
-[![status](https://badgen.net/github/status/alphagov/govuk_publishing_components/main)](https://github.com/alphagov/govuk_publishing_components/actions?query=branch%3Amain)
+[![status](https://github.com/alphagov/govuk_publishing_components/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/alphagov/govuk_publishing_components/actions/workflows/ci.yml?query=branch%3Amain)
 [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
 [![Stylelint Style Guide](https://img.shields.io/badge/code_style-stylelint-brightgreen.svg)](https://github.com/alphagov/stylelint-config-gds/)
 


### PR DESCRIPTION
## What
- Fix the status icon used in README.md
- Updated the approach to use GitHub instead: https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge
- The status and new link for the icon will be for Continuous integration on the main branch

## Why
- The request to badgen.net to generate the status icon in the readme file is currently returning a 404 error
- Consistent with the approach used in govuk-frontend - https://github.com/alphagov/govuk-frontend
- Allow others to quickly view the status

## Visual Changes

### Before
<img width="420" alt="Screenshot 2024-07-04 at 12 04 33" src="https://github.com/alphagov/govuk_publishing_components/assets/28779939/9d72eae7-aaad-4ef2-b7bf-f66435e66b97">

### After
<img width="420" alt="Screenshot 2024-07-04 at 12 05 37" src="https://github.com/alphagov/govuk_publishing_components/assets/28779939/4ef2df60-5e5f-4d93-8e37-fec560fc54ef">

## Further info
If badgen.net is preferred, it is possible to fix the 404 using the code below:

```md
[![status](https://badgen.net/github/checks/alphagov/govuk_publishing_components/main?label=status)](https://github.com/alphagov/govuk_publishing_components/actions?query=branch%3Amain)
```

Example:
[![status](https://badgen.net/github/checks/alphagov/govuk_publishing_components/main?label=status)](https://github.com/alphagov/govuk_publishing_components/actions?query=branch%3Amain)

Badget.net docs - https://badgen.net/github