### PR TITLE
Only set gtm_cookies_win=x for preview in GTM script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Only set `gtm_cookies_win=x` for preview in Google Tag Manager script ([PR #4097](https://github.com/alphagov/govuk_publishing_components/pull/4097))
+
 ## 39.2.2
 
 * Adjust govspeak chart label positioning ([PR #4094](https://github.com/alphagov/govuk_publishing_components/pull/4094))

--- a/app/views/govuk_publishing_components/components/_google_tag_manager_script.html.erb
+++ b/app/views/govuk_publishing_components/components/_google_tag_manager_script.html.erb
@@ -2,11 +2,12 @@
   gtm_auth ||= nil
   gtm_preview ||= nil
 
-  gtm_attributes = %w(gtm_cookies_win=x)
+  gtm_attributes = []
     gtm_attributes << "gtm_auth=" + gtm_auth if gtm_auth
-    gtm_attributes << "gtm_preview=" + gtm_preview if gtm_preview
+    gtm_attributes << "gtm_preview=#{gtm_preview}&gtm_cookies_win=x" if gtm_preview
   gtm_attributes = gtm_attributes.join('&')
 %>
+
 <%= javascript_tag nonce: true do -%>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],


### PR DESCRIPTION
## What
Only set gtm_cookies_win=x for preview in GTM script

## Why
The GTA doesn’t work as expected for DGU.

It appears that gtm_cookies_win=x allows GTM Preview to change the environment of a page, which means that they win over gtm_auth and gtm_preview parameters.

Setting gtm_cookies_win=x  let the GTM editor decide which environment they want to use, regardless of what was in the tracking snippet. 

This makes it identically to the behaviour in ga4-core.js. The commit message suggest that it can slow down GTM:
https://github.com/alphagov/govuk_publishing_components/blob/eb66a18f86/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js#L25

https://govuk.zendesk.com/agent/tickets/5626599

## Visual Changes
n/a

