### PR TITLE
Add brand colour for MHCLG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add brand colour for MHCLG [(PR #4100)](https://github.com/alphagov/govuk_publishing_components/pull/4100)
+
 ## 39.2.3
 
 * Only set `gtm_cookies_win=x` for preview in Google Tag Manager script ([PR #4097](https://github.com/alphagov/govuk_publishing_components/pull/4097))

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
@@ -96,3 +96,27 @@
     border-color: #045f71;
   }
 }
+
+// This change should be removed after relevant govuk-frontend release
+
+.brand--ministry-of-housing-communities-and-local-government {
+  .brand__color {
+    color: #00625e;
+
+    &:link,
+    &:visited,
+    &:active {
+      color: #00625e;
+    }
+
+    &:hover,
+    &:focus {
+      color: $govuk-focus-text-colour;
+    }
+  }
+
+  &.brand__border-color,
+  .brand__border-color {
+    border-color: #00625e;
+  }
+}


### PR DESCRIPTION
The new MHCLG has a new brand colour which will need adding into Whitehall. It's a fairly urgent change hence why we are adding it to publishing components, and not just waiting for the update to govuk-frontend

