### PR TITLE
Version 39.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 39.2.5
 
 * LUX version 4.0.23 ([PR #4102](https://github.com/alphagov/govuk_publishing_components/pull/4102))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (39.2.4)
+    govuk_publishing_components (39.2.5)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "39.2.4".freeze
+  VERSION = "39.2.5".freeze
 end


### PR DESCRIPTION
## 39.2.5

* LUX version 4.0.23 ([PR #4102](https://github.com/alphagov/govuk_publishing_components/pull/4102))