### PR TITLE
Version 40.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 40.0.0
 
 * **BREAKING:** Upgrade to govuk frontend 5.1 ([PR #4041](https://github.com/alphagov/govuk_publishing_components/pull/4041))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (39.2.5)
+    govuk_publishing_components (40.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "39.2.5".freeze
+  VERSION = "40.0.0".freeze
 end


### PR DESCRIPTION
Release notes to highlight the breaking change in what is likely to be version 40 of govuk-publishing-components.

## 40.0.0

* **BREAKING:** Upgrade to govuk frontend 5.1 ([PR #4041](https://github.com/alphagov/govuk_publishing_components/pull/4041))

This release upgrades govuk-frontend from version 4.8.0 to version 5.1.0.

The PR description for [Upgrade to govuk frontend 5.1](https://github.com/alphagov/govuk_publishing_components/pull/4041) contains info on what has changed in the publishing components gem to upgrade to v5.1.0 of govuk-frontend.

For further details on all changes in govuk-frontend, please refer to the release notes:

[Release GOV.UK Frontend v5.0.0 · alphagov/govuk-frontend](https://github.com/alphagov/govuk-frontend/releases/tag/v5.0.0)
[Release GOV.UK Frontend v5.1.0 · alphagov/govuk-frontend](https://github.com/alphagov/govuk-frontend/releases/tag/v5.1.0)