### PR TITLE
Add Brakeman to CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,15 @@ jobs:
   dependency-review:
     name: Dependency Review scan
     uses: alphagov/govuk-infrastructure/.github/workflows/dependency-review.yml@main
+
+  security-analysis:
+    name: Security Analysis
+    uses: alphagov/govuk-infrastructure/.github/workflows/brakeman.yml@main
+    secrets: inherit
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
   
   # This matrix job runs the test suite against multiple Ruby versions
   test_matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 40.0.1
+* Add Brakeman to CI jobs ([PR #4108](https://github.com/alphagov/govuk_publishing_components/pull/4108)) 
+
 ## 40.0.0
 
 * **BREAKING:** Upgrade to govuk frontend 5.1 ([PR #4041](https://github.com/alphagov/govuk_publishing_components/pull/4041))


### PR DESCRIPTION
## What
Adds Brakeman to the CI jobs to appease the angry CI robot, as outlined here: https://docs.publishing.service.gov.uk/manual/brakeman.html

## Why
As per the above linked docs: 

[Brakeman](https://github.com/presidentbeef/brakeman) is a static analysis tool which checks Rails applications for security vulnerabilities. It is effectively a type of linter, similar to [rubocop](https://github.com/rubocop-hq/rubocop). It is configured as a reusable workflow and should be included as a job in the CI pipeline of all GOV.UK Ruby repositories.

