### PR TITLE
Disable browser corrections for header search field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 ## Unreleased
 
 * Allow disabling `search` component input spelling correction ([PR #4112](https://github.com/alphagov/govuk_publishing_components/pull/4112))
+* Disable `search` component input spelling correction in `layout_super_navigation_header` and
+  `layout_header` components ([PR #4115](https://github.com/alphagov/govuk_publishing_components/pull/4115))
 
 ## 40.0.1
 * Add Brakeman to CI jobs ([PR #4108](https://github.com/alphagov/govuk_publishing_components/pull/4108))

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -347,6 +347,7 @@
                   label_custom_class: "gem-c-layout-super-navigation-header__search-label--large-navbar",
                   size: "large",
                   margin_bottom: 0,
+                  disable_corrections: true,
                   data_attributes: {
                     track_category: "headerClicked",
                     track_action: "searchSubmitted",

--- a/app/views/govuk_publishing_components/components/layout_header/_search.html.erb
+++ b/app/views/govuk_publishing_components/components/layout_header/_search.html.erb
@@ -19,6 +19,7 @@
     id: "site-search-text",
     margin_bottom: 0,
     no_border: true,
+    disable_corrections: true,
     data_attributes: {
       track_category: "headerClicked",
       track_action: "searchSubmitted",


### PR DESCRIPTION
## What
This applies the `disable_corrections` setting from #4112 to the `search` components used in the `layout_super_navigation_header` and `layout_header` components.

## Why
We expect this to improve the quality of search results for users on mobile as their browsers will no longer excessively autocorrect, and in case of genuine misspellings, the site search engine can cope with that well anyway.

## Visual Changes
None.