### PR TITLE
[DO NOT MERGE] Update cards component design and use one column by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Allow disabling `search` component input spelling correction ([PR #4112](https://github.com/alphagov/govuk_publishing_components/pull/4112))
+* **BREAKING:** Update cards component design and use one column by default ([PR #4116](https://github.com/alphagov/govuk_publishing_components/pull/4116))
 
 ## 40.0.1
 * Add Brakeman to CI jobs ([PR #4108](https://github.com/alphagov/govuk_publishing_components/pull/4108))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
@@ -9,23 +9,12 @@
 .gem-c-cards__list {
   list-style: none;
   padding: 0;
-  // Remove the outermost left and right margin from the internal margin of the list items.
-  margin: 0 govuk-spacing(-3);
-
+  margin: 0;
   display: grid;
-  grid-auto-flow: row;   // Use CSS grid to calculate the number of rows
-  grid-auto-rows: fractions(1); // Set all rows to same fractional height of the complete grid
-  grid-template-columns: fractions(1);
-
-  @include govuk-media-query($from: "tablet") {
-    grid-template-columns: fractions(2);
-  }
+  grid-column-gap: govuk-spacing(6); // Use deprecated grid-column-gap for Grade C browser support
+  column-gap: govuk-spacing(6);
 
   @include govuk-media-query($from: "desktop") {
-    // Note that browsers that don't support CSS grid display the component as one column on all
-    // breakpoints
-    grid-template-columns: fractions(3);
-
     // For browsers that don't support CSS grid, constrain the width to 50% to improve usability
     // especially for screen magnifier users
     width: 50%;
@@ -38,16 +27,21 @@
 }
 
 .gem-c-cards__list--two-column-desktop {
+  @include govuk-media-query($from: "tablet") {
+    grid-auto-rows: fractions(1); // Set all rows to same fractional height of the complete grid
+    grid-template-columns: fractions(2); // Note that browsers that don't support CSS grid display the component as one column on all breakpoints
+  }
+}
+
+.gem-c-cards__list--three-column-desktop {
   @include govuk-media-query($from: "desktop") {
-    grid-template-columns: fractions(2);
+    grid-auto-rows: fractions(1); // Set all rows to same fractional height of the complete grid
+    grid-template-columns: fractions(3); // Note that browsers that don't support CSS grid display the component as one column on all breakpoints
   }
 }
 
 .gem-c-cards__list-item {
   border-top: 1px solid $govuk-border-colour;
-  // We use grid to split the container into column widths, so manage the horizontal spacing with
-  // internal margins.
-  margin: 0 govuk-spacing(3);
   padding: govuk-spacing(1) 0 govuk-spacing(4) 0;
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
@@ -49,12 +49,17 @@
   // this wrapper ensures that the clickable area of the card only
   // covers the area of the card containing text so in a grid of cards
   // there is space above and below each link
-  padding: govuk-spacing(2) govuk-spacing(6) govuk-spacing(2) 0;
+  padding: 19px 0 4px;
   position: relative;
 }
 
 .gem-c-cards__sub-heading {
-  margin-bottom: govuk-spacing(2);
+  margin: 0 govuk-spacing(6) govuk-spacing(2) 0;
+
+  // Ensure card content width is constrained to two thirds on desktop
+  @include govuk-media-query($from: "desktop") {
+    max-width: 66.6667%;
+  }
 }
 
 .gem-c-cards__link {
@@ -97,7 +102,20 @@
 }
 
 .gem-c-cards__description {
-  margin: 0 govuk-spacing(-6) 0 0;
+  margin: 0 govuk-spacing(6) 0 0;
+
+  // Ensure card content width is constrained to two thirds on desktop
+  @include govuk-media-query($from: "desktop") {
+    max-width: 66.6667%;
+  }
+}
+
+.gem-c-cards__list--two-column-desktop,
+.gem-c-cards__list--three-column-desktop {
+  .gem-c-cards__sub-heading,
+  .gem-c-cards__description {
+    max-width: 100%;
+  }
 }
 
 @include govuk-media-query($media-type: print) {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
@@ -80,10 +80,12 @@
     border-right: $width solid $govuk-brand-colour;
     border-top: $width solid $govuk-brand-colour;
     content: "";
+    display: block;
     height: $dimension;
     position: absolute;
     right: govuk-spacing(1);
-    top: govuk-spacing(3);
+    top: 50%;
+    margin-top: 5px;
     @include prefixed-transform($rotate: 45deg);
     width: $dimension;
   }

--- a/app/views/govuk_publishing_components/components/_cards.html.erb
+++ b/app/views/govuk_publishing_components/components/_cards.html.erb
@@ -5,9 +5,11 @@
   items ||= nil
   sub_heading_level ||= 3
   two_column_layout ||= false
+  three_column_layout ||= false
 
   ul_classes = %w[gem-c-cards__list]
   ul_classes << 'gem-c-cards__list--two-column-desktop' if two_column_layout
+  ul_classes << 'gem-c-cards__list--three-column-desktop' if three_column_layout
 
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)

--- a/app/views/govuk_publishing_components/components/docs/cards.yml
+++ b/app/views/govuk_publishing_components/components/docs/cards.yml
@@ -71,9 +71,42 @@ examples:
             path: http://www.gov.uk
           description: Owning or renting and council services
   two_column_layout:
-    description:  Override default three column layout on desktop by passing through `two_column_layout` parameter (defaults to `false`).
+    description:  Override default single column layout on desktop by passing through `two_column_layout` parameter (defaults to `false`).
     data:
       two_column_layout: true
+      items:
+        - link:
+            text: Benefits
+            path: http://www.gov.uk
+          description: Includes eligibility, appeals, tax credits and Universal Credit
+        - link:
+            text: Births, deaths, marriages and&nbsp;care
+            path: http://www.gov.uk
+          description: Parenting, civil partnerships, divorce and Lasting Power of Attorney
+        - link:
+            text: Business and self-employed
+            path: http://www.gov.uk
+          description: Tools and guidance for businesses
+        - link:
+            text: Childcare and parenting
+            path: http://www.gov.uk
+          description: Includes giving birth, fostering, adopting, benefits for children, childcare and schools
+        - link:
+            text: Citizenship and living in the&nbsp;UK
+            path: http://www.gov.uk
+          description: Voting, community participation, life in the UK, international projects
+        - link:
+            text: Crime, justice and the&nbsp;law
+            path: http://www.gov.uk
+          description: Legal processes, courts and the police
+        - link:
+            text: Disabled people
+            path: http://www.gov.uk
+          description: Includes carers, your rights, benefits and the Equality Act
+  three_column_layout:
+    description:  Override default single column layout on desktop by passing through `three_column_layout` parameter (defaults to `false`).
+    data:
+      three_column_layout: true
       items:
         - link:
             text: Benefits

--- a/spec/components/cards_spec.rb
+++ b/spec/components/cards_spec.rb
@@ -58,6 +58,22 @@ describe "Cards", type: :view do
     assert_select "ul.gem-c-cards__list.gem-c-cards__list--two-column-desktop", count: 1
   end
 
+  it "renders three column list variant" do
+    test_data = {
+      three_column_layout: true,
+      items: [
+        {
+          link: {
+            text: "Benefits",
+            path: "http://www.gov.uk",
+          },
+        },
+      ],
+    }
+    render_component(test_data)
+    assert_select "ul.gem-c-cards__list.gem-c-cards__list--three-column-desktop", count: 1
+  end
+
   it "renders sub-heading using default heading level" do
     test_data = {
       items: [

--- a/spec/dummy/app/views/welcome/public_example.html.erb
+++ b/spec/dummy/app/views/welcome/public_example.html.erb
@@ -1,20 +1,293 @@
-<h1 class="govuk-heading-xl">Hello! I am an example public GOV.UK page</h1>
+ <div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
 
-<p class="govuk-body">
-  Pages with the public layout can use some GOV.UK styles. For example, the grid:
-</p>
-
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-m">Two-thirds column</h1>
-      <p class="govuk-body">This is a paragraph inside a two-thirds wide column</p>
-    </div>
-
-    <div class="govuk-grid-column-one-third">
-      <h3 class="govuk-heading-m">One-third column</h3>
-      <p class="govuk-body">This is a paragraph inside a one-third wide column</p>
-    </div>
+    <%= render "govuk_publishing_components/components/cards", {
+    heading: "One column of cards, inside two thirds layout",
+    items: [
+      {
+        link: {
+          text: "Benefits",
+          path: "http://www.gov.uk"
+        },
+        description: "Includes eligibility, appeals, tax credits and Universal Credit"
+      },
+      {
+        link: {
+          text: "Births, deaths, marriages and care",
+          path: "http://www.gov.uk"
+        },
+        description: "Parenting, civil partnerships, divorce and Lasting Power of Attorney"
+      },
+      {
+        link: {
+          text: "Business and self-employed",
+          path: "http://www.gov.uk"
+        },
+        description: "Tools and guidance for businesses"
+      },
+      {
+        link: {
+          text: "Childcare and parenting",
+          path: "http://www.gov.uk"
+        },
+        description: "Includes giving birth, fostering, adopting, benefits for children, childcare and schools"
+      },
+      {
+        link: {
+          text: "Citizenship and living in the UK",
+          path: "http://www.gov.uk"
+        },
+        description: "Voting, community participation, life in the UK, international projects"
+      },
+      {
+        link: {
+          text: "Crime, justice and the law",
+          path: "http://www.gov.uk"
+        },
+        description: "Legal processes, courts and the police"
+      },
+      {
+        link: {
+          text: "Disabled people",
+          path: "http://www.gov.uk"
+        },
+        description: "Includes carers, your rights, benefits and the Equality Act"
+      },
+      {
+        link: {
+          text: "Driving and transport",
+          path: "http://www.gov.uk"
+        },
+        description: "Includes vehicle tax, MOT and driving licences"
+      },
+      {
+        link: {
+          text: "Education and learning",
+          path: "http://www.gov.uk"
+        },
+        description: "Includes student loans, admissions and apprenticeships"
+      },
+      {
+        link: {
+          text: "Employing people",
+          path: "http://www.gov.uk"
+        },
+        description: "Includes pay, contracts, hiring and redundancies"
+      },
+      {
+        link: {
+          text: "Environment and countryside",
+          path: "http://www.gov.uk"
+        },
+        description: "Includes flooding, recycling and wildlife"
+      },
+      {
+        link: {
+          text: "Housing and local services",
+          path: "http://www.gov.uk"
+        },
+        description: "Owning or renting and council services"
+      }
+    ]
+    } %>
   </div>
+</div>
+
+<hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+
+    <%= render "govuk_publishing_components/components/cards", {
+    heading: "Two columns of cards, inside a full-width layout",
+    two_column_layout: true,
+    items: [
+      {
+        link: {
+          text: "Benefits",
+          path: "http://www.gov.uk"
+        },
+        description: "Includes eligibility, appeals, tax credits and Universal Credit"
+      },
+      {
+        link: {
+          text: "Births, deaths, marriages and care",
+          path: "http://www.gov.uk"
+        },
+        description: "Parenting, civil partnerships, divorce and Lasting Power of Attorney"
+      },
+      {
+        link: {
+          text: "Business and self-employed",
+          path: "http://www.gov.uk"
+        },
+        description: "Tools and guidance for businesses"
+      },
+      {
+        link: {
+          text: "Childcare and parenting",
+          path: "http://www.gov.uk"
+        },
+        description: "Includes giving birth, fostering, adopting, benefits for children, childcare and schools"
+      },
+      {
+        link: {
+          text: "Citizenship and living in the UK",
+          path: "http://www.gov.uk"
+        },
+        description: "Voting, community participation, life in the UK, international projects"
+      },
+      {
+        link: {
+          text: "Crime, justice and the law",
+          path: "http://www.gov.uk"
+        },
+        description: "Legal processes, courts and the police"
+      },
+      {
+        link: {
+          text: "Disabled people",
+          path: "http://www.gov.uk"
+        },
+        description: "Includes carers, your rights, benefits and the Equality Act"
+      },
+      {
+        link: {
+          text: "Driving and transport",
+          path: "http://www.gov.uk"
+        },
+        description: "Includes vehicle tax, MOT and driving licences"
+      },
+      {
+        link: {
+          text: "Education and learning",
+          path: "http://www.gov.uk"
+        },
+        description: "Includes student loans, admissions and apprenticeships"
+      },
+      {
+        link: {
+          text: "Employing people",
+          path: "http://www.gov.uk"
+        },
+        description: "Includes pay, contracts, hiring and redundancies"
+      },
+      {
+        link: {
+          text: "Environment and countryside",
+          path: "http://www.gov.uk"
+        },
+        description: "Includes flooding, recycling and wildlife"
+      },
+      {
+        link: {
+          text: "Housing and local services",
+          path: "http://www.gov.uk"
+        },
+        description: "Owning or renting and council services"
+      }
+    ]
+    } %>
+  </div>
+</div>
+
+<hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render "govuk_publishing_components/components/cards", {
+    heading: "Three columns of cards, inside a full-width layout",
+    three_column_layout: true,
+    items: [
+      {
+        link: {
+          text: "Benefits",
+          path: "http://www.gov.uk"
+        },
+        description: "Includes eligibility, appeals, tax credits and Universal Credit"
+      },
+      {
+        link: {
+          text: "Births, deaths, marriages and care",
+          path: "http://www.gov.uk"
+        },
+        description: "Parenting, civil partnerships, divorce and Lasting Power of Attorney"
+      },
+      {
+        link: {
+          text: "Business and self-employed",
+          path: "http://www.gov.uk"
+        },
+        description: "Tools and guidance for businesses"
+      },
+      {
+        link: {
+          text: "Childcare and parenting",
+          path: "http://www.gov.uk"
+        },
+        description: "Includes giving birth, fostering, adopting, benefits for children, childcare and schools"
+      },
+      {
+        link: {
+          text: "Citizenship and living in the UK",
+          path: "http://www.gov.uk"
+        },
+        description: "Voting, community participation, life in the UK, international projects"
+      },
+      {
+        link: {
+          text: "Crime, justice and the law",
+          path: "http://www.gov.uk"
+        },
+        description: "Legal processes, courts and the police"
+      },
+      {
+        link: {
+          text: "Disabled people",
+          path: "http://www.gov.uk"
+        },
+        description: "Includes carers, your rights, benefits and the Equality Act"
+      },
+      {
+        link: {
+          text: "Driving and transport",
+          path: "http://www.gov.uk"
+        },
+        description: "Includes vehicle tax, MOT and driving licences"
+      },
+      {
+        link: {
+          text: "Education and learning",
+          path: "http://www.gov.uk"
+        },
+        description: "Includes student loans, admissions and apprenticeships"
+      },
+      {
+        link: {
+          text: "Employing people",
+          path: "http://www.gov.uk"
+        },
+        description: "Includes pay, contracts, hiring and redundancies"
+      },
+      {
+        link: {
+          text: "Environment and countryside",
+          path: "http://www.gov.uk"
+        },
+        description: "Includes flooding, recycling and wildlife"
+      },
+      {
+        link: {
+          text: "Housing and local services",
+          path: "http://www.gov.uk"
+        },
+        description: "Owning or renting and council services"
+      }
+    ]
+    } %>
+  </div>
+</div>
+ 
 <% content_for :before_content do %>
   <% render "govuk_publishing_components/components/back_link", href:'/' %>
 <% end %>


### PR DESCRIPTION
## What
- **BREAKING:** Update the cards component to use a one column by default
  - The card component previously used a 3 column layout by default, you can still use the 3 column layout by passing `three_column_layout: true` to the component
- Add a test and update docs for the new `three_column_layout` option
- Update spacing for the card component to match the new design
  - Use grid `column-gap` instead of margin
- Align the chevron icon vertically, the card component content now has margin-right set to 30px to ensure it does not overlap with the chevron icon

## Why
Several variations of the card component exist, updating the card component in the gem will allow us to:
- Remove custom styling for the homepage from `frontend`
- Update the browse templates used in `collections` to display a single column layout instead of a grid as this was the most performant variant in our AB test

[Trello](https://trello.com/c/U1DIkmLc/2721-update-card-component-to-support-single-column-layout-and-vertically-aligned-chevron-m)

## Visual Changes

| Before | After |
| --- | --- |
| <img width="299" alt="card-before" src="https://github.com/user-attachments/assets/7e1a848f-1673-4bf8-a1ff-a7276af59040"> | <img width="304" alt="card-after" src="https://github.com/user-attachments/assets/ade77bac-95c8-48a7-86dd-fcfaaa8af736"> |

The new card component design and variations can be previewed on https://components-gem-pr-4116.herokuapp.com/component-guide/cards/preview