### PR TITLE
Update cards component design and use one column by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Resolve DartSass mixed declaration deprecations ([PR #4125](https://github.com/alphagov/govuk_publishing_components/pull/4125))
 * Drop support for Ruby 3.1 ([PR #4124](https://github.com/alphagov/govuk_publishing_components/pull/4124))
+* Update cards component design and use one column by default ([PR #4118](https://github.com/alphagov/govuk_publishing_components/pull/4118))
 
 ## 41.0.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
@@ -9,23 +9,12 @@
 .gem-c-cards__list {
   list-style: none;
   padding: 0;
-  // Remove the outermost left and right margin from the internal margin of the list items.
-  margin: 0 govuk-spacing(-3);
-
+  margin: 0;
   display: grid;
-  grid-auto-flow: row;   // Use CSS grid to calculate the number of rows
-  grid-auto-rows: fractions(1); // Set all rows to same fractional height of the complete grid
-  grid-template-columns: fractions(1);
-
-  @include govuk-media-query($from: "tablet") {
-    grid-template-columns: fractions(2);
-  }
+  grid-column-gap: govuk-spacing(6); // Use deprecated grid-column-gap for Grade C browser support
+  column-gap: govuk-spacing(6);
 
   @include govuk-media-query($from: "desktop") {
-    // Note that browsers that don't support CSS grid display the component as one column on all
-    // breakpoints
-    grid-template-columns: fractions(3);
-
     // For browsers that don't support CSS grid, constrain the width to 50% to improve usability
     // especially for screen magnifier users
     width: 50%;
@@ -38,16 +27,21 @@
 }
 
 .gem-c-cards__list--two-column-desktop {
+  @include govuk-media-query($from: "tablet") {
+    grid-auto-rows: fractions(1); // Set all rows to same fractional height of the complete grid
+    grid-template-columns: fractions(2); // Note that browsers that don't support CSS grid display the component as one column on all breakpoints
+  }
+}
+
+.gem-c-cards__list--three-column-desktop {
   @include govuk-media-query($from: "desktop") {
-    grid-template-columns: fractions(2);
+    grid-auto-rows: fractions(1); // Set all rows to same fractional height of the complete grid
+    grid-template-columns: fractions(3); // Note that browsers that don't support CSS grid display the component as one column on all breakpoints
   }
 }
 
 .gem-c-cards__list-item {
   border-top: 1px solid $govuk-border-colour;
-  // We use grid to split the container into column widths, so manage the horizontal spacing with
-  // internal margins.
-  margin: 0 govuk-spacing(3);
   padding: govuk-spacing(1) 0 govuk-spacing(4) 0;
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
@@ -49,12 +49,17 @@
   // this wrapper ensures that the clickable area of the card only
   // covers the area of the card containing text so in a grid of cards
   // there is space above and below each link
-  padding: govuk-spacing(2) govuk-spacing(6) govuk-spacing(2) 0;
+  padding: 19px 0 4px;
   position: relative;
 }
 
 .gem-c-cards__sub-heading {
-  margin-bottom: govuk-spacing(2);
+  margin: 0 govuk-spacing(6) govuk-spacing(2) 0;
+
+  // Ensure card content width is constrained to two thirds on desktop
+  @include govuk-media-query($from: "desktop") {
+    max-width: 66.6667%;
+  }
 }
 
 .gem-c-cards__link {
@@ -97,7 +102,20 @@
 }
 
 .gem-c-cards__description {
-  margin: 0 govuk-spacing(-6) 0 0;
+  margin: 0 govuk-spacing(6) 0 0;
+
+  // Ensure card content width is constrained to two thirds on desktop
+  @include govuk-media-query($from: "desktop") {
+    max-width: 66.6667%;
+  }
+}
+
+.gem-c-cards__list--two-column-desktop,
+.gem-c-cards__list--three-column-desktop {
+  .gem-c-cards__sub-heading,
+  .gem-c-cards__description {
+    max-width: 100%;
+  }
 }
 
 @include govuk-media-query($media-type: print) {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
@@ -114,9 +114,20 @@
 
 .gem-c-cards__list--two-column-desktop,
 .gem-c-cards__list--three-column-desktop {
-  .gem-c-cards__sub-heading,
-  .gem-c-cards__description {
+  .gem-c-cards__sub-heading {
     max-width: 100%;
+  }
+
+  .gem-c-cards__description {
+    margin: 0;
+    max-width: 100%;
+  }
+
+  .gem-c-cards__link {
+    &::before {
+      top: 27px;
+      margin: 0;
+    }
   }
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
@@ -80,10 +80,12 @@
     border-right: $width solid $govuk-brand-colour;
     border-top: $width solid $govuk-brand-colour;
     content: "";
+    display: block;
     height: $dimension;
     position: absolute;
     right: govuk-spacing(1);
-    top: govuk-spacing(3);
+    top: 50%;
+    margin-top: 5px;
     @include prefixed-transform($rotate: 45deg);
     width: $dimension;
   }

--- a/app/views/govuk_publishing_components/components/_cards.html.erb
+++ b/app/views/govuk_publishing_components/components/_cards.html.erb
@@ -3,9 +3,12 @@
   heading ||= nil
   items ||= nil
   sub_heading_level ||= 3
-  two_column_layout ||= false
+  columns ||= false
+
   ul_classes = %w[gem-c-cards__list]
-  ul_classes << 'gem-c-cards__list--two-column-desktop' if two_column_layout
+  ul_classes << 'gem-c-cards__list--two-column-desktop' if columns == 2
+  ul_classes << 'gem-c-cards__list--three-column-desktop' if columns == 3
+
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-cards")

--- a/app/views/govuk_publishing_components/components/docs/cards.yml
+++ b/app/views/govuk_publishing_components/components/docs/cards.yml
@@ -1,13 +1,11 @@
-name: Cards (experimental)
+name: Cards
 description: A grid of cards that have a link and a description
 body: |
-  The component renders the cards as an unordered list element and visually presents it as a grid. It doesn't use the [GOV.UK Design System grid](https://design-system.service.gov.uk/styles/layout/#grid-system) but sets its own so that it can separately target desktop, tablet and mobile columns.
+  The component renders the cards as an unordered list element and visually presents it using CSS grid to display the cards in either a one (default), two or three column layout. It doesn't use the [GOV.UK Design System grid](https://design-system.service.gov.uk/styles/layout/#grid-system) but sets its own so that it can separately target desktop, tablet and mobile columns.
 
-  You can display the grid in three or two columns on desktop. Browsers that don't support CSS grid always display one column.
+  Browsers that don't support CSS grid always display one column.
 
   You must set a `href` for all the links.
-
-  This component is currently experimental. If you are using it, please feed back any research findings to the GOV.UK Explore team.
 accessibility_criteria: |
   The component must:
 
@@ -71,9 +69,42 @@ examples:
             path: http://www.gov.uk
           description: Owning or renting and council services
   two_column_layout:
-    description:  Override default three column layout on desktop by passing through `two_column_layout` parameter (defaults to `false`).
+    description:  Override default single column layout on desktop by setting the `columns` parameter to `2`.
     data:
-      two_column_layout: true
+      columns: 2
+      items:
+        - link:
+            text: Benefits
+            path: http://www.gov.uk
+          description: Includes eligibility, appeals, tax credits and Universal Credit
+        - link:
+            text: Births, deaths, marriages and&nbsp;care
+            path: http://www.gov.uk
+          description: Parenting, civil partnerships, divorce and Lasting Power of Attorney
+        - link:
+            text: Business and self-employed
+            path: http://www.gov.uk
+          description: Tools and guidance for businesses
+        - link:
+            text: Childcare and parenting
+            path: http://www.gov.uk
+          description: Includes giving birth, fostering, adopting, benefits for children, childcare and schools
+        - link:
+            text: Citizenship and living in the&nbsp;UK
+            path: http://www.gov.uk
+          description: Voting, community participation, life in the UK, international projects
+        - link:
+            text: Crime, justice and the&nbsp;law
+            path: http://www.gov.uk
+          description: Legal processes, courts and the police
+        - link:
+            text: Disabled people
+            path: http://www.gov.uk
+          description: Includes carers, your rights, benefits and the Equality Act
+  three_column_layout:
+    description: Override default single column layout on desktop by setting the `columns` parameter to `3`.
+    data:
+      columns: 3
       items:
         - link:
             text: Benefits

--- a/spec/components/cards_spec.rb
+++ b/spec/components/cards_spec.rb
@@ -42,9 +42,40 @@ describe "Cards", type: :view do
     assert_select "h3.gem-c-cards__heading.govuk-heading-m", count: 1
   end
 
+  it "renders the one column list variant by default" do
+    test_data = {
+      items: [
+        {
+          link: {
+            text: "Benefits",
+            path: "http://www.gov.uk",
+          },
+        },
+      ],
+    }
+    render_component(test_data)
+    assert_select "ul.gem-c-cards__list", count: 1
+  end
+
+  it "renders the one column list variant by default when passed an invalid parameter" do
+    test_data = {
+      columns: "2",
+      items: [
+        {
+          link: {
+            text: "Benefits",
+            path: "http://www.gov.uk",
+          },
+        },
+      ],
+    }
+    render_component(test_data)
+    assert_select "ul.gem-c-cards__list", count: 1
+  end
+
   it "renders two column list variant" do
     test_data = {
-      two_column_layout: true,
+      columns: 2,
       items: [
         {
           link: {
@@ -56,6 +87,22 @@ describe "Cards", type: :view do
     }
     render_component(test_data)
     assert_select "ul.gem-c-cards__list.gem-c-cards__list--two-column-desktop", count: 1
+  end
+
+  it "renders three column list variant" do
+    test_data = {
+      columns: 3,
+      items: [
+        {
+          link: {
+            text: "Benefits",
+            path: "http://www.gov.uk",
+          },
+        },
+      ],
+    }
+    render_component(test_data)
+    assert_select "ul.gem-c-cards__list.gem-c-cards__list--three-column-desktop", count: 1
   end
 
   it "renders sub-heading using default heading level" do


### PR DESCRIPTION
## What
- Update the cards component to use a one column by default
  - The one column layout variation was the winner of the AB test when used on the browse pages, so we will be using the variation on both `collections` and `frontend` in the future. The only place that would still use the three column layout is the account settings page in `signon`
  - Add a new `columns` option which is used to set the number for columns to use
  - Removed the `two_column_layout` option
- Update tests and docs for the new `columns` option
  - Use new `columns` option
  - Add test for three column variation of the card component
- Update spacing for the card component to match the new design
  - Use grid `column-gap` instead of margin
- Align the chevron icon vertically, the card component content now has margin-right set to 30px to ensure it does not overlap with the chevron icon

## Why
Several variations of the card component exist, updating the card component in the gem will allow us to:
- Remove custom styling for the homepage from `frontend`
- Update the browse templates used in `collections` to display a single column layout instead of a grid as this was the most performant variant in our AB test

[Trello](https://trello.com/c/U1DIkmLc/2721-update-card-component-to-support-single-column-layout-and-vertically-aligned-chevron-m)

## Visual Changes

### One column layout
| Before | After |
| --- | --- |
| <img width="299" alt="card-before" src="https://github.com/user-attachments/assets/7e1a848f-1673-4bf8-a1ff-a7276af59040"> | <img width="304" alt="card-after" src="https://github.com/user-attachments/assets/ade77bac-95c8-48a7-86dd-fcfaaa8af736"> |

### Two/Three column layout
| Before | After |
| --- | --- |
| ![card-2-3-before](https://github.com/user-attachments/assets/288fcda3-5386-444d-9f0b-33303e4c9809) | ![cards-2-3-after](https://github.com/user-attachments/assets/f43208c1-4760-44a5-9855-f7884a3ef250) |

The new card component design and variations can be previewed on https://components-gem-pr-4118.herokuapp.com/component-guide/cards/preview