### PR TITLE
Release version 40.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,11 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 40.1.0
 
 * Allow disabling `search` component input spelling correction ([PR #4112](https://github.com/alphagov/govuk_publishing_components/pull/4112))
 * Disable `search` component input spelling correction in `layout_super_navigation_header` and
   `layout_header` components ([PR #4115](https://github.com/alphagov/govuk_publishing_components/pull/4115))
-
-## 40.0.1
 * Add Brakeman to CI jobs ([PR #4108](https://github.com/alphagov/govuk_publishing_components/pull/4108))
 
 ## 40.0.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (40.0.0)
+    govuk_publishing_components (40.1.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "40.0.0".freeze
+  VERSION = "40.1.0".freeze
 end


### PR DESCRIPTION
# 40.1.0

* Allow disabling `search` component input spelling correction ([PR #4112](https://github.com/alphagov/govuk_publishing_components/pull/4112))
* Disable `search` component input spelling correction in `layout_super_navigation_header` and `layout_header` components ([PR #4115](https://github.com/alphagov/govuk_publishing_components/pull/4115))
* Add Brakeman to CI jobs ([PR #4108](https://github.com/alphagov/govuk_publishing_components/pull/4108))