### PR TITLE
Drop support for Ruby 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,13 @@ jobs:
       contents: read
       security-events: write
       actions: read
-  
+
   # This matrix job runs the test suite against multiple Ruby versions
   test_matrix:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [3.1, 3.2, 3.3]
+        ruby: [3.2, 3.3]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Drop support for Ruby 3.1 ([PR #4124](https://github.com/alphagov/govuk_publishing_components/pull/4124))
+
 ## 41.0.0
 
 * **BREAKING:** Remove Universal Analytics ([PR #4068](https://github.com/alphagov/govuk_publishing_components/pull/4068))

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.description = "A gem to document components in GOV.UK frontend applications"
   s.homepage    = "https://github.com/alphagov/govuk_publishing_components"
   s.license     = "MIT"
-  s.required_ruby_version = ">= 3.1"
+  s.required_ruby_version = ">= 3.2"
   s.post_install_message = "govuk_publishing_components has now migrated to dartsass-rails from sassc-rails for stylesheet compilation since LibSass is deprecated. While both implementations are supported, it is recommended to update your application to use the latest implementation of Sass (dartsass-rails). You can find further details in the docs - https://docs.publishing.service.gov.uk/manual/migrate-to-dart-sass-from-libsass.html."
 
   s.files = Dir["{node_modules/govuk-frontend,node_modules/axe-core,node_modules/sortablejs,node_modules/govuk-single-consent,app,config,db,lib}/**/*", "LICENCE.md", "README.md"]


### PR DESCRIPTION
This will unblock: https://github.com/alphagov/govuk_publishing_components/pull/4123

Ruby 3.1 is a few months from end-of-life and in security fixes only territory. This update is somewhat forced upon us by the sass-embedded dependency which has dropped support for Ruby 3.1 in some circumstances [1] which causes the dartsass-rails gem to fail [2].

The consequences of this change should be pretty much negligible as there are not GOV.UK apps on Ruby 3.1 anymore and the .ruby-version for this repo was already (yet mistakenly) updated to Ruby 3.2.

[1]: https://github.com/sass-contrib/sass-embedded-host-ruby/blob/19323666b359bf3d58b562af09fdc75440453608/sass-embedded.gemspec#L39-L43
[2]: https://github.com/alphagov/govuk_publishing_components/pull/4123
