### PR TITLE
Resolve DartSass mixed declaration deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Resolve DartSass mixed declaration deprecations ([PR #4125](https://github.com/alphagov/govuk_publishing_components/pull/4125))
 * Drop support for Ruby 3.1 ([PR #4124](https://github.com/alphagov/govuk_publishing_components/pull/4124))
 
 ## 41.0.0

--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -13,8 +13,8 @@ $gem-guide-border-width: 1px;
   @extend %govuk-list--bullet;
 
   li {
-    @include govuk-font($size: 19);
     margin-bottom: $govuk-gutter-half;
+    @include govuk-font($size: 19);
   }
 
   p {
@@ -44,28 +44,28 @@ $gem-guide-border-width: 1px;
 }
 
 .component-violation {
-  @include govuk-text-colour;
   border: 3px solid $govuk-error-colour;
   margin: 0 0 $govuk-gutter;
   padding: $govuk-gutter $govuk-gutter;
+  @include govuk-text-colour;
 
   .component-violation__title {
-    @include govuk-font($size: 24, $weight: bold);
     margin: 0;
+    @include govuk-font($size: 24, $weight: bold);
   }
 
   .component-violation__link {
     display: block;
-    @include govuk-font($size: 19, $weight: bold);
     color: $govuk-error-colour;
     margin: $govuk-gutter-half 0;
+    @include govuk-font($size: 19, $weight: bold);
   }
 }
 
 .component-doc-h2 {
+  margin: ($govuk-gutter * 1.5) 0 $govuk-gutter;
   @include govuk-text-colour;
   @include govuk-font($size: 27, $weight: bold);
-  margin: ($govuk-gutter * 1.5) 0 $govuk-gutter;
 
   small {
     @include govuk-font($size: 16, $weight: bold);
@@ -73,8 +73,8 @@ $gem-guide-border-width: 1px;
 }
 
 .component-doc-h3 {
-  @include govuk-text-colour;
   margin: $govuk-gutter 0 $govuk-gutter-half;
+  @include govuk-text-colour;
   @include govuk-font($size: 19, $weight: bold);
 }
 
@@ -149,9 +149,9 @@ $gem-guide-border-width: 1px;
 
 .component-guide-preview--violation,
 .component-guide-preview--warning {
-  @include govuk-text-colour;
   margin-top: -$gem-guide-border-width;
 
+  @include govuk-text-colour;
   @include govuk-font($size: 19);
 
   &:empty {
@@ -185,13 +185,12 @@ $gem-guide-border-width: 1px;
   }
 
   &::before {
-    @include govuk-font($size: 16);
     content: attr(data-content);
     position: absolute;
     top: 0;
     left: 0;
     padding: .2105em .7894em;
-    font-weight: bold;
+    @include govuk-font($size: 16, $weight: bold);
   }
 }
 
@@ -217,9 +216,9 @@ $gem-guide-border-width: 1px;
     margin: 0 0 $govuk-gutter * 1.5;
 
     .example-title {
+      margin: $govuk-gutter-half 0;
       @include govuk-text-colour;
       @include govuk-font($size: 24, $weight: bold);
-      margin: $govuk-gutter-half 0;
     }
 
     .example-title small {
@@ -508,8 +507,8 @@ $code-delete-bg: #fadddd;
 
 .component__application-name {
   display: block;
-  @include govuk-font($size: 16);
   font-weight: normal;
+  @include govuk-font($size: 16);
 }
 
 .component__count {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
@@ -26,9 +26,9 @@
 }
 
 .gem-c-action-link__link-wrapper {
-  @include govuk-font(19, $weight: bold, $line-height: 1.3);
   display: table-cell;
   vertical-align: middle;
+  @include govuk-font(19, $weight: bold, $line-height: 1.3);
 }
 
 .gem-c-action-link__link {
@@ -73,10 +73,9 @@
 }
 
 .gem-c-action-link__subtext {
-  @include govuk-font(19);
   display: block;
-  font-weight: normal;
   color: inherit;
+  @include govuk-font(19);
 
   @include govuk-media-query($from: tablet) {
     position: relative;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
@@ -10,9 +10,9 @@ $thumbnail-shadow-width: 0 2px 2px;
 $thumbnail-icon-border-colour: govuk-colour("mid-grey");
 
 .gem-c-attachment {
+  position: relative;
   @include govuk-font(19);
   @include govuk-clearfix;
-  position: relative;
 
   .govuk-details {
     margin: govuk-spacing(3) 0;
@@ -51,8 +51,8 @@ $thumbnail-icon-border-colour: govuk-colour("mid-grey");
 }
 
 .gem-c-attachment__title {
-  @include govuk-font($size: 27);
   margin: 0 0 govuk-spacing(3);
+  @include govuk-font($size: 27);
 }
 
 .gem-c-attachment__link {
@@ -60,9 +60,9 @@ $thumbnail-icon-border-colour: govuk-colour("mid-grey");
 }
 
 .gem-c-attachment__metadata {
-  @include govuk-font($size: 19);
   margin: 0 0 govuk-spacing(3);
   color: $govuk-secondary-text-colour;
+  @include govuk-font($size: 19);
 
   &:last-of-type {
     margin-bottom: 0;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_big-number.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_big-number.scss
@@ -6,10 +6,10 @@
 }
 
 .gem-c-big-number__value {
-  @include govuk-font($size: false, $weight: bold);
   line-height: 1;
   font-size: 80px;
   font-size: govuk-px-to-rem(80px);
+  @include govuk-font($size: false, $weight: bold);
 }
 
 .gem-c-big-number__label {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_button.scss
@@ -31,11 +31,11 @@
 }
 
 .gem-c-button__info-text {
-  @include govuk-text-colour;
-  @include govuk-font($size: 16);
   display: block;
   max-width: 14em;
   margin-top: .5em;
+  @include govuk-text-colour;
+  @include govuk-font($size: 16);
 }
 
 .gem-c-button--secondary {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_contents-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_contents-list.scss
@@ -12,18 +12,18 @@
 }
 
 .gem-c-contents-list__title {
+  margin: 0;
   @include govuk-text-colour;
   @include govuk-font($size: 16, $weight: regular, $line-height: 1.5);
-  margin: 0;
 }
 
 .gem-c-contents-list__list,
 .gem-c-contents-list__nested-list {
-  @include govuk-text-colour;
-  @include govuk-font($size: 16);
   margin: 0;
   padding: 0;
   list-style-type: none;
+  @include govuk-text-colour;
+  @include govuk-font($size: 16);
 }
 
 .gem-c-contents-list__link {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_contextual-guidance.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_contextual-guidance.scss
@@ -15,10 +15,8 @@
 
 .gem-c-contextual-guidance__wrapper {
   position: relative;
-
-  @include govuk-font(19);
-
   margin-bottom: govuk-spacing(7);
+  @include govuk-font(19);
 
   @include govuk-media-query($from: tablet) {
     margin-bottom: govuk-spacing(7);

--- a/app/assets/stylesheets/govuk_publishing_components/components/_contextual-sidebar.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_contextual-sidebar.scss
@@ -17,8 +17,9 @@
 }
 
 .gem-c-contextual-sidebar__text {
-  @include govuk-font(16);
   margin-bottom: govuk-spacing(1);
+  @include govuk-font(16);
+
   @include govuk-media-query($from: tablet) {
     margin-bottom: govuk-spacing(2);
   }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cross-service-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cross-service-header.scss
@@ -47,17 +47,6 @@ $govuk-header-link-underline-thickness: 3px;
 
 .gem-c-cross-service-header__button {
   display: none;
-
-  .toggle-enabled & {
-    display: inline;
-    display: flex;
-
-    @include govuk-media-query($from: tablet) {
-      display: none;
-    }
-  }
-
-  @include govuk-font($size: 19, $weight: bold);
   position: relative;
   align-items: center;
   cursor: pointer;
@@ -67,6 +56,17 @@ $govuk-header-link-underline-thickness: 3px;
   margin: 0;
   padding: govuk-spacing(2) 0 govuk-spacing(1) govuk-spacing(4);
   background: none;
+
+  @include govuk-font($size: 19, $weight: bold);
+
+  .toggle-enabled & {
+    display: inline;
+    display: flex;
+
+    @include govuk-media-query($from: tablet) {
+      display: none;
+    }
+  }
 
   &::before {
     content: "";
@@ -141,11 +141,11 @@ $govuk-header-link-underline-thickness: 3px;
 
 // start One Login header styles
 .gem-c-one-login-header {
-  @include govuk-font($size: 19);
   color: govuk-colour("white");
   background: govuk-colour("black");
   border-bottom: govuk-spacing(2) solid $govuk-link-colour;
   position: relative;
+  @include govuk-font($size: 19);
 }
 
 .gem-c-one-login-header__container {
@@ -171,9 +171,9 @@ $govuk-header-link-underline-thickness: 3px;
 .gem-c-one-login-header__nav__link {
   &:link,
   &:visited {
+    text-decoration: none;
     @include govuk-typography-common;
     @include govuk-link-style-inverse;
-    text-decoration: none;
 
     &:hover {
       text-decoration: underline;
@@ -235,14 +235,14 @@ $govuk-header-link-underline-thickness: 3px;
 }
 
 .gem-c-one-login-header__link--homepage {
-  // Font size needs to be set on the link so that the box sizing is correct
-  // in Firefox
-  @include govuk-font($size: false, $weight: bold);
-
   display: inline-block;
   margin-right: govuk-spacing(2);
   font-size: 30px; // We don't have a mixin that produces 30px font size
   line-height: 1;
+
+  // Font size needs to be set on the link so that the box sizing is correct
+  // in Firefox
+  @include govuk-font($size: false, $weight: bold);
 
   @include govuk-media-query($from: tablet) {
     display: inline;
@@ -366,11 +366,11 @@ $govuk-header-link-underline-thickness: 3px;
 }
 
 .gem-c-service-header__heading {
-  @include govuk-font($size: 24, $weight: bold);
   color: $govuk-text-colour;
   padding: govuk-spacing(3) 0;
   margin: 0;
   flex-grow: 1;
+  @include govuk-font($size: 24, $weight: bold);
 
   @include govuk-media-query($until: tablet) {
     padding: govuk-spacing(1) 0;
@@ -382,10 +382,10 @@ $govuk-header-link-underline-thickness: 3px;
 }
 
 .gem-c-service-header__nav-list {
-  @include govuk-font($size: 19, $weight: bold);
   list-style: none;
   margin: 0;
   padding: 0;
+  @include govuk-font($size: 19, $weight: bold);
 
   @include govuk-media-query($from: tablet) {
     @include govuk-font($size: 19, $weight: bold);

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -1,10 +1,10 @@
 @import "govuk_publishing_components/individual_component_support";
 
 .gem-c-document-list {
-  @include govuk-text-colour;
-  @include govuk-font(19);
   margin: 0;
   padding: 0;
+  @include govuk-text-colour;
+  @include govuk-font(19);
 }
 
 .gem-c-document-list__item {
@@ -19,8 +19,8 @@
 }
 
 .gem-c-document-list__item-title {
-  @include govuk-font($size: 19, $weight: bold);
   display: inline-block;
+  @include govuk-font($size: 19, $weight: bold);
 }
 
 .gem-c-document-list--no-underline {
@@ -57,8 +57,8 @@
 }
 
 .gem-c-document-list__item-description {
-  @include govuk-text-colour;
   margin: govuk-spacing(1) 0;
+  @include govuk-text-colour;
 }
 
 .gem-c-document-list__subtext {
@@ -79,12 +79,16 @@
 }
 
 .gem-c-document-list__attribute {
-  @include govuk-text-colour;
-  @include govuk-font(16);
-  color: $govuk-secondary-text-colour;
   display: inline-block;
   list-style: none;
   padding-right: govuk-spacing(4);
+  @include govuk-text-colour;
+  @include govuk-font(16);
+
+  & { // stylelint-disable-line no-duplicate-selectors
+    // overriding govuk-text-colour mixin
+    color: $govuk-secondary-text-colour;
+  }
 
   .direction-rtl & {
     padding-right: 0;
@@ -103,8 +107,8 @@
 }
 
 .gem-c-document-list__highlight-text {
-  @include govuk-font(16, bold);
   margin: 0 0 govuk-spacing(3) 0;
+  @include govuk-font(16, bold);
 }
 
 .gem-c-document-list__children {
@@ -125,10 +129,10 @@
 }
 
 .gem-c-document-list-child {
-  @include govuk-font($size: 16);
   position: relative;
   padding-left: govuk-spacing(5);
   padding-top: govuk-spacing(2);
+  @include govuk-font($size: 16);
 
   &::before {
     content: "";
@@ -171,9 +175,9 @@
 }
 
 .gem-c-document-list-child__description {
-  @include govuk-text-colour;
   margin-top: govuk-spacing(1);
   margin-bottom: govuk-spacing(1);
+  @include govuk-text-colour;
 
   @include govuk-media-query($until: tablet) {
     display: none;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_emergency-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_emergency-banner.scss
@@ -1,11 +1,11 @@
 @import "govuk_publishing_components/individual_component_support";
 
 .gem-c-emergency-banner {
-  @include govuk-font(19);
   background-color: govuk-colour("mid-grey");
   color: govuk-colour("white");
   margin-top: 2px;
   padding: govuk-spacing(3) 0;
+  @include govuk-font(19);
 
   @include govuk-media-query($from: tablet) {
     padding: govuk-spacing(6) 0;
@@ -22,8 +22,8 @@
 }
 
 .gem-c-emergency-banner__heading {
-  @include govuk-font(24, $weight: bold);
   margin: 0;
+  @include govuk-font(24, $weight: bold);
 }
 
 .gem-c-emergency-banner__heading--homepage {
@@ -35,10 +35,10 @@
 }
 
 .gem-c-emergency-banner__description {
-  @include govuk-font(19);
   color: govuk-colour("white");
   margin-top: 0;
   margin-bottom: govuk-spacing(4);
+  @include govuk-font(19);
 
   &:last-child {
     margin-bottom: 0;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_error-alert.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_error-alert.scss
@@ -13,8 +13,8 @@
 }
 
 .gem-c-error-alert__message {
-  @include govuk-font(19, $weight: bold);
   margin: 0;
+  @include govuk-font(19, $weight: bold);
 }
 
 .gem-c-error-summary__title {
@@ -29,8 +29,8 @@
 }
 
 .gem-c-error-summary__body {
-  @include govuk-font(19);
   margin: 0;
+  @include govuk-font(19);
 }
 
 .gem-c-error-alert:focus {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_error-summary.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_error-summary.scss
@@ -2,6 +2,6 @@
 @import "govuk/components/error-summary/error-summary";
 
 .gem-c-error-summary__list-item {
-  @include govuk-font($size: 19, $weight: bold);
   color: $govuk-error-colour;
+  @include govuk-font($size: 19, $weight: bold);
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -93,13 +93,13 @@
 }
 
 .gem-c-feedback__prompt-link {
-  @include govuk-font(19);
   background: transparent;
   color: govuk-colour("black");
   box-shadow: 0 3px 0 govuk-colour("black");
   border: 1px govuk-colour("black") solid;
   margin-bottom: 0;
   width: 100%;
+  @include govuk-font(19);
 
   @include govuk-media-query($from: tablet) {
     @include govuk-font(16);
@@ -173,15 +173,15 @@
 
   // this comes from the backend so we can't put a class on it
   h2 {
+    margin: 0 0 govuk-spacing(3) 0;
     @include govuk-text-colour;
     @include govuk-font($size: 24, $weight: bold);
-    margin: 0 0 govuk-spacing(3) 0;
   }
 
   p {
+    margin: 0 0 govuk-spacing(3) 0;
     @include govuk-text-colour;
     @include govuk-font($size: 19);
-    margin: 0 0 govuk-spacing(3) 0;
   }
 
   a {
@@ -192,10 +192,10 @@
 }
 
 .gem-c-feedback__error-message {
-  @include govuk-font(19, $weight: bold);
   display: block;
   padding: 4px 0 0;
   color: $govuk-error-colour;
+  @include govuk-font(19, $weight: bold);
 }
 
 .gem-c-feedback__form {
@@ -208,21 +208,21 @@
 }
 
 .gem-c-feedback__form-heading {
+  margin: 0 0 govuk-spacing(3) 0;
   @include govuk-text-colour;
   @include govuk-font(24, $weight: bold);
-  margin: 0 0 govuk-spacing(3) 0;
 }
 
 .gem-c-feedback__form-paragraph {
+  margin: 0 0 govuk-spacing(6) 0;
   @include govuk-text-colour;
   @include govuk-font(19);
-  margin: 0 0 govuk-spacing(6) 0;
 }
 
 .gem-c-feedback__form-label {
-  @include govuk-font(16);
   display: block;
   padding-bottom: govuk-spacing(3);
+  @include govuk-font(16);
 }
 
 .gem-c-feedback__close {
@@ -249,10 +249,10 @@
 // static.css on GOV.UK overwrites the component styles using input[type="text"]
 // so we need to apply  govuk-input styles using a stronger selector
 .gem-c-feedback .gem-c-input[type="text"] {
-  @include govuk-font($size: 19);
   margin: 0;
   padding: govuk-spacing(1);
   border: $govuk-border-width-form-element solid $govuk-input-border-colour;
+  @include govuk-font($size: 19);
 
   &:focus {
     outline: $govuk-focus-width solid $govuk-focus-colour;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -1,14 +1,14 @@
 @import "govuk_publishing_components/individual_component_support";
 
 .gem-c-image-card {
-  @include govuk-clearfix;
-  @include govuk-text-colour;
   position: relative;
   margin-bottom: govuk-spacing(6);
   display: flex;
   display: -ms-flexbox;
   flex-direction: column-reverse;
   -ms-flex-direction: column-reverse;
+  @include govuk-text-colour;
+  @include govuk-clearfix;
 
   @include govuk-media-query($from: mobile, $until: tablet) {
     display: block;
@@ -183,11 +183,11 @@
 
 .gem-c-image-card__context,
 .gem-c-image-card__metadata {
-  @include govuk-font($size: false);
   font-size: 16px;
   font-size: govuk-px-to-rem(16px);
   margin: 0 0 calc(govuk-spacing(3) / 2);
   color: govuk-colour("dark-grey");
+  @include govuk-font($size: false);
 
   @include govuk-media-query($from: tablet) {
     margin-bottom: 0;
@@ -195,18 +195,18 @@
 }
 
 .gem-c-image-card__description {
-  @include govuk-font($size: 19);
   padding-top: calc(govuk-spacing(3) / 2);
   word-wrap: break-word;
+  @include govuk-font($size: 19);
 }
 
 .gem-c-image-card__list {
-  @include govuk-font($size: 19);
   position: relative;
   z-index: 2;
   padding: calc(govuk-spacing(3) / 2) 0 0 0;
   margin: 0;
   list-style: none;
+  @include govuk-font($size: 19);
 
   .gem-c-image-card__list-item {
     margin-bottom: govuk-spacing(2);
@@ -245,13 +245,16 @@
 
 .gem-c-image-card--large {
   .gem-c-image-card__image-wrapper {
-    @include govuk-grid-column($width: one-half, $at: tablet);
-
     margin-bottom: govuk-spacing(2);
     float: none;
     width: auto;
     max-width: 100%;
-    padding: 0;
+    @include govuk-grid-column($width: one-half, $at: tablet);
+
+    & { // stylelint-disable-line no-duplicate-selectors
+      // overriding the padding from govuk-grid-column mixin
+      padding: 0;
+    }
 
     @include govuk-media-query($from: tablet) {
       padding: 0 govuk-spacing(2) 0 0;
@@ -260,10 +263,13 @@
   }
 
   .gem-c-image-card__text-wrapper {
+    overflow: hidden;
     @include govuk-grid-column($width: one-half, $at: tablet);
 
-    padding: 0;
-    overflow: hidden;
+    & { // stylelint-disable-line no-duplicate-selectors
+      // overriding the padding from govuk-grid-column mixin
+      padding: 0;
+    }
 
     @include govuk-media-query($from: tablet) {
       float: right;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_intervention.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_intervention.scss
@@ -1,11 +1,11 @@
 @import "govuk_publishing_components/individual_component_support";
 
 .gem-c-intervention {
+  background-color: govuk-colour("light-grey");
+  border-left: 10px solid $govuk-success-colour;
   @include govuk-text-colour;
   @include govuk-responsive-padding(3);
   @include govuk-responsive-margin(6, "bottom");
-  background-color: govuk-colour("light-grey");
-  border-left: 10px solid $govuk-success-colour;
 
   .govuk-body:last-of-type {
     margin-bottom: 0;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_inverse-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_inverse-header.scss
@@ -11,11 +11,11 @@
 
 .gem-c-inverse-header .gem-c-inverse-header__supplement,
 .gem-c-inverse-header .publication-header__last-changed {
+  color: govuk-colour("white");
+  margin: 0;
   // This publication-header class is injected on publication pages, really
   // it should be a component class or be a component in it's own right.
   @include govuk-font($size: 16, $line-height: 1.5);
-  color: govuk-colour("white");
-  margin: 0;
 }
 
 .gem-c-inverse-header--full-width {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -107,13 +107,13 @@ $after-button-padding-left: govuk-spacing(4);
 }
 
 .gem-c-layout-super-navigation-header__button-container {
-  @include govuk-media-query($until: "tablet") {
-    margin-right: govuk-spacing(-3);
-  }
-
   top: -$black-bar-height;
   position: absolute;
   right: 0;
+
+  @include govuk-media-query($until: "tablet") {
+    margin-right: govuk-spacing(-3);
+  }
 
   @include govuk-media-query($until: 300px) {
     position: static;
@@ -147,15 +147,14 @@ $after-button-padding-left: govuk-spacing(4);
 // Top level navigation links and search link.
 .gem-c-layout-super-navigation-header__navigation-item-link,
 .gem-c-layout-super-navigation-header__search-item-link {
-  @include govuk-link-common;
-  @include govuk-link-style-no-visited-state;
-
   display: inline-block;
   font-size: 19px;
   font-size: govuk-px-to-rem(19px);
   font-weight: bold;
   padding: govuk-spacing(3) 0;
   position: relative;
+  @include govuk-link-common;
+  @include govuk-link-style-no-visited-state;
 
   @include govuk-media-query($from: "desktop") {
     display: block;
@@ -169,6 +168,12 @@ $after-button-padding-left: govuk-spacing(4);
   &,
   &:link,
   &:visited {
+    // stylelint-disable max-nesting-depth
+    float: left;
+    font-size: 16px;
+    font-size: govuk-px-to-rem(16px);
+    height: govuk-spacing(4);
+
     @include focus-and-focus-visible {
       @include govuk-focused-text;
     }
@@ -195,12 +200,6 @@ $after-button-padding-left: govuk-spacing(4);
       @include make-selectable-area-bigger;
       @include pseudo-underline($left: $after-link-padding, $right: $after-link-padding);
     }
-
-    // stylelint-disable max-nesting-depth
-    float: left;
-    font-size: 16px;
-    font-size: govuk-px-to-rem(16px);
-    height: govuk-spacing(4);
 
     &::before {
       @include chevron(govuk-colour("white"), true);
@@ -393,6 +392,19 @@ $after-button-padding-left: govuk-spacing(4);
 
 // Styles for top level navigation toggle button.
 .gem-c-layout-super-navigation-header__navigation-top-toggle-button {
+  font-size: 16px;
+  font-size: govuk-px-to-rem(16px);
+  font-weight: 700;
+  background: govuk-colour("black");
+  border: 0;
+  box-sizing: border-box;
+  color: govuk-colour("white");
+  cursor: pointer;
+  height: $black-bar-height;
+  padding: 0;
+  position: relative;
+  margin: 0;
+  vertical-align: top;
   @include govuk-link-common;
   @include govuk-link-style-no-visited-state;
   @include govuk-link-style-no-underline;
@@ -414,20 +426,6 @@ $after-button-padding-left: govuk-spacing(4);
       }
     }
   }
-
-  font-size: 16px;
-  font-size: govuk-px-to-rem(16px);
-  font-weight: 700;
-  background: govuk-colour("black");
-  border: 0;
-  box-sizing: border-box;
-  color: govuk-colour("white");
-  cursor: pointer;
-  height: $black-bar-height;
-  padding: 0;
-  position: relative;
-  margin: 0;
-  vertical-align: top;
 
   @include govuk-media-query($from: "desktop") {
     background: govuk-colour("black");
@@ -490,11 +488,11 @@ $after-button-padding-left: govuk-spacing(4);
     // stylelint-disable max-nesting-depth
     &:hover {
       .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
+        color: govuk-colour("mid-grey");
+
         &::before {
           @include chevron(govuk-colour("mid-grey"), true);
         }
-
-        color: govuk-colour("mid-grey");
       }
 
       &::after {
@@ -607,7 +605,6 @@ $after-button-padding-left: govuk-spacing(4);
 
 // Styles for search toggle button.
 .gem-c-layout-super-navigation-header__search-toggle-button {
-  @include govuk-font($size: 19, $weight: "bold", $line-height: 20px);
   background: none;
   border: 0;
   color: govuk-colour("white");
@@ -616,6 +613,7 @@ $after-button-padding-left: govuk-spacing(4);
   padding: govuk-spacing(3);
   position: relative;
   width: $search-width-or-height;
+  @include govuk-font($size: 19, $weight: "bold", $line-height: 20px);
 
   @include focus-and-focus-visible {
     @include govuk-focused-text;
@@ -753,13 +751,13 @@ $after-button-padding-left: govuk-spacing(4);
 
 // Dropdown menu.
 .gem-c-layout-super-navigation-header__navigation-dropdown-menu {
-  @include govuk-media-query($until: 300px) {
-    padding-top: 80px;
-  }
-
   background: govuk-colour("light-grey");
   border-bottom: 1px govuk-colour("mid-grey") solid;
   padding-top: govuk-spacing(6);
+
+  @include govuk-media-query($until: 300px) {
+    padding-top: 80px;
+  }
 
   @include govuk-media-query($from: "desktop") {
     padding-top: govuk-spacing(8);
@@ -877,11 +875,11 @@ $after-button-padding-left: govuk-spacing(4);
 }
 
 .gem-c-layout-super-navigation-header__navigation-second-item-description {
-  @include govuk-typography-common;
   font-size: 16px;
   font-size: govuk-px-to-rem(16px);
   font-weight: normal;
   margin: govuk-spacing(1) 0 0 0;
+  @include govuk-typography-common;
 }
 
 .gem-c-layout-super-navigation-header__search-form {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_lead-paragraph.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_lead-paragraph.scss
@@ -1,12 +1,12 @@
 @import "govuk_publishing_components/individual_component_support";
 
 .gem-c-lead-paragraph {
-  @include govuk-text-colour;
-  @include govuk-font(24);
   margin-top: 0;
-  @include responsive-bottom-margin;
   // Ensure the text has a line-length of around 60 characters
   max-width: 30em;
+  @include govuk-text-colour;
+  @include responsive-bottom-margin;
+  @include govuk-font(24);
 }
 
 .gem-c-lead-paragraph--inverse {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_metadata.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_metadata.scss
@@ -7,9 +7,9 @@
   @include govuk-clearfix;
 
   a {
+    font-weight: bold;
     @include govuk-link-common;
     @include govuk-link-style-default;
-    font-weight: bold;
   }
 
   .gem-c-metadata__definition-link {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_notice.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_notice.scss
@@ -2,8 +2,8 @@
 @import "govuk/components/notification-banner/notification-banner";
 
 .gem-c-notice {
-  @include govuk-responsive-margin(8, "bottom");
   clear: both;
+  @include govuk-responsive-margin(8, "bottom");
 
   .govuk-govspeak {
     p:last-child {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_option-select.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_option-select.scss
@@ -28,8 +28,8 @@
 }
 
 .gem-c-option-select__title {
-  @include govuk-font(19);
   margin: 0;
+  @include govuk-font(19);
 }
 
 .gem-c-option-select__button {
@@ -111,8 +111,8 @@
 }
 
 .gem-c-option-select__filter-input {
-  @include govuk-font(19);
   background: url("option-select/input-icon.svg") govuk-colour("white") no-repeat -5px -3px;
+  @include govuk-font(19);
 
   @include govuk-media-query($from: tablet) {
     @include govuk-font(16);
@@ -152,9 +152,9 @@
 }
 
 .gem-c-option-select__selected-counter {
-  @include govuk-font($size: 16);
   color: $govuk-text-colour;
   margin-top: 3px;
+  @include govuk-font($size: 16);
 }
 
 .gem-c-option-select.js-closed {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_organisation-logo.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_organisation-logo.scss
@@ -2,12 +2,12 @@
 
 // Default logo corresponds with the "medium stacked" Whitehall equivalent
 .gem-c-organisation-logo {
-  @include govuk-font($size: 19);
   font-weight: 400;
-  line-height: 1.35;
   // When this is a heading the margin needs to be set to stop it from
   // inheriting the browser's default margin:
   margin: 0;
+  @include govuk-typography-common;
+  @include govuk-font-size($size: 19, $line-height: 1.35);
 }
 
 .gem-c-organisation-logo__container {
@@ -52,7 +52,11 @@
 .gem-c-organisation-logo__link {
   @include govuk-link-common;
   @include govuk-link-style-text;
-  font-family: HelveticaNeue, "Helvetica Neue", Arial, Helvetica, sans-serif;
+
+  & { // stylelint-disable-line no-duplicate-selectors
+    // overriding the govuk-link font
+    font-family: HelveticaNeue, "Helvetica Neue", Arial, Helvetica, sans-serif;
+  }
 
   &:hover {
     color: $govuk-link-hover-colour;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_organisation-logo.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_organisation-logo.scss
@@ -7,7 +7,13 @@
   // inheriting the browser's default margin:
   margin: 0;
   @include govuk-typography-common;
-  @include govuk-font-size($size: 19, $line-height: 1.35);
+  @include govuk-font-size(19);
+
+  @include govuk-media-query($until: tablet) {
+    // only override line-height on small screens otherwise use govuk-font-size
+    // line-height
+    line-height: 1.35;
+  }
 }
 
 .gem-c-organisation-logo__container {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_panel.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_panel.scss
@@ -2,8 +2,8 @@
 @import "govuk/components/panel/panel";
 
 .gem-c-panel__prepend {
-  @include govuk-font($size: 24, $weight: bold);
   margin-bottom: govuk-spacing(3);
+  @include govuk-font($size: 24, $weight: bold);
 }
 
 .gem-c-panel__append {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_related-navigation.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_related-navigation.scss
@@ -1,30 +1,30 @@
 @import "govuk_publishing_components/individual_component_support";
 
 .gem-c-related-navigation {
-  @include govuk-text-colour;
   border-top: 2px solid govuk-colour("blue");
   margin-bottom: govuk-spacing(9);
+  @include govuk-text-colour;
 }
 
 .gem-c-related-navigation__main-heading {
-  @include govuk-font(19, $weight: bold);
   margin-top: govuk-spacing(3);
   margin-bottom: govuk-spacing(2);
+  @include govuk-font(19, $weight: bold);
 }
 
 .gem-c-related-navigation__sub-heading {
-  @include govuk-font(16);
   border-top: 1px solid govuk-colour("mid-grey");
   margin: 0;
   padding-top: govuk-spacing(3);
+  @include govuk-font(16);
 }
 
 .gem-c-related-navigation__sub-heading--footer {
-  @include govuk-font(19, $weight: bold);
   border-top: 0;
   padding-top: 0;
   margin-top: govuk-spacing(3);
   margin-bottom: govuk-spacing(2);
+  @include govuk-font(19, $weight: bold);
 }
 
 .gem-c-related-navigation__main-heading + .gem-c-related-navigation__sub-heading {
@@ -33,9 +33,9 @@
 }
 
 .gem-c-related-navigation__sub-heading--other {
-  @include govuk-font(19, $weight: bold);
   border-top: 0;
   padding-top: 0;
+  @include govuk-font(19, $weight: bold);
 }
 
 .gem-c-related-navigation__nav-section {
@@ -59,9 +59,9 @@
 }
 
 .gem-c-related-navigation__toggle {
+  display: none;
   @include govuk-link-common;
   @include govuk-link-style-no-visited-state;
-  display: none;
 
   .js-enabled & {
     display: inline-block;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_reorderable-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_reorderable-list.scss
@@ -1,13 +1,12 @@
 @import "govuk_publishing_components/individual_component_support";
 
 .gem-c-reorderable-list {
-  @include govuk-font(19, bold);
-
   list-style-type: none;
   margin-bottom: govuk-spacing(6);
   margin-top: 0;
   padding-left: 0;
   position: relative;
+  @include govuk-font(19, bold);
 
   .govuk-form-group {
     margin-bottom: 0;
@@ -57,8 +56,8 @@
 }
 
 .gem-c-reorderable-list__description {
-  @include govuk-font(16, regular);
   margin: 0;
+  @include govuk-font(16, regular);
 }
 
 .gem-c-reorderable-list__actions {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -28,13 +28,13 @@ $large-input-size: 50px;
 }
 
 .gem-c-search__label {
-  @include govuk-font($size: 19, $line-height: $input-size);
   display: block;
   color: $govuk-text-colour;
+  @include govuk-font($size: 19, $line-height: $input-size);
 
   h1 {
-    @include govuk-font($size: 19, $line-height: $input-size);
     margin: 0;
+    @include govuk-font($size: 19, $line-height: $input-size);
   }
 
   .js-enabled & {
@@ -65,7 +65,6 @@ $large-input-size: 50px;
 }
 
 .gem-c-search__input[type="search"] { // overly specific to prevent some overrides from outside
-  @include govuk-font($size: 19, $line-height: (28 / 19));
   margin: 0;
   width: 100%;
   height: govuk-em(40, 16);
@@ -77,6 +76,8 @@ $large-input-size: 50px;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+  @include govuk-font($size: 19, $line-height: (28 / 19));
+
   @include govuk-media-query($from: tablet) {
     height: govuk-em(40, 19);
     padding: govuk-em(6, 19);

--- a/app/assets/stylesheets/govuk_publishing_components/components/_share-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_share-links.scss
@@ -22,9 +22,8 @@ $share-button-height: 30px;
 }
 
 .gem-c-share-links__link {
-  @include govuk-font(16, $weight: bold);
   margin-right: govuk-spacing(6);
-
+  @include govuk-font(16, $weight: bold);
   @include govuk-template-link-focus-override;
 }
 
@@ -64,9 +63,9 @@ $column-width: 9.5em;
 
 .gem-c-share-links--columns {
   .gem-c-share-links__list {
-    @include govuk-clearfix;
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax($column-width, 1fr));
+    @include govuk-clearfix;
   }
 
   .gem-c-share-links__list-item {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-header.scss
@@ -1,14 +1,13 @@
 @import "govuk_publishing_components/individual_component_support";
 
 .gem-c-step-nav-header {
-  @include govuk-font(24, $weight: bold);
-  @include govuk-text-colour;
-
   position: relative;
   padding: 10px;
   background: govuk-colour("light-grey");
   border-bottom: solid 1px govuk-colour("blue");
   margin-top: govuk-spacing(3);
+  @include govuk-font(24, $weight: bold);
+  @include govuk-text-colour;
 
   @include govuk-media-query($from: tablet) {
     padding: govuk-spacing(5);
@@ -16,8 +15,8 @@
 }
 
 .gem-c-step-nav-header__part-of {
-  @include govuk-font(19, $weight: bold);
   display: block;
+  @include govuk-font(19, $weight: bold);
 }
 
 @include govuk-media-query($media-type: print) {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-related.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-related.scss
@@ -1,9 +1,9 @@
 @import "govuk_publishing_components/individual_component_support";
 
 .gem-c-step-nav-related {
-  @include govuk-text-colour;
   border-top: 2px solid govuk-colour("blue");
   margin-bottom: govuk-spacing(6);
+  @include govuk-text-colour;
 }
 
 .gem-c-step-nav-related__heading {
@@ -13,18 +13,18 @@
 }
 
 .gem-c-step-nav-related__links {
-  @include govuk-font(16);
   list-style: none;
   margin: 0;
   padding: 0;
+  @include govuk-font(16);
 }
 
 .gem-c-step-nav-related--singular {
   margin-bottom: govuk-spacing(2) + 3;
 
   .gem-c-step-nav-related__heading {
-    @include govuk-font(19, $weight: bold, $line-height: 1.4);
     margin-top: govuk-spacing(4);
+    @include govuk-font(19, $weight: bold, $line-height: 1.4);
   }
 
   .gem-c-step-nav-related__pretitle {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
@@ -29,10 +29,10 @@ $top-border: solid 1px govuk-colour("mid-grey");
 // we want to ensure that both large and small step navs have the same size font on mobile
 // this will stop text resizing if compatibility mode is turned off
 @mixin step-nav-font($size, $tablet-size: $size, $weight: normal, $line-height: 1.3, $tablet-line-height: $line-height) {
-  @include govuk-typography-common;
   font-size: $size + px;
   font-weight: $weight;
   line-height: $line-height;
+  @include govuk-typography-common;
 
   @include govuk-media-query($from: tablet) {
     font-size: $tablet-size + px;
@@ -167,12 +167,12 @@ $top-border: solid 1px govuk-colour("mid-grey");
 }
 
 .gem-c-step-nav__button--title {
-  @include step-nav-font(19, $weight: bold, $line-height: 1.2);
   display: inline-block;
   padding: govuk-spacing(1) 0 0;
   text-align: left;
   color: govuk-colour("black");
   width: 100%;
+  @include step-nav-font(19, $weight: bold, $line-height: 1.2);
 
   .gem-c-step-nav--large & {
     @include step-nav-font(19, $tablet-size: 24, $weight: bold);
@@ -184,11 +184,11 @@ $top-border: solid 1px govuk-colour("mid-grey");
 }
 
 .gem-c-step-nav__button--controls {
-  @include step-nav-font(15);
   position: relative;
   z-index: 1; // this and relative position stops focus outline underlap with border of accordion
   margin: .5em 0 14px;
   padding: govuk-spacing(1) 0 govuk-spacing(1);
+  @include step-nav-font(15);
 
   .gem-c-step-nav--large & {
     @include step-nav-font(15, $tablet-size: 19);
@@ -321,8 +321,8 @@ $top-border: solid 1px govuk-colour("mid-grey");
 }
 
 .gem-c-step-nav__circle--number {
-  @include step-nav-font(16, $weight: bold, $line-height: 29px);
   border: solid $stroke-width govuk-colour("mid-grey");
+  @include step-nav-font(16, $weight: bold, $line-height: 29px);
 
   .gem-c-step-nav--large & {
     @include step-nav-font(16, $tablet-size: 19, $weight: bold, $line-height: 29px, $tablet-line-height: 34px);
@@ -339,10 +339,10 @@ $top-border: solid 1px govuk-colour("mid-grey");
 }
 
 .gem-c-step-nav__circle--logic {
-  @include step-nav-font(19, $weight: bold, $line-height: 28px);
   left: 3px;
   width: govuk-em($number-circle-size, 19);
   height: govuk-em($number-circle-size, 19);
+  @include step-nav-font(19, $weight: bold, $line-height: 28px);
 
   .gem-c-step-nav--large & {
     @include step-nav-font(19, $tablet-size: 24, $weight: bold, $line-height: 28px, $tablet-line-height: 34px);
@@ -395,9 +395,9 @@ $top-border: solid 1px govuk-colour("mid-grey");
 }
 
 .gem-c-step-nav__title {
-  @include govuk-text-colour;
-  @include step-nav-font(19, $weight: bold, $line-height: 1.4);
   margin: 0;
+  @include step-nav-font(19, $weight: bold, $line-height: 1.4);
+  @include govuk-text-colour;
 
   .gem-c-step-nav--large & {
     @include step-nav-font(19, $tablet-size: 24, $weight: bold, $line-height: 1.4);
@@ -405,11 +405,11 @@ $top-border: solid 1px govuk-colour("mid-grey");
 }
 
 .gem-c-step-nav__toggle-link {
-  @include step-nav-font(15, $line-height: 1.2);
   display: block;
   color: $govuk-link-colour;
   text-transform: capitalize;
   padding-bottom: govuk-spacing(6);
+  @include step-nav-font(15, $line-height: 1.2);
 
   .gem-c-step-nav--large & {
     @include step-nav-font(15, $tablet-size: 19, $line-height: 1.2);
@@ -417,9 +417,9 @@ $top-border: solid 1px govuk-colour("mid-grey");
 }
 
 .gem-c-step-nav__panel {
-  @include govuk-text-colour;
-  @include step-nav-font(16);
   padding-bottom: govuk-spacing(5);
+  @include step-nav-font(16);
+  @include govuk-text-colour;
 
   .gem-c-step-nav--large & {
     @include step-nav-font(16, $tablet-size: 19);

--- a/app/assets/stylesheets/govuk_publishing_components/components/_subscription-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_subscription-links.scss
@@ -58,10 +58,10 @@
 .gem-c-subscription-links__item--button {
   cursor: pointer;
   display: none;
-  @include govuk-font(19, $weight: bold);
   padding: govuk-spacing(2);
   border: 1px solid $gem-quiet-button-colour;
   background-color: $gem-secondary-button-background-colour;
+  @include govuk-font(19, $weight: bold);
 
   .js-enabled & {
     display: inline-block;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_table.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_table.scss
@@ -33,11 +33,11 @@ $table-row-even-background-colour: govuk-colour("light-grey");
     }
 
     .app-table__sort-link {
-      @include govuk-link-style-no-visited-state;
       position: relative;
       padding-right: $sort-link-arrow-size;
       color: $govuk-link-colour;
       text-decoration: none;
+      @include govuk-link-style-no-visited-state;
     }
 
     .app-table__sort-link:focus {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_translation-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_translation-nav.scss
@@ -1,18 +1,18 @@
 @import "govuk_publishing_components/individual_component_support";
 
 .gem-c-translation-nav {
+  margin-bottom: govuk-spacing(6);
+  border-bottom: 1px solid $govuk-border-colour;
   @include responsive-top-margin;
   @include govuk-text-colour;
   @include govuk-font(16);
-  margin-bottom: govuk-spacing(6);
-  border-bottom: 1px solid $govuk-border-colour;
 }
 
 .gem-c-translation-nav__list {
-  @include govuk-clearfix;
   list-style: none;
   margin: 0 (- govuk-spacing(2));
   padding: 0;
+  @include govuk-clearfix;
 }
 
 .gem-c-translation-nav__list-item {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_warning-text.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_warning-text.scss
@@ -2,11 +2,11 @@
 @import "govuk/components/warning-text/warning-text";
 
 .gem-c-warning-text .govuk-warning-text__text {
+  margin: 0;
   // Ensure the font-size is always set to 19px
   // This prevents the default user agent styles being applied to heading elements used in the warning-text component following a change in v5.0.0, see:
   // https://github.com/alphagov/govuk-frontend/pull/4267
   @include govuk-font($size: 19, $weight: bold);
-  margin: 0;
 }
 
 .gem-c-warning-text__text--no-indent {

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
@@ -56,8 +56,8 @@
 
     .attachment-details {
       h2 {
-        @include govuk-font($size: 27);
         margin: 0;
+        @include govuk-font($size: 27);
       }
 
       p {
@@ -97,12 +97,13 @@
       }
 
       .accessibility-warning {
-        h2 {
-          @include govuk-font($size: 16);
-          margin: 0;
-        }
         word-break: break-word;
         word-wrap: break-word;
+
+        h2 {
+          margin: 0;
+          @include govuk-font($size: 16);
+        }
       }
 
       .js-hidden {

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_contact.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_contact.scss
@@ -19,8 +19,8 @@
   }
 
   .contact {
-    @include govuk-clearfix;
     position: relative;
+    @include govuk-clearfix;
 
     .content {
       float: none;

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_highlight-answer.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_highlight-answer.scss
@@ -13,14 +13,14 @@ $highlight-answer-color: govuk-colour("white");
     margin: 0 -1em 1em;
 
     p {
-      @include govuk-font($size: 24, $weight: bold);
       color: $highlight-answer-color;
+      @include govuk-font($size: 24, $weight: bold);
 
       em {
-        @include govuk-font($size: 80, $weight: bold);
         display: block;
         padding-top: .1em;
         color: $highlight-answer-color;
+        @include govuk-font($size: 80, $weight: bold);
       }
     }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_stat-headline.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_stat-headline.scss
@@ -17,14 +17,14 @@
     }
 
     p {
-      @include govuk-font($size: 19, $weight: bold);
       margin: 0;
+      @include govuk-font($size: 19, $weight: bold);
     }
 
     em {
-      @include govuk-font($size: 80, $weight: bold);
       display: block;
       margin: 3px 0 -5px;
+      @include govuk-font($size: 80, $weight: bold);
     }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_tables.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_tables.scss
@@ -33,9 +33,9 @@
     }
 
     th {
-      @include govuk-font($size: 19, $weight: bold);
       text-align: left;
       color: $govuk-text-colour;
+      @include govuk-font($size: 19, $weight: bold);
     }
 
     td small {

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_warning-callout.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_warning-callout.scss
@@ -30,8 +30,8 @@
     }
 
     p {
-      @include govuk-font($size: 19, $weight: bold);
       margin-left: 1em;
+      @include govuk-font($size: 19, $weight: bold);
     }
   }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_markdown-typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_markdown-typography.scss
@@ -8,9 +8,9 @@
   ol,
   ul,
   p {
-    @include govuk-font($size: 19);
     margin-top: $govuk-gutter-half;
     margin-bottom: $govuk-gutter-half;
+    @include govuk-font($size: 19);
 
     @include govuk-media-query($from: tablet) {
       margin-top: $gutter-two-thirds;
@@ -24,15 +24,15 @@
   // thus H1's are not expected and are discouraged by bare styling
 
   h1 {
-    @include govuk-font($size: 19);
     margin: 0;
     padding: 0;
+    @include govuk-font($size: 19);
   }
 
   h2 {
-    @include govuk-font($size: 27, $weight: bold);
     margin-top: $govuk-gutter;
     margin-bottom: 0;
+    @include govuk-font($size: 27, $weight: bold);
 
     @include govuk-media-query($from: desktop) {
       margin-top: $govuk-gutter * 1.5;
@@ -41,9 +41,9 @@
   }
 
   h3 {
-    @include govuk-font($size: 19, $weight: bold);
     margin-top: $govuk-gutter + 5px;
     margin-bottom: 0;
+    @include govuk-font($size: 19, $weight: bold);
   }
 
   // H4, H5 and H6 are discouraged and thus styled the same
@@ -51,9 +51,9 @@
   h4,
   h5,
   h6 {
-    @include govuk-font($size: 19, $weight: bold);
     margin-top: $govuk-gutter + 5px;
     margin-bottom: 0;
+    @include govuk-font($size: 19, $weight: bold);
 
     + p {
       margin-top: 5px;


### PR DESCRIPTION
Note: I've branched this onto https://github.com/alphagov/govuk_publishing_components/pull/4123 since it is fixes for when that is merged.

Sass has deprecated mixed declarations [1] and this generates us hundreds of warnings for versions of dartsass with this deprecation [2] which we see in this project after the update to dartsass-rails 0.51 [3].

This commit resolves these deprecations and when combined with Andy's PR [4] all Sass warnings are resolved.

This mixed declaration warning is super annoying for us. In short it prevents mixing declarations on an element with those of a nested element and requires the ones on the individual element to come first. This seems fine in theory however in practice we use mixins as a way to set nested declarations (generally media query) at the same time as setting an element declaration - e.g. the govuk-font mixin.

The way to resolve this has been to tediously move the use of mixins that have nested rules so that they occur after the element rules. It'll be very easy to re-introduce warnings here so it'll be good when DartSass turn the old behaviour off.

The risk on the changes made here is that some of the CSS that was following the rules before overrode declarations from the mixin and thus creates a visual difference. Although I've tried to be careful I am somewhat relying on Percy to catch issues here.

[1]: https://sass-lang.com/documentation/breaking-changes/mixed-decls/
[2]: https://github.com/alphagov/govuk_publishing_components/actions/runs/10181528374/job/28161909452?pr=4123
[3]: https://github.com/alphagov/govuk_publishing_components/pull/4123
[4]: https://github.com/alphagov/govuk_publishing_components/pull/4106