### PR TITLE
Replace deprecated govuk-frontend mixin

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_accordion.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_accordion.scss
@@ -31,7 +31,7 @@
   // Change the summary subheading size.
   .govuk-accordion__section-summary {
     @include govuk-typography-common;
-    @include govuk-typography-responsive($size: 16, $important: true);
+    @include govuk-font-size($size: 16, $important: true);
   }
 
   // Hide the unusable "Show all" and "Show" sections.


### PR DESCRIPTION
## What / why
This PR is a cherry pick of the first commit from https://github.com/alphagov/govuk_publishing_components/pull/4106 because the other commits are going to have to wait while we finish updating apps to dart-sass, but we might as well get this one out in the meantime.

Specific change:

- `govuk-typography-responsive` was renamed to `govuk-font-size` in version 5.1.0 of `govuk-frontend`
- changing this to remove a compilation warning
- release notes here: https://github.com/alphagov/govuk-frontend/releases/tag/v5.1.0

## Visual Changes
None.

Trello card: https://trello.com/c/gW2NW1sB/142-fix-sass-compilation-warnings