### PR TITLE
Version 41.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 41.1.0
 
 * Upgrade to LUX v4.0.25 ([PR #4129](https://github.com/alphagov/govuk_publishing_components/pull/4129))
 * Resolve DartSass mixed declaration deprecations ([PR #4125](https://github.com/alphagov/govuk_publishing_components/pull/4125))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (41.0.0)
+    govuk_publishing_components (41.1.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "41.0.0".freeze
+  VERSION = "41.1.0".freeze
 end


### PR DESCRIPTION
## 41.1.0

* Upgrade to LUX v4.0.25 ([PR #4129](https://github.com/alphagov/govuk_publishing_components/pull/4129))
* Resolve DartSass mixed declaration deprecations ([PR #4125](https://github.com/alphagov/govuk_publishing_components/pull/4125))
* Drop support for Ruby 3.1 ([PR #4124](https://github.com/alphagov/govuk_publishing_components/pull/4124))
* Update cards component design and use one column by default ([PR #4118](https://github.com/alphagov/govuk_publishing_components/pull/4118))
