### PR TITLE
Fix the print styles for inverse components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * New print styles for layout components ([PR #4137](https://github.com/alphagov/govuk_publishing_components/pull/4137))
 * New print styles for step-by-step components ([PR #4138](https://github.com/alphagov/govuk_publishing_components/pull/4138))
 * New print styles for govspeak components ([PR #4136](https://github.com/alphagov/govuk_publishing_components/pull/4136))
+* Fix the print styles for inverse components ([PR #4135](https://github.com/alphagov/govuk_publishing_components/pull/4135))
 
 ## 41.1.1
 

--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -136,6 +136,12 @@ $gem-guide-border-width: 1px;
   &.component-output {
     padding: 0;
   }
+
+  @include govuk-media-query($media-type: print) {
+    &[class*="-background"] {
+      background-color: unset;
+    }
+  }
 }
 
 .component-guide-preview--simple {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_inverse-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_inverse-header.scss
@@ -27,3 +27,15 @@
 .gem-c-inverse-header--padding-top {
   padding-top: govuk-spacing(3);
 }
+
+@include govuk-media-query($media-type: print) {
+  .gem-c-inverse-header {
+    background-color: unset;
+    border-bottom: 2pt solid $govuk-print-text-colour;
+
+    &,
+    & * {
+      color: $govuk-print-text-colour !important; // stylelint-disable-line declaration-no-important
+    }
+  }
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -913,12 +913,6 @@ $after-button-padding-left: govuk-spacing(4);
   font-size: 24px;
 }
 
-@include govuk-media-query($media-type: print) {
-  .gem-c-layout-super-navigation-header__content {
-    display: none;
-  }
-}
-
 // Ensure the total space to the left of the logo for mobile screen sizes is 24px (margin is 15px)
 @include govuk-media-query($until: tablet) {
   .gem-c-layout-super-navigation-header__header-logo--large-navbar {
@@ -987,5 +981,17 @@ $after-button-padding-left: govuk-spacing(4);
   .gem-c-layout-super-navigation-header__search-label--large-navbar {
     font-size: 24px;
     font-size: govuk-px-to-rem(24px);
+  }
+}
+
+@include govuk-media-query($media-type: print) {
+  .gem-c-layout-super-navigation-header {
+    border-top: 1pt solid $govuk-print-text-colour;
+    margin: 0;
+    background-color: none;
+  }
+
+  .gem-c-layout-super-navigation-header__header-logo {
+    padding: 10px 0 !important; // stylelint-disable-line declaration-no-important
   }
 }

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -109,7 +109,7 @@
     </div>
     <nav
       aria-labelledby="super-navigation-menu-heading"
-      class="gem-c-layout-super-navigation-header__content"
+      class="gem-c-layout-super-navigation-header__content govuk-!-display-none-print"
       data-module="super-navigation-mega-menu"
     >
       <h2 id="super-navigation-menu-heading" class="govuk-visually-hidden">


### PR DESCRIPTION
## What
A number of our components can be displayed inverted: white text on a dark background. These components should be set back to non-inverted for print: black text on a white background. 

For components that imply layout separation with their background colours, those aspects should be communicated with borders or other solutions that work better in print.

This is part of the work to improve print styles across all of the public facing components in this repo.

[Trello card](https://trello.com/c/tYpEnJfI/257-check-print-styles-for-inverse-components)

## Why

People still print a lot of pages from [GOV.UK](http://gov.uk/). And recent discussions have highlighted potential problems, or at least a perception that HTML pages when printed aren't as good as PDFs. We're trying to move away from/discourage the use of PDFs on [GOV.UK](http://gov.uk/), so improving the print experience could help.

- Inverted text can be harder to read on the printed page
- Inverted components waste ink if the browser is set to print background colours
- Inverted components use styles that print with low contrast

## Visual Changes [TODO]
