### PR TITLE
New print styles for govspeak components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * New print styles for the tabs component ([PR #4140](https://github.com/alphagov/govuk_publishing_components/pull/4140))
 * New print styles for layout components ([PR #4137](https://github.com/alphagov/govuk_publishing_components/pull/4137))
 * New print styles for step-by-step components ([PR #4138](https://github.com/alphagov/govuk_publishing_components/pull/4138))
+* New print styles for govspeak components ([PR #4136](https://github.com/alphagov/govuk_publishing_components/pull/4136))
 
 ## 41.1.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
@@ -31,6 +31,10 @@
       padding-top: 0;
     }
 
+    @include govuk-media-query($media-type: print) {
+      padding-left: 0;
+    }
+
     .attachment-thumb {
       position: relative;
       float: left;
@@ -51,6 +55,10 @@
       svg {
         fill: govuk-colour("mid-grey");
         stroke: govuk-colour("mid-grey");
+      }
+
+      @include govuk-media-query($media-type: print) {
+        margin-left: 0;
       }
     }
 
@@ -109,6 +117,23 @@
       .js-hidden {
         display: none;
       }
+
+      // stylelint-disable declaration-no-important
+      @include govuk-media-query($media-type: print) {
+        a,
+        a:link,
+        a:link:visited {
+          color: $govuk-print-text-colour !important;
+
+          &::after {
+            display: block;
+            margin: 1mm auto;
+            font-weight: normal;
+            font-size: 12pt !important;
+          }
+        }
+      }
+      // stylelint-enable declaration-no-important
     }
   }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_button.scss
@@ -24,4 +24,21 @@
   .govuk-button--start {
     @extend .govuk-button--start;
   }
+
+  @include govuk-media-query($media-type: print) {
+    .gem-c-button {
+      box-shadow: none;
+      border: 2pt solid $govuk-print-text-colour;
+
+      &,
+      & * {
+        background-color: unset;
+        color: $govuk-print-text-colour !important; // stylelint-disable-line declaration-no-important
+      }
+
+      &::after {
+        display: none;
+      }
+    }
+  }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_highlight-answer.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_highlight-answer.scss
@@ -43,5 +43,16 @@ $highlight-answer-color: govuk-colour("white");
         }
       }
     }
+
+    // stylelint-disable declaration-no-important
+    @include govuk-media-query($media-type: print) {
+      background-color: unset;
+
+      &,
+      & * {
+        color: $govuk-print-text-colour !important;
+      }
+    }
+    // stylelint-enable declaration-no-important
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_media-player.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_media-player.scss
@@ -25,3 +25,9 @@
   height: 100%;
   border: 0;
 }
+
+@include govuk-media-query($media-type: print) {
+  .gem-c-govspeak__youtube-video {
+    break-inside: avoid;
+  }
+}


### PR DESCRIPTION
## What
This PR adds/improves print styles for the following govspeak components. Follow the links for examples:

[`attachment`](https://components.publishing.service.gov.uk/component-guide/govspeak#attachment)
[`button`](https://components.publishing.service.gov.uk/component-guide/govspeak#buttons)
[`highlight_answer`](https://components.publishing.service.gov.uk/component-guide/govspeak#highlight_answer)
[`media_player`](https://components.publishing.service.gov.uk/component-guide/govspeak#with_youtube_embed)

This is part of the work to improve print styles across all of the public facing components in this repo.

[Trello card](https://trello.com/c/irMHNKBd/186-review-and-fix-component-print-styles)

## Why
People still print a lot of pages from [GOV.UK](http://gov.uk/). And recent discussions have highlighted potential problems, or at least a perception that HTML pages when printed aren't as good as PDFs. We're trying to move away from/discourage the use of PDFs on [GOV.UK](http://gov.uk/), so improving the print experience could help.
