### PR TITLE
New print styles for layout components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * New print styles for the table component ([PR #4139](https://github.com/alphagov/govuk_publishing_components/pull/4139))
 * New print styles for the tabs component ([PR #4140](https://github.com/alphagov/govuk_publishing_components/pull/4140))
+* New print styles for layout components ([PR #4137](https://github.com/alphagov/govuk_publishing_components/pull/4137))
 
 ## 41.1.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-footer.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-footer.scss
@@ -20,3 +20,11 @@
   // the right column.
   margin-bottom: 20px;
 }
+
+// stylelint-disable declaration-no-important
+@include govuk-media-query($media-type: print) {
+  .gem-c-layout-footer {
+    font-size: 12pt !important;
+  }
+}
+// stylelint-enable declaration-no-important

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
@@ -167,3 +167,25 @@
 .gem-c-header__nav {
   clear: both;
 }
+
+@include govuk-media-query($media-type: print) {
+  .gem-c-layout-header .govuk-header__container {
+    border-color: $govuk-print-text-colour;
+
+    .govuk-grid-column-two-thirds {
+      width: auto;
+      float: none;
+    }
+
+    .govuk-header__logo {
+      margin: 0;
+      padding: 0 2mm 2mm 0;
+    }
+
+    .gem-c-header__product-name,
+    .gem-c-environment-tag {
+      color: $govuk-print-text-colour;
+      background-color: unset;
+    }
+  }
+}

--- a/app/views/govuk_publishing_components/components/_layout_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_header.html.erb
@@ -31,11 +31,11 @@
         </div>
       </div>
       <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full govuk-grid-column-one-third-from-desktop gem-c-layout-header__search">
+        <div class="govuk-grid-column-full govuk-grid-column-one-third-from-desktop gem-c-layout-header__search govuk-!-display-none-print">
           <%= render "govuk_publishing_components/components/layout_header/search" %>
         </div>
         <% if navigation_items.any? %>
-          <div class="govuk-header__content gem-c-header__content govuk-grid-column-full">
+          <div class="govuk-header__content gem-c-header__content govuk-grid-column-full govuk-!-display-none-print">
             <%= render "govuk_publishing_components/components/layout_header/navigation_items", navigation_items: navigation_items, navigation_aria_label: navigation_aria_label  %>
           </div>
         <% end %>
@@ -50,12 +50,12 @@
           } %>
         </div>
         <% if navigation_items.any? %>
-          <div class="govuk-header__content gem-c-header__content govuk-grid-column-full">
+          <div class="govuk-header__content gem-c-header__content govuk-grid-column-full govuk-!-display-none-print">
             <%= render "govuk_publishing_components/components/layout_header/navigation_items", navigation_items: navigation_items, navigation_aria_label: navigation_aria_label %>
           </div>
         <% end %>
         <% if search %>
-          <div class="govuk-grid-column-one-third gem-c-layout-header__search">
+          <div class="govuk-grid-column-one-third gem-c-layout-header__search govuk-!-display-none-print">
             <%= render "govuk_publishing_components/components/layout_header/search" %>
           </div>
         <% end %>

--- a/app/views/govuk_publishing_components/components/layout_header/_navigation_items.html.erb
+++ b/app/views/govuk_publishing_components/components/layout_header/_navigation_items.html.erb
@@ -12,7 +12,7 @@
     >
       <%= t("components.layout_header.menu") %>
     </button>
-    <ul id="navigation" class="govuk-header__navigation-list">
+    <ul id="navigation" class="govuk-header__navigation-list govuk-!-display-none-print">
       <% navigation_items.each_with_index do |item, index| %>
         <%
           li_classes = %w(govuk-header__navigation-item)

--- a/app/views/govuk_publishing_components/components/layout_header/_search.html.erb
+++ b/app/views/govuk_publishing_components/components/layout_header/_search.html.erb
@@ -9,7 +9,7 @@
 </button>
 <form
   action="/search"
-  class="gem-c-layout-header__search-form govuk-clearfix"
+  class="gem-c-layout-header__search-form govuk-clearfix govuk-!-display-none-print"
   id="search"
   method="get"
   role="search"


### PR DESCRIPTION
## What
New and updated print styles for the `layout-header` and `layout-footer` components.

For the header, we hide some of the elements that would be redundant in print, and force text and border colours to black. The background is also unset to ensure it doesn't print, otherwise it would print with black text on black.

This is part of the work to improve print styles across all of the public facing components in this repo.

[Trello card](https://trello.com/c/irMHNKBd/186-review-and-fix-component-print-styles)

## Why
People still print a lot of pages from [GOV.UK](http://gov.uk/). And recent discussions have highlighted potential problems, or at least a perception that HTML pages when printed aren't as good as PDFs. We're trying to move away from/discourage the use of PDFs on [GOV.UK](http://gov.uk/), so improving the print experience could help.
