### PR TITLE
New print styles for step-by-step components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * New print styles for the table component ([PR #4139](https://github.com/alphagov/govuk_publishing_components/pull/4139))
 * New print styles for the tabs component ([PR #4140](https://github.com/alphagov/govuk_publishing_components/pull/4140))
 * New print styles for layout components ([PR #4137](https://github.com/alphagov/govuk_publishing_components/pull/4137))
+* New print styles for step-by-step components ([PR #4138](https://github.com/alphagov/govuk_publishing_components/pull/4138))
 
 ## 41.1.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-header.scss
@@ -22,7 +22,8 @@
 @include govuk-media-query($media-type: print) {
   .gem-c-step-nav-header {
     padding: 0 0 govuk-spacing(4) 0;
-    background: none;
+    background: unset;
+    border-color: $govuk-print-text-colour;
   }
 
   .gem-c-step-nav-header__part-of {
@@ -31,5 +32,17 @@
 
   .gem-c-step-nav-header__title {
     @include govuk-font(24, $weight: bold);
+
+    &,
+    &:link,
+    &:link:visited {
+      color: $govuk-print-text-colour;
+    }
+
+    &::after {
+      display: block;
+      margin: 1mm auto;
+      font-size: 12pt !important; // stylelint-disable-line declaration-no-important
+    }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-related.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-related.scss
@@ -44,3 +44,27 @@
 .gem-c-step-nav-related__link-item {
   margin-top: govuk-spacing(3);
 }
+
+// stylelint-disable declaration-no-important
+@include govuk-media-query($media-type: print) {
+  .gem-c-step-nav-related {
+    background: unset;
+    border-color: $govuk-print-text-colour;
+  }
+
+  .gem-c-step-nav-related__heading,
+  .gem-c-step-nav-related__link-item {
+    .govuk-link,
+    .govuk-link:link,
+    .govuk-link:link:visited {
+      color: $govuk-print-text-colour !important;
+
+      &::after {
+        display: block;
+        margin: 1mm auto;
+        font-size: 12pt !important;
+      }
+    }
+  }
+}
+// stylelint-enable declaration-no-important


### PR DESCRIPTION
## What
This PR adds/improves print styles for the following components:

[step-by-step-nav-header](https://components.publishing.service.gov.uk/component-guide/step_by_step_nav_header)
[step-by-step-nav-related](https://components.publishing.service.gov.uk/component-guide/step_by_step_nav_related)

This is part of the work to improve print styles across all of the public facing components in this repo.

[Trello card](https://trello.com/c/irMHNKBd/186-review-and-fix-component-print-styles)

## Why
People still print a lot of pages from [GOV.UK](http://gov.uk/). And recent discussions have highlighted potential problems, or at least a perception that HTML pages when printed aren't as good as PDFs. We're trying to move away from/discourage the use of PDFs on [GOV.UK](http://gov.uk/), so improving the print experience could help.