### PR TITLE
New print styles for the `table` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* New print styles for the table component ([PR #4139](https://github.com/alphagov/govuk_publishing_components/pull/4139))
+
 ## 41.1.1
 
 * Update card component styles ([PR #4141](https://github.com/alphagov/govuk_publishing_components/pull/4141))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_table.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_table.scss
@@ -125,3 +125,35 @@ $table-row-even-background-colour: govuk-colour("light-grey");
     border: 0;
   }
 }
+
+// stylelint-disable declaration-no-important
+@include govuk-media-query($media-type: print) {
+  .govuk-table--sortable {
+    outline: none;
+
+    * {
+      color: $govuk-print-text-colour !important;
+      background-color: initial !important;
+    }
+
+    .govuk-table__header,
+    .govuk-table__cell {
+      border-bottom: 1px solid $govuk-print-text-colour !important;
+    }
+
+    .govuk-table__header {
+      font-weight: 700;
+      border-right: 0;
+    }
+
+    .app-table__sort-link {
+      padding: 0 !important;
+
+      &::before,
+      &::after {
+        display: none !important;
+      }
+    }
+  }
+}
+// stylelint-enable declaration-no-important

--- a/app/views/govuk_publishing_components/components/_table.html.erb
+++ b/app/views/govuk_publishing_components/components/_table.html.erb
@@ -58,7 +58,7 @@
 
 <% if filterable %>
   <div data-module="table">
-    <div class="js-gem-c-table__filter govuk-!-display-none">
+    <div class="js-gem-c-table__filter govuk-!-display-none govuk-!-display-none-print">
       <%= render "govuk_publishing_components/components/input", {
         label: {
           text: label


### PR DESCRIPTION
## What
This PR adds/improves print styles for tables:

- sortable tables now print the same as other tables
- the filter element is hidden for print

This is part of the work to improve print styles across all of the public facing components in this repo.

[Trello card](https://trello.com/c/irMHNKBd/186-review-and-fix-component-print-styles)

## Why
People still print a lot of pages from [GOV.UK](http://gov.uk/). And recent discussions have highlighted potential problems, or at least a perception that HTML pages when printed aren't as good as PDFs. We're trying to move away from/discourage the use of PDFs on [GOV.UK](http://gov.uk/), so improving the print experience could help.
