### PR TITLE
New print styles for the `tabs` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * New print styles for the table component ([PR #4139](https://github.com/alphagov/govuk_publishing_components/pull/4139))
+* New print styles for the tabs component ([PR #4140](https://github.com/alphagov/govuk_publishing_components/pull/4140))
 
 ## 41.1.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_tabs.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_tabs.scss
@@ -31,3 +31,35 @@ li.govuk-tabs__list-item { // stylelint-disable-line selector-no-qualifying-type
     }
   }
 }
+
+@include govuk-media-query($media-type: print) {
+  .govuk-tabs__title {
+    display: block !important; // stylelint-disable-line declaration-no-important
+  }
+
+  .govuk-tabs__tab.govuk-tabs__tab {
+    text-decoration: none;
+  }
+
+  .govuk-tabs__list.govuk-tabs__list {
+    border: 0;
+  }
+
+  .govuk-tabs__list-item.govuk-tabs__list-item {
+    all: unset;
+    display: block;
+
+    &::before {
+      content: "—";
+      padding-right: 2mm;
+      margin: 0;
+    }
+  }
+
+  .govuk-tabs__panel.govuk-tabs__panel {
+    border: 0;
+    padding: 0;
+    margin: 0.75cm 0;
+    display: block;
+  }
+}


### PR DESCRIPTION
## What
This PR adds/improves print styles for tabs:

- display all tabs when printed, don't replicate the shown/hidden screen states
- linearise the tabs into a single column

This is part of the work to improve print styles across all of the public facing components in this repo.

[Trello card](https://trello.com/c/irMHNKBd/186-review-and-fix-component-print-styles)

## Why
People still print a lot of pages from [GOV.UK](http://gov.uk/). And recent discussions have highlighted potential problems, or at least a perception that HTML pages when printed aren't as good as PDFs. We're trying to move away from/discourage the use of PDFs on [GOV.UK](http://gov.uk/), so improving the print experience could help.
