### PR TITLE
Update card component styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Update card component styles ([PR #4141](https://github.com/alphagov/govuk_publishing_components/pull/4141))
+
 ## 41.1.0
 
 * Upgrade to LUX v4.0.25 ([PR #4129](https://github.com/alphagov/govuk_publishing_components/pull/4129))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
@@ -3,7 +3,11 @@
 @import "mixins/prefixed-transform";
 
 .gem-c-cards__heading {
-  margin: 0 0 govuk-spacing(6) 0;
+  @include govuk-responsive-margin(6, "bottom");
+}
+
+.gem-c-cards__heading--underline + .gem-c-cards__list {
+  border-top: 1px solid $govuk-border-colour;
 }
 
 .gem-c-cards__list {
@@ -22,6 +26,14 @@
     // Reset the width for browsers that support CSS grid
     @supports (display: grid) {
       width: initial;
+    }
+  }
+}
+
+.gem-c-cards__list--one-column {
+  .gem-c-cards__list-item {
+    &:first-child {
+      border-top: 0;
     }
   }
 }

--- a/app/views/govuk_publishing_components/components/_cards.html.erb
+++ b/app/views/govuk_publishing_components/components/_cards.html.erb
@@ -6,6 +6,7 @@
   columns ||= false
 
   ul_classes = %w[gem-c-cards__list]
+  ul_classes << 'gem-c-cards__list--one-column' unless columns
   ul_classes << 'gem-c-cards__list--two-column-desktop' if columns == 2
   ul_classes << 'gem-c-cards__list--three-column-desktop' if columns == 3
 
@@ -16,7 +17,11 @@
 <% if items.present? %>
   <%= tag.div(**component_helper.all_attributes) do %>
     <% if heading %>
-      <%= content_tag(shared_helper.get_heading_level, class: "gem-c-cards__heading govuk-heading-m") do %>
+        <%
+          heading_classes = %w[gem-c-cards__heading govuk-heading-m]
+          heading_classes << "gem-c-cards__heading--underline" unless columns
+        %>
+        <%= content_tag(shared_helper.get_heading_level, class: heading_classes) do %>
         <%= heading %>
       <% end %>
     <% end %>

--- a/app/views/govuk_publishing_components/components/docs/cards.yml
+++ b/app/views/govuk_publishing_components/components/docs/cards.yml
@@ -40,34 +40,30 @@ examples:
             text: Citizenship and living in the&nbsp;UK
             path: http://www.gov.uk
           description: Voting, community participation, life in the UK, international projects
+  one_column_layout_without_heading:
+    description: No border at the top of the list of cards is present when using a one column layout without a heading. The first card item will still include a top border when using a 2 or 3 column layout as shown in the examples below.
+    data:
+      items:
         - link:
-            text: Crime, justice and the&nbsp;law
+            text: Benefits
             path: http://www.gov.uk
-          description: Legal processes, courts and the police
+          description: Includes eligibility, appeals, tax credits and Universal Credit
         - link:
-            text: Disabled people
+            text: Births, deaths, marriages and&nbsp;care
             path: http://www.gov.uk
-          description: Includes carers, your rights, benefits and the Equality Act
+          description: Parenting, civil partnerships, divorce and Lasting Power of Attorney
         - link:
-            text: Driving and transport
+            text: Business and self-employed
             path: http://www.gov.uk
-          description: Includes vehicle tax, MOT and driving licences
+          description: Tools and guidance for businesses
         - link:
-            text: Education and learning
+            text: Childcare and parenting
             path: http://www.gov.uk
-          description: Includes student loans, admissions and apprenticeships
+          description: Includes giving birth, fostering, adopting, benefits for children, childcare and schools
         - link:
-            text: Employing people
+            text: Citizenship and living in the&nbsp;UK
             path: http://www.gov.uk
-          description: Includes pay, contracts, hiring and redundancies
-        - link:
-            text: Environment and countryside
-            path: http://www.gov.uk
-          description: Includes flooding, recycling and wildlife
-        - link:
-            text: Housing and local services
-            path: http://www.gov.uk
-          description: Owning or renting and council services
+          description: Voting, community participation, life in the UK, international projects
   two_column_layout:
     description:  Override default single column layout on desktop by setting the `columns` parameter to `2`.
     data:
@@ -93,14 +89,6 @@ examples:
             text: Citizenship and living in the&nbsp;UK
             path: http://www.gov.uk
           description: Voting, community participation, life in the UK, international projects
-        - link:
-            text: Crime, justice and the&nbsp;law
-            path: http://www.gov.uk
-          description: Legal processes, courts and the police
-        - link:
-            text: Disabled people
-            path: http://www.gov.uk
-          description: Includes carers, your rights, benefits and the Equality Act
   three_column_layout:
     description: Override default single column layout on desktop by setting the `columns` parameter to `3`.
     data:
@@ -126,14 +114,6 @@ examples:
             text: Citizenship and living in the&nbsp;UK
             path: http://www.gov.uk
           description: Voting, community participation, life in the UK, international projects
-        - link:
-            text: Crime, justice and the&nbsp;law
-            path: http://www.gov.uk
-          description: Legal processes, courts and the police
-        - link:
-            text: Disabled people
-            path: http://www.gov.uk
-          description: Includes carers, your rights, benefits and the Equality Act
   custom_heading_levels:
     description: |
       Override default heading level by passing through `heading_level` parameter (defaults to `<h2>`).

--- a/spec/components/cards_spec.rb
+++ b/spec/components/cards_spec.rb
@@ -25,6 +25,22 @@ describe "Cards", type: :view do
     assert_select "h2.gem-c-cards__heading.govuk-heading-m", count: 1
   end
 
+  it "renders list heading with a bottom border when using the default number of columns" do
+    test_data = {
+      heading: "Topics",
+      items: [
+        {
+          link: {
+            text: "Benefits",
+            path: "http://www.gov.uk",
+          },
+        },
+      ],
+    }
+    render_component(test_data)
+    assert_select "h2.gem-c-cards__heading.govuk-heading-m.gem-c-cards__heading--underline", count: 1
+  end
+
   it "renders list heading using custom heading level" do
     test_data = {
       heading: "Topics",


### PR DESCRIPTION
## What
When using a single column layout, the top border will now only be visible when a heading is used.

Updated `gem-c-cards__heading` to use a responsive margin-bottom.

## Why
To match the intended design of the card component when using a single column layout with a heading.

[Trello card](https://trello.com/c/F3N53ubq/1189-update-border-top-for-card-component)

## Visual Changes

### Card top border

| Before | After |
| --- | --- |
| <img width="974" alt="cards-desktop-before" src="https://github.com/user-attachments/assets/68e9fcb6-974d-4610-bfa9-c25d2fea720e"> | <img width="969" alt="cards-desktop-after" src="https://github.com/user-attachments/assets/74d74297-37c0-41c5-abe1-6e4fb4baee65"> |

### Card heading margin now responsive

| Before | After |
| --- | --- |
| <img width="364" alt="card-mobile-heading-before" src="https://github.com/user-attachments/assets/41da4e23-5704-4777-adf9-071ed1405c36"> | <img width="364" alt="card-mobile-heading-after" src="https://github.com/user-attachments/assets/9190fb1f-5fa6-4959-8e3e-685a5b3d5dd5"> |