### PR TITLE
Add dynamic search autocomplete component (experimental) 

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/components/autocomplete.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/autocomplete.js
@@ -552,8 +552,6 @@ window.GOVUK.Modules.GovukAutocomplete = window.GOVUKFrontend.Autocomplete;
 
     var renderResultHtml = function (result, props, inputVal) {
       var index = result.toLowerCase().indexOf(inputVal.toLowerCase())
-
-      console.log('props', props)
       return `<li ${props}>${suggestionIcon ? searchIcon : ''}<span class='govuk-!-font-weight-bold'>${result.substring(0, index)}</span>${result.substring(index, index + inputVal.length)}<span class='govuk-!-font-weight-bold'>${result.substring(index + inputVal.length, result.length)}<span><div class='gem-c-autocomplete__result--border'></div></li>`
     }
 

--- a/app/assets/javascripts/govuk_publishing_components/components/autocomplete.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/autocomplete.js
@@ -68,7 +68,7 @@ window.GOVUK.Modules.GovukAutocomplete = window.GOVUKFrontend.Autocomplete;
   // string in the format: `key1='value1' key2='value2'` for easy use in an HTML string.
   function Props (index, selectedIndex, baseClass) {
     this.id = `${baseClass}-result-${index}`
-    this.class = `${baseClass}-result`
+    this.class = `${baseClass}__result`
     this['data-result-index'] = index
     this.role = 'option'
     if (index === selectedIndex) {
@@ -330,7 +330,7 @@ window.GOVUK.Modules.GovukAutocomplete = window.GOVUKFrontend.Autocomplete;
     this.resetPosition = true
     this.positionResults = positionResults
     this.root = typeof root === 'string' ? document.querySelector(root) : root
-    this.root.insertAdjacentHTML('beforeend', '<ul class="gem-c-autocomplete-result-list govuk-body" role="listbox"></ul><div aria-atomic="true" aria-live="polite" role="status" class="govuk-visually-hidden">No results.</div>')
+    this.root.insertAdjacentHTML('beforeend', '<ul class="gem-c-autocomplete__result-list govuk-body" role="listbox"></ul><div aria-atomic="true" aria-live="polite" role="status" class="govuk-visually-hidden">No results.</div>')
     this.input = this.root.querySelector('input')
     this.assistiveHint = this.root.querySelector('.assistive-hint')
     this.resultList = this.root.querySelector('ul')
@@ -472,7 +472,7 @@ window.GOVUK.Modules.GovukAutocomplete = window.GOVUKFrontend.Autocomplete;
 
     this.input.setAttribute(
       'aria-activedescendant',
-      selectedIndex > -1 ? `${this.baseClass}-result-${selectedIndex}` : ''
+      selectedIndex > -1 ? `${this.baseClass}__result-${selectedIndex}` : ''
     )
 
     if (this.resetPosition) {
@@ -548,11 +548,13 @@ window.GOVUK.Modules.GovukAutocomplete = window.GOVUKFrontend.Autocomplete;
     var positionResults = this.positionResults
     var submitOnSelect = this.submitOnSelect
 
-    var searchIcon = '<span class="search-icon"><svg width="20" height="20" viewBox="0 0 27 27" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"><circle cx="12.0161" cy="11.0161" r="8.51613" stroke="currentColor" stroke-width="3" /><line x1="17.8668" y1="17.3587" x2="26.4475" y2="25.9393" stroke="currentColor" stroke-width="3" /></svg></span>'
+    var searchIcon = '<span class="gem-c-autocomplete__result--search-icon"><svg width="20" height="20" viewBox="0 0 27 27" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"><circle cx="12.0161" cy="11.0161" r="8.51613" stroke="currentColor" stroke-width="3" /><line x1="17.8668" y1="17.3587" x2="26.4475" y2="25.9393" stroke="currentColor" stroke-width="3" /></svg></span>'
 
     var renderResultHtml = function (result, props, inputVal) {
       var index = result.toLowerCase().indexOf(inputVal.toLowerCase())
-      return `<li ${props}>${suggestionIcon ? searchIcon : ''}<span class='govuk-!-font-weight-bold'>${result.substring(0, index)}</span>${result.substring(index, index + inputVal.length)}<span class='govuk-!-font-weight-bold'>${result.substring(index + inputVal.length, result.length)}<span><div class='border'></div></li>`
+
+      console.log('props', props)
+      return `<li ${props}>${suggestionIcon ? searchIcon : ''}<span class='govuk-!-font-weight-bold'>${result.substring(0, index)}</span>${result.substring(index, index + inputVal.length)}<span class='govuk-!-font-weight-bold'>${result.substring(index + inputVal.length, result.length)}<span><div class='gem-c-autocomplete__result--border'></div></li>`
     }
 
     new Autocomplete(this.$module, // eslint-disable-line no-new

--- a/app/assets/javascripts/govuk_publishing_components/components/autocomplete.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/autocomplete.js
@@ -1,0 +1,569 @@
+//= require ../vendor/polyfills/closest.js
+/* global fetch */
+
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {}
+window.GOVUK.Modules.GovukAutocomplete = window.GOVUKFrontend.Autocomplete;
+
+(function (Modules) {
+  'use strict'
+
+  var util = {
+    getRelativePosition: function (element1, element2) {
+      var position1 = element1.getBoundingClientRect()
+      var position2 = element2.getBoundingClientRect()
+
+      var positionAbove =
+        /* 1 */ position1.bottom + position2.height > window.innerHeight &&
+        /* 2 */ window.innerHeight - position1.bottom < position1.top &&
+        /* 3 */ window.pageYOffset + position1.top - position2.height > 0
+
+      return positionAbove ? 'above' : 'below'
+    },
+    debounce: function (func, wait, immediate) {
+      let timeout
+
+      return function executedFunction () {
+        var context = this
+        var args = arguments
+
+        var later = function () {
+          timeout = null
+          if (!immediate) func.apply(context, args)
+        }
+
+        var callNow = immediate && !timeout
+        clearTimeout(timeout)
+        timeout = setTimeout(later, wait)
+
+        if (callNow) func.apply(context, args)
+      }
+    },
+    getAriaLabel: function (labelStr) {
+      if (labelStr?.length) {
+        var isLabelId = labelStr.startsWith('#')
+
+        return {
+          attribute: isLabelId ? 'aria-labelledby' : 'aria-label',
+          content: isLabelId ? labelStr.substring(1) : labelStr
+        }
+      }
+    },
+    isPromise: function (value) {
+      return Boolean(value && typeof value.then === 'function')
+    },
+    isFunction: function (value) {
+      return Boolean(typeof value === 'function')
+    },
+    isArray: function (string) {
+      try {
+        return Array.isArray(JSON.parse(string))
+      } catch (e) {
+        return false
+      }
+    }
+  }
+
+  // Creates a props object with overridden toString function. toString returns an attributes
+  // string in the format: `key1='value1' key2='value2'` for easy use in an HTML string.
+  function Props (index, selectedIndex, baseClass) {
+    this.id = `${baseClass}-result-${index}`
+    this.class = `${baseClass}-result`
+    this['data-result-index'] = index
+    this.role = 'option'
+    if (index === selectedIndex) {
+      this['aria-selected'] = 'true'
+    }
+  }
+
+  Props.prototype.toString = function () {
+    return Object.keys(this).reduce(
+      (str, key) => `${str} ${key}='${this[key]}'`,
+      ''
+    )
+  }
+
+  function AutocompleteCore (
+    search,
+    autoSelect,
+    setValue,
+    setAttribute,
+    onUpdate,
+    onSubmit,
+    onShow,
+    onHide,
+    onLoading,
+    onLoaded,
+    submitOnSelect
+  ) {
+    this.value = ''
+    this.searchCounter = 0
+    this.results = []
+    this.selectedIndex = -1
+    this.selectedResult = null
+
+    switch (true) {
+      case util.isFunction(search):
+        this.search = (value) => Promise.resolve(search(value))
+        break
+      case util.isArray(search):
+        this.search = () => Promise.resolve(JSON.parse(search))
+        break
+      default:
+        this.search = async (value) => {
+          var url = new URL(search)
+          url.searchParams.append('q', value)
+
+          var response = await fetch(url)
+          var completes = await response.json()
+          return completes
+        }
+        break
+    }
+
+    this.autoSelect = autoSelect || false
+    this.setValue = setValue || function () { }
+    this.setAttribute = setAttribute || function () { }
+    this.onUpdate = onUpdate || function () { }
+    this.onSubmit = onSubmit || function () { }
+    this.onShow = onShow
+    this.onHide = onHide || function () { }
+    this.onLoading = onLoading || function () { }
+    this.onLoaded = onLoaded || function () { }
+    this.submitOnSelect = submitOnSelect || false
+  }
+
+  AutocompleteCore.prototype.destroy = function () {
+    this.search = null
+    this.setValue = null
+    this.setAttribute = null
+    this.onUpdate = null
+    this.onSubmit = null
+    this.onShow = null
+    this.onHide = null
+    this.onLoading = null
+    this.onLoaded = null
+  }
+
+  AutocompleteCore.prototype.handleInput = function (event) {
+    var value = event.target.value
+    this.updateResults(value)
+    this.value = value
+  }
+
+  AutocompleteCore.prototype.handleKeyUp = function (event) {
+    var activeEl = event.target.getAttribute('aria-activedescendant')
+    if (activeEl) {
+      event.target.value = document.getElementById(activeEl).innerText
+    }
+  }
+
+  AutocompleteCore.prototype.handleKeyDown = function (event) {
+    const keyCodes = {
+      9: 'tab',
+      13: 'enter',
+      27: 'escape',
+      32: 'space',
+      38: 'up',
+      40: 'down'
+    }
+
+    switch (keyCodes[event.keyCode]) {
+      case 'up':
+      case 'down': {
+        const selectedIndex =
+        event.keyCode === 38 ? this.selectedIndex - 1 : this.selectedIndex + 1
+        event.preventDefault()
+        this.handleArrows(selectedIndex)
+        break
+      }
+      case 'tab': {
+        this.selectResult()
+        break
+      }
+      case 'enter':
+      case 'space': {
+        if (event.keyCode === 32) {
+          event.preventDefault()
+        }
+        this.selectedResult =
+          this.results[this.selectedIndex] || this.selectedResult
+        this.selectResult()
+
+        if (this.submitOnSelect && event.target.closest('form')) {
+          event.target.closest('form').submit()
+        }
+        break
+      }
+      case 'escape': {
+        this.hideResults()
+        this.setValue()
+        break
+      }
+    }
+  }
+
+  AutocompleteCore.prototype.handleFocus = function (event) {
+    var value = event.target.value
+    this.updateResults(value)
+    this.value = value
+  }
+
+  AutocompleteCore.prototype.handleBlur = function () {
+    this.hideResults()
+  }
+
+  AutocompleteCore.prototype.handleResultMouseDown = function (event) {
+    event.preventDefault()
+  }
+
+  AutocompleteCore.prototype.handleResultClick = function (event) {
+    var target = event.target
+    var result = target.closest('[data-result-index]')
+    if (result) {
+      this.selectedIndex = parseInt(result.dataset.resultIndex, 10)
+      var selectedResult = this.results[this.selectedIndex]
+      this.selectResult()
+      this.onSubmit(selectedResult)
+    }
+
+    if (this.submitOnSelect && event.target.closest('form')) {
+      event.target.closest('form').submit()
+    }
+  }
+
+  AutocompleteCore.prototype.handleArrows = function (selectedIndex) {
+    // Loop selectedIndex back to first or last result if out of bounds
+    var resultsCount = this.results.length
+    this.selectedIndex =
+      ((selectedIndex % resultsCount) + resultsCount) % resultsCount
+
+    // Update results and aria attributes
+    this.onUpdate(this.results, this.selectedIndex)
+  }
+
+  AutocompleteCore.prototype.selectResult = function () {
+    var selectedResult = this.results[this.selectedIndex]
+    if (selectedResult) {
+      this.setValue(selectedResult)
+    }
+    this.hideResults()
+  }
+
+  AutocompleteCore.prototype.updateResults = function (value) {
+    if (value && value.length) {
+      var currentSearch = ++this.searchCounter
+      this.onLoading()
+      this.search(value).then((results) => {
+        if (currentSearch !== this.searchCounter) {
+          return
+        }
+        this.results = results
+        this.onLoaded()
+
+        if (typeof this.results === 'undefined' || this.results.length === 0) {
+          this.hideResults()
+          return
+        }
+
+        this.selectedIndex = this.autoSelect ? 0 : -1
+        this.onUpdate(this.results, this.selectedIndex)
+        this.showResults()
+      })
+    }
+  }
+
+  AutocompleteCore.prototype.showResults = function () {
+    this.setAttribute('aria-expanded', true)
+    this.onShow()
+  }
+
+  AutocompleteCore.prototype.hideResults = function () {
+    this.selectedIndex = -1
+    this.results = []
+    this.setAttribute('aria-expanded', false)
+    this.setAttribute('aria-activedescendant', '')
+    this.onUpdate(this.results, this.selectedIndex)
+    this.onHide()
+  }
+
+  AutocompleteCore.prototype.checkSelectedResultVisible = function (resultsElement) {
+    var selectedResultElement = resultsElement.querySelector(
+      `[data-result-index='${this.selectedIndex}']`
+    )
+    if (!selectedResultElement) {
+      return
+    }
+
+    var resultsPosition = resultsElement.getBoundingClientRect()
+    var selectedPosition = selectedResultElement.getBoundingClientRect()
+
+    if (selectedPosition.top < resultsPosition.top) {
+      // Element is above viewable area
+      resultsElement.scrollTop -= resultsPosition.top - selectedPosition.top
+    } else if (selectedPosition.bottom > resultsPosition.bottom) {
+      // Element is below viewable area
+      resultsElement.scrollTop +=
+        selectedPosition.bottom - resultsPosition.bottom
+    }
+  }
+
+  function Autocomplete (
+    root,
+    search,
+    renderResult,
+    debounceTime = 0,
+    numberSuggestions,
+    positionResults,
+    submitOnSelect = false,
+    onUpdate = () => { },
+    onSubmit = () => { },
+    baseClass = 'gem-c-autocomplete',
+    autoSelect = false,
+    getResultValue = function (result) { return result },
+    resultListLabel
+  ) {
+    this.numberSuggestions = numberSuggestions
+    this.expanded = false
+    this.loading = false
+    this.position = {}
+    this.resetPosition = true
+    this.positionResults = positionResults
+    this.root = typeof root === 'string' ? document.querySelector(root) : root
+    this.root.insertAdjacentHTML('beforeend', '<ul class="gem-c-autocomplete-result-list govuk-body" role="listbox"></ul><div aria-atomic="true" aria-live="polite" role="status" class="govuk-visually-hidden">No results.</div>')
+    this.input = this.root.querySelector('input')
+    this.assistiveHint = this.root.querySelector('.assistive-hint')
+    this.resultList = this.root.querySelector('ul')
+    this.liveRegion = this.root.querySelector('[role="status"]')
+    this.baseClass = baseClass
+    this.getResultValue = getResultValue
+    this.onUpdate = onUpdate
+    if (typeof renderResult === 'function') {
+      this.renderResult = renderResult
+    }
+
+    this.resultListLabel = resultListLabel
+    this.submitOnSelect = submitOnSelect
+
+    const core = new AutocompleteCore(search,
+      autoSelect,
+      this.setValue.bind(this),
+      this.setAttribute.bind(this),
+      this.handleUpdate.bind(this),
+      onSubmit,
+      this.handleShow.bind(this),
+      this.handleHide.bind(this),
+      this.handleLoading.bind(this),
+      this.handleLoaded.bind(this),
+      this.submitOnSelect
+    )
+
+    if (debounceTime > 0) {
+      core.handleInput = util.debounce(core.handleInput, debounceTime)
+    }
+    this.core = core
+
+    this.initialize()
+
+    return this
+  }
+
+  Autocomplete.prototype.initialize = function () {
+    this.input.setAttribute('role', 'combobox')
+    this.input.setAttribute('autocomplete', 'off')
+    this.input.setAttribute('autocapitalize', 'off')
+    this.input.setAttribute('spellcheck', 'false')
+    this.input.setAttribute('aria-autocomplete', 'list')
+    this.input.setAttribute('aria-haspopup', 'listbox')
+    this.input.setAttribute('aria-expanded', 'false')
+
+    this.resultList.setAttribute('role', 'listbox')
+
+    var resultListAriaLabel = util.getAriaLabel(this.resultListLabel)
+    resultListAriaLabel &&
+      this.resultList.setAttribute(
+        resultListAriaLabel.attribute,
+        resultListAriaLabel.content
+      )
+
+    if (this.positionResults === 'absolute') {
+      this.resultList.style.position = 'absolute'
+    }
+    this.resultList.style.zIndex = '1'
+    this.resultList.style.width = '100%'
+    this.resultList.style.boxSizing = 'border-box'
+
+    this.resultList.id = `${this.baseClass}-result-list-${this.root.getAttribute('data-id-postfix')}`
+
+    this.input.setAttribute('aria-owns', this.resultList.id)
+
+    this.addAssistiveHint()
+
+    document.body.addEventListener('click', this.handleDocumentClick.bind(this))
+    this.input.addEventListener('input', this.core.handleInput.bind(this.core))
+    this.input.addEventListener('keydown', this.core.handleKeyDown.bind(this.core))
+    this.input.addEventListener('keyup', this.core.handleKeyUp.bind(this.core))
+    this.input.addEventListener('focus', this.core.handleFocus.bind(this.core))
+    this.input.addEventListener('blur', this.core.handleBlur.bind(this.core))
+    this.resultList.addEventListener(
+      'mousedown',
+      this.core.handleResultMouseDown
+    )
+    this.resultList.addEventListener('click', this.core.handleResultClick.bind(this.core))
+    this.updateStyle()
+  }
+
+  Autocomplete.prototype.addAssistiveHint = function () {
+    var hintId = `${this.baseClass}-assistive-hint-${this.root.getAttribute('data-id-postfix')}`
+    this.root.insertAdjacentHTML('beforeend', `<span id="${hintId}" class="govuk-visually-hidden">When autocomplete results are available use up and down arrows to review and enter to select. Touch device users, explore by touch or with swipe gestures.</span>`)
+    this.input.setAttribute('aria-describedby', `${hintId}`)
+  }
+
+  Autocomplete.prototype.destroy = function () {
+    document.body.removeEventListener('click', this.handleDocumentClick)
+    this.input.removeEventListener('input', this.core.handleInput.bind(this.core))
+    this.input.removeEventListener('keydown', this.core.handleKeyDown.bind(this.core))
+    this.input.removeEventListener('keyup', this.core.handleKeyUp.bind(this.core))
+    this.input.removeEventListener('focus', this.core.handleFocus.bind(this.core))
+    this.input.removeEventListener('blur', this.core.handleBlur.bind(this.core))
+    this.resultList.removeEventListener(
+      'mousedown',
+      this.core.handleResultMouseDown
+    )
+    this.resultList.removeEventListener('click', this.core.handleResultClick.bind(this.core))
+
+    this.root = null
+    this.input = null
+    this.resultList = null
+    this.getResultValue = null
+    this.onUpdate = null
+    this.renderResult = null
+    this.core.destroy()
+    this.core = null
+  }
+
+  Autocomplete.prototype.setAttribute = function (attribute, value) {
+    this.input.setAttribute(attribute, value)
+  }
+
+  Autocomplete.prototype.setValue = function (result) {
+    this.input.value = result ? this.getResultValue(result) : ''
+  }
+
+  Autocomplete.prototype.renderResult = function (result, props) {
+    return `<li ${props}>${this.getResultValue(result)}</li>`
+  }
+
+  Autocomplete.prototype.handleUpdate = function (results, selectedIndex) {
+    if (results.length > this.numberSuggestions) {
+      results = results.slice(0, this.numberSuggestions)
+    }
+
+    this.resultList.innerHTML = ''
+    results.forEach((result, index) => {
+      const props = new Props(index, selectedIndex, this.baseClass)
+      const resultHTML = this.renderResult(result, props, this.input.value)
+      if (typeof resultHTML === 'string') {
+        this.resultList.insertAdjacentHTML('beforeend', resultHTML)
+      } else {
+        this.resultList.insertAdjacentElement('beforeend', resultHTML)
+      }
+    })
+
+    this.input.setAttribute(
+      'aria-activedescendant',
+      selectedIndex > -1 ? `${this.baseClass}-result-${selectedIndex}` : ''
+    )
+
+    if (this.resetPosition) {
+      this.resetPosition = false
+      this.position = util.getRelativePosition(this.input, this.resultList)
+      this.updateStyle()
+    }
+    this.core.checkSelectedResultVisible(this.resultList)
+    this.onUpdate(results, selectedIndex)
+    this.updateStatus(results.length)
+  }
+
+  Autocomplete.prototype.updateStatus = function (resultCount) {
+    this.liveRegion.innerHTML = resultCount === 0 ? 'No results.' : `${resultCount} results available.`
+  }
+
+  Autocomplete.prototype.handleShow = function () {
+    this.expanded = true
+    this.updateStyle()
+  }
+
+  Autocomplete.prototype.handleHide = function () {
+    this.expanded = false
+    this.resetPosition = true
+    this.updateStyle()
+  }
+
+  Autocomplete.prototype.handleLoading = function () {
+    this.loading = true
+    this.updateStyle()
+  }
+
+  Autocomplete.prototype.handleLoaded = function () {
+    this.loading = false
+    this.updateStyle()
+  }
+
+  Autocomplete.prototype.handleDocumentClick = function (event) {
+    if (this.root.contains(event.target)) {
+      return
+    }
+    this.core.hideResults()
+  }
+
+  Autocomplete.prototype.updateStyle = function () {
+    this.root.dataset.expanded = this.expanded
+    this.root.dataset.loading = this.loading
+    this.root.dataset.position = this.position
+
+    this.resultList.style.visibility = this.expanded ? 'visible' : 'hidden'
+    this.resultList.style.pointerEvents = this.expanded ? 'auto' : 'none'
+
+    this.resultList.style.bottom = null
+    this.resultList.style.top = '100%'
+  }
+
+  function GemAutocomplete ($module) {
+    this.$module = $module
+
+    this.numberSuggestions = $module.getAttribute('data-display-number-suggestions')
+    this.suggestionIcon = $module.getAttribute('data-suggestion-icon')
+    this.debounceTime = $module.getAttribute('data-request-debounce-time')
+    this.positionResults = $module.getAttribute('data-position-results')
+    this.submitOnSelect = $module.getAttribute('data-submit-on-select')
+    this.staticOptions = $module.getAttribute('data-source')
+  }
+
+  GemAutocomplete.prototype.init = function (source) {
+    this.source = source || this.staticOptions
+    var numberSuggestions = this.numberSuggestions
+    var suggestionIcon = this.suggestionIcon
+    var debounceTime = this.debounceTime
+    var positionResults = this.positionResults
+    var submitOnSelect = this.submitOnSelect
+
+    var searchIcon = '<span class="search-icon"><svg width="20" height="20" viewBox="0 0 27 27" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"><circle cx="12.0161" cy="11.0161" r="8.51613" stroke="currentColor" stroke-width="3" /><line x1="17.8668" y1="17.3587" x2="26.4475" y2="25.9393" stroke="currentColor" stroke-width="3" /></svg></span>'
+
+    var renderResultHtml = function (result, props, inputVal) {
+      var index = result.toLowerCase().indexOf(inputVal.toLowerCase())
+      return `<li ${props}>${suggestionIcon ? searchIcon : ''}<span class='govuk-!-font-weight-bold'>${result.substring(0, index)}</span>${result.substring(index, index + inputVal.length)}<span class='govuk-!-font-weight-bold'>${result.substring(index + inputVal.length, result.length)}<span><div class='border'></div></li>`
+    }
+
+    new Autocomplete(this.$module, // eslint-disable-line no-new
+      this.source,
+      renderResultHtml,
+      debounceTime,
+      numberSuggestions,
+      positionResults,
+      submitOnSelect
+    )
+  }
+
+  Modules.GemAutocomplete = GemAutocomplete
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/govuk_publishing_components/components/autocomplete.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/autocomplete.js
@@ -314,7 +314,6 @@ window.GOVUK.Modules.GovukAutocomplete = window.GOVUKFrontend.Autocomplete;
     renderResult,
     debounceTime = 0,
     numberSuggestions,
-    positionResults,
     submitOnSelect = false,
     onUpdate = () => { },
     onSubmit = () => { },
@@ -328,7 +327,6 @@ window.GOVUK.Modules.GovukAutocomplete = window.GOVUKFrontend.Autocomplete;
     this.loading = false
     this.position = {}
     this.resetPosition = true
-    this.positionResults = positionResults
     this.root = typeof root === 'string' ? document.querySelector(root) : root
     this.root.insertAdjacentHTML('beforeend', '<ul class="gem-c-autocomplete__result-list govuk-body" role="listbox"></ul><div aria-atomic="true" aria-live="polite" role="status" class="govuk-visually-hidden">No results.</div>')
     this.input = this.root.querySelector('input')
@@ -386,9 +384,6 @@ window.GOVUK.Modules.GovukAutocomplete = window.GOVUKFrontend.Autocomplete;
         resultListAriaLabel.content
       )
 
-    if (this.positionResults === 'absolute') {
-      this.resultList.style.position = 'absolute'
-    }
     this.resultList.style.zIndex = '1'
     this.resultList.style.width = '100%'
     this.resultList.style.boxSizing = 'border-box'
@@ -535,7 +530,6 @@ window.GOVUK.Modules.GovukAutocomplete = window.GOVUKFrontend.Autocomplete;
     this.numberSuggestions = $module.getAttribute('data-display-number-suggestions')
     this.suggestionIcon = $module.getAttribute('data-suggestion-icon')
     this.debounceTime = $module.getAttribute('data-request-debounce-time')
-    this.positionResults = $module.getAttribute('data-position-results')
     this.submitOnSelect = $module.getAttribute('data-submit-on-select')
     this.staticOptions = $module.getAttribute('data-source')
   }
@@ -545,7 +539,6 @@ window.GOVUK.Modules.GovukAutocomplete = window.GOVUKFrontend.Autocomplete;
     var numberSuggestions = this.numberSuggestions
     var suggestionIcon = this.suggestionIcon
     var debounceTime = this.debounceTime
-    var positionResults = this.positionResults
     var submitOnSelect = this.submitOnSelect
 
     var searchIcon = '<span class="gem-c-autocomplete__result--search-icon"><svg width="20" height="20" viewBox="0 0 27 27" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"><circle cx="12.0161" cy="11.0161" r="8.51613" stroke="currentColor" stroke-width="3" /><line x1="17.8668" y1="17.3587" x2="26.4475" y2="25.9393" stroke="currentColor" stroke-width="3" /></svg></span>'
@@ -560,7 +553,6 @@ window.GOVUK.Modules.GovukAutocomplete = window.GOVUKFrontend.Autocomplete;
       renderResultHtml,
       debounceTime,
       numberSuggestions,
-      positionResults,
       submitOnSelect
     )
   }

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -12,6 +12,7 @@
 @import "components/action-link";
 @import "components/attachment";
 @import "components/attachment-link";
+@import "components/autocomplete";
 @import "components/back-link";
 @import "components/big-number";
 @import "components/breadcrumbs";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_autocomplete.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_autocomplete.scss
@@ -20,6 +20,9 @@
   background: govuk-colour("white");
   list-style: none;
   position: relative;
+  z-index: 1;
+  width: 100%;
+  top: 100%;
 }
 
 .gem-c-autocomplete__result { 
@@ -40,6 +43,7 @@
   &--search-icon {
     padding-right: govuk-spacing(2);
     vertical-align: middle;
+    color: $govuk-secondary-text-colour;
   }
 
   &--border {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_autocomplete.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_autocomplete.scss
@@ -2,11 +2,6 @@
 
 .gem-c-autocomplete {
   position: relative;
-
-  > .govuk-form-group,
-  > .gem-c-search {
-    margin-bottom: 0;
-  }
 }
 
 .gem-c-autocomplete__result-list {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_autocomplete.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_autocomplete.scss
@@ -3,47 +3,47 @@
 .gem-c-autocomplete {
   position: relative;
 
-  > div {
+  > .govuk-form-group {
     margin-bottom: 0;
   }
-  
-  .gem-c-autocomplete-result-list {
-    border: 1px solid $govuk-border-colour;
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-    overflow-y: auto;
-    -webkit-overflow-scrolling: touch;
-    background: govuk-colour("white");
-    list-style: none;
-    position: relative;
-  }
-  
-  .gem-c-autocomplete-result {
-    cursor: default;
-    padding: govuk-spacing(2) govuk-spacing(2) 0 govuk-spacing(2);
-    position: relative;
+}
 
-    .search-icon {
-      padding-right: govuk-spacing(2);
-      vertical-align: middle;
-    }
-  
-    .border {
-      height: govuk-spacing(2);
-      display: block;
-      width: 100%;
-      border-bottom: 1px solid $govuk-border-colour;
-    }
-  
-    &:last-child .border {
-      border-bottom: 0;
-    }
-  
-    &:hover,
-    &[aria-selected="true"] {
-      background-color: govuk-colour("light-grey");
-      cursor: pointer;
-    }
+.gem-c-autocomplete__result-list {
+  border: 1px solid $govuk-border-colour;
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  background: govuk-colour("white");
+  list-style: none;
+  position: relative;
+}
+
+.gem-c-autocomplete__result { 
+  cursor: default;
+  padding: govuk-spacing(2) govuk-spacing(2) 0 govuk-spacing(2);
+  position: relative;
+
+  &:last-child .gem-c-autocomplete__result--border {
+    border-bottom: 0;
+  }
+
+  &:hover,
+  &[aria-selected="true"] {
+    background-color: govuk-colour("light-grey");
+    cursor: pointer;
+  }
+
+  &--search-icon {
+    padding-right: govuk-spacing(2);
+    vertical-align: middle;
+  }
+
+  &--border {
+    height: govuk-spacing(2);
+    display: block;
+    width: 100%;
+    border-bottom: 1px solid $govuk-border-colour;
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_autocomplete.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_autocomplete.scss
@@ -1,0 +1,49 @@
+@import "govuk_publishing_components/individual_component_support";
+
+.gem-c-autocomplete {
+  position: relative;
+
+  > div {
+    margin-bottom: 0;
+  }
+  
+  .gem-c-autocomplete-result-list {
+    border: 1px solid $govuk-border-colour;
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    background: govuk-colour("white");
+    list-style: none;
+    position: relative;
+  }
+  
+  .gem-c-autocomplete-result {
+    cursor: default;
+    padding: govuk-spacing(2) govuk-spacing(2) 0 govuk-spacing(2);
+    position: relative;
+
+    .search-icon {
+      padding-right: govuk-spacing(2);
+      vertical-align: middle;
+    }
+  
+    .border {
+      height: govuk-spacing(2);
+      display: block;
+      width: 100%;
+      border-bottom: 1px solid $govuk-border-colour;
+    }
+  
+    &:last-child .border {
+      border-bottom: 0;
+    }
+  
+    &:hover,
+    &[aria-selected="true"] {
+      background-color: govuk-colour("light-grey");
+      cursor: pointer;
+    }
+  }
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/_autocomplete.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_autocomplete.scss
@@ -3,7 +3,8 @@
 .gem-c-autocomplete {
   position: relative;
 
-  > .govuk-form-group {
+  > .govuk-form-group,
+  > .gem-c-search {
     margin-bottom: 0;
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_autocomplete.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_autocomplete.scss
@@ -4,6 +4,12 @@
   position: relative;
 }
 
+.gem-c-autocomplete--absolute {
+  .gem-c-autocomplete__result-list {
+    position: absolute;
+  }
+}
+
 .gem-c-autocomplete__result-list {
   border: 1px solid $govuk-border-colour;
   margin: 0;

--- a/app/views/govuk_publishing_components/components/_autocomplete.html.erb
+++ b/app/views/govuk_publishing_components/components/_autocomplete.html.erb
@@ -32,11 +32,9 @@ end
     raise ArgumentError, "The autocomplete requires a source url or array to retrieve suggestions"
   end %>
   <% if (block = yield).empty? %>
-    <%= render "govuk_publishing_components/components/input", {
-      label: {
-        text: "Search"
-      },
-      name: "search"
+    <%= render "govuk_publishing_components/components/search", {
+      inline_label: false,
+      label_text: "Search"
     } %>
   <% else %>
     <%= block %>

--- a/app/views/govuk_publishing_components/components/_autocomplete.html.erb
+++ b/app/views/govuk_publishing_components/components/_autocomplete.html.erb
@@ -1,0 +1,44 @@
+<%
+add_gem_component_stylesheet("autocomplete")
+display_number_suggestions ||= 5
+suggestion_icon ||= ''
+request_debounce_time ||= ''
+source ||= nil
+position_results ||= nil
+submit_form_on_select ||= false
+idPostfix ||= "#{SecureRandom.hex(4)}"
+
+component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+component_helper.add_class("gem-c-autocomplete")
+component_helper.add_data_attribute({ module: "gem-autocomplete" })
+component_helper.add_data_attribute({ source: source })
+component_helper.add_data_attribute({ id_postfix: idPostfix })
+
+component_helper.add_data_attribute({ display_number_suggestions: display_number_suggestions })
+component_helper.add_data_attribute({ suggestion_icon: suggestion_icon })
+component_helper.add_data_attribute({ submit_on_select: submit_form_on_select })
+
+if position_results.present?
+  component_helper.add_data_attribute({ position_results: 'absolute' })
+end
+
+if request_debounce_time.present?
+  component_helper.add_data_attribute({ request_debounce_time: request_debounce_time })
+end
+%>
+
+<%= tag.div(**component_helper.all_attributes) do %>
+  <% if source.nil?
+    raise ArgumentError, "The autocomplete requires a source url or array to retrieve suggestions"
+  end %>
+  <% if (block = yield).empty? %>
+    <%= render "govuk_publishing_components/components/input", {
+      label: {
+        text: "Search"
+      },
+      name: "search"
+    } %>
+  <% else %>
+    <%= block %>
+  <% end %>
+<% end %>

--- a/app/views/govuk_publishing_components/components/_autocomplete.html.erb
+++ b/app/views/govuk_publishing_components/components/_autocomplete.html.erb
@@ -1,42 +1,34 @@
 <%
-add_gem_component_stylesheet("autocomplete")
-display_number_suggestions ||= 5
-suggestion_icon ||= ''
-request_debounce_time ||= ''
-source ||= nil
-position_results ||= nil
-submit_form_on_select ||= false
-idPostfix ||= "#{SecureRandom.hex(4)}"
+  add_gem_component_stylesheet("autocomplete")
+  display_number_suggestions ||= 5
+  suggestion_icon ||= ''
+  request_debounce_time ||= ''
+  source ||= nil
+  position_results ||= nil
+  submit_form_on_select ||= false
+  idPostfix ||= "#{SecureRandom.hex(4)}"
 
-component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
-component_helper.add_class("gem-c-autocomplete")
-component_helper.add_data_attribute({ module: "gem-autocomplete" })
-component_helper.add_data_attribute({ source: source })
-component_helper.add_data_attribute({ id_postfix: idPostfix })
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("gem-c-autocomplete")
+  component_helper.add_data_attribute({ module: "gem-autocomplete" })
+  component_helper.add_data_attribute({ source: source })
+  component_helper.add_data_attribute({ id_postfix: idPostfix })
 
-component_helper.add_data_attribute({ display_number_suggestions: display_number_suggestions })
-component_helper.add_data_attribute({ suggestion_icon: suggestion_icon })
-component_helper.add_data_attribute({ submit_on_select: submit_form_on_select })
+  component_helper.add_data_attribute({ display_number_suggestions: display_number_suggestions })
+  component_helper.add_data_attribute({ suggestion_icon: suggestion_icon })
+  component_helper.add_data_attribute({ submit_on_select: submit_form_on_select })
 
-if position_results.present?
-  component_helper.add_data_attribute({ position_results: 'absolute' })
-end
-
-if request_debounce_time.present?
-  component_helper.add_data_attribute({ request_debounce_time: request_debounce_time })
-end
+  component_helper.add_data_attribute({ position_results: 'absolute' }) if position_results.present?
+  component_helper.add_data_attribute({ request_debounce_time: request_debounce_time }) if request_debounce_time.present?
 %>
 
 <%= tag.div(**component_helper.all_attributes) do %>
   <% if source.nil?
     raise ArgumentError, "The autocomplete requires a source url or array to retrieve suggestions"
   end %>
-  <% if (block = yield).empty? %>
-    <%= render "govuk_publishing_components/components/search", {
-      inline_label: false,
-      label_text: "Search"
-    } %>
-  <% else %>
-    <%= block %>
-  <% end %>
+  <%= render "govuk_publishing_components/components/search", {
+    inline_label: false,
+    label_text: "Search",
+    margin_bottom: 0
+  } %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/_autocomplete.html.erb
+++ b/app/views/govuk_publishing_components/components/_autocomplete.html.erb
@@ -18,7 +18,8 @@
   component_helper.add_data_attribute({ suggestion_icon: suggestion_icon })
   component_helper.add_data_attribute({ submit_on_select: submit_form_on_select })
 
-  component_helper.add_data_attribute({ position_results: 'absolute' }) if position_results.present?
+  ; component_helper.add_data_attribute({ position_results: 'absolute' }) if position_results.present?
+  component_helper.add_class("gem-c-autocomplete--absolute") if position_results.present?
   component_helper.add_data_attribute({ request_debounce_time: request_debounce_time }) if request_debounce_time.present?
 %>
 

--- a/app/views/govuk_publishing_components/components/_autocomplete.html.erb
+++ b/app/views/govuk_publishing_components/components/_autocomplete.html.erb
@@ -2,11 +2,11 @@
   add_gem_component_stylesheet("autocomplete")
   display_number_suggestions ||= 5
   suggestion_icon ||= ''
-  request_debounce_time ||= ''
+  throttle_delay_time ||= ''
   source ||= nil
   position_results ||= nil
   submit_form_on_select ||= false
-  idPostfix ||= "#{SecureRandom.hex(4)}"
+  idPostfix = "#{SecureRandom.hex(4)}"
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-autocomplete")
@@ -18,9 +18,8 @@
   component_helper.add_data_attribute({ suggestion_icon: suggestion_icon })
   component_helper.add_data_attribute({ submit_on_select: submit_form_on_select })
 
-  ; component_helper.add_data_attribute({ position_results: 'absolute' }) if position_results.present?
   component_helper.add_class("gem-c-autocomplete--absolute") if position_results.present?
-  component_helper.add_data_attribute({ request_debounce_time: request_debounce_time }) if request_debounce_time.present?
+  component_helper.add_data_attribute({ throttle_delay_time: throttle_delay_time }) if throttle_delay_time.present?
 %>
 
 <%= tag.div(**component_helper.all_attributes) do %>

--- a/app/views/govuk_publishing_components/components/docs/autocomplete.yml
+++ b/app/views/govuk_publishing_components/components/docs/autocomplete.yml
@@ -36,10 +36,6 @@ examples:
   default:
     data:
       source: ['prime minister','deputy prime minister','contact prime minister','email prime minister','last prime minister']
-  source:
-    description: (Required) Url to get suggestion data from or an array of suggestions. Query parameter of ?q={inputValue} will be appended The array option exists mainly for the purposes of demonstration and testing where an HTTP endpoint is not ideal. If you have a static array of suggestions consider another approach that enhances an HTML select element.
-    data:
-      source: ['prime minister','deputy prime minister','contact prime minister','email prime minister','last prime minister']
   number_of_suggestions_to_display:
     description: The number of suggestions to be displayed to the user. If not specified the default is 5 suggestions.
     data:
@@ -60,10 +56,10 @@ examples:
       Options that cannot be demoed in the context of the example below.
 
       * **submit_form_on_select** Submits the surrounding form when a suggestion is selected. Defaults to false. Note that this isnt neccessarily the best behaviour in accessibilty terms.
-      * **request_debounce_time** Interval time (milliseconds) to debounce request for data.
+      * **throttle_delay_time** Interval time (milliseconds) to delay requests for data (sometimes refered to as debounce).
     data:
       source: ['prime minister','deputy prime minister','contact prime minister','email prime minister','last prime minister']
       submit_form_on_select: true
-      request_debounce_time: 100
+      throttle_delay_time: 100
 
 

--- a/app/views/govuk_publishing_components/components/docs/autocomplete.yml
+++ b/app/views/govuk_publishing_components/components/docs/autocomplete.yml
@@ -1,0 +1,70 @@
+
+name: Autocomplete (experimental)
+description: The autocomplete component lets users select from a dynamic list of suggestions to populate the value of a text input element.
+govuk_frontend_components:
+  - autocomplete
+body: |
+  If suggestions come from a static source then enchancing a server rendered HTML select element is a better option.
+
+  This component is currently experimental because more research is needed to validate it pending autocomplete implementation documented in the [GDS roadmap](https://design-system.service.gov.uk/community/upcoming-components-patterns/).  If using this component, [please feed back any research findings to the Design System team](https://design-system.service.gov.uk/get-in-touch/).
+accessibility_criteria: |
+  * Be focusable with a keyboard
+  * Indicate when it has keyboard focus
+  * Inform the user that it is an editable field
+  * Inform the user if there is a pre-filled value
+  * Inform the user that autocomplete is available
+  * Explain how to use autocomplete
+  * Inform the user that content has been expanded
+  * Inform the user when there are matches, or if there are no matches
+  * Inform the user as the number of matches changes
+  * Enable the user to navigate the available matches using touch or keyboard
+  * Inform the user when a match is selected
+  * Inform the user if a match is pre-selected
+  * Enable the user to confirm the selected match
+  * Inform the user when a match is confirmed
+  * Return focus to the editable field when a selected match is confirmed
+uses_component_wrapper_helper: true
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    description: url to get suggestion data from or an array of suggestions (required). Query parameter of ?q={inputValue} will be appended The array option exists mainly for the purposes of demonstration and testing where an HTTP endpoint is not ideal. If you have a static array of suggestions consider another approach that enhances an HTML select element.
+    data:
+      source: ['prime minister','deputy prime minister','contact prime minister','email prime minister','last prime minister']
+  custom_input_element:
+    description: Pass a block if you need to apply autocomplete to a custom input element
+    data:
+      source: ['prime minister','deputy prime minister','contact prime minister','email prime minister','last prime minister']
+      block: |
+        <!-- example content -->
+          <%= render "govuk_publishing_components/components/search", {
+            inline_label: false,
+            label_text: "Search"
+          } %>
+  number_of_suggestions_to_display:
+    description: The number of suggestions to be displayed to the user. If not specified the default is 5 suggestions. Number of results if they are truly dynamic should ideally limited at the backend with a limit url param.
+    data:
+      source: ['prime minister','deputy prime minister','contact prime minister','email prime minister','last prime minister']
+      display_number_suggestions: 3
+  position_results:
+    description: Wether results are positioned relative or absolute to surrounding content. Defaults to relative
+    data:
+      source: ['prime minister','deputy prime minister','contact prime minister','email prime minister','last prime minister']
+      position_results: absolute
+  suggestion_icon:
+    description: Display each suggestion with left aligned search icon
+    data:
+      source: ['prime minister','deputy prime minister','contact prime minister','email prime minister','last prime minister']
+      suggestion_icon: true
+  other_configuration_options:
+    description: |
+      Options that cannot be demoed in the context of the example below.
+
+      * **submit_form_on_select** Submits the surrounding form when a suggestion is selected. Defaults to false. Note that this isnt neccessarily the best behaviour in accessibilty terms.
+      * **request_debounce_time** Interval time (milliseconds) to debounce request for data.
+    data:
+      source: ['prime minister','deputy prime minister','contact prime minister','email prime minister','last prime minister']
+      submit_form_on_select: true
+      request_debounce_time: 100
+
+

--- a/app/views/govuk_publishing_components/components/docs/autocomplete.yml
+++ b/app/views/govuk_publishing_components/components/docs/autocomplete.yml
@@ -2,11 +2,15 @@
 name: Autocomplete (experimental)
 description: The autocomplete component lets users select from a dynamic list of suggestions to populate the value of a search input element.
 body: |
-  This component does not perform any matching of user input to refine suggestions. The assumption is that the backend that the query string is supplied to does the matching and returns only results that are appropriate.
+  This component does not perform any matching of user input to refine suggestions. The assumption is that the backend returns only results that match the query string.
 
-  A static list of suggestions are used for these examples (see source option below) but if suggestions come from a static source then enhancing a server rendered HTML select element is a better option.
+  This component is currently experimental because more research is needed to validate it pending autocomplete implementation documented in the [GDS roadmap](https://design-system.service.gov.uk/community/upcoming-components-patterns/).
 
-  This component is currently experimental because more research is needed to validate it pending autocomplete implementation documented in the [GDS roadmap](https://design-system.service.gov.uk/community/upcoming-components-patterns/).  If using this component, [please feed back any research findings to the Design System team](https://design-system.service.gov.uk/get-in-touch/).
+  ### source (required configuration option)
+
+  Url to request suggestion data from. A query parameter of q={inputValue} will be appended to this url.
+
+  Supplying source as a hardcoded array exists for the purposes of demonstration and testing where an actual HTTP endpoint is not ideal.
 accessibility_criteria: |
   The autocomplete must:
 
@@ -30,27 +34,14 @@ shared_accessibility_criteria:
   - link
 examples:
   default:
-    description: (Required) Url to get suggestion data from or an array of suggestions. Query parameter of ?q={inputValue} will be appended The array option exists mainly for the purposes of demonstration and testing where an HTTP endpoint is not ideal. If you have a static array of suggestions consider another approach that enhances an HTML select element.
     data:
       source: ['prime minister','deputy prime minister','contact prime minister','email prime minister','last prime minister']
   source:
     description: (Required) Url to get suggestion data from or an array of suggestions. Query parameter of ?q={inputValue} will be appended The array option exists mainly for the purposes of demonstration and testing where an HTTP endpoint is not ideal. If you have a static array of suggestions consider another approach that enhances an HTML select element.
     data:
       source: ['prime minister','deputy prime minister','contact prime minister','email prime minister','last prime minister']
-  custom_input_element:
-    description: Pass a block if you need to apply autocomplete to a custom input element
-    data:
-      source: ['prime minister','deputy prime minister','contact prime minister','email prime minister','last prime minister']
-      block: |
-        <!-- example content -->
-        <%= render "govuk_publishing_components/components/input", {
-          label: {
-            text: "Enter some text"
-          },
-          name: "query"
-        } %>
   number_of_suggestions_to_display:
-    description: The number of suggestions to be displayed to the user. If not specified the default is 5 suggestions. Number of results if they are truly dynamic should ideally limited at the backend with a limit url param.
+    description: The number of suggestions to be displayed to the user. If not specified the default is 5 suggestions.
     data:
       source: ['prime minister','deputy prime minister','contact prime minister','email prime minister','last prime minister']
       display_number_suggestions: 3

--- a/app/views/govuk_publishing_components/components/docs/autocomplete.yml
+++ b/app/views/govuk_publishing_components/components/docs/autocomplete.yml
@@ -1,13 +1,13 @@
 
 name: Autocomplete (experimental)
 description: The autocomplete component lets users select from a dynamic list of suggestions to populate the value of a text input element.
-govuk_frontend_components:
-  - autocomplete
 body: |
-  If suggestions come from a static source then enchancing a server rendered HTML select element is a better option.
+  If suggestions come from a static source then enhancing a server rendered HTML select element is a better option.
 
   This component is currently experimental because more research is needed to validate it pending autocomplete implementation documented in the [GDS roadmap](https://design-system.service.gov.uk/community/upcoming-components-patterns/).  If using this component, [please feed back any research findings to the Design System team](https://design-system.service.gov.uk/get-in-touch/).
 accessibility_criteria: |
+  The autocomplete must:
+
   * Be focusable with a keyboard
   * Indicate when it has keyboard focus
   * Inform the user that it is an editable field
@@ -28,6 +28,10 @@ shared_accessibility_criteria:
   - link
 examples:
   default:
+    description: The url to get suggestion data from or an array of suggestions (required). Query parameter of ?q={inputValue} will be appended to request url. The array option exists mainly for the purposes of demonstration and testing where an HTTP endpoint is not ideal. If you have a static array of suggestions consider another approach that enhances an HTML select element.
+    data:
+      source: ['prime minister','deputy prime minister','contact prime minister','email prime minister','last prime minister']
+  source:
     description: url to get suggestion data from or an array of suggestions (required). Query parameter of ?q={inputValue} will be appended The array option exists mainly for the purposes of demonstration and testing where an HTTP endpoint is not ideal. If you have a static array of suggestions consider another approach that enhances an HTML select element.
     data:
       source: ['prime minister','deputy prime minister','contact prime minister','email prime minister','last prime minister']
@@ -47,7 +51,7 @@ examples:
       source: ['prime minister','deputy prime minister','contact prime minister','email prime minister','last prime minister']
       display_number_suggestions: 3
   position_results:
-    description: Wether results are positioned relative or absolute to surrounding content. Defaults to relative
+    description: Controls whether autocomplete suggestions are positioned relative to the input (so that content below is pushed down when they appear) or absolute (content below is overlapped when they appear). Defaults to relative.
     data:
       source: ['prime minister','deputy prime minister','contact prime minister','email prime minister','last prime minister']
       position_results: absolute

--- a/app/views/govuk_publishing_components/components/docs/autocomplete.yml
+++ b/app/views/govuk_publishing_components/components/docs/autocomplete.yml
@@ -1,8 +1,10 @@
 
 name: Autocomplete (experimental)
-description: The autocomplete component lets users select from a dynamic list of suggestions to populate the value of a text input element.
+description: The autocomplete component lets users select from a dynamic list of suggestions to populate the value of a search input element.
 body: |
-  If suggestions come from a static source then enhancing a server rendered HTML select element is a better option.
+  This component does not perform any matching of user input to refine suggestions. The assumption is that the backend that the query string is supplied to does the matching and returns only results that are appropriate.
+
+  A static list of suggestions are used for these examples (see source option below) but if suggestions come from a static source then enhancing a server rendered HTML select element is a better option.
 
   This component is currently experimental because more research is needed to validate it pending autocomplete implementation documented in the [GDS roadmap](https://design-system.service.gov.uk/community/upcoming-components-patterns/).  If using this component, [please feed back any research findings to the Design System team](https://design-system.service.gov.uk/get-in-touch/).
 accessibility_criteria: |
@@ -28,11 +30,11 @@ shared_accessibility_criteria:
   - link
 examples:
   default:
-    description: The url to get suggestion data from or an array of suggestions (required). Query parameter of ?q={inputValue} will be appended to request url. The array option exists mainly for the purposes of demonstration and testing where an HTTP endpoint is not ideal. If you have a static array of suggestions consider another approach that enhances an HTML select element.
+    description: (Required) Url to get suggestion data from or an array of suggestions. Query parameter of ?q={inputValue} will be appended The array option exists mainly for the purposes of demonstration and testing where an HTTP endpoint is not ideal. If you have a static array of suggestions consider another approach that enhances an HTML select element.
     data:
       source: ['prime minister','deputy prime minister','contact prime minister','email prime minister','last prime minister']
   source:
-    description: url to get suggestion data from or an array of suggestions (required). Query parameter of ?q={inputValue} will be appended The array option exists mainly for the purposes of demonstration and testing where an HTTP endpoint is not ideal. If you have a static array of suggestions consider another approach that enhances an HTML select element.
+    description: (Required) Url to get suggestion data from or an array of suggestions. Query parameter of ?q={inputValue} will be appended The array option exists mainly for the purposes of demonstration and testing where an HTTP endpoint is not ideal. If you have a static array of suggestions consider another approach that enhances an HTML select element.
     data:
       source: ['prime minister','deputy prime minister','contact prime minister','email prime minister','last prime minister']
   custom_input_element:
@@ -41,10 +43,12 @@ examples:
       source: ['prime minister','deputy prime minister','contact prime minister','email prime minister','last prime minister']
       block: |
         <!-- example content -->
-          <%= render "govuk_publishing_components/components/search", {
-            inline_label: false,
-            label_text: "Search"
-          } %>
+        <%= render "govuk_publishing_components/components/input", {
+          label: {
+            text: "Enter some text"
+          },
+          name: "query"
+        } %>
   number_of_suggestions_to_display:
     description: The number of suggestions to be displayed to the user. If not specified the default is 5 suggestions. Number of results if they are truly dynamic should ideally limited at the backend with a limit url param.
     data:

--- a/package.json
+++ b/package.json
@@ -53,5 +53,6 @@
   "resolutions": {
     "stylelint/strip-ansi": "6.0.1",
     "stylelint/string-width": "4.2.3"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,5 @@
   "resolutions": {
     "stylelint/strip-ansi": "6.0.1",
     "stylelint/string-width": "4.2.3"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/spec/components/autocomplete_spec.rb
+++ b/spec/components/autocomplete_spec.rb
@@ -35,10 +35,10 @@ describe "Autocomplete", type: :view do
     assert_select "[data-display-number-suggestions='3']", count: 1
   end
 
-  it "add debounce time data attribute" do
-    render_component({ source: "/url", request_debounce_time: 100 })
+  it "add throttle delay time data attribute" do
+    render_component({ source: "/url", throttle_delay_time: 100 })
 
-    assert_select "[data-request-debounce-time='100']", count: 1
+    assert_select "[data-throttle-delay-time='100']", count: 1
   end
 
   it "add position results data attribute" do

--- a/spec/components/autocomplete_spec.rb
+++ b/spec/components/autocomplete_spec.rb
@@ -23,17 +23,6 @@ describe "Autocomplete", type: :view do
     end
   end
 
-  def block
-    "<input class=\"gem-c-search__item gem-c-search__input\" name=\"q\" title=\"Search\" type=\"search\" value=\"\" role=\"combobox\" autocomplete=\"off\" autocapitalize=\"off\" spellcheck=\"false\" >".html_safe
-  end
-
-  it "renders one custom input element" do
-    render_component(test_data) { block }
-
-    assert_select "input", count: 1
-    assert_select ".gem-c-search__input", count: 1
-  end
-
   it "add suggestion icon data attribute" do
     render_component({ source: "/url", suggestion_icon: true })
 

--- a/spec/components/autocomplete_spec.rb
+++ b/spec/components/autocomplete_spec.rb
@@ -44,7 +44,7 @@ describe "Autocomplete", type: :view do
   it "add position results data attribute" do
     render_component({ source: "/url", position_results: "absolute" })
 
-    assert_select "[data-position-results='absolute']", count: 1
+    assert_select ".gem-c-autocomplete--absolute", count: 1
   end
 
   it "add submit on select data attribute" do

--- a/spec/components/autocomplete_spec.rb
+++ b/spec/components/autocomplete_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+describe "Autocomplete", type: :view do
+  def component_name
+    "autocomplete"
+  end
+
+  test_data = {
+    source: "/url",
+  }
+
+  it "renders with default attributes and content" do
+    render_component(test_data)
+
+    assert_select "input", count: 1
+    assert_select "[data-suggestion-icon='true']", count: 0
+    assert_select "[data-display-number-suggestions='5']", count: 1
+  end
+
+  it "throws error if no suggestion source_url provided" do
+    assert_raises ActionView::Template::Error do
+      render_component({})
+    end
+  end
+
+  def block
+    "<input class=\"gem-c-search__item gem-c-search__input\" name=\"q\" title=\"Search\" type=\"search\" value=\"\" role=\"combobox\" autocomplete=\"off\" autocapitalize=\"off\" spellcheck=\"false\" >".html_safe
+  end
+
+  it "renders one custom input element" do
+    render_component(test_data) { block }
+
+    assert_select "input", count: 1
+    assert_select ".gem-c-search__input", count: 1
+  end
+
+  it "add suggestion icon data attribute" do
+    render_component({ source: "/url", suggestion_icon: true })
+
+    assert_select "[data-suggestion-icon='true']", count: 1
+  end
+
+  it "add number suggestions to display data attribute" do
+    render_component({ source: "/url", display_number_suggestions: 3 })
+
+    assert_select "[data-display-number-suggestions='3']", count: 1
+  end
+
+  it "add debounce time data attribute" do
+    render_component({ source: "/url", request_debounce_time: 100 })
+
+    assert_select "[data-request-debounce-time='100']", count: 1
+  end
+
+  it "add position results data attribute" do
+    render_component({ source: "/url", position_results: "absolute" })
+
+    assert_select "[data-position-results='absolute']", count: 1
+  end
+
+  it "add submit on select data attribute" do
+    render_component({ source: "/url", submit_form_on_select: true })
+
+    assert_select "[data-submit-on-select='true']", count: 1
+  end
+end

--- a/spec/javascripts/components/autocomplete-spec.js
+++ b/spec/javascripts/components/autocomplete-spec.js
@@ -38,7 +38,7 @@ describe('Autocomplete component', function () {
     jasmine.clock().install()
 
     $input = autocomplete.querySelector('input')
-    $resultList = autocomplete.querySelector('.gem-c-autocomplete-result-list')
+    $resultList = autocomplete.querySelector('.gem-c-autocomplete__result-list')
   })
 
   afterEach(function () {
@@ -112,13 +112,13 @@ describe('Autocomplete component', function () {
       describe('keyboard behaviour', function () {
         it('user can navigate the available matches using keyboard', function () {
           $input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', keyCode: 40 }))
-          expect($input.getAttribute('aria-activedescendant')).toBe('gem-c-autocomplete-result-0')
+          expect($input.getAttribute('aria-activedescendant')).toBe('gem-c-autocomplete__result-0')
 
           $input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', keyCode: 38 }))
-          expect($input.getAttribute('aria-activedescendant')).toBe('gem-c-autocomplete-result-4')
+          expect($input.getAttribute('aria-activedescendant')).toBe('gem-c-autocomplete__result-4')
 
           $input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', keyCode: 40 }))
-          expect($input.getAttribute('aria-activedescendant')).toBe('gem-c-autocomplete-result-0')
+          expect($input.getAttribute('aria-activedescendant')).toBe('gem-c-autocomplete__result-0')
         })
 
         it('space key closes the menu, sets the query, focuses the input', () => {

--- a/spec/javascripts/components/autocomplete-spec.js
+++ b/spec/javascripts/components/autocomplete-spec.js
@@ -2,13 +2,9 @@
 /* global GOVUK, KeyboardEvent */
 
 describe('Autocomplete component', function () {
-  var autocomplete
+  var $autocomplete
+  var instance
   var container
-  var html =
-    `<div class="gem-c-autocomplete" data-expanded="false" data-loading="false" data-source="/url" data-display-number-suggestions="5">
-        <label for="input-1" class="gem-c-label govuk-label">Country</label>
-        <input class="gem-c-input govuk-input" id="input-1" name="country" type="text" role="combobox" aria-autocomplete="list" aria-haspopup="listbox" aria-expanded="false">
-    </div>`
   var $input
   var $resultList
   var $status
@@ -20,25 +16,28 @@ describe('Autocomplete component', function () {
     'last prime minister'
   ]
 
-  function sourceMock () {
-    return data
-  }
+  var html =
+  `<div class="gem-c-autocomplete" data-expanded="false" data-loading="false" data-source="[&quot;prime minister&quot;,&quot;deputy prime minister&quot;,&quot;contact prime minister&quot;,&quot;email prime minister&quot;,&quot;last prime minister&quot;]" data-display-number-suggestions="5">
+      <label for="input-1" class="gem-c-label govuk-label">Country</label>
+      <input class="gem-c-input govuk-input" id="input-1" name="country" type="text" role="combobox" aria-autocomplete="list" aria-haspopup="listbox" aria-expanded="false">
+  </div>`
 
   function startAutocomplete () {
-    new GOVUK.Modules.GemAutocomplete(autocomplete).init(sourceMock)
+    instance = new GOVUK.Modules.GemAutocomplete($autocomplete).init()
   }
 
   beforeEach(function () {
     container = document.createElement('div')
     container.innerHTML = html
     document.body.appendChild(container)
-    autocomplete = document.querySelector('.gem-c-autocomplete')
+    $autocomplete = document.querySelector('.gem-c-autocomplete')
+
     startAutocomplete()
 
     jasmine.clock().install()
 
-    $input = autocomplete.querySelector('input')
-    $resultList = autocomplete.querySelector('.gem-c-autocomplete__result-list')
+    $input = $autocomplete.querySelector('input')
+    $resultList = $autocomplete.querySelector('.gem-c-autocomplete__result-list')
   })
 
   afterEach(function () {
@@ -67,15 +66,25 @@ describe('Autocomplete component', function () {
       expect(document.querySelectorAll(`#gem-c-autocomplete-assistive-hint-${idPostfix}`).length).toBe(1)
     })
 
-    it('base class', async function () {
+    it('throttle delay time', async function () {
+      instance.core.throttleDelayTime = 2000
+
+      spyOn(instance.core, 'updateResults')
+
+      $input.value = 'r'
+      await $input.focus()
+
+      $input.value += 'r'
+      await $input.focus()
+
+      expect(instance.core.updateResults.calls.count()).toBe(1)
+    })
+
+    it('base class', function () {
       // to be implemented
     })
 
-    it('debounce', async function () {
-      // to be implemented
-    })
-
-    it('form behaviour', async function () {
+    it('form behaviour', function () {
       // to be implemented
     })
 
@@ -88,7 +97,7 @@ describe('Autocomplete component', function () {
 
       describe('general behaviour', function () {
         it('inform the user that content has been expanded', function () {
-          expect(autocomplete.getAttribute('data-expanded')).toBe('true')
+          expect($autocomplete.getAttribute('data-expanded')).toBe('true')
           expect($input.getAttribute('aria-expanded')).toBe('true')
           expect($resultList.getAttribute('role')).toBe('listbox')
           expect($status.getAttribute('aria-atomic')).toBe('true')
@@ -112,13 +121,13 @@ describe('Autocomplete component', function () {
       describe('keyboard behaviour', function () {
         it('user can navigate the available matches using keyboard', function () {
           $input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', keyCode: 40 }))
-          expect($input.getAttribute('aria-activedescendant')).toBe('gem-c-autocomplete__result-0')
+          expect($input.getAttribute('aria-activedescendant')).toBe('gem-c-autocomplete-result-0')
 
           $input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', keyCode: 38 }))
-          expect($input.getAttribute('aria-activedescendant')).toBe('gem-c-autocomplete__result-4')
+          expect($input.getAttribute('aria-activedescendant')).toBe('gem-c-autocomplete-result-4')
 
           $input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', keyCode: 40 }))
-          expect($input.getAttribute('aria-activedescendant')).toBe('gem-c-autocomplete__result-0')
+          expect($input.getAttribute('aria-activedescendant')).toBe('gem-c-autocomplete-result-0')
         })
 
         it('space key closes the menu, sets the query, focuses the input', () => {

--- a/spec/javascripts/components/autocomplete-spec.js
+++ b/spec/javascripts/components/autocomplete-spec.js
@@ -1,0 +1,155 @@
+/* eslint-env jasmine */
+/* global GOVUK, KeyboardEvent */
+
+describe('Autocomplete component', function () {
+  var autocomplete
+  var container
+  var html =
+    `<div class="gem-c-autocomplete" data-expanded="false" data-loading="false" data-source="/url" data-display-number-suggestions="5">
+        <label for="input-1" class="gem-c-label govuk-label">Country</label>
+        <input class="gem-c-input govuk-input" id="input-1" name="country" type="text" role="combobox" aria-autocomplete="list" aria-haspopup="listbox" aria-expanded="false">
+    </div>`
+  var $input
+  var $resultList
+  var $status
+  var data = [
+    'prime minister',
+    'deputy prime minister',
+    'contact prime minister',
+    'email prime minister',
+    'last prime minister'
+  ]
+
+  function sourceMock () {
+    return data
+  }
+
+  function startAutocomplete () {
+    new GOVUK.Modules.GemAutocomplete(autocomplete).init(sourceMock)
+  }
+
+  beforeEach(function () {
+    container = document.createElement('div')
+    container.innerHTML = html
+    document.body.appendChild(container)
+    autocomplete = document.querySelector('.gem-c-autocomplete')
+    startAutocomplete()
+
+    jasmine.clock().install()
+
+    $input = autocomplete.querySelector('input')
+    $resultList = autocomplete.querySelector('.gem-c-autocomplete-result-list')
+  })
+
+  afterEach(function () {
+    jasmine.clock().uninstall()
+    document.body.removeChild(container)
+  })
+
+  describe('initial component state', function () {
+    it('is an editable field that is focusable', async function () {
+      await $input.focus()
+
+      expect($input.getAttribute('role')).toBe('combobox')
+      expect(document.activeElement).toEqual($input)
+      expect($input.getAttribute('aria-autocomplete')).toBe('list')
+    })
+
+    it('user informed of status and instructions', async function () {
+      await $input.focus()
+      $status = document.querySelector('[role="status"]')
+
+      expect($input.getAttribute('aria-expanded')).toBe('false')
+      expect($status.innerHTML).toBe('No results.')
+
+      var idPostfix = container.getAttribute('data-id-postfix')
+      expect($input.getAttribute('aria-describedby')).toBe(`gem-c-autocomplete-assistive-hint-${idPostfix}`)
+      expect(document.querySelectorAll(`#gem-c-autocomplete-assistive-hint-${idPostfix}`).length).toBe(1)
+    })
+
+    it('base class', async function () {
+      // to be implemented
+    })
+
+    it('debounce', async function () {
+      // to be implemented
+    })
+
+    it('form behaviour', async function () {
+      // to be implemented
+    })
+
+    describe('user interaction', function () {
+      beforeEach(async function () {
+        $input.value = 'p'
+        $status = document.querySelector('[role="status"]')
+        await $input.focus()
+      })
+
+      describe('general behaviour', function () {
+        it('inform the user that content has been expanded', function () {
+          expect(autocomplete.getAttribute('data-expanded')).toBe('true')
+          expect($input.getAttribute('aria-expanded')).toBe('true')
+          expect($resultList.getAttribute('role')).toBe('listbox')
+          expect($status.getAttribute('aria-atomic')).toBe('true')
+          expect($status.getAttribute('aria-live')).toBe('polite')
+        })
+
+        it('inform the user when there are matches', function () {
+          expect($resultList.querySelectorAll('li').length).toBe(5)
+          expect($status.innerHTML).toBe('5 results available.')
+        })
+
+        it('allows user to select a suggestion and returns focus to input', function () {
+          $input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', keyCode: 40 }))
+          $input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', keyCode: 13 }))
+
+          expect($input.value).toBe(data[0])
+          expect(document.activeElement).toEqual($input)
+        })
+      })
+
+      describe('keyboard behaviour', function () {
+        it('user can navigate the available matches using keyboard', function () {
+          $input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', keyCode: 40 }))
+          expect($input.getAttribute('aria-activedescendant')).toBe('gem-c-autocomplete-result-0')
+
+          $input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', keyCode: 38 }))
+          expect($input.getAttribute('aria-activedescendant')).toBe('gem-c-autocomplete-result-4')
+
+          $input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', keyCode: 40 }))
+          expect($input.getAttribute('aria-activedescendant')).toBe('gem-c-autocomplete-result-0')
+        })
+
+        it('space key closes the menu, sets the query, focuses the input', () => {
+          $input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', keyCode: 40 }))
+          $input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Space', keyCode: 32 }))
+
+          expect($input.value).toBe(data[0])
+          expect(document.activeElement).toEqual($input)
+          expect($input.getAttribute('aria-expanded')).toBe('false')
+        })
+
+        it('esc key closes the menu, focuses the input', () => {
+          $input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', keyCode: 40 }))
+          $input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Esc', keyCode: 27 }))
+
+          expect($input.value).toBe('')
+          expect(document.activeElement).toEqual($input)
+          expect($input.getAttribute('aria-expanded')).toBe('false')
+        })
+      })
+
+      describe('mouse behaviour', function () {
+        it('user can select suggestion with mouse', async function () {
+          var $option1 = document.querySelector('.gem-c-autocomplete ul li:nth-child(1)')
+          $option1.click()
+
+          expect($input.value).toBe(data[0])
+          expect(document.activeElement).toEqual($input)
+          expect($input.getAttribute('aria-expanded')).toBe('false')
+        })
+      })
+    })
+  })
+})

--- a/spec/lib/govuk_publishing_components/app_helpers/asset_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/app_helpers/asset_helper_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe GovukPublishingComponents::AppHelpers::AssetHelper do
     end
 
     it "detect the total number of stylesheet paths" do
-      expect(get_component_css_paths.count).to eql(74)
+      expect(get_component_css_paths.count).to eql(75)
     end
 
     it "initialize empty asset helper" do


### PR DESCRIPTION
Taking this out of draft status and its becoming reviewable although work continuing:

TODO
- more javascript tests
- ~add more config options (e.g relative/absolute result display, submit on enter)~
- ~add aria live region to rendered component~
- add analytics tracking
- add visual tests

## What
The autocomplete component lets users select from a dynamic list of suggestions to populate the value of a search input element `govuk_publishing_components/components/search`. If suggestions come from a static source then enhancing a server rendered HTML select element is a better option [govuk accessible autocomplete](https://github.com/alphagov/accessible-autocomplete)

Inspiration for this came from:

[govuk accessible autocomplete](https://github.com/alphagov/accessible-autocomplete)
[Adam Silver Blog](https://adamsilver.io/blog/building-an-accessible-autocomplete-control/)

The configuration options are deliberatley minimal to serve immediate requirements but additional options should be easy to add. For that would be nice if argument spread syntax (ES6) could be used and would make adding options easier. As currently the JS is written in ES5 style.
<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
A component is needed that displays dynamic suggestions from a http endpoint based on what the user types. The current use case is suggestions from Google's Vertex solution that is being integrated on homepage and search results page(s)
<!-- What are the reasons behind this change being made? -->

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->
<img width="957" alt="Screenshot 2024-08-16 at 08 40 31" src="https://github.com/user-attachments/assets/cfad3c8d-e4a5-4067-ae42-3743837fbc86">


<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

### Before


### After
