### PR TITLE
Add 'Chat entry' component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Ensure that organisation logos always print ([PR #4162](https://github.com/alphagov/govuk_publishing_components/pull/4162))
 * Fix some layout_header search visual bugs ([PR #4156](https://github.com/alphagov/govuk_publishing_components/pull/4156))
 * Fix issue with using special characters in content-list ([PR #4157](https://github.com/alphagov/govuk_publishing_components/pull/4157))
+* Add 'Chat entry' component ([PR #4151](https://github.com/alphagov/govuk_publishing_components/pull/4151))
 
 ## 42.0.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -18,6 +18,7 @@
 @import "components/button";
 @import "components/cards";
 @import "components/character-count";
+@import "components/chat-entry";
 @import "components/checkboxes";
 @import "components/contents-list";
 @import "components/contextual-guidance";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_chat-entry.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_chat-entry.scss
@@ -1,0 +1,36 @@
+@import "govuk_publishing_components/individual_component_support";
+
+.gem-c-chat-entry {
+  display: flex;
+  align-items: flex-start;
+}
+
+.gem-c-chat-entry--border-top {
+  border-top: 2px solid govuk-colour("blue");
+  padding-top: govuk-spacing(5);
+}
+
+.gem-c-chat-entry--border-bottom {
+  border-bottom: 2px solid govuk-colour("blue");
+  padding-bottom: govuk-spacing(5);
+}
+
+.gem-c-chat-entry__image {
+  flex-shrink: 0;
+  height: 104px;
+  margin-right: govuk-spacing(3);
+  width: 104px;
+
+  @include govuk-media-query($from: tablet) {
+    height: 80px;
+    width: 80px;
+  }
+}
+
+.gem-c-chat-entry__heading {
+  margin: 0 0 govuk-spacing(2);
+  font-size: 19px;
+  font-size: govuk-px-to-rem(19);
+  line-height: 1.25;
+  @include govuk-typography-common;
+}

--- a/app/views/govuk_publishing_components/components/_chat_entry.html.erb
+++ b/app/views/govuk_publishing_components/components/_chat_entry.html.erb
@@ -1,0 +1,46 @@
+<%
+  add_gem_component_stylesheet("chat-entry")
+  local_assigns[:margin_bottom] ||= 6
+  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+  href ||= "/chat"
+  heading_text ||= t("components.chat_entry.heading")
+  description_text ||= t("components.chat_entry.description")
+  border_top ||= false
+  border_bottom ||= false
+
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("gem-c-chat-entry")
+  component_helper.add_class("gem-c-chat-entry--border-top") if border_top
+  component_helper.add_class("gem-c-chat-entry--border-bottom") if border_bottom
+  component_helper.add_class(shared_helper.get_margin_bottom)
+%>
+
+<%= tag.div(**component_helper.all_attributes) do %>
+  <svg class="gem-c-chat-entry__image" viewBox="0 0 104 104" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
+    <rect width="100%" height="100%" fill="#D2E2F1" />
+    <path d="M37.5733 65.7452L51.6131 77.9999H27.9707L37.5733 65.7452Z" fill="#1D70B8" />
+    <path d="M52 78C66.3594 78 78 66.3594 78 52C78 37.6406 66.3594 26 52 26C37.6406 26 26 37.6406 26 52C26 66.3594 37.6406 78 52 78Z" fill="#1D70B8" />
+    <mask id="mask0_48346_4836" style="mask-type: alpha" maskUnits="userSpaceOnUse" x="40" y="58" width="24" height="10">
+      <rect x="41.2962" y="59.1165" width="21.4029" height="6.98153" fill="#D9D9D9" stroke="#F499BE" stroke-width="1.89313" />
+    </mask>
+    <g mask="url(#mask0_48346_4836)">
+      <path
+        d="M46.5668 60.156C47.8844 63.1549 51.3835 64.518 54.3824 63.2004C57.3813 61.8829 58.7443 58.3837 57.4268 55.3848C56.1093 52.3859 52.6101 51.0229 49.6112 52.3404C46.6123 53.658 45.2493 57.1571 46.5668 60.156Z"
+        stroke="#F499BE"
+        stroke-width="4.43733"
+      />
+    </g>
+    <path d="M43.3401 39.3198L50.2778 51.515H36.4023L43.3401 39.3198Z" fill="#FFDD00" />
+    <circle cx="60.2488" cy="45.4078" r="6.10621" fill="#F47738" />
+  </svg>
+
+  <div class="gem-c-chat-entry__description">
+    <%= content_tag(shared_helper.get_heading_level, class: "gem-c-chat-entry__heading") do %>
+      <%= link_to heading_text, href, class: "govuk-link" %>
+    <% end %>
+
+    <% if description_text %>
+      <p class="govuk-body govuk-!-margin-bottom-0"><%= description_text %></p>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/chat_entry.yml
+++ b/app/views/govuk_publishing_components/components/docs/chat_entry.yml
@@ -1,0 +1,36 @@
+name: Chat entry
+description: Entry point for GOV.UK Chat
+accessibility_criteria: |
+  The heading must:
+
+  - be part of a correct heading structure for a page
+  - be semantically represented as a heading
+  - convey the heading level
+uses_component_wrapper_helper: true
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+  with_custom_href,_heading_and_or_description:
+    data:
+      href: /chat
+      heading_text: Go to GOV.UK Chat
+      description_text: Get answers to your business questions
+  with_a_different_heading_level:
+    description: Chat entry has a `h2` by default, but this can be changed. The heading level does not change any styling.
+    data:
+      heading_level: 3
+  with_a_border_top:
+    data:
+      border_top: true
+  with_a_border_bottom:
+    data:
+      border_bottom: true
+  with_a_border_top_and_a_border_bottom:
+    data:
+      border_top: true
+      border_bottom: true
+  with_margin_bottom:
+    data:
+      margin_bottom: 3

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -36,6 +36,9 @@ ar:
       type:
         characters: أحرف
         words: كلمات
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: أو
     contents_list:
@@ -140,8 +143,8 @@ ar:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: العثور عن كل المحتوى من %{organisation}

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -32,6 +32,9 @@ az:
       type:
         characters: simvol
         words: söz
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: və ya
     contents_list:
@@ -137,8 +140,8 @@ az:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: "%{organisation}-dan bütün məzmunu tap"

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -34,6 +34,9 @@ be:
       type:
         characters: знакаў
         words: словаў
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: або
     contents_list:
@@ -143,8 +146,8 @@ be:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: Шукаць увесь змест з %{organisation}

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -32,6 +32,9 @@ bg:
       type:
         characters: символа
         words: думи
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: или
     contents_list:
@@ -141,8 +144,8 @@ bg:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: Намиране на цялото съдържание от %{organisation}

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -32,6 +32,9 @@ bn:
       type:
         characters: ক্যারেক্টার
         words: শব্দসমষ্টি
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: অথবা
     contents_list:
@@ -138,8 +141,8 @@ bn:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: "%{organisation}-এর সকল বিষয়বস্তু খুঁজে বের করুন"

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -33,6 +33,9 @@ cs:
       type:
         characters: znaky
         words: slova
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: nebo
     contents_list:
@@ -142,8 +145,8 @@ cs:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: Najít veškerý obsah z %{organisation}

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -36,6 +36,9 @@ cy:
       type:
         characters: nodau
         words: geiriau
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: neu
     contents_list:
@@ -141,8 +144,8 @@ cy:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: Dod o hyd i'r holl gynnwys gan %{organisation}

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -32,6 +32,9 @@ da:
       type:
         characters: Tegn
         words: ord
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: eller
     contents_list:
@@ -138,8 +141,8 @@ da:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: Find alt indhold fra %{organisation}

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -32,6 +32,9 @@ de:
       type:
         characters: Zeichen
         words: Wörter
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: oder
     contents_list:
@@ -141,8 +144,8 @@ de:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: Alle Inhalte von %{organisation} finden

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -35,6 +35,9 @@ dr:
       type:
         characters: ارقام
         words: کلمات
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: یا
     contents_list:
@@ -139,8 +142,8 @@ dr:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: تمام محتویات را از اینجا بدست بیاورید %{organisation}

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -32,6 +32,9 @@ el:
       type:
         characters: χαρακτήρες
         words: λέξεις
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: ή
     contents_list:
@@ -137,8 +140,8 @@ el:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: Εύρεση όλου του περιεχομένου από τον οργανισμό %{Organization}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,9 @@ en:
       type:
         characters: characters
         words: words
+    chat_entry:
+      heading: Try GOV.UK Chat
+      description: Sign up to GOV.UK’s experimental new AI tool and find answers to your business questions
     checkboxes:
       or: or
     contents_list:

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -32,6 +32,9 @@ es-419:
       type:
         characters: caracteres
         words: palabras
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: o
     contents_list:
@@ -137,8 +140,8 @@ es-419:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: Buscar todo el contenido de %{organisation}

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -32,6 +32,9 @@ es:
       type:
         characters: caracteres
         words: palabras
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: o bien
     contents_list:
@@ -137,8 +140,8 @@ es:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: Buscar todo el contenido de %{organization}

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -32,6 +32,9 @@ et:
       type:
         characters: tähemärki
         words: sõnu
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: või
     contents_list:
@@ -140,8 +143,8 @@ et:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: Leidke kogu ettevõtte %{organization} sisu

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -32,6 +32,9 @@ fa:
       type:
         characters: کاراکتر
         words: کلمه
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: یا
     contents_list:
@@ -136,8 +139,8 @@ fa:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: یافتن تمام محتوا از %{organisation}

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -32,6 +32,9 @@ fi:
       type:
         characters: merkkejä
         words: sanoja
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: tai
     contents_list:
@@ -139,8 +142,8 @@ fi:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: Etsi kaikki sisältö alkaen %{organisation}

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -32,6 +32,9 @@ fr:
       type:
         characters: caractères
         words: mots
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: ou
     contents_list:
@@ -137,8 +140,8 @@ fr:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: Rechercher tout le contenu de %{organisation}

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -34,6 +34,9 @@ gd:
       type:
         characters: Figiúr
         words: Carachtar
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: Cá háit
     contents_list:
@@ -139,8 +142,8 @@ gd:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: Faigh gach rud ó %{organisation}

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -32,6 +32,9 @@ gu:
       type:
         characters: અક્ષરો
         words: શબ્દો
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: અથવા
     contents_list:
@@ -137,8 +140,8 @@ gu:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: "%{organisation} થી તમામ સામગ્રી શોધો"

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -32,6 +32,9 @@ he:
       type:
         characters: תווים
         words: מילים
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: או
     contents_list:
@@ -137,8 +140,8 @@ he:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: מצא את כל התוכן של %{organization}

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -32,6 +32,9 @@ hi:
       type:
         characters: अक्षर
         words: शब्द
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: या
     contents_list:
@@ -137,8 +140,8 @@ hi:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: "%{organization} से सभी सामग्री खोजें"

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -33,6 +33,9 @@ hr:
       type:
         characters: znakova
         words: riječi
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: ili
     contents_list:
@@ -138,8 +141,8 @@ hr:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: Pronađi sav sadržaj %{organization}

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -32,6 +32,9 @@ hu:
       type:
         characters: karakterek
         words: szavak
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: vagy
     contents_list:
@@ -140,8 +143,8 @@ hu:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: Keresse meg a(z) %{organisation} szervezet minden tartalmát

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -34,6 +34,9 @@ hy:
       type:
         characters: նիշ
         words: բառ
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: կամ
     contents_list:
@@ -141,8 +144,8 @@ hy:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: Գտնել %{organisation} ողջ բովանդակությունը

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -31,6 +31,9 @@ id:
       type:
         characters: karakter
         words: kata
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: atau
     contents_list:
@@ -137,8 +140,8 @@ id:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: Temukan semua konten dari %{organisation}

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -32,6 +32,9 @@ is:
       type:
         characters: stafi
         words: orð
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: eða
     contents_list:
@@ -137,8 +140,8 @@ is:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: Finna allt efni frá %{organisation}

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -32,6 +32,9 @@ it:
       type:
         characters: caratteri
         words: parole
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: o
     contents_list:
@@ -137,8 +140,8 @@ it:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: Trova tutto il contenuto da %{organisation}

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -31,6 +31,9 @@ ja:
       type:
         characters: 文字
         words: 単語
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: または
     contents_list:
@@ -133,8 +136,8 @@ ja:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: "％{organisation} からすべてのコンテンツを検索"

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -32,6 +32,9 @@ ka:
       type:
         characters: სიმბოლოები
         words: სიტყვები
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: ან
     contents_list:
@@ -140,8 +143,8 @@ ka:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: ყველა მასალის ნახვა %{organisation}-დან

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -32,6 +32,9 @@ kk:
       type:
         characters: таңба
         words: сөз
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: немесе
     contents_list:
@@ -137,8 +140,8 @@ kk:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: "%{organisation} ішіндегі барлық мазмұнды табу"

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -31,6 +31,9 @@ ko:
       type:
         characters:
         words:
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or:
     contents_list:
@@ -132,8 +135,8 @@ ko:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -33,6 +33,9 @@ lt:
       type:
         characters: spaudos ženklų
         words: žodžių
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: arba
     contents_list:
@@ -142,8 +145,8 @@ lt:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: Rasti visą turinį iš %{organisation}

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -32,6 +32,9 @@ lv:
       type:
         characters: rakstzīmes
         words: vārdi
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: vai
     contents_list:
@@ -141,8 +144,8 @@ lv:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: Meklēt visu saturu no %{organisation}

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -31,6 +31,9 @@ ms:
       type:
         characters: aksara
         words: perkataan
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: atau
     contents_list:
@@ -136,8 +139,8 @@ ms:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: Cari semua kandungan dari %{organisation}

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -34,6 +34,9 @@ mt:
       type:
         characters: karattri
         words: kliem
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: jew
     contents_list:
@@ -139,8 +142,8 @@ mt:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: Sib il-kontenut kollu mingħand %{organisation}

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -32,6 +32,9 @@ nl:
       type:
         characters: karakters
         words: woorden
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: of
     contents_list:
@@ -137,8 +140,8 @@ nl:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: Zoek alle inhoud van %{organisation}

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -32,6 +32,9 @@
       type:
         characters: tegn
         words: ord
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: eller
     contents_list:
@@ -137,8 +140,8 @@
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: Finn alt innhold fra %{organization}

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -32,6 +32,9 @@ pa-pk:
       type:
         characters: کردار
         words: الفاظ
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: یا
     contents_list:
@@ -133,8 +136,8 @@ pa-pk:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: "%{organisation} توں سارا مواد تلاش کرو"

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -32,6 +32,9 @@ pa:
       type:
         characters: ਅੱਖਰ
         words: ਸ਼ਬਦ
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: ਜਾਂ
     contents_list:
@@ -137,8 +140,8 @@ pa:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: "%{organisation} ਤੋਂ ਸਾਰੀ ਸਮਗਰੀ ਲੱਭੋ"

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -34,6 +34,9 @@ pl:
       type:
         characters: znaków
         words: słów
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: lub
     contents_list:
@@ -141,8 +144,8 @@ pl:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: Znajdź całą zawartość od %{organizacja}

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -32,6 +32,9 @@ ps:
       type:
         characters: کرکټرونه
         words: ټکي
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: یا
     contents_list:
@@ -134,8 +137,8 @@ ps:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: له%{organization} څخه ټوله مینځپانګه ومومئ

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -32,6 +32,9 @@ pt:
       type:
         characters: carateres
         words: palavras
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: ou
     contents_list:
@@ -137,8 +140,8 @@ pt:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: Encontrar todo o conteúdo de %{organisation}

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -33,6 +33,9 @@ ro:
       type:
         characters: caractere
         words: cuvinte
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: sau
     contents_list:
@@ -138,8 +141,8 @@ ro:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: Găsiți tot conținutul de la %{organisation}

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -34,6 +34,9 @@ ru:
       type:
         characters: символов
         words: слов
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: или
     contents_list:
@@ -141,8 +144,8 @@ ru:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: Найти весь контент от %{organization}

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -32,6 +32,9 @@ si:
       type:
         characters: අක්ෂර
         words: වචන
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: හෝ
     contents_list:
@@ -137,8 +140,8 @@ si:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: "%{organisation} වෙතින් සියලුම අන්තර්ගතය සෝයන්න"

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -33,6 +33,9 @@ sk:
       type:
         characters: znakov
         words: slov
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: alebo
     contents_list:
@@ -142,8 +145,8 @@ sk:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: Nájsť všetok obsah z %{organisation}

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -36,6 +36,9 @@ sl:
       type:
         characters: znaki
         words: besede
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: ali
     contents_list:
@@ -144,8 +147,8 @@ sl:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: Oglejte si vse gradivo %{organisation}

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -32,6 +32,9 @@ so:
       type:
         characters: dabeecadaha
         words: kalmadaha
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: ama
     contents_list:
@@ -137,8 +140,8 @@ so:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: Raadi dhamaan waxyaabaha uu ka koobanyahay %{organisation}

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -32,6 +32,9 @@ sq:
       type:
         characters: karaktere
         words: fjalë
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: ose
     contents_list:
@@ -137,8 +140,8 @@ sq:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: Gjeni të gjithë përmbajtjen nga %{organisation}

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -33,6 +33,9 @@ sr:
       type:
         characters: znakova
         words: reči
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: ili
     contents_list:
@@ -138,8 +141,8 @@ sr:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: Pronađite sav sadržaj organizacije %{organisation}

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -32,6 +32,9 @@ sv:
       type:
         characters: tecken
         words: ord
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: eller
     contents_list:
@@ -137,8 +140,8 @@ sv:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: Hitta allt innehåll från %{organisation}

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -32,6 +32,9 @@ sw:
       type:
         characters: herufi
         words: maneno
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: au
     contents_list:
@@ -137,8 +140,8 @@ sw:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: Tafuta maudhui yote kutoka %{organisation}

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -32,6 +32,9 @@ ta:
       type:
         characters: எழுத்துருக்கள்
         words: சொற்கள்
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: அல்லது
     contents_list:
@@ -138,8 +141,8 @@ ta:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: "%{organisation}-லிருந்து அனைத்து உள்ளடக்கத்தையும் கண்டறி"

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -31,6 +31,9 @@ th:
       type:
         characters: ตัวอักษร
         words: คำ
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: หรือ
     contents_list:
@@ -135,8 +138,8 @@ th:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: ค้นหาเนื้อหาทั้งหมดจาก %{organisation}

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -32,6 +32,9 @@ tk:
       type:
         characters: şekiller
         words: sözler
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: ýa-da
     contents_list:
@@ -138,8 +141,8 @@ tk:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: Ähli mazmunyny %{organisation}-dan tapyň

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -32,6 +32,9 @@ tr:
       type:
         characters: karakter
         words: kelime
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: veya
     contents_list:
@@ -138,8 +141,8 @@ tr:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: "%{organisation} kaynaklı tüm içeriği bul"

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -34,6 +34,9 @@ uk:
       type:
         characters: символів
         words: слів
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: або
     contents_list:
@@ -144,8 +147,8 @@ uk:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: Знайти весь вміст від %{organization}

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -32,6 +32,9 @@ ur:
       type:
         characters: حروف
         words: الفاظ
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: یا
     contents_list:
@@ -134,8 +137,8 @@ ur:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: "%{organisation} کا تمام مواد تلاش کریں"

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -32,6 +32,9 @@ uz:
       type:
         characters: белгилар
         words: сўзлар
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: ёки
     contents_list:
@@ -139,8 +142,8 @@ uz:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: "%{organization}  дан бутун контентни топиш"

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -31,6 +31,9 @@ vi:
       type:
         characters: ký tự
         words: từ
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: hoặc
     contents_list:
@@ -136,8 +139,8 @@ vi:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: Tìm tất cả nội dung từ %{organisation}

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -31,6 +31,9 @@ zh-hk:
       type:
         characters: 字元
         words: 字彙
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: 或
     contents_list:
@@ -135,8 +138,8 @@ zh-hk:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: 從 %{organisation} 獲得更多內容

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -31,6 +31,9 @@ zh-tw:
       type:
         characters: 字元
         words: 字
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: 或
     contents_list:
@@ -135,8 +138,8 @@ zh-tw:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: 從 %{organisation} 找到所有內容

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -31,6 +31,9 @@ zh:
       type:
         characters: 字符
         words: 单词
+    chat_entry:
+      description:
+      heading:
     checkboxes:
       or: 或
     contents_list:
@@ -135,8 +138,8 @@ zh:
     notice:
       banner_title:
     option_select:
-      found_single:
       found_multiple:
+      found_single:
       selected:
     organisation_schema:
       all_content_search_description: 查找 %{organisation} 的全部内容

--- a/spec/components/chat_entry_spec.rb
+++ b/spec/components/chat_entry_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+describe "Chat entry", type: :view do
+  def component_name
+    "chat_entry"
+  end
+
+  it "renders the chat entry component" do
+    render_component({})
+
+    assert_select ".gem-c-chat-entry"
+    assert_select "h2.gem-c-chat-entry__heading [href]", href: "/chat", text: "Try GOV.UK Chat"
+    assert_select ".gem-c-chat-entry__description .govuk-body", text: "Sign up to GOV.UK’s experimental new AI tool and find answers to your business questions"
+  end
+
+  it "renders the chat entry component with a custom href, heading and description" do
+    render_component({
+      href: "/govuk-chat",
+      heading_text: "Go to GOV.UK Chat",
+      description_text: "Get answers to your business questions",
+    })
+
+    assert_select ".gem-c-chat-entry"
+    assert_select "h2.gem-c-chat-entry__heading [href]", href: "/govuk-chat", text: "Go to GOV.UK Chat"
+    assert_select ".gem-c-chat-entry__description .govuk-body", text: "Get answers to your business questions"
+  end
+
+  it "renders the chat entry component with a different heading level" do
+    render_component({
+      heading_level: 3,
+    })
+
+    assert_select "h3.gem-c-chat-entry__heading [href]", href: "/chat", text: "Try GOV.UK Chat"
+  end
+
+  it "renders the chat entry component with a border top" do
+    render_component({
+      border_top: true,
+    })
+
+    assert_select ".gem-c-chat-entry.gem-c-chat-entry--border-top"
+  end
+
+  it "renders the chat entry component with a border bottom" do
+    render_component({
+      border_bottom: true,
+    })
+
+    assert_select ".gem-c-chat-entry.gem-c-chat-entry--border-bottom"
+  end
+
+  it "renders the chat entry component with a border top and a border bottom" do
+    render_component({
+      border_top: true,
+      border_bottom: true,
+    })
+
+    assert_select ".gem-c-chat-entry.gem-c-chat-entry--border-top.gem-c-chat-entry--border-bottom"
+  end
+end

--- a/spec/lib/govuk_publishing_components/app_helpers/asset_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/app_helpers/asset_helper_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe GovukPublishingComponents::AppHelpers::AssetHelper do
     end
 
     it "detect the total number of stylesheet paths" do
-      expect(get_component_css_paths.count).to eql(74)
+      expect(get_component_css_paths.count).to eql(75)
     end
 
     it "initialize empty asset helper" do


### PR DESCRIPTION
## What

Add 'Chat entry' component

**Review URL**: https://components-gem-pr-4151.herokuapp.com/component-guide/chat_entry

## Why

A new component is required that will need to be integrated across multiple apps as the entry point to GOV.UK Chat.

## Visual Changes

### > Tablet

![0 0 0 0_3212_component-guide_chat_entry(Surface Pro 7) (2)](https://github.com/user-attachments/assets/7a75bc1a-a8b9-4f2d-8eb5-cdec832e0590)

### Mobile

![0 0 0 0_3212_component-guide_chat_entry(iPhone SE)](https://github.com/user-attachments/assets/73455071-e2d9-4a10-88b3-6e3a87d83665)

### With a border top

![0 0 0 0_3212_component-guide_chat_entry(Surface Pro 7) (3)](https://github.com/user-attachments/assets/4a515672-3e74-4184-b573-b35ba5f02014)

### With a border top and a border bottom

![0 0 0 0_3212_component-guide_chat_entry(Surface Pro 7) (6)](https://github.com/user-attachments/assets/d26d6f22-454f-4d8a-ac22-d66da65dce2d)

## Anything else

The description text "Find answers to your business questions with GOV.UK's experimental new AI tool" is currently displayed using the old typescale, as shown in the screenshots above and in the component guide. This aligns with the current text display across GOV.UK, since the new typescale is still behind a feature flag. Once the new typescale is enabled, either by default or manually, the text will display at 19px across all viewport sizes.