### PR TITLE
Version 41.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 41.1.2
 
 * Add icon for external in attachment component ([PR #4150](https://github.com/alphagov/govuk_publishing_components/pull/4150))
 * New print styles for the table component ([PR #4139](https://github.com/alphagov/govuk_publishing_components/pull/4139))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (41.1.1)
+    govuk_publishing_components (41.1.2)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "41.1.1".freeze
+  VERSION = "41.1.2".freeze
 end


### PR DESCRIPTION
## 41.1.2

* Add icon for external in attachment component ([PR #4150](https://github.com/alphagov/govuk_publishing_components/pull/4150))
* New print styles for the table component ([PR #4139](https://github.com/alphagov/govuk_publishing_components/pull/4139))
* New print styles for the tabs component ([PR #4140](https://github.com/alphagov/govuk_publishing_components/pull/4140))
* New print styles for layout components ([PR #4137](https://github.com/alphagov/govuk_publishing_components/pull/4137))
* New print styles for step-by-step components ([PR #4138](https://github.com/alphagov/govuk_publishing_components/pull/4138))
* New print styles for govspeak components ([PR #4136](https://github.com/alphagov/govuk_publishing_components/pull/4136))
* Fix the print styles for inverse components ([PR #4135](https://github.com/alphagov/govuk_publishing_components/pull/4135))
