### PR TITLE
Release Version 42.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 42.0.0
 
 * **BREAKING:** Drop libsass support ([PR #4106](https://github.com/alphagov/govuk_publishing_components/pull/4106))
 * **BREAKING:** Drop support for legacy browsers ([PR #4111](https://github.com/alphagov/govuk_publishing_components/pull/4111))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (41.1.2)
+    govuk_publishing_components (42.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "41.1.2".freeze
+  VERSION = "42.0.0".freeze
 end


### PR DESCRIPTION
## 42.0.0

* **BREAKING:** Drop libsass support ([PR #4106](https://github.com/alphagov/govuk_publishing_components/pull/4106))
* **BREAKING:** Drop support for legacy browsers ([PR #4111](https://github.com/alphagov/govuk_publishing_components/pull/4111))