### PR TITLE
Fix issue with using special characters in content-list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Ensure that organisation logos always print ([PR #4162](https://github.com/alphagov/govuk_publishing_components/pull/4162))
 * Fix some layout_header search visual bugs ([PR #4156](https://github.com/alphagov/govuk_publishing_components/pull/4156))
+* Fix issue with using special characters in content-list ([PR #4157](https://github.com/alphagov/govuk_publishing_components/pull/4157))
 
 ## 42.0.0
 

--- a/app/views/govuk_publishing_components/components/docs/contents_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/contents_list.yml
@@ -42,9 +42,9 @@ examples:
       underline_links: true
       contents:
         - href: "#first-thing"
-          text: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+          text: Lorem &amp; ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
         - href: "#second-thing"
-          text: Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+          text: Ut enim &mdash; ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
         - href: "#third-thing"
           text: Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
   long_text:
@@ -93,7 +93,7 @@ examples:
           active: true
           text: 2. Second thing
         - href: "#third-thing"
-          text: 3. Third thing
+          text: 3. Third &amp;thing
   formats_complex_numbers:
     data:
       format_numbers: true

--- a/lib/govuk_publishing_components/presenters/contents_list_helper.rb
+++ b/lib/govuk_publishing_components/presenters/contents_list_helper.rb
@@ -44,7 +44,8 @@ module GovukPublishingComponents
         text = text.gsub(/&nbsp;/, " ")
         text = text.gsub("/\u00a0/", " ")
         text = text.gsub(160.chr("UTF-8"), " ")
-        strip_tags(text.tr("\n", "")).strip
+        text = text.strip
+        strip_tags(text.tr("\n", ""))
       end
 
       def get_index_total

--- a/spec/components/contents_list_spec.rb
+++ b/spec/components/contents_list_spec.rb
@@ -14,8 +14,17 @@ describe "Contents list", type: :view do
 
   def contents_list_with_special_chars
     [
+      { href: "/one", text: "First item&nbsp;in the menu" },
+      { href: "/two", text: "Second item &mdash; in the menu" },
+      { href: "/three", text: "Third item &amp; in the menu" },
+    ]
+  end
+
+  def numbered_contents_list_with_special_chars
+    [
       { href: "/one", text: "\n1.&nbsp;First item   in the menu" },
       { href: "/two", text: "\n2.\u00a0Second item     in the menu" },
+      { href: "/three", text: "\n3. Third item &amp; in the menu" },
     ]
   end
 
@@ -66,6 +75,14 @@ describe "Contents list", type: :view do
     assert_select ".gem-c-contents-list"
     assert_select ".gem-c-contents-list__link.govuk-link--no-underline[href='/one']", text: "1. One"
     assert_select ".gem-c-contents-list__link.govuk-link--no-underline[href='#two']", text: "2. Two"
+  end
+
+  it "renders a list of contents links containing special characters" do
+    render_component(contents: contents_list_with_special_chars)
+
+    assert_select ".gem-c-contents-list__link.govuk-link--no-underline[href='/one']", text: "First item in the menu"
+    assert_select ".gem-c-contents-list__link.govuk-link--no-underline[href='/two']", text: "Second item — in the menu"
+    assert_select ".gem-c-contents-list__link.govuk-link--no-underline[href='/three']", text: "Third item & in the menu"
   end
 
   it "renders with dashes hidden from screen readers" do
@@ -133,15 +150,19 @@ describe "Contents list", type: :view do
   end
 
   it "formats numbers in contents links containing special characters" do
-    render_component(contents: contents_list_with_special_chars, format_numbers: true)
+    render_component(contents: numbered_contents_list_with_special_chars, format_numbers: true)
     link_selector1 = ".gem-c-contents-list__list-item--numbered a[href='/one']"
     link_selector2 = ".gem-c-contents-list__list-item--numbered a[href='/two']"
+    link_selector3 = ".gem-c-contents-list__list-item--numbered a[href='/three']"
 
     assert_select "#{link_selector1} .gem-c-contents-list__number", text: "1."
     assert_select "#{link_selector1} .gem-c-contents-list__numbered-text", text: "First item in the menu"
 
     assert_select "#{link_selector2} .gem-c-contents-list__number", text: "2."
     assert_select "#{link_selector2} .gem-c-contents-list__numbered-text", text: "Second item in the menu"
+
+    assert_select "#{link_selector3} .gem-c-contents-list__number", text: "3."
+    assert_select "#{link_selector3} .gem-c-contents-list__numbered-text", text: "Third item & in the menu"
   end
 
   it "does not format numbers in a nested list" do


### PR DESCRIPTION
## What
- Fix an issue with ampersands not rendering as expected in the browser by calling the `strip` method on the text earlier in the `clean_string` method in `contents_list_helper.rb`
- Updated and refactored tests to check the ampersand is rendered as expected as well as other special characters
- Included special characters in the content-list document list as Percy will capture any visual changes should the tests be updated or removed in the future

## Why
The content-list component is not rendering the special characters as expected, an example of this can be seen on https://www.gov.uk/guidance/research-and-development-rd-tax-relief-the-merged-scheme-and-enhanced-rd-intensive-support

[Trello card](https://trello.com/c/FwnkPDJR/29-contents-list-component-not-rendering-ampersands-as-expected)

## Visual Changes

| Before | After |
| --- | --- |
| ![contents-list-before](https://github.com/user-attachments/assets/45cdea26-2377-4144-b4fa-832a9eec94f1) | ![contents-list-after](https://github.com/user-attachments/assets/6f0030c3-f795-41bd-af1b-4b87b411f3d9) |