### PR TITLE
Upgrade to govuk-frontend v5.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* **BREAKING:** Upgrade to govuk-frontend v5.5.0 ([PR #4115](https://github.com/alphagov/govuk_publishing_components/pull/4160))
+
 ## 42.1.0
 
 * Ensure that organisation logos always print ([PR #4162](https://github.com/alphagov/govuk_publishing_components/pull/4162))

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -5,7 +5,7 @@
 @import "govuk_publishing_components/component_support";
 
 // Include all govuk frontend components
-@import "govuk/components/all";
+@import "govuk/components/index";
 
 // components
 @import "components/accordion";

--- a/app/assets/stylesheets/govuk_publishing_components/component_support.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/component_support.scss
@@ -1,10 +1,10 @@
 // This file should be included in an application prior to specific components
 // It provides supporting gem component helpers and mixins
 // and everything else from govuk-frontend not included in govuk_frontend_support
-@import "govuk/core/all";
-@import "govuk/objects/all";
-@import "govuk/utilities/all";
-@import "govuk/overrides/all";
+@import "govuk/core/index";
+@import "govuk/objects/index";
+@import "govuk/utilities/index";
+@import "govuk/overrides/index";
 
 @import "govuk_publishing_components/components/helpers/brand-colours";
 @import "govuk_publishing_components/components/helpers/link";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_breadcrumbs.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_breadcrumbs.scss
@@ -41,7 +41,7 @@
     }
 
     .govuk-breadcrumbs__list-item::before {
-      top: 18px;
+      top: 20px;
     }
 
     .govuk-breadcrumbs__link::after {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_govspeak-html-publication.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_govspeak-html-publication.scss
@@ -69,7 +69,8 @@
     table.financial-data {
       .numeric {
         text-align: right;
-        @include govuk-font(16, $weight: regular, $tabular: true);
+        @include govuk-font-tabular-numbers;
+        @include govuk-font(16, $weight: regular);
       }
 
       // make all elements inside thead look the same
@@ -82,10 +83,11 @@
 
       thead th,
       thead td {
-        @include govuk-font(16, $weight: bold, $tabular: true);
+        @include govuk-font-tabular-numbers;
+        @include govuk-font(16, $weight: bold);
 
         &.numeric {
-          @include govuk-font(16, $weight: bold, $tabular: true);
+          @include govuk-font(16, $weight: bold);
         }
       }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-for-admin.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-for-admin.scss
@@ -1,1 +1,1 @@
-// uses govuk/all
+// uses govuk/index

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -73,8 +73,8 @@ $large-input-size: 50px;
 .gem-c-search__input[type="search"] { // overly specific to prevent some overrides from outside
   margin: 0;
   width: 100%;
-  height: govuk-em(40, 16);
-  padding: govuk-em(6, 16);
+  height: govuk-em(40, 19);
+  padding: govuk-em(6, 19);
   border: $govuk-border-width-form-element solid $govuk-input-border-colour;
   background: govuk-colour("white");
   border-radius: 0; // otherwise iphones apply an automatic border radius
@@ -83,11 +83,6 @@ $large-input-size: 50px;
   -moz-appearance: none;
   appearance: none;
   @include govuk-font($size: 19, $line-height: calc(28 / 19));
-
-  @include govuk-media-query($from: tablet) {
-    height: govuk-em(40, 19);
-    padding: govuk-em(6, 19);
-  }
 
   // the .focus class is added by JS and ensures that the input remains above the label once clicked/filled in
   &:focus,

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
@@ -120,3 +120,25 @@
     border-color: #00625e;
   }
 }
+
+.brand--department-for-business-and-trade {
+  .brand__color {
+    color: #cf102d;
+
+    &:link,
+    &:visited,
+    &:active {
+      color: #cf102d;
+    }
+
+    &:hover,
+    &:focus {
+      color: $govuk-focus-text-colour;
+    }
+  }
+
+  &.brand__border-color,
+  .brand__border-color {
+    border-color: #cf102d;
+  }
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
@@ -20,7 +20,7 @@
       // element as required by the heading component, adds 2KB to the CSS
       &.brand__border-color,
       .brand__border-color {
-        border-color: govuk-organisation-colour($organisation, $websafe: false);
+        border-color: govuk-organisation-colour($organisation, $contrast-safe: false);
       }
     }
   }
@@ -49,7 +49,7 @@
 
   &.brand__border-color,
   .brand__border-color {
-    border-color: govuk-organisation-colour("office-of-the-leader-of-the-house-of-commons", $websafe: false);
+    border-color: govuk-organisation-colour("office-of-the-leader-of-the-house-of-commons", $contrast-safe: false);
   }
 }
 // colours for the prime ministers office are not included in the toolkit

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_govuk-frontend-settings.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_govuk-frontend-settings.scss
@@ -13,3 +13,4 @@
 
 $govuk-image-url-function: "app-image-url";
 $govuk-font-url-function: "app-font-url";
+$govuk-new-typography-scale: true;

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_govuk-frontend-settings.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_govuk-frontend-settings.scss
@@ -14,3 +14,4 @@
 $govuk-image-url-function: "app-image-url";
 $govuk-font-url-function: "app-font-url";
 $govuk-new-typography-scale: true;
+$govuk-new-organisation-colours: true;

--- a/app/views/govuk_publishing_components/components/_breadcrumbs.html.erb
+++ b/app/views/govuk_publishing_components/components/_breadcrumbs.html.erb
@@ -15,6 +15,7 @@
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class(classes.join(" "))
+  component_helper.add_aria_attribute({ label: "Breadcrumb" })
   component_helper.add_data_attribute({ module: "ga4-link-tracker" })
 %>
 
@@ -22,7 +23,7 @@
   <%= raw JSON.pretty_generate(breadcrumb_presenter.structured_data) %>
 </script>
 
-<%= tag.div(**component_helper.all_attributes) do %>
+<%= tag.nav(**component_helper.all_attributes) do %>
   <ol class="govuk-breadcrumbs__list">
     <% breadcrumbs.each_with_index do |crumb, index| %>
       <% breadcrumb = GovukPublishingComponents::Presenters::Breadcrumb.new(crumb, index) %>

--- a/app/views/govuk_publishing_components/components/docs/organisation_logo.yml
+++ b/app/views/govuk_publishing_components/components/docs/organisation_logo.yml
@@ -46,7 +46,7 @@ examples:
       organisation:
         name: 'Department for<br>Business &amp; Trade'
         url: '/government/organisations/department-for-business-and-trade'
-        brand: 'department-for-business-and-trade'
+        brand: 'department-for-business-trade'
         crest: 'dbt'
   executive_office:
     data:

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "axe-core": "^4.10.0",
-    "govuk-frontend": "5.1.0",
+    "govuk-frontend": "5.4.0",
     "govuk-single-consent": "^3.0.9",
     "sortablejs": "^1.15.2"
   },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "axe-core": "^4.10.0",
-    "govuk-frontend": "5.4.0",
+    "govuk-frontend": "5.5.0",
     "govuk-single-consent": "^3.0.9",
     "sortablejs": "^1.15.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1347,10 +1347,10 @@ globjoin@^0.1.4:
   resolved "https://registry.yarnpkg.com/globjoin/-/globjoin-0.1.4.tgz#2f4494ac8919e3767c5cbb691e9f463324285d43"
   integrity sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM=
 
-govuk-frontend@5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-5.1.0.tgz#55e520940b587ddd023e96251efaa076acc9bd5f"
-  integrity sha512-Dc3J+uOI4i2VR3BVyfxbf6qVjTT4n4bBqbD0/Io6feP8pt/4IfKdP1vWimZf+BwMKKMXacw10hmdy5UcD6Cr8w==
+govuk-frontend@5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-5.4.0.tgz#8f2e0b55ef7c7552a1efe68c7b40ff1b4a393e72"
+  integrity sha512-F3YwQYrYQqIPfNxsoph6O78Ey1unCB6cy6omx8KeWY9G504lWZFBSIaiUCma1jNLw9bOUU7Ui+tXG09jjqy0Mw==
 
 govuk-single-consent@^3.0.9:
   version "3.0.9"
@@ -2783,16 +2783,7 @@ statuses@2.0.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
   integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@4.2.3, string-width@^4.1.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@4.2.3, string-width@^4.1.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -2855,14 +2846,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1347,10 +1347,10 @@ globjoin@^0.1.4:
   resolved "https://registry.yarnpkg.com/globjoin/-/globjoin-0.1.4.tgz#2f4494ac8919e3767c5cbb691e9f463324285d43"
   integrity sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM=
 
-govuk-frontend@5.4.0:
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-5.4.0.tgz#8f2e0b55ef7c7552a1efe68c7b40ff1b4a393e72"
-  integrity sha512-F3YwQYrYQqIPfNxsoph6O78Ey1unCB6cy6omx8KeWY9G504lWZFBSIaiUCma1jNLw9bOUU7Ui+tXG09jjqy0Mw==
+govuk-frontend@5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-5.5.0.tgz#dfb2426788dbf570ef7d2742983bc54e68f17f34"
+  integrity sha512-lNSHCOzgk6LfgelcdtJxTLK1BX/cpjCUyEB3LnzliD9o9YQckNMsbj5+jSOs2RFy6XBJ/DJqxj2TKfjBCuzpyA==
 
 govuk-single-consent@^3.0.9:
   version "3.0.9"


### PR DESCRIPTION
## What/  Why
<!-- What are the reasons behind this change being made? -->
- Upgrade to `govuk-frontend` v5.5.0
- See their CHANGELOG for changes: https://github.com/alphagov/govuk-frontend/blob/main/CHANGELOG.md
- Incorporates this PR's commit in order to fix the search styles: https://github.com/alphagov/govuk_publishing_components/pull/3991 
- This `finder-frontend` PR also relies on this upgrade https://github.com/alphagov/finder-frontend/pull/3334
- I have tested this PR in `finder-frontend` with the two PRs above included, and the search on mobile looked correct

Trello card: https://trello.com/c/l2yxZZ9k/274-upgrade-to-govuk-frontend-54

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

### The upgrade changes the typography Scale

<img width="941" alt="image" src="https://github.com/user-attachments/assets/ce1d00a1-db37-4fef-ad37-83df43d67192">
<img width="941" alt="image" src="https://github.com/user-attachments/assets/ef7960b8-170b-47ae-a1cf-dc06caf0e4ef">


### The upgrade adds new organisation colours

<img width="570" alt="image" src="https://github.com/user-attachments/assets/dc63742a-4dbd-4783-8a42-26684694cf0a">
<img width="570" alt="image" src="https://github.com/user-attachments/assets/7a5e458d-4583-4e7a-acb1-27fb8e0f517d">
<img width="560" alt="image" src="https://github.com/user-attachments/assets/8e65a328-b21e-493c-a6aa-251fb8c6a9e1">
<img width="560" alt="image" src="https://github.com/user-attachments/assets/9b31060c-2b5e-4018-878d-bde78bf79594">

### The upgrade fixes the checkbox component's conditional reveal email address alignment

<img width="489" alt="image" src="https://github.com/user-attachments/assets/d3cfb3d3-ad02-4ea6-8318-31c11ed204b1">
<img width="489" alt="image" src="https://github.com/user-attachments/assets/914b1efb-f4df-4b45-8d17-f98023ccadd9">

### The upgrade fixes the alignment on the radio button conditional reveal
<img width="569" alt="image" src="https://github.com/user-attachments/assets/bbfcc7c7-a2a1-44a1-ba24-9db43a82bdfe">
<img width="569" alt="image" src="https://github.com/user-attachments/assets/475273bd-723b-4269-aac2-7a994bb0fd3e">

### I fixed a misalignment of the Breadcrumb chevron on mobile
Feel free to critique as I eyeballed the alignment
<img width="279" alt="image" src="https://github.com/user-attachments/assets/64adf14f-a2d5-4aea-a5eb-63561d0194c2">

<img width="279" alt="image" src="https://github.com/user-attachments/assets/585ecb68-14af-40a1-ad9c-3fc8d42ee0d3">
