### PR TITLE
Ensure that organisation logos always print

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Ensure that organisation logos always print ([PR #4162](https://github.com/alphagov/govuk_publishing_components/pull/4162))
+
 ## 42.0.0
 
 * **BREAKING:** Drop libsass support ([PR #4106](https://github.com/alphagov/govuk_publishing_components/pull/4106))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_organisation-logo.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_organisation-logo.scss
@@ -145,3 +145,10 @@
   @include crest($crest: "wales_crest", $xpos: 9px);
   @include tall-crest;
 }
+
+@include govuk-media-query($media-type: print) {
+  .gem-c-organisation-logo__container {
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
+  }
+}


### PR DESCRIPTION
## What
When printing a page containing organisation logos, we want to ensure that any images are always printed. Without the images, each logo is printed as text only with an empty space for the logo and looks quite strange. 

In addition, browsers don't print background images by default, and will only print them if a hidden option is selected from the printer dialogue. This PR forces the browser to always print the logo images regardless of settings.

This is part of the work to improve our print styles more generally. [Trello](https://trello.com/c/K58GNTxY/268-fix-organisational-logo-components-to-print-correctly)

## Why
Printing the logo images helps users to establish recognition for each organisation. 

## Visual Changes

### Before

<img width="552" alt="image" src="https://github.com/user-attachments/assets/662cd9c4-7800-4078-aaf7-d8db3ac61498">

### After

<img width="552" alt="image" src="https://github.com/user-attachments/assets/e8350c2d-131a-40fb-8d1e-b245c2987435">
