### PR TITLE
Fix the search toggle in layout header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix the search toggle in layout header ([PR #4163](https://github.com/alphagov/govuk_publishing_components/pull/4163))
+
 ## 43.0.1
 
 * Fix card component padding based on heading ([PR #4169](https://github.com/alphagov/govuk_publishing_components/pull/4169))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
@@ -148,8 +148,6 @@
 }
 
 .gem-c-layout-header__search-form {
-  display: none;
-
   &.js-visible {
     display: block;
   }

--- a/app/views/govuk_publishing_components/components/layout_header/_navigation_items.html.erb
+++ b/app/views/govuk_publishing_components/components/layout_header/_navigation_items.html.erb
@@ -1,9 +1,12 @@
-<% navigation_aria_label ||= "Top level" %>
+<%
+  navigation_aria_label ||= "Top level"
+  navigation_id = "navigation-#{SecureRandom.hex(4)}"
+%>
 
 <% if navigation_items.any? %>
   <%= tag.nav class: "gem-c-header__nav govuk-header__navigation govuk-header__navigation--end", aria: { label: navigation_aria_label } do %>
     <button
-      aria-controls="navigation"
+      aria-controls="<%= navigation_id %>"
       aria-label="Show or hide Top Level Navigation"
       class="govuk-header__menu-button govuk-js-header-toggle gem-c-header__menu-button govuk-!-display-none-print"
       type="button"
@@ -12,7 +15,7 @@
     >
       <%= t("components.layout_header.menu") %>
     </button>
-    <ul id="navigation" class="govuk-header__navigation-list govuk-!-display-none-print">
+    <ul id="<%= navigation_id %>" class="govuk-header__navigation-list govuk-!-display-none-print">
       <% navigation_items.each_with_index do |item, index| %>
         <%
           li_classes = %w(govuk-header__navigation-item)

--- a/app/views/govuk_publishing_components/components/layout_header/_search.html.erb
+++ b/app/views/govuk_publishing_components/components/layout_header/_search.html.erb
@@ -1,17 +1,21 @@
+<%
+  search_form_id = "search-#{SecureRandom.hex(4)}"
+%>
+
 <button
   class="search-toggle govuk-js-header-toggle"
   data-search-toggle-for="search"
   data-button-name="search"
   data-show-text="<%= t("components.layout_header.show_button") %>"
   data-hide-text="<%= t("components.layout_header.hide_button") %>"
-  aria-controls="search"
+  aria-controls="<%= search_form_id %>"
 >
   <%= t("components.layout_header.show_button") %>
 </button>
 <form
   action="/search"
   class="gem-c-layout-header__search-form govuk-clearfix govuk-!-display-none-print"
-  id="search"
+  id="<%= search_form_id %>"
   method="get"
   role="search"
 >

--- a/app/views/govuk_publishing_components/components/layout_header/_search.html.erb
+++ b/app/views/govuk_publishing_components/components/layout_header/_search.html.erb
@@ -1,9 +1,10 @@
 <button
-  class="search-toggle js-header-toggle"
+  class="search-toggle govuk-js-header-toggle"
   data-search-toggle-for="search"
   data-button-name="search"
   data-show-text="<%= t("components.layout_header.show_button") %>"
   data-hide-text="<%= t("components.layout_header.hide_button") %>"
+  aria-controls="search"
 >
   <%= t("components.layout_header.show_button") %>
 </button>


### PR DESCRIPTION
## What
Fix the search toggle in layout header

## Why
On mobile and tablet screen sizes clicking on the search icon in the layout header did not reveal the hidden search form element, `gem-c-layout-header__search-form`.

The reason for this is that as of [V3.0.0 of govuk-frontend](https://github.com/alphagov/govuk-frontend/blob/main/CHANGELOG.md#update-the-html-for-navigation-in-the-header), classes have a `govuk-` prefix. The HTML for the search template has been updated to reflect this, as well as using the `aria-controls` attribute to target the element to be toggled.

The toggle functionality, makes use of the `hidden` attribute to show/hide the target element, `display: none` has been removed from `.gem-c-layout-header__search-form` to ensure that the search form visibility can be toggled and can be accessed when JS is disabled.

[Trello card]()
Fixes: https://github.com/alphagov/govuk_publishing_components/issues/4154

## Visual Changes

### JS Disabled - Mobile/Tablet

| Before | After |
| --- | --- |
| <img width="394" alt="js-disabled-before" src="https://github.com/user-attachments/assets/cfd8a62c-4704-4fa4-ada7-e8b5a1e77f48"> | <img width="395" alt="js-enabled-after" src="https://github.com/user-attachments/assets/9c5f1760-9dec-4300-acbf-638da403a03e"> |

### JS Enabled - Search toggle button clicked - Mobile/Tablet

| Before | After |
| --- | --- |
| <img width="396" alt="js-enabled-click-before" src="https://github.com/user-attachments/assets/ee124e23-12e9-489c-80a5-4c2fde218c78"> |   <img width="388" alt="js-disabled-click-after" src="https://github.com/user-attachments/assets/ca17e45e-beb6-4584-8227-608041a69062"> |

**Note:** Percy is showing some visual regression changes on mobile, this is likely because the search-form is now displayed by default, then later hidden by JavaScript.