### PR TITLE
Fix print issues on layout-super-navigation-header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+Unreleased
+
+* Fix print issues on layout-super-navigation-header ([PR #4165](https://github.com/alphagov/govuk_publishing_components/pull/4165))
+
 ## 43.0.0
 
 * **BREAKING:** Upgrade to govuk-frontend v5.5.0 ([PR #4160](https://github.com/alphagov/govuk_publishing_components/pull/4160))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -986,9 +986,23 @@ $after-button-padding-left: govuk-spacing(4);
 
 @include govuk-media-query($media-type: print) {
   .gem-c-layout-super-navigation-header {
-    border-top: 1pt solid $govuk-print-text-colour;
-    margin: 0;
-    background-color: none;
+    border-top: 0;
+    border-bottom: 2pt solid $govuk-print-text-colour;
+    margin: 0 0 5mm;
+    background-color: transparent;
+
+    &:has(.gem-c-layout-super-navigation-header__header-logo .govuk-visually-hidden) {
+      border: 0;
+      margin-left: 24px;
+    }
+
+    * {
+      color: $govuk-print-text-colour;
+    }
+
+    .govuk-width-container {
+      margin: 0;
+    }
   }
 
   .gem-c-layout-super-navigation-header__header-logo {


### PR DESCRIPTION
## What

The print styles on the layout-super-navigation-header are incorrect and need to be updated:

- Background should always print transparent
- Foreground should always print black
- No top border
- Bottom border should match new changes in cross service header
- Left/right margins are not required for print due to background removal

[Trello](https://trello.com/c/4Lk0dUxa/292-fix-print-issues-on-layout-super-navigation-header)

## Why
- The top bar has an extra top border and redundant left/right spacing when printed, it also doesn’t match the changes made to the cross service header (coming in #4073)
- The background color bug was recently introduced in the previous print styles work and needs fixing: it prevents the inverted background from printing correctly.

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

### Before
<img width="552" alt="image" src="https://github.com/user-attachments/assets/dea5f65b-f759-449e-9527-023d34aaf966">

### After
![image](https://github.com/user-attachments/assets/d020eb4b-3f95-4142-ba30-4a8fa4e59c7a)
