### PR TITLE
Fix card component padding based on heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 Unreleased
 
+* Fix card component padding based on heading ([PR #4169](https://github.com/alphagov/govuk_publishing_components/pull/4169))
 * Fix print issues on layout-super-navigation-header ([PR #4165](https://github.com/alphagov/govuk_publishing_components/pull/4165))
 
 ## 43.0.0

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
@@ -6,10 +6,6 @@
   @include govuk-responsive-margin(6, "bottom");
 }
 
-.gem-c-cards__heading--underline + .gem-c-cards__list {
-  border-top: 1px solid $govuk-border-colour;
-}
-
 .gem-c-cards__list {
   list-style: none;
   padding: 0;
@@ -34,6 +30,22 @@
   .gem-c-cards__list-item {
     &:first-child {
       border-top: 0;
+
+      .gem-c-cards__list-item-wrapper {
+        padding-top: 0;
+      }
+    }
+  }
+}
+
+.gem-c-cards__heading--underline + .gem-c-cards__list {
+  border-top: 1px solid $govuk-border-colour;
+
+  .gem-c-cards__list-item {
+    &:first-child {
+      .gem-c-cards__list-item-wrapper {
+        padding-top: 19px;
+      }
     }
   }
 }


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

Fixed the card component styling by removing the spacing from the first list item in one-column lists that do not have a heading. For lists with a border and a heading, the padding and spacing are retained to ensure consistency. 

Related [Trello Card](https://trello.com/c/mXZOHPnZ/2773-update-homepage-services-and-information-section-to-use-the-card-component-from-the-gem-s-m) --> _when replacing the card component to the customised card component on the GOV.UK homepage, this is where I noticed there was a visual difference in the spacing._

## Why
<!-- What are the reasons behind this change being made? -->
The previous padding settings for the first list item without a heading created extra spacing that wasn't necessarily required. Therefore, by reducing this it provided a more consistent look across different layouts, which helps improve the visual design of the card component.

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->
**Deployment**: https://components-gem-pr-4169.herokuapp.com/component-guide/cards

### Mobile:
| Before | After |
| --- | --- |
| <img width="287" alt="image" src="https://github.com/user-attachments/assets/d686b16d-f3e2-43b1-b1ea-e39a203c0b8a"> | <img width="380" alt="image" src="https://github.com/user-attachments/assets/51b46af4-a258-41bd-aa07-355e6035df37"> |

### Tablet:
| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/819d166f-9df6-4b45-948f-70c6224db6ff) | ![image](https://github.com/user-attachments/assets/fed2a4cc-0b1d-4f3a-a626-afd12be1ba86) |

### Laptop:
| Before | After |
| --- | --- |
|![image](https://github.com/user-attachments/assets/1d02c39d-6ff1-4942-8331-c4a7a8688c18) | ![image](https://github.com/user-attachments/assets/daac486d-70f8-40f9-8ae6-feaa9ea1f7d7)) |

