### PR TITLE
Version 43.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 43.0.0
 
-* **BREAKING:** Upgrade to govuk-frontend v5.5.0 ([PR #4115](https://github.com/alphagov/govuk_publishing_components/pull/4160))
+* **BREAKING:** Upgrade to govuk-frontend v5.5.0 ([PR #4160](https://github.com/alphagov/govuk_publishing_components/pull/4160))
 
 ## 42.1.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (42.1.0)
+    govuk_publishing_components (43.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "42.1.0".freeze
+  VERSION = "43.0.0".freeze
 end


### PR DESCRIPTION
## 43.0.0

* **BREAKING:** Upgrade to govuk-frontend v5.5.0 ([PR #4115](https://github.com/alphagov/govuk_publishing_components/pull/4160))