### PR TITLE
Version 43.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 43.0.1
 
 * Fix card component padding based on heading ([PR #4169](https://github.com/alphagov/govuk_publishing_components/pull/4169))
 * Fix print issues on layout-super-navigation-header ([PR #4165](https://github.com/alphagov/govuk_publishing_components/pull/4165))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (43.0.0)
+    govuk_publishing_components (43.0.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "43.0.0".freeze
+  VERSION = "43.0.1".freeze
 end


### PR DESCRIPTION
## 43.0.1

* Fix card component padding based on heading ([PR #4169](https://github.com/alphagov/govuk_publishing_components/pull/4169))
* Fix print issues on layout-super-navigation-header ([PR #4165](https://github.com/alphagov/govuk_publishing_components/pull/4165))
* Remove unused org colour classes ([PR #4173](https://github.com/alphagov/govuk_publishing_components/pull/4173))