### PR TITLE
Improve print styles for layout-footer component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Fix the search toggle in layout header ([PR #4163](https://github.com/alphagov/govuk_publishing_components/pull/4163))
 * Replace 'unset' property in printed background colours ([PR #4184](https://github.com/alphagov/govuk_publishing_components/pull/4184))
+* Improve print styles for layout-footer component ([PR #4178](https://github.com/alphagov/govuk_publishing_components/pull/4178))
 
 ## 43.0.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-footer.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-footer.scss
@@ -21,10 +21,39 @@
   margin-bottom: 20px;
 }
 
-// stylelint-disable declaration-no-important
 @include govuk-media-query($media-type: print) {
+  .govuk-footer {
+    background: none;
+    margin: 25mm 0 0;
+    padding: 5mm 0 0;
+    border-top: 2pt solid $govuk-print-text-colour;
+
+    .govuk-width-container {
+      margin: 0;
+    }
+  }
+
+  .govuk-footer__meta,
+  .govuk-footer__meta-item {
+    border: 0;
+    padding: 0;
+    margin: 0;
+  }
+
+  .govuk-footer__licence-description {
+    padding-right: 10mm;
+  }
+
+  .govuk-footer__copyright-logo {
+    min-width: auto;
+    padding-top: 13mm;
+    background-size: 15mm;
+    background-position: center top;
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
+  }
+
   .gem-c-layout-footer {
-    font-size: 12pt !important;
+    font-size: 10pt !important; // stylelint-disable-line declaration-no-important
   }
 }
-// stylelint-enable declaration-no-important

--- a/app/views/govuk_publishing_components/components/_layout_footer.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_footer.html.erb
@@ -63,7 +63,7 @@
         <% end %>
       </div>
 
-      <hr class="govuk-footer__section-break">
+      <hr class="govuk-footer__section-break govuk-!-display-none-print">
     <% end %>
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">


### PR DESCRIPTION
## What
This improves the print styles for the `layout-footer` component as part of the work to improve print styles for page layouts. [Trello](https://trello.com/c/tcXZsXup/193-review-and-fix-page-level-print-styles). 
- Extra borders and padding are removed
- internal elements now run flush to their left/right edges

Note that for consistency [all variants of the layout-footer](https://components.publishing.service.gov.uk/component-guide/layout_footer) now render identically when printed .

## Why
Although we made improvements to the `layout-footer` as part of #4073, we did not look at how the component might interact with other components on the page. This PR further improves the component in context of page types. 

## Visual Changes

### Before and After: Component on a typical page
![image](https://github.com/user-attachments/assets/f39ae4da-f63c-4704-bb45-e986017ddedb)

