### PR TITLE
Improve print styles for inverse-header component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fix the search toggle in layout header ([PR #4163](https://github.com/alphagov/govuk_publishing_components/pull/4163))
 * Replace 'unset' property in printed background colours ([PR #4184](https://github.com/alphagov/govuk_publishing_components/pull/4184))
 * Improve print styles for layout-footer component ([PR #4178](https://github.com/alphagov/govuk_publishing_components/pull/4178))
+* Improve print styles for inverse-header component ([PR #4179](https://github.com/alphagov/govuk_publishing_components/pull/4179))
 
 ## 43.0.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_inverse-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_inverse-header.scss
@@ -31,6 +31,8 @@
 @include govuk-media-query($media-type: print) {
   .gem-c-inverse-header {
     background: none;
+    padding-left: 0;
+    padding-right: 0;
     border-bottom: 2pt solid $govuk-print-text-colour;
 
     &,


### PR DESCRIPTION
## What
This improves the print styles for the `inverse-header` component as part of the work to improve print styles for page layouts:

- Padding is removed for better alignment with printed page content

[Trello](https://trello.com/c/tcXZsXup/193-review-and-fix-page-level-print-styles)

## Why
Although we made improvements to this component as part of #4073, we did not look at how the component might interact with other components on the page. This PR further improves the component in context of page types. 

## Visual Changes

### Before and After: Component Preview

<img width="50%" alt="image" src="https://github.com/user-attachments/assets/1f3cd449-0eda-4a5c-b426-de157c98a3f4"><img width="50%" alt="image" src="https://github.com/user-attachments/assets/bbcfc22f-efc3-45d3-b3a1-261995af267a">

### Before and After: Component on a HTML Publication page
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/c5892298-1f4f-4d3c-91fc-f20d46ec0d85"><img width="50%" alt="image" src="https://github.com/user-attachments/assets/1695cf45-a2da-4657-ad77-ae13461df8d4">



