### PR TITLE
Replace 'unset' property in printed background colours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Fix the search toggle in layout header ([PR #4163](https://github.com/alphagov/govuk_publishing_components/pull/4163))
+* Replace 'unset' property in printed background colours ([PR #4184](https://github.com/alphagov/govuk_publishing_components/pull/4184))
 
 ## 43.0.1
 

--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -139,7 +139,7 @@ $gem-guide-border-width: 1px;
 
   @include govuk-media-query($media-type: print) {
     &[class*="-background"] {
-      background-color: unset;
+      background: none;
     }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cross-service-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cross-service-header.scss
@@ -443,7 +443,7 @@ $govuk-header-link-underline-thickness: 3px;
   }
 
   .gem-c-one-login-header {
-    background-color: initial;
+    background: none;
     border-bottom: 2pt solid $govuk-print-text-colour;
 
     * {
@@ -456,6 +456,8 @@ $govuk-header-link-underline-thickness: 3px;
   }
 
   .gem-c-service-header {
+    background: none;
+
     .govuk-width-container {
       margin: 0;
     }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_intervention.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_intervention.scss
@@ -26,7 +26,7 @@
 @include govuk-media-query($media-type: print) {
   .gem-c-intervention {
     break-inside: avoid;
-    background-color: transparent;
+    background: none;
     border-color: $govuk-print-text-colour;
 
     .govuk-body {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_inverse-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_inverse-header.scss
@@ -30,7 +30,7 @@
 
 @include govuk-media-query($media-type: print) {
   .gem-c-inverse-header {
-    background-color: unset;
+    background: none;
     border-bottom: 2pt solid $govuk-print-text-colour;
 
     &,

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
@@ -183,7 +183,7 @@
     .gem-c-header__product-name,
     .gem-c-environment-tag {
       color: $govuk-print-text-colour;
-      background-color: unset;
+      background: none;
     }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -989,7 +989,7 @@ $after-button-padding-left: govuk-spacing(4);
     border-top: 0;
     border-bottom: 2pt solid $govuk-print-text-colour;
     margin: 0 0 5mm;
-    background-color: transparent;
+    background: none;
 
     &:has(.gem-c-layout-super-navigation-header__header-logo .govuk-visually-hidden) {
       border: 0;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_metadata.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_metadata.scss
@@ -100,7 +100,7 @@
   .gem-c-metadata {
     break-inside: avoid;
     color: $govuk-print-text-colour !important;
-    background-color: unset;
+    background: none;
     margin-bottom: 5mm;
 
     a,

--- a/app/assets/stylesheets/govuk_publishing_components/components/_phase-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_phase-banner.scss
@@ -32,7 +32,7 @@
   .gem-c-phase-banner {
     &,
     & * {
-      background-color: unset !important;
+      background: none !important;
       color: $govuk-print-text-colour !important;
     }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-header.scss
@@ -22,7 +22,7 @@
 @include govuk-media-query($media-type: print) {
   .gem-c-step-nav-header {
     padding: 0 0 govuk-spacing(4) 0;
-    background: unset;
+    background: none;
     border-color: $govuk-print-text-colour;
   }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-related.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-related.scss
@@ -48,7 +48,7 @@
 // stylelint-disable declaration-no-important
 @include govuk-media-query($media-type: print) {
   .gem-c-step-nav-related {
-    background: unset;
+    background: none;
     border-color: $govuk-print-text-colour;
   }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_success-alert.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_success-alert.scss
@@ -9,7 +9,7 @@
 @include govuk-media-query($media-type: print) {
   .gem-c-success-alert {
     break-inside: avoid;
-    background-color: initial;
+    background: none;
     border-color: $govuk-print-text-colour;
 
     * {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_table.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_table.scss
@@ -133,7 +133,7 @@ $table-row-even-background-colour: govuk-colour("light-grey");
 
     * {
       color: $govuk-print-text-colour !important;
-      background-color: initial !important;
+      background: none !important;
     }
 
     .govuk-table__header,

--- a/app/assets/stylesheets/govuk_publishing_components/components/_warning-text.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_warning-text.scss
@@ -28,7 +28,7 @@
   }
 
   .govuk-warning-text__icon {
-    background-color: transparent;
+    background: none;
     color: $govuk-print-text-colour;
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_button.scss
@@ -32,7 +32,7 @@
 
       &,
       & * {
-        background-color: unset;
+        background: none;
         color: $govuk-print-text-colour !important; // stylelint-disable-line declaration-no-important
       }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_highlight-answer.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_highlight-answer.scss
@@ -44,15 +44,13 @@ $highlight-answer-color: govuk-colour("white");
       }
     }
 
-    // stylelint-disable declaration-no-important
     @include govuk-media-query($media-type: print) {
-      background-color: unset;
+      background: none;
 
       &,
       & * {
-        color: $govuk-print-text-colour !important;
+        color: $govuk-print-text-colour !important; // stylelint-disable-line declaration-no-important
       }
     }
-    // stylelint-enable declaration-no-important
   }
 }


### PR DESCRIPTION
## What
In improving print styles in gem components (#4073), we used `background-color: unset` to revert backgrounds to transparent for print. This would ensure that inverse components would always print non-inverted, saving ink.

After discussion we decided to change this to use `background: none` instead, because:
- the use of `unset` is uncommon and not well understood, and its behaviour can be unpredictable
- `background: none` is a more common accepted approach and easier to understand. We've taken into account that resetting all background properties can be considered a [CSS anti-pattern](https://csswizardry.com/2016/12/css-shorthand-syntax-considered-an-anti-pattern/), however we're confident in this case that it won't have any adverse effects because we're not using any other background properties in the affected components.

This PR also makes consistent other treatments of background, such as `background-color: transparent` or `background: initial`.