### PR TITLE
Fix govuk-frontend Sass compilation warning

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/govuk_frontend_support.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/govuk_frontend_support.scss
@@ -8,6 +8,10 @@
 @import "components/mixins/govuk-template-link-focus-override";
 @import "components/mixins/css3";
 
+$govuk-suppressed-warnings: (
+  organisation-colours
+);
+
 $gem-secondary-button-colour: #00823b;
 $gem-secondary-button-hover-colour: darken($gem-secondary-button-colour, 5%);
 $gem-secondary-button-background-colour: govuk-colour("white");


### PR DESCRIPTION
## What
Adds the `govuk-suppressed-warnings` flag to suppress warnings about the [organisation colour changes](https://frontend.design-system.service.gov.uk/sass-api-reference/#govuk-suppressed-warnings).

## Why
We were getting a ton of messages in the Sass compilation like this:

```
10:33:48 css.1  | [2024-09-02 10:33:48] Compiled spec/dummy/app/assets/stylesheets/views/_app-view.scss to spec/dummy/app/assets/builds/views/_app-view.css.
10:33:48 css.1  | WARNING: `department-for-business-energy-industrial-strategy` was dissolved in 2023. It was replaced by `department-for-business-trade`, `department-for-energy-security-net-zero` and `department-science-innovation-technology`. To silence this warning, update $govuk-suppressed-warnings with key: "organisation-colours"
10:33:48 css.1  |     node_modules/govuk-frontend/dist/govuk/helpers/_colour.scss 81:5         govuk-organisation-colour()
10:33:48 css.1  |     govuk_publishing_components/components/helpers/_brand-colours.scss 5:16  organisation-brand-colour()
10:33:48 css.1  |     govuk_publishing_components/components/helpers/_brand-colours.scss 29:1  @import
10:33:48 css.1  |     govuk_publishing_components/component_support.scss 9:9                   @import
10:33:48 css.1  |     govuk_publishing_components/_all_components.scss 5:9                     @import
10:33:48 css.1  |     spec/dummy/app/assets/stylesheets/application.scss 1:9                   root stylesheet
```

## Visual Changes
None.
