### PR TITLE
Add ga4 tracking to chat entry component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add the password input component ([PR #4176](https://github.com/alphagov/govuk_publishing_components/pull/4176))
+* Add ga4 tracking to chat entry component ([PR #4196](https://github.com/alphagov/govuk_publishing_components/pull/4196))
 
 ## 43.0.2
 

--- a/app/views/govuk_publishing_components/components/_chat_entry.html.erb
+++ b/app/views/govuk_publishing_components/components/_chat_entry.html.erb
@@ -7,12 +7,24 @@
   description_text ||= t("components.chat_entry.description")
   border_top ||= false
   border_bottom ||= false
+  disable_ga4 ||= false
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-chat-entry")
   component_helper.add_class("gem-c-chat-entry--border-top") if border_top
   component_helper.add_class("gem-c-chat-entry--border-bottom") if border_bottom
   component_helper.add_class(shared_helper.get_margin_bottom)
+  component_helper.add_data_attribute({ module: "ga4-link-tracker" }) unless disable_ga4
+
+  unless disable_ga4
+    ga4_link_data = {
+      ga4_link: {
+        event_name: "navigation",
+        type: "callout",
+        section: "GOV.UK Chat entry",
+      }.to_json
+    }
+  end
 %>
 
 <%= tag.div(**component_helper.all_attributes) do %>
@@ -36,7 +48,7 @@
 
   <div class="gem-c-chat-entry__description">
     <%= content_tag(shared_helper.get_heading_level, class: "gem-c-chat-entry__heading") do %>
-      <%= link_to heading_text, href, class: "govuk-link" %>
+      <%= link_to heading_text, href, class: "govuk-link", data: ga4_link_data %>
     <% end %>
 
     <% if description_text %>

--- a/app/views/govuk_publishing_components/components/docs/chat_entry.yml
+++ b/app/views/govuk_publishing_components/components/docs/chat_entry.yml
@@ -34,3 +34,8 @@ examples:
   with_margin_bottom:
     data:
       margin_bottom: 3
+  without_ga4_tracking:
+    description: |
+      Disables GA4 tracking on the component. Tracking is enabled by default. This adds a data module and data-attributes with JSON data. See the [ga4-link-tracker documentation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-link-tracker.md) for more information.
+    data:
+      disable_ga4: true

--- a/spec/components/chat_entry_spec.rb
+++ b/spec/components/chat_entry_spec.rb
@@ -57,4 +57,20 @@ describe "Chat entry", type: :view do
 
     assert_select ".gem-c-chat-entry.gem-c-chat-entry--border-top.gem-c-chat-entry--border-bottom"
   end
+
+  it "renders the chat entry component with ga4 data attributes by default" do
+    render_component({})
+
+    assert_select '.gem-c-chat-entry[data-module="ga4-link-tracker"]'
+    assert_select '.gem-c-chat-entry .govuk-link[data-ga4-link=\'{"event_name":"navigation","type":"callout","section":"GOV.UK Chat entry"}\']'
+  end
+
+  it "renders the chat entry component without ga4 data attributes when passed disable_ga4: true" do
+    render_component({
+      disable_ga4: true,
+    })
+
+    assert_select '.gem-c-chat-entry[data-module="ga4-link-tracker"]', false
+    assert_select ".gem-c-chat-entry[data-ga4-link]", false
+  end
 end


### PR DESCRIPTION
## What
This PR adds GA4 tracking to the chat entry component.

## Why
Requested by the PA on the AI team.