### PR TITLE
Updates `asset_helper_spec` for new component

### DIFF
--- a/spec/lib/govuk_publishing_components/app_helpers/asset_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/app_helpers/asset_helper_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe GovukPublishingComponents::AppHelpers::AssetHelper do
     end
 
     it "detect the total number of stylesheet paths" do
-      expect(get_component_css_paths.count).to eql(76)
+      expect(get_component_css_paths.count).to eql(77)
     end
 
     it "initialize empty asset helper" do


### PR DESCRIPTION
## What
Updates the test to count number of components after the addition of the new Summary Card component
