### PR TITLE
Remove aria-label on menu button

### DIFF
--- a/app/views/govuk_publishing_components/components/layout_header/_navigation_items.html.erb
+++ b/app/views/govuk_publishing_components/components/layout_header/_navigation_items.html.erb
@@ -7,7 +7,6 @@
   <%= tag.nav class: "gem-c-header__nav govuk-header__navigation govuk-header__navigation--end", aria: { label: navigation_aria_label } do %>
     <button
       aria-controls="<%= navigation_id %>"
-      aria-label="Show or hide Top Level Navigation"
       class="govuk-header__menu-button govuk-js-header-toggle gem-c-header__menu-button govuk-!-display-none-print"
       type="button"
       data-button-name="menu"


### PR DESCRIPTION
## What
This PR removes the `aria-label` from the menu button in the [navigation items component](https://github.com/alphagov/govuk_publishing_components/blob/main/app/views/govuk_publishing_components/components/layout_header/_navigation_items.html.erb) in the layout header.

This what identified as a level A WCAG failure during a DAC audit of GOV.UK Chat because the [aria-label (“Show or hide Top Level Navigation”)](https://github.com/alphagov/govuk_publishing_components/blob/60ab84d7936da9a8f9ce05bff5c8fcd8f5f734bf/app/views/govuk_publishing_components/components/layout_header/_navigation_items.html.erb#L10) did not match the visual text of the [menu button (“Menu”)](https://github.com/alphagov/govuk_publishing_components/blob/60ab84d7936da9a8f9ce05bff5c8fcd8f5f734bf/app/views/govuk_publishing_components/components/layout_header/_navigation_items.html.erb#L16). DAC suggested removing the `aria-label` altogether and just relying on the button text.

There may be more context around this that I’m not aware of so I’m happy to close this PR if this is already known/intentional and no action is required.

Also, apologies if going straight for raising a PR is a bit too hasty - happy to go through the process of raising an issue first and going from there if that’s preferable.

## Why
Identified as a level A WCAG failure (specifically [2.5.3 Label in Name](https://www.w3.org/TR/WCAG22/#label-in-name))
