### PR TITLE
Fix govspeak highlight answer margin

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_highlight-answer.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_highlight-answer.scss
@@ -10,7 +10,7 @@ $highlight-answer-color: govuk-colour("white");
     color: $highlight-answer-color;
     text-align: center;
     padding: 1.75em .75em 1.25em;
-    margin: 0 -1em 1em;
+    margin: 0 0 1em;
 
     p {
       color: $highlight-answer-color;


### PR DESCRIPTION
## What
Fixes a layout issue with the govspeak 'highlight answer' feature.

- had a negative left/right margin, which was causing it to overflow out of its containing element slightly
- see example: https://www.gov.uk/corporation-tax-rates

## Why
Spotted recently by @kubabartwicki 

## Visual Changes
Before | After
------ | ------
![Screenshot 2024-09-06 at 09 08 44](https://github.com/user-attachments/assets/51b481b0-9584-4f21-8d3b-a484e70506c8) | ![Screenshot 2024-09-06 at 09 10 10](https://github.com/user-attachments/assets/6b3e4a8b-6b5f-441f-952b-7876ab9438f5)
