### PR TITLE
Hide printed URLs when printing tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Hide printed URLs when printing tables ([PR #4209](https://github.com/alphagov/govuk_publishing_components/pull/4209))
+
 ## 43.1.0
 
 * Add the password input component ([PR #4176](https://github.com/alphagov/govuk_publishing_components/pull/4176))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_table.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_table.scss
@@ -128,6 +128,13 @@ $table-row-even-background-colour: govuk-colour("light-grey");
 
 // stylelint-disable declaration-no-important
 @include govuk-media-query($media-type: print) {
+  .govuk-table,
+  .gem-c-table {
+    a::after {
+      display: none !important;
+    }
+  }
+
   .govuk-table--sortable {
     outline: none;
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_tables.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_tables.scss
@@ -97,3 +97,12 @@
     }
   }
 }
+
+@include govuk-media-query($media-type: print) {
+  .govspeak,
+  .gem-c-govspeak {
+    table a::after {
+      display: none !important; // stylelint-disable-line declaration-no-important
+    }
+  }
+}


### PR DESCRIPTION
## What
When printing tables, hide the URLs generated by the global print styles in govuk-frontend. [Trello](https://trello.com/c/zuT5SiYJ/324-hide-printed-urls-when-printing-tables)

## Why
When links are printed, the print styles in govuk-frontend append the URL of the link so that they are more useful to the reader. But these links can break the layout of tables and prevent all columns from printing.

## Visual Changes
### BEFORE
![image](https://github.com/user-attachments/assets/82274e23-b8c7-44f8-a88d-c9f221dda4d7)

### AFTER
![image](https://github.com/user-attachments/assets/36a0601c-dfe2-4508-9235-5557aa4899b6)
