### PR TITLE
Improve the password input component custom text feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Use component wrapper in hint component ([PR #4214](https://github.com/alphagov/govuk_publishing_components/pull/4214))
 * Hide printed URLs when printing tables ([PR #4209](https://github.com/alphagov/govuk_publishing_components/pull/4209))
 * Fix action link component print styles ([PR #4213](https://github.com/alphagov/govuk_publishing_components/pull/4213))
+* Improve the password input component custom text feature ([PR #4211](https://github.com/alphagov/govuk_publishing_components/pull/4211))
 
 ## 43.1.0
 

--- a/app/views/govuk_publishing_components/components/_password_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_password_input.html.erb
@@ -6,9 +6,24 @@
   error_text ||= nil
   error_text_prefix ||= t("components.password_input.error_text_prefix")
 
+  button_show_password_aria_label ||= t("components.password_input.button_aria_label")
+  button_hide_password_aria_label ||= t("components.password_input.button_aria_hide_label")
+  button_show_password_text ||= t("components.password_input.button")
+  button_hide_password_text ||= t("components.password_input.button_hide")
+  password_shown_announcement ||= t("components.password_input.password_shown_announcement")
+  password_hidden_announcement ||= t("components.password_input.password_hidden_announcement")
+
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
-  component_helper.add_data_attribute({ module: "govuk-password-input" })
+  component_helper.add_data_attribute({
+    module: "govuk-password-input",
+      "i18n.show-password": button_show_password_text,
+      "i18n.hide-password": button_hide_password_text,
+      "i18n.show-password-aria-label": button_show_password_aria_label,
+      "i18n.hide-password-aria-label": button_hide_password_aria_label,
+      "i18n.password-shown-announcement": password_shown_announcement,
+      "i18n.password-hidden-announcement": password_hidden_announcement,
+    })
   component_helper.add_class('govuk-form-group')
   component_helper.add_class('govuk-form-group--error') if error_text
   component_helper.add_class('govuk-password-input')
@@ -34,7 +49,6 @@
     aria_controls << '-with-error-message'
     paragraph_id = uid + '-password-input-with-error-message-error'
   end
-
 %>
 
 <%= tag.div(**component_helper.all_attributes) do %>
@@ -70,9 +84,9 @@
       hidden: true,
       aria: {
         controls: aria_controls,
-        label: t("components.password_input.button_aria_label")
+        label: button_show_password_aria_label
       }) do %>
-        <%= t("components.password_input.button") %>
+        <%= button_show_password_text %>
       <% end %>
   </div>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/password_input.yml
+++ b/app/views/govuk_publishing_components/components/docs/password_input.yml
@@ -33,11 +33,26 @@ examples:
     data:
       error_text: Enter a password
   with_custom_label_and_error_text:
-    description: For translations or other purposes, the text presented to the user in this component can be changed. Note that the error text prefix is hidden visually and used by assistive tools when there is an error. By default, the prefix is "Error".
+    description: |
+      For translations or other purposes, the text presented to the user in this component can be changed.
+
+      Note that the error text prefix and announcements are hidden visually and used by assistive tools when there is an error.
+
+      By default, the error prefix is "Error".
+
+      By default, the password shown announcement is "Your password is visible".
+
+      By default, the password hidden announcement is "Your password is hidden".
     data:
       label_text: Secret number
       error_text_prefix: Incompatible
       error_text: 6 is scared of 7, so they can't be next to each other.
+      button_show_password_aria_label: View password
+      button_hide_password_aria_label: Obscure password
+      button_show_password_text: View
+      button_hide_password_text: Obscure
+      password_shown_announcement: Secret number is in view
+      password_hidden_announcement: Secret number is obscured
   with_margin_bottom:
     description: |
       The component accepts a number for margin bottom from `0` to `9` (`0px` to `60px`) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to having a margin bottom of `30px`.

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -150,9 +150,13 @@ ar:
       all_content_search_description: العثور عن كل المحتوى من %{organisation}
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: ترقيم الصفحات

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -147,9 +147,13 @@ az:
       all_content_search_description: "%{organisation}-dan bütün məzmunu tap"
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Səhifələrə bölmə

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -153,9 +153,13 @@ be:
       all_content_search_description: Шукаць увесь змест з %{organisation}
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Месцаванне старонак

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -151,9 +151,13 @@ bg:
       all_content_search_description: Намиране на цялото съдържание от %{organisation}
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Страниране

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -148,9 +148,13 @@ bn:
       all_content_search_description: "%{organisation}-এর সকল বিষয়বস্তু খুঁজে বের করুন"
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: পেজিনেশন

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -152,9 +152,13 @@ cs:
       all_content_search_description: Najít veškerý obsah z %{organisation}
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Stránkování

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -151,9 +151,13 @@ cy:
       all_content_search_description: Dod o hyd i'r holl gynnwys gan %{organisation}
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Tudalennu

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -148,9 +148,13 @@ da:
       all_content_search_description: Find alt indhold fra %{organisation}
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Paginering

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -151,9 +151,13 @@ de:
       all_content_search_description: Alle Inhalte von %{organisation} finden
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Seitenzahlen

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -149,9 +149,13 @@ dr:
       all_content_search_description: تمام محتویات را از اینجا بدست بیاورید %{organisation}
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: صفحه گذاری

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -147,9 +147,13 @@ el:
       all_content_search_description: Εύρεση όλου του περιεχομένου από τον οργανισμό %{Organization}
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Σελιδοποίηση

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -253,10 +253,14 @@ en:
     organisation_schema:
       all_content_search_description: Find all content from %{organisation}
     password_input:
-      label: "Password"
-      button: "Show"
-      button_aria_label: "Show password"
-      error_text_prefix: "Error"
+      label: Password
+      button: Show
+      button_hide: Hide
+      button_aria_label: Show password
+      button_aria_hide_label: Hide password
+      password_shown_announcement: Your password is visible
+      password_hidden_announcement: Your password is hidden
+      error_text_prefix: Error
     previous_and_next_navigation:
       next: Next
       pagination: Pagination

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -147,9 +147,13 @@ es-419:
       all_content_search_description: Buscar todo el contenido de %{organisation}
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Paginación

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -147,9 +147,13 @@ es:
       all_content_search_description: Buscar todo el contenido de %{organization}
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Paginación

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -150,9 +150,13 @@ et:
       all_content_search_description: Leidke kogu ettevõtte %{organization} sisu
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Lehekülgede jaotus

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -146,9 +146,13 @@ fa:
       all_content_search_description: یافتن تمام محتوا از %{organisation}
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: صفحه‌بندی

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -149,9 +149,13 @@ fi:
       all_content_search_description: Etsi kaikki sisältö alkaen %{organisation}
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Sivunumerointi

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -147,9 +147,13 @@ fr:
       all_content_search_description: Rechercher tout le contenu de %{organisation}
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Pagination

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -149,9 +149,13 @@ gd:
       all_content_search_description: Faigh gach rud ó %{organisation}
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Leathanach

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -147,9 +147,13 @@ gu:
       all_content_search_description: "%{organisation} થી તમામ સામગ્રી શોધો"
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: પૃષ્ઠ ક્રમાંકન

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -147,9 +147,13 @@ he:
       all_content_search_description: מצא את כל התוכן של %{organization}
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: חלוקה לעמודים

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -147,9 +147,13 @@ hi:
       all_content_search_description: "%{organization} से सभी सामग्री खोजें"
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: पृष्ठांकन

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -148,9 +148,13 @@ hr:
       all_content_search_description: Pronađi sav sadržaj %{organization}
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Paginacija

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -150,9 +150,13 @@ hu:
       all_content_search_description: Keresse meg a(z) %{organisation} szervezet minden tartalmát
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Lapszámozás

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -151,9 +151,13 @@ hy:
       all_content_search_description: Գտնել %{organisation} ողջ բովանդակությունը
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Էջադրում

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -147,9 +147,13 @@ id:
       all_content_search_description: Temukan semua konten dari %{organisation}
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Paginasi

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -147,9 +147,13 @@ is:
       all_content_search_description: Finna allt efni frá %{organisation}
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Síðuuppsetning

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -147,9 +147,13 @@ it:
       all_content_search_description: Trova tutto il contenuto da %{organisation}
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Impaginazione

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -143,9 +143,13 @@ ja:
       all_content_search_description: "％{organisation} からすべてのコンテンツを検索"
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: ページ付け

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -150,9 +150,13 @@ ka:
       all_content_search_description: ყველა მასალის ნახვა %{organisation}-დან
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: პაგინაცია

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -147,9 +147,13 @@ kk:
       all_content_search_description: "%{organisation} ішіндегі барлық мазмұнды табу"
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Беттеу

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -142,9 +142,13 @@ ko:
       all_content_search_description:
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -152,9 +152,13 @@ lt:
       all_content_search_description: Rasti visą turinį iš %{organisation}
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Suskirstymas puslapiais

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -151,9 +151,13 @@ lv:
       all_content_search_description: Meklēt visu saturu no %{organisation}
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Numerācija

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -146,9 +146,13 @@ ms:
       all_content_search_description: Cari semua kandungan dari %{organisation}
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Penomboran

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -149,9 +149,13 @@ mt:
       all_content_search_description: Sib il-kontenut kollu mingħand %{organisation}
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Paġinazzjoni

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -147,9 +147,13 @@ nl:
       all_content_search_description: Zoek alle inhoud van %{organisation}
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Paginering

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -147,9 +147,13 @@
       all_content_search_description: Finn alt innhold fra %{organization}
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Paginering

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -143,9 +143,13 @@ pa-pk:
       all_content_search_description: "%{organisation} توں سارا مواد تلاش کرو"
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: ورقہ بندی

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -147,9 +147,13 @@ pa:
       all_content_search_description: "%{organisation} ਤੋਂ ਸਾਰੀ ਸਮਗਰੀ ਲੱਭੋ"
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: ਪੰਨਾ

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -151,9 +151,13 @@ pl:
       all_content_search_description: Znajdź całą zawartość od %{organizacja}
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Numeracja stron

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -144,9 +144,13 @@ ps:
       all_content_search_description: له%{organization} څخه ټوله مینځپانګه ومومئ
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: مخینه

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -147,9 +147,13 @@ pt:
       all_content_search_description: Encontrar todo o conteúdo de %{organisation}
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Paginação

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -148,9 +148,13 @@ ro:
       all_content_search_description: Găsiți tot conținutul de la %{organisation}
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Paginație

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -151,9 +151,13 @@ ru:
       all_content_search_description: Найти весь контент от %{organization}
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Разбивка

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -147,9 +147,13 @@ si:
       all_content_search_description: "%{organisation} වෙතින් සියලුම අන්තර්ගතය සෝයන්න"
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: පිටු අංකය

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -152,9 +152,13 @@ sk:
       all_content_search_description: Nájsť všetok obsah z %{organisation}
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Stránkovanie

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -154,9 +154,13 @@ sl:
       all_content_search_description: Oglejte si vse gradivo %{organisation}
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Oštevilčenje

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -147,9 +147,13 @@ so:
       all_content_search_description: Raadi dhamaan waxyaabaha uu ka koobanyahay %{organisation}
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Lambar siinta boga

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -147,9 +147,13 @@ sq:
       all_content_search_description: Gjeni të gjithë përmbajtjen nga %{organisation}
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Numërtimi

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -148,9 +148,13 @@ sr:
       all_content_search_description: Pronađite sav sadržaj organizacije %{organisation}
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Broj stranice

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -147,9 +147,13 @@ sv:
       all_content_search_description: Hitta allt innehåll från %{organisation}
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Paginering

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -147,9 +147,13 @@ sw:
       all_content_search_description: Tafuta maudhui yote kutoka %{organisation}
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Nambari za kurasa

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -148,9 +148,13 @@ ta:
       all_content_search_description: "%{organisation}-லிருந்து அனைத்து உள்ளடக்கத்தையும் கண்டறி"
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: பக்கமிடுதல்

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -145,9 +145,13 @@ th:
       all_content_search_description: ค้นหาเนื้อหาทั้งหมดจาก %{organisation}
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: การแบ่งหน้า

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -148,9 +148,13 @@ tk:
       all_content_search_description: Ähli mazmunyny %{organisation}-dan tapyň
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Sahypa

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -148,9 +148,13 @@ tr:
       all_content_search_description: "%{organisation} kaynaklı tüm içeriği bul"
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Sayfa

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -154,9 +154,13 @@ uk:
       all_content_search_description: Знайти весь вміст від %{organization}
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Поділ на сторінки

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -144,9 +144,13 @@ ur:
       all_content_search_description: "%{organisation} کا تمام مواد تلاش کریں"
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: صفحہ بندی

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -149,9 +149,13 @@ uz:
       all_content_search_description: "%{organization}  дан бутун контентни топиш"
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Саҳифаларнинг рақамланиши

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -146,9 +146,13 @@ vi:
       all_content_search_description: Tìm tất cả nội dung từ %{organisation}
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: Phân trang

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -145,9 +145,13 @@ zh-hk:
       all_content_search_description: 從 %{organisation} 獲得更多內容
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: 分頁

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -145,9 +145,13 @@ zh-tw:
       all_content_search_description: 從 %{organisation} 找到所有內容
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: 分頁

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -145,9 +145,13 @@ zh:
       all_content_search_description: 查找 %{organisation} 的全部内容
     password_input:
       button:
+      button_aria_hide_label:
       button_aria_label:
+      button_hide:
       error_text_prefix:
       label:
+      password_hidden_announcement:
+      password_shown_announcement:
     previous_and_next_navigation:
       next:
       pagination: 分页

--- a/spec/components/password_input_spec.rb
+++ b/spec/components/password_input_spec.rb
@@ -18,6 +18,16 @@ describe "Password Input", type: :view do
     assert_select "p#1234-password-input-with-error-message-error", false
     assert_select "div.govuk-password-input input.govuk-input--error", false
     assert_select "div.govuk-form-group--error", false
+
+    # As the following data attributes contain period symbols, we must use an alternative to assert_select.
+    html = Nokogiri::HTML(rendered)
+    password_input_component = html.at(".govuk-password-input")
+    expect(password_input_component.attr("data-i18n.show-password")).to eql("Show")
+    expect(password_input_component.attr("data-i18n.hide-password")).to eql("Hide")
+    expect(password_input_component.attr("data-i18n.show-password-aria-label")).to eql("Show password")
+    expect(password_input_component.attr("data-i18n.hide-password-aria-label")).to eql("Hide password")
+    expect(password_input_component.attr("data-i18n.password-shown-announcement")).to eql("Your password is visible")
+    expect(password_input_component.attr("data-i18n.password-hidden-announcement")).to eql("Your password is hidden")
   end
 
   it "renders a password input with extra classes and a paragraph when error_text is passed" do
@@ -35,9 +45,26 @@ describe "Password Input", type: :view do
       label_text: "Secret number",
       error_text_prefix: "Incompatible",
       error_text: "6 is scared of 7, so they can't be next to each other.",
+      button_show_password_aria_label: "View password",
+      button_hide_password_aria_label: "Obscure password",
+      button_show_password_text: "View",
+      button_hide_password_text: "Obscure",
+      password_shown_announcement: "Password is in view",
+      password_hidden_announcement: "Password is obscured",
     })
     assert_select "div.govuk-password-input label", "Secret number"
     assert_select "p#1234-password-input-with-error-message-error", "Incompatible: 6 is scared of 7, so they can't be next to each other."
+    assert_select "div.govuk-password-input button", "View"
+
+    # As the following data attributes contain period symbols, we must use an alternative to assert_select.
+    html = Nokogiri::HTML(rendered)
+    password_input_component = html.at(".govuk-password-input")
+    expect(password_input_component.attr("data-i18n.show-password")).to eql("View")
+    expect(password_input_component.attr("data-i18n.hide-password")).to eql("Obscure")
+    expect(password_input_component.attr("data-i18n.show-password-aria-label")).to eql("View password")
+    expect(password_input_component.attr("data-i18n.hide-password-aria-label")).to eql("Obscure password")
+    expect(password_input_component.attr("data-i18n.password-shown-announcement")).to eql("Password is in view")
+    expect(password_input_component.attr("data-i18n.password-hidden-announcement")).to eql("Password is obscured")
   end
 
   it "accepts margin_bottom values" do


### PR DESCRIPTION
## What / Why
<!-- What are the reasons behind this change being made? -->
- Adds the ability to modify the "Show/Hide" button text in the password input component, as well as the component labels.
- This feature was not obvious in the design system docs, so it was missed during our initial implementation of the component.

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

The example in the doc has been expanded.
