### PR TITLE
Fix action link component print styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Use component wrapper in hint component ([PR #4214](https://github.com/alphagov/govuk_publishing_components/pull/4214))
 * Hide printed URLs when printing tables ([PR #4209](https://github.com/alphagov/govuk_publishing_components/pull/4209))
+* Fix action link component print styles ([PR #4213](https://github.com/alphagov/govuk_publishing_components/pull/4213))
 
 ## 43.1.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
@@ -178,3 +178,22 @@
     }
   }
 }
+
+@include govuk-media-query($media-type: print) {
+  .gem-c-action-link {
+    * {
+      color: $govuk-print-text-colour !important; // stylelint-disable-line declaration-no-important
+    }
+
+    &::before {
+      display: none;
+    }
+
+    .gem-c-action-link__link {
+      &::after {
+        display: block;
+        font-size: 12pt;
+      }
+    }
+  }
+}

--- a/app/views/govuk_publishing_components/components/_action_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_action_link.html.erb
@@ -17,7 +17,7 @@
   dark_large_icon ||= false
   light_icon ||= false
 
-  css_classes = %w(gem-c-action-link govuk-!-display-none-print)
+  css_classes = %w(gem-c-action-link)
   css_classes << "gem-c-action-link--light-text" if light_text
   css_classes << "gem-c-action-link--dark-icon" if dark_icon
   css_classes << "gem-c-action-link--dark-large-icon" if dark_large_icon


### PR DESCRIPTION
## What
Re-enable the printing of the action-link component and apply consistent improvements to the printed URLs (reducing size, placing on their own line, forcing all colours to black) [Trello](https://trello.com/c/cVgisHQw/312-fix-action-link-component-print-styles)

## Why
As part of the improvements to print styles, we prevented the `action-link` component from printing at all as generally speaking printing links isn’t very helpful as they’re mainly interactive elements. However we noticed this caused problems printing certain pages, particularly the homepage Popular section which now displays nothing when printed as the entire block is composed of `action-link` components.

## Visual Changes

Before | After
------ | ------
<img width="560" alt="image" src="https://github.com/user-attachments/assets/10ce63d4-3ab4-472e-b3b6-9f2736301e73"> | <img width="560" alt="image" src="https://github.com/user-attachments/assets/1d2292f7-17e6-4f36-97a1-8436fe9f2e22">