### PR TITLE
Fix cookie expiration date potentially relying on user's timezone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Set aria-label text in govuk_logo.html to "GOV.UK" ([PR #4217](https://github.com/alphagov/govuk_publishing_components/pull/4217))
+* Fix cookie expiration date potentially relying on user's timezone ([PR #4219](https://github.com/alphagov/govuk_publishing_components/pull/4219))
 
 ## 43.1.1
 

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
@@ -202,12 +202,14 @@
 
   window.GOVUK.deleteCookie = function (cookie) {
     window.GOVUK.cookie(cookie, null)
+    window.GOVUK.expireCookie(cookie)
+  }
 
-    if (window.GOVUK.cookie(cookie)) {
-      // We need to handle deleting cookies on the domain and the .domain
-      document.cookie = cookie + '=;expires=' + new Date() + ';'
-      document.cookie = cookie + '=;expires=' + new Date() + ';domain=' + window.location.hostname + ';path=/'
-    }
+  window.GOVUK.expireCookie = function (cookie, value = '') {
+    // We need to handle deleting cookies on the domain and the .domain
+    var thePast = new Date(0) // 0 = 0 seconds since UTC started (1970/01/01)
+    document.cookie = cookie + '=' + value + ';expires=' + thePast + ';'
+    document.cookie = cookie + '=' + value + ';expires=' + thePast + ';domain=' + window.location.hostname + ';path=/'
   }
 
   window.GOVUK.deleteUnconsentedCookies = function () {

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-settings.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-settings.js
@@ -107,7 +107,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     try {
       documentReferrer = document.referrer || new URL(document.referrer).pathname
     } catch (e) {
-      console.error('Error grabbing referrer for cookie settings', window.location, e)
+      console.warn('Error grabbing referrer for cookie settings', window.location, e)
     }
     return documentReferrer
   }

--- a/spec/javascripts/govuk_publishing_components/lib/cookie-functions-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/cookie-functions-spec.js
@@ -93,6 +93,22 @@ describe('Cookie helper functions', function () {
       expect(GOVUK.getConsentCookie()).toEqual({ essential: true, settings: false, usage: false, campaigns: false })
     })
 
+    it('deletes cookies by setting the expiration date to 1st January 1970', function () {
+      GOVUK.setCookie('JS-Detection', 'test', { days: 99999, domain: '.gov.uk', path: '/' })
+      expect(GOVUK.getCookie('JS-Detection')).toEqual('test')
+      window.GOVUK.expireCookie('JS-Detection', 1234568) // Should set the expiration date to 1970-01-01
+      expect(GOVUK.getCookie('JS-Detection')).toEqual(null)
+    })
+
+    it('calls expireCookie in the deleteCookie function', function () {
+      spyOn(window.GOVUK, 'expireCookie')
+      GOVUK.setCookie('JS-Detection', 'test', { days: 99999, domain: '.gov.uk', path: '/' })
+      expect(GOVUK.getCookie('JS-Detection')).toEqual('test')
+      window.GOVUK.deleteCookie('JS-Detection')
+      expect(GOVUK.getCookie('JS-Detection')).toEqual(null)
+      expect(window.GOVUK.expireCookie.calls.count()).toBe(1)
+    })
+
     it('deletes cookies after default consent cookie set', function () {
       var date = new Date()
       date.setTime(date.valueOf() + (365 * 24 * 60 * 60 * 1000))


### PR DESCRIPTION
## What /  Why
<!-- What are the reasons behind this change being made? -->
- We were using `Date.now()` as our way of instantly expiring cookies, but based on testing in the browser, the cookie would expire based on the UTC timezone rather than the user's timezone.  I believe `Date.now()` was grabbing the user's timezone which may have been causing issues if their timezone was ahead of UTC.
- It looks like the cookie would persist for an period of time depending on how far their timezone is ahead of UTC. An assumption of the worst case scenario is that their timezone could be 14 hours ahead of UTC, so certain cookies may have persisted for that long.
- I believe this is what is causing some weird cookie behaviour on [this GA4 card](https://trello.com/c/5TNoJ3rt/842-issue-with-absent-client-ids-related-to-postal-voteservicegovuk-redirect-links):  - I think on load our code is trying to delete this cookie to be extra safe, but it's doing that by making it expire at the `Date.now()` time. Currently we're an hour ahead of UTC, so I think this was setting an empty GA cookie to expire an hour in the future instead of deleting instantly.


As the screenshot shows, the two GA4 cookies should not exist when consent hasn't been given, but because their expiry date was set to `Date.now()` they were set to expire an hour in the future (as we're in BST at the moment, so 1 hour ahead of UTC - this screenshot was taken at 14:30 BST and UTC would've been 13:30.)

<img width="789" alt="image" src="https://github.com/user-attachments/assets/316d0497-92b1-42d7-8f71-ade08a926f1c">

- Therefore, I've set the cookies to expire 1st January 1970, just as that's the simplest value to pass through to `new Date()`.
- I separated the expiration code into a function as it was difficult to test when it was nested within `deleteCookie`.  `deleteCookie` caused false positives as it seems to have two passes of cookie deletion, so the other deletion pass was causing my expiration code tests to falsely pass, as the expiration code wasn't actually the thing that was deleting the cookie, it was the other line in that function.

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None