### PR TITLE
Update metatags for GA4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Update metatags for GA4 ([PR #4222](https://github.com/alphagov/govuk_publishing_components/pull/4222))
 * Set aria-label text in govuk_logo.html to "GOV.UK" ([PR #4217](https://github.com/alphagov/govuk_publishing_components/pull/4217))
 
 ## 43.1.1

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
@@ -33,7 +33,7 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
             navigation_page_type: this.getMetaContent('navigation-page-type'),
             navigation_list_type: this.getMetaContent('navigation-list-type'),
             step_navs: this.getMetaContent('stepnavs'),
-            taxonomy_level1: this.getMetaContent('themes'),
+            taxonomy_level1: this.getMetaContent('taxonomy_level1'),
             taxonomy_main: this.getMetaContent('taxon-slug'),
             taxonomy_main_id: this.getMetaContent('taxon-id'),
             taxonomy_all: this.getMetaContent('taxon-slugs'),

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
@@ -48,8 +48,8 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
             publishing_government: this.removeHyphensAndDowncase(this.getMetaContent('publishing-government') || this.getMetaContent('ga4-publishing-government')),
             political_status: this.getMetaContent('political-status') || this.getMetaContent('ga4-political-status'),
             primary_publishing_organisation: this.getMetaContent('primary-publishing-organisation'),
-            organisations: this.getMetaContent('analytics:organisations'),
-            world_locations: this.getMetaContent('analytics:world-locations'),
+            organisations: this.getMetaContent('organisations'),
+            world_locations: this.getMetaContent('world-locations'),
 
             /* The existence of a referrer parameter indicates that the page has been dynamically updated via an AJAX request
             and therefore we can use it to set the dynamic property appropriately. This value is used by PA's to differentiate

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.js
@@ -28,17 +28,17 @@
   var STATE_PATTERN = /state=.[^&]+/g
 
   function shouldStripDates () {
-    var metas = document.querySelectorAll('meta[name="govuk:static-analytics:strip-dates"]')
+    var metas = document.querySelectorAll('meta[name="govuk:ga4-strip-dates"]')
     return metas.length > 0
   }
 
   function shouldStripPostcodes () {
-    var metas = document.querySelectorAll('meta[name="govuk:static-analytics:strip-postcodes"]')
+    var metas = document.querySelectorAll('meta[name="govuk:ga4-strip-postcodes"]')
     return metas.length > 0
   }
 
   function queryStringParametersToStrip () {
-    var meta = document.querySelector('meta[name="govuk:static-analytics:strip-query-string-parameters"]')
+    var meta = document.querySelector('meta[name="govuk:ga4-strip-query-string-parameters"]')
     var value = false
     if (meta) {
       value = meta.getAttribute('content')

--- a/docs/analytics-ga4/pii-remover.md
+++ b/docs/analytics-ga4/pii-remover.md
@@ -23,7 +23,7 @@ var PIIRemover = new GOVUK.PIIRemover()
 var myInfo = 'this is an@email.com address, this is a 2019-01-21 date, this is a sw1a 1aa postcode,'
 
 var example1 = PIIRemover.stripPII(myInfo)
-// this is [email] address, this is a 2019-01-21 date, this is a sw1a 1aa postcode 
+// this is [email] address, this is a 2019-01-21 date, this is a sw1a 1aa postcode
 
 var example2 = PIIRemover.stripPIIWithOverride(myInfo, true, false)
 // this is [email] address, this is a [date] date, this is a sw1a 1aa postcode
@@ -40,7 +40,7 @@ var myArray = ['email@gov.uk', 'hello world']
 var example5 = PIIRemover.stripPII(myArray)
 // ['[email]', 'hello world']
 
-// Meta tag of <meta name="govuk:static-analytics:strip-query-string-parameters" content="strip-parameter-1,strip-parameter-2" />
+// Meta tag of <meta name="govuk:ga4-strip-query-string-parameters" content="strip-parameter-1,strip-parameter-2" />
 var myQueryString = '/test?strip-parameter-1=secret&strip-parameter-2=more-secret'
 var example6 = PIIRemover.stripPII(myQueryString)
 // /test?strip-parameter-1=[strip-parameter-1]&strip-parameter-2=[strip-parameter-2]
@@ -68,10 +68,10 @@ However, this will redact dates and postcodes from every call of the PIIRemover.
 
 ### For query string parameters:
 
-Query string parameters are redacted if there is presence of a `meta[name="govuk:static-analytics:strip-query-string-parameters"]` meta tag, with comma separated query string parameters keys in its `content` attribute. The usage of this query string PII removal in production is unknown at this time.
+Query string parameters are redacted if there is presence of a `meta[name="govuk:ga4-strip-query-string-parameters"]` meta tag, with comma separated query string parameters keys in its `content` attribute. The usage of this query string PII removal in production is unknown at this time.
 
 Add this meta tag with your query string parameter keys in the `content` section:
-`<meta name="govuk:static-analytics:strip-query-string-parameters" content="query-string-key-1,query-string-key-2"`
+`<meta name="govuk:ga4-strip-query-string-parameters" content="query-string-key-1,query-string-key-2"`
 
 
 ## Using the stripPIIWithOverride() function

--- a/lib/govuk_publishing_components/presenters/meta_tags.rb
+++ b/lib/govuk_publishing_components/presenters/meta_tags.rb
@@ -41,8 +41,8 @@ module GovukPublishingComponents
         meta_tags["govuk:section"] = content_item[:section] if content_item[:section]
         meta_tags["govuk:withdrawn"] = "withdrawn" if content_item[:withdrawn_notice].present?
         meta_tags["govuk:content-has-history"] = "true" if has_content_history?
-        meta_tags["govuk:static-analytics:strip-dates"] = "true" if should_strip_dates_pii?(content_item, local_assigns)
-        meta_tags["govuk:static-analytics:strip-postcodes"] = "true" if should_strip_postcode_pii?(content_item, local_assigns)
+        meta_tags["govuk:ga4-strip-dates"] = "true" if should_strip_dates_pii?(content_item, local_assigns)
+        meta_tags["govuk:ga4-strip-postcodes"] = "true" if should_strip_postcode_pii?(content_item, local_assigns)
         meta_tags["govuk:first-published-at"] = content_item[:first_published_at] if content_item[:first_published_at]
         meta_tags["govuk:updated-at"] = content_item[:updated_at] if content_item[:updated_at]
         meta_tags["govuk:public-updated-at"] = content_item[:public_updated_at] if content_item[:public_updated_at]

--- a/lib/govuk_publishing_components/presenters/meta_tags.rb
+++ b/lib/govuk_publishing_components/presenters/meta_tags.rb
@@ -106,7 +106,7 @@ module GovukPublishingComponents
 
       def add_taxonomy_tags(meta_tags)
         themes = root_taxon_slugs(content_item)
-        meta_tags["govuk:themes"] = themes.to_a.sort.join(", ") unless themes.empty?
+        meta_tags["govuk:taxonomy_level1"] = themes.to_a.sort.join(", ") unless themes.empty?
 
         taxons = if content_item[:document_type] == "taxon"
                    [content_item]

--- a/lib/govuk_publishing_components/presenters/meta_tags.rb
+++ b/lib/govuk_publishing_components/presenters/meta_tags.rb
@@ -64,11 +64,11 @@ module GovukPublishingComponents
         organisations += links[:organisations] || []
         organisations += links[:worldwide_organisations] || []
         organisations_content = organisations.map { |link| "<#{link[:analytics_identifier]}>" }.uniq.join
-        meta_tags["govuk:analytics:organisations"] = organisations_content if organisations.any?
+        meta_tags["govuk:organisations"] = organisations_content if organisations.any?
 
         world_locations = links[:world_locations] || []
         world_locations_content = world_locations.map { |link| "<#{link[:analytics_identifier]}>" }.join
-        meta_tags["govuk:analytics:world-locations"] = world_locations_content if world_locations.any?
+        meta_tags["govuk:world-locations"] = world_locations_content if world_locations.any?
 
         meta_tags
       end

--- a/spec/components/meta_tags_spec.rb
+++ b/spec/components/meta_tags_spec.rb
@@ -105,7 +105,7 @@ describe "Meta tags", type: :view do
     assert_political_status_for(political, current, "non-political")
   end
 
-  it "renders themes metatag for root taxon" do
+  it "renders taxonomy_level1 metatag for root taxon" do
     taxon = {
       title: "Root taxon",
       base_path: "/root-taxon",
@@ -114,10 +114,10 @@ describe "Meta tags", type: :view do
       },
     }
     render_component(content_item: example_document_for("taxon", "taxon").merge(taxon))
-    assert_meta_tag("govuk:themes", "root-taxon")
+    assert_meta_tag("govuk:taxonomy_level1", "root-taxon")
   end
 
-  it "renders themes metatag for child taxon" do
+  it "renders taxonomy_level1 metatag for child taxon" do
     taxon = {
       title: "Child taxon",
       links: {
@@ -131,10 +131,10 @@ describe "Meta tags", type: :view do
       },
     }
     render_component(content_item: example_document_for("taxon", "taxon").merge(taxon))
-    assert_meta_tag("govuk:themes", "root-taxon")
+    assert_meta_tag("govuk:taxonomy_level1", "root-taxon")
   end
 
-  it "renders themes metatag for content item" do
+  it "renders taxonomy_level1 metatag for content item" do
     content_item = {
       links: {
         taxons: [
@@ -155,10 +155,10 @@ describe "Meta tags", type: :view do
       },
     }
     render_component(content_item: example_document_for("case_study", "case_study").merge(content_item))
-    assert_meta_tag("govuk:themes", "root-taxon")
+    assert_meta_tag("govuk:taxonomy_level1", "root-taxon")
   end
 
-  it "renders themes metatag for content item with multiple roots" do
+  it "renders taxonomy_level1 metatag for content item with multiple roots" do
     content_item = {
       links: {
         taxons: [
@@ -198,15 +198,15 @@ describe "Meta tags", type: :view do
       },
     }
     render_component(content_item: example_document_for("case_study", "case_study").merge(content_item))
-    assert_meta_tag("govuk:themes", "education-root-taxon, parenting-root-taxon")
+    assert_meta_tag("govuk:taxonomy_level1", "education-root-taxon, parenting-root-taxon")
   end
 
-  it "does not render themes metatag for content item with no taxon" do
+  it "does not render taxonomy_level1 metatag for content item with no taxon" do
     content_item = {
       links: {},
     }
     render_component(content_item: example_document_for("case_study", "case_study").merge(content_item))
-    assert_select "meta[name='govuk:themes']", 0
+    assert_select "meta[name='govuk:taxonomy_level1']", 0
   end
 
   it "renders taxon metatags for root taxon" do

--- a/spec/components/meta_tags_spec.rb
+++ b/spec/components/meta_tags_spec.rb
@@ -351,37 +351,37 @@ describe "Meta tags", type: :view do
     assert_meta_tag("govuk:content-has-history", "true")
   end
 
-  it "renders the static-analytics:strip-dates tag if the content item is a 'smart-answer'" do
+  it "renders the ga4-strip-dates tag if the content item is a 'smart-answer'" do
     render_component(content_item: { document_type: "smart_answer" })
-    assert_meta_tag("govuk:static-analytics:strip-dates", "true")
+    assert_meta_tag("govuk:ga4-strip-dates", "true")
   end
 
-  it "doesn't render the static-analytics:strip-dates tag if the document_type isn't relevant" do
+  it "doesn't render the ga4-strip-dates tag if the document_type isn't relevant" do
     render_component(content_item: { document_type: "guidance" })
-    assert_no_meta_tag("govuk:static-analytics:strip-dates")
+    assert_no_meta_tag("govuk:ga4-strip-dates")
   end
 
-  it "renders the static-analytics:strip-dates tag if explicitly told to even if it wouldn't otherwise" do
+  it "renders the ga4-strip-dates tag if explicitly told to even if it wouldn't otherwise" do
     render_component(content_item: { document_type: "guidance" }, strip_dates_pii: true)
-    assert_meta_tag("govuk:static-analytics:strip-dates", "true")
+    assert_meta_tag("govuk:ga4-strip-dates", "true")
   end
 
-  it "doesn't render the static-analytics:strip-dates tag if explicitly told not to even if it would otherwise" do
+  it "doesn't render the ga4-strip-dates tag if explicitly told not to even if it would otherwise" do
     render_component(content_item: { document_type: "smart_answer" }, strip_dates_pii: false)
-    assert_no_meta_tag("govuk:static-analytics:strip-dates")
+    assert_no_meta_tag("govuk:ga4-strip-dates")
   end
 
-  it "renders the static-analytics:strip-postcodes tag if the document_type is relevant" do
+  it "renders the ga4-strip-postcodes tag if the document_type is relevant" do
     formats_that_might_include_postcodes = GovukPublishingComponents::Presenters::MetaTags::FORMATS_THAT_MIGHT_INCLUDE_POSTCODES
     formats_that_might_include_postcodes.each do |format|
       render_component(content_item: { document_type: format })
-      assert_meta_tag("govuk:static-analytics:strip-postcodes", "true")
+      assert_meta_tag("govuk:ga4-strip-postcodes", "true")
     end
   end
 
-  it "doesn't render the static-analytics:strip-postcodes tag if the document_type isn't relevant" do
+  it "doesn't render the ga4-strip-postcodes tag if the document_type isn't relevant" do
     render_component(content_item: { document_type: "guidance" })
-    assert_no_meta_tag("govuk:static-analytics:strip-postcodes")
+    assert_no_meta_tag("govuk:ga4-strip-postcodes")
   end
 
   it "renders govuk:primary-publishing-organisation if primary_publishing_organisation" do
@@ -421,16 +421,16 @@ describe "Meta tags", type: :view do
     assert_no_meta_tag("govuk:primary-publishing-organisation")
   end
 
-  it "renders the static-analytics:strip-postcodes tag if explicitly told to even if it wouldn't otherwise" do
+  it "renders the ga4-strip-postcodes tag if explicitly told to even if it wouldn't otherwise" do
     render_component(content_item: { document_type: "guidance" }, strip_postcode_pii: true)
-    assert_meta_tag("govuk:static-analytics:strip-postcodes", "true")
+    assert_meta_tag("govuk:ga4-strip-postcodes", "true")
   end
 
-  it "doesn't render the static-analytics:strip-postcodes tag if explicitly told not to even if it would otherwise" do
+  it "doesn't render the ga4-strip-postcodes tag if explicitly told not to even if it would otherwise" do
     formats_that_might_include_postcodes = GovukPublishingComponents::Presenters::MetaTags::FORMATS_THAT_MIGHT_INCLUDE_POSTCODES
     formats_that_might_include_postcodes.each do |format|
       render_component(content_item: { document_type: format }, strip_postcode_pii: false)
-      assert_no_meta_tag("govuk:static-analytics:strip-postcodes")
+      assert_no_meta_tag("govuk:ga4-strip-postcodes")
     end
   end
 

--- a/spec/components/meta_tags_spec.rb
+++ b/spec/components/meta_tags_spec.rb
@@ -14,8 +14,8 @@ describe "Meta tags", type: :view do
     assert_meta_tag("govuk:format", "case_study")
     assert_meta_tag("govuk:publishing-app", "whitehall")
     assert_meta_tag("govuk:rendering-app", "government-frontend")
-    assert_meta_tag("govuk:analytics:organisations", "<L2><W4>")
-    assert_meta_tag("govuk:analytics:world-locations", "<WL3>")
+    assert_meta_tag("govuk:organisations", "<L2><W4>")
+    assert_meta_tag("govuk:world-locations", "<WL3>")
     assert_meta_tag("govuk:first-published-at", "2012-12-17T15:45:44.000+00:00")
     assert_meta_tag("govuk:updated-at", "2018-08-04T10:18:42.566Z")
     assert_meta_tag("govuk:public-updated-at", "2012-12-17T15:45:44.000+00:00")
@@ -37,7 +37,7 @@ describe "Meta tags", type: :view do
 
   it "renders organisation meta tag if current page is organisation" do
     render_component(content_item: example_document_for("organisation", "organisation"))
-    assert_meta_tag("govuk:analytics:organisations", "<D1197>")
+    assert_meta_tag("govuk:organisations", "<D1197>")
     assert_meta_tag("govuk:primary-publishing-organisation", "Department for Exiting the European Union")
   end
 
@@ -50,7 +50,7 @@ describe "Meta tags", type: :view do
     }
 
     render_component(content_item:)
-    assert_meta_tag("govuk:analytics:organisations", "<O1><W4>")
+    assert_meta_tag("govuk:organisations", "<O1><W4>")
   end
 
   it "renders world locations in a meta tag with angle brackets" do
@@ -68,7 +68,7 @@ describe "Meta tags", type: :view do
     }
 
     render_component(content_item:)
-    assert_meta_tag("govuk:analytics:world-locations", "<WL3><WL123>")
+    assert_meta_tag("govuk:world-locations", "<WL3><WL123>")
   end
 
   it "renders publishing government slug when government and political keys included" do

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
@@ -162,7 +162,7 @@ describe('Google Tag Manager page view tracking', function () {
       },
       {
         gtmName: 'taxonomy_level1',
-        tagName: 'themes',
+        tagName: 'taxonomy_level1',
         value: 'this theme'
       },
       {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
@@ -325,14 +325,14 @@ describe('Google Tag Manager page view tracking', function () {
   })
 
   it('returns a pageview on a page marked with ids for contributing organisations', function () {
-    createMetaTags('analytics:organisations', 'some organisations')
+    createMetaTags('organisations', 'some organisations')
     expected.page_view.organisations = 'some organisations'
     GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
     expect(window.dataLayer[0]).toEqual(expected)
   })
 
   it('returns a pageview on a page marked with world locations', function () {
-    createMetaTags('analytics:world-locations', 'some world locations')
+    createMetaTags('world-locations', 'some world locations')
     expected.page_view.world_locations = 'some world locations'
     GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
     expect(window.dataLayer[0]).toEqual(expected)

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.spec.js
@@ -123,7 +123,7 @@ describe('GOVUK.analyticsGa4.PIIRemover', function () {
     })
   })
 
-  describe('when there is a govuk:static-analytics:strip-postcodes meta tag present', function () {
+  describe('when there is a govuk:ga4-strip-postcodes meta tag present', function () {
     beforeEach(function () {
       pageWantsPostcodesStripped()
       pii = new GOVUK.analyticsGa4.PIIRemover()
@@ -142,7 +142,7 @@ describe('GOVUK.analyticsGa4.PIIRemover', function () {
     })
   })
 
-  describe('when there is a govuk:static-analytics:strip-query-string-parameters meta tag present', function () {
+  describe('when there is a govuk:ga4-strip-query-string-parameters meta tag present', function () {
     it('strips specified query strings that are identified in a string', function () {
       pageWantsQueryStringParametersStripped(['strip-parameter-1', 'strip-parameter-2'])
       pii = new GOVUK.analyticsGa4.PIIRemover()
@@ -172,7 +172,7 @@ describe('GOVUK.analyticsGa4.PIIRemover', function () {
     })
   })
 
-  describe('when there is a govuk:static-analytics:strip-dates meta tag present', function () {
+  describe('when there is a govuk:ga4-strip-dates meta tag present', function () {
     beforeEach(function () {
       pageWantsDatesStripped()
       pii = new GOVUK.analyticsGa4.PIIRemover()
@@ -271,20 +271,20 @@ describe('GOVUK.analyticsGa4.PIIRemover', function () {
   })
 
   function resetHead () {
-    $('head').find('meta[name="govuk:static-analytics:strip-postcodes"]').remove()
-    $('head').find('meta[name="govuk:static-analytics:strip-dates"]').remove()
-    $('head').find('meta[name="govuk:static-analytics:strip-query-string-parameters"]').remove()
+    $('head').find('meta[name="govuk:ga4-strip-postcodes"]').remove()
+    $('head').find('meta[name="govuk:ga4-strip-dates"]').remove()
+    $('head').find('meta[name="govuk:ga4-strip-query-string-parameters"]').remove()
   }
 
   function pageWantsDatesStripped () {
-    $('head').append('<meta name="govuk:static-analytics:strip-dates" value="does not matter" />')
+    $('head').append('<meta name="govuk:ga4-strip-dates" value="does not matter" />')
   }
 
   function pageWantsPostcodesStripped () {
-    $('head').append('<meta name="govuk:static-analytics:strip-postcodes" value="does not matter" />')
+    $('head').append('<meta name="govuk:ga4-strip-postcodes" value="does not matter" />')
   }
 
   function pageWantsQueryStringParametersStripped (parameters) {
-    $('head').append('<meta name="govuk:static-analytics:strip-query-string-parameters" content="' + parameters.join(', ') + '" />')
+    $('head').append('<meta name="govuk:ga4-strip-query-string-parameters" content="' + parameters.join(', ') + '" />')
   }
 })

--- a/spec/javascripts/helpers/SpecHelper.js
+++ b/spec/javascripts/helpers/SpecHelper.js
@@ -16,12 +16,7 @@ var resetCookies = function () {
   document.cookie.split(';').forEach(function (c) { document.cookie = c.replace(/^ +/, '').replace(/=.*/, '=;expires=' + new Date().toUTCString() + ';path=/') })
 }
 
-// external-link-tracker.js adds a click event to the body for matching links
-// gets called once in production but multiple times in testing e.g. in static-analytics-spec
-// every time it does `new GOVUK.StaticAnalytics()` so need to remove this using .off()
 beforeEach(function () {
-  $('body').off()
-
   window.GOVUK.stopSendingAnalytics = false
 })
 


### PR DESCRIPTION
## What
Updates GOV.UK page metatags used by GA4 to make them more consistent. See individual commits for details.

Must be deployed with https://github.com/alphagov/slimmer/pull/341

## Why
This is some final tidying up post GA4 launch, to make things more consistent and clear.

## Visual Changes
None.

Trello card: https://trello.com/c/lIVmnFpY/336-page-view-enhancement-some-meta-tags-start-with-analytics