### PR TITLE
Stop redacting dates in GA4 tracking on GOVUK search pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Update metatags for GA4 ([PR #4222](https://github.com/alphagov/govuk_publishing_components/pull/4222))
 * Set aria-label text in govuk_logo.html to "GOV.UK" ([PR #4217](https://github.com/alphagov/govuk_publishing_components/pull/4217))
 * Fix cookie expiration date potentially relying on user's timezone ([PR #4219](https://github.com/alphagov/govuk_publishing_components/pull/4219))
+* Stop redacting dates in GA4 tracking on GOVUK search pages ([PR #4223](https://github.com/alphagov/govuk_publishing_components/pull/4223))
 * Remove 100 character limit on search results ([PR #4230](https://github.com/alphagov/govuk_publishing_components/pull/4230))
 
 ## 43.1.1

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -295,7 +295,7 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
         var PIIRemover = new window.GOVUK.analyticsGa4.PIIRemover()
         searchTerm = searchTerm.replace(/\++|(%2B)+/gm, ' ') // Turn + characters or unicode + characters (%2B) into a space.
         searchTerm = window.GOVUK.analyticsGa4.core.trackFunctions.removeLinesAndExtraSpaces(searchTerm)
-        searchTerm = PIIRemover.stripPIIWithOverride(searchTerm, true, true)
+        searchTerm = PIIRemover.stripPIIWithOverride(searchTerm, false, true)
         searchTerm = searchTerm.toLowerCase()
         return searchTerm
       }

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
@@ -11,6 +11,7 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
 
     init: function (referrer) {
       if (window.dataLayer) {
+        this.stripDates = !this.getSearchTerm()
         var data = {
           event: 'page_view',
           page_view: {
@@ -78,7 +79,8 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
     },
 
     getLocation: function () {
-      return this.PIIRemover.stripPIIWithOverride(this.stripGaParam(document.location.href), true, true)
+      // We don't want to remove dates on search pages.
+      return this.PIIRemover.stripPIIWithOverride(this.stripGaParam(document.location.href), this.stripDates, true)
     },
 
     getSearchTerm: function () {
@@ -110,8 +112,9 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
     getQueryString: function () {
       var queryString = window.GOVUK.analyticsGa4.core.trackFunctions.getSearch()
       if (queryString) {
+        // We don't want to remove dates on search pages.
         queryString = this.stripGaParam(queryString)
-        queryString = this.PIIRemover.stripPIIWithOverride(queryString, true, true)
+        queryString = this.PIIRemover.stripPIIWithOverride(queryString, this.stripDates, true)
         queryString = queryString.substring(1) // removes the '?' character from the start.
         return queryString
       }

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
@@ -297,7 +297,7 @@ describe('GA4 core', function () {
 
     it('standardises search terms for consistency across trackers', function () {
       var searchTerm = 'NO UPPERCASE, NO %2B plus + signs, NO PII email@example.com SW1A 2AA 1st Jan 1990 and    NO    extra    spaces \n \r      '
-      var expected = 'no uppercase, no plus signs, no pii [email] [postcode] [date] and no extra spaces'
+      var expected = 'no uppercase, no plus signs, no pii [email] [postcode] 1st jan 1990 and no extra spaces'
 
       searchTerm = GOVUK.analyticsGa4.core.trackFunctions.standardiseSearchTerm(searchTerm)
       expect(searchTerm).toEqual(expected)


### PR DESCRIPTION
## What / Why
- Removes date redaction from the `standardiseSearchTerm` function, - this function ensures the search term tracks the same across multiple parameters, so dates should no longer be redacted wherever we grab a search term.
- Also removes date redaction from the `location`, `query_string`, and `search_term` values in the PageView tracker.
- The PAs have requested this, as some of the filters use dates, and I believe there was a discussion at some point about dates being useful for search tracking. https://trello.com/c/RYSxnFZ1/841-remove-date-redaction-from-search-terms.

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
