### PR TITLE
New class to collapse columns for print

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Remove 100 character limit on search results ([PR #4230](https://github.com/alphagov/govuk_publishing_components/pull/4230))
 * Add GA4 redaction to GWF and GB EORI numbers ([PR #4227](https://github.com/alphagov/govuk_publishing_components/pull/4227))
 * Add files for secondary navigation: ([PR #4229](https://github.com/alphagov/govuk_publishing_components/pull/4229))
+* New class to collapse columns for print ([PR #4224](https://github.com/alphagov/govuk_publishing_components/pull/4224))
 
 ## 43.1.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/component_support.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/component_support.scss
@@ -12,3 +12,5 @@
 @import "govuk_publishing_components/components/mixins/media-down";
 @import "govuk_publishing_components/components/mixins/margins";
 @import "govuk_publishing_components/components/mixins/css3";
+
+@import "govuk_publishing_components/lib/print_support";

--- a/app/assets/stylesheets/govuk_publishing_components/lib/_print_support.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/lib/_print_support.scss
@@ -1,0 +1,27 @@
+// A helper class for removing column layouts when printing.
+// This should be applied to row/column layouts, by adding the
+// class to elements with a `govuk-grid-row` class. The columns
+// will then print at the full width of the page.
+// Note that only the immediate child columns will be affected.
+// If a child column also contains a row/column layout of
+// further elements, these will be unaffected and will retain
+// their existing column layout. Use the class again on these
+// nested grids to apply fullwidth column printing if required.
+
+@include govuk-media-query($media-type: print) {
+  .gem-print-columns-none {
+    width: 100%;
+
+    > .govuk-width-container {
+      margin: 0;
+      max-width: none;
+    }
+
+    > [class*="govuk-grid-column"] {
+      position: static !important; // stylelint-disable-line declaration-no-important
+      float: none;
+      clear: both;
+      width: 100%;
+    }
+  }
+}


### PR DESCRIPTION
## What
Provide a new helper class to "collapse" row/column layouts when printing. This class forces all floated columns in the associated row to print at full page width. [Trello](https://trello.com/c/MTJDEqDS/325-investigate-generic-print-styles-for-govuk-frontend-layout)

## Why
When printing various page types, the 2/3rds + 1/3rds column layout causes issues with cropped content and a generally poor printing experience because the full page isn't used. By selectively collapsing floated columns, we can avoid most of these issues and improve the printing experience by using the full width of the page.

### Before/After page type: GUIDE
| Before    | After |
| -------- | ------- |
| <img width="" alt="image" src="https://github.com/user-attachments/assets/94525704-5818-4f43-850f-3e34cda379ac">  | <img width="" alt="image" src="https://github.com/user-attachments/assets/f00b498a-33cd-4b7d-aceb-f577bc1cc6e1"> |

### Before/After page type: DETAILED_GUIDE
| Before    | After |
| -------- | ------- |
| <img width="" alt="image" src="https://github.com/user-attachments/assets/65a00b21-d7f9-44ae-a604-2fac79b3dc7e">| <img width="" alt="image" src="https://github.com/user-attachments/assets/997de607-001b-444e-a96a-963df97995c2">|

### Before/After page type: HTML_PUBLICATION (Portrait, no change}
| Before    | After |
| -------- | ------- |
| <img width="" alt="image" src="https://github.com/user-attachments/assets/800e7f6a-deec-46d5-ac2d-42196aecc9a0">| <img width="" alt="image" src="https://github.com/user-attachments/assets/9dfeb21f-7cdf-4113-b58e-8ac3d2cec83f">|


### Before/After page type: HTML_PUBLICATION (Landscape}
| Before    | After |
| -------- | ------- |
| <img width="" alt="image" src="https://github.com/user-attachments/assets/6caadb54-9669-48ed-83da-1a7ceea7a158">| <img width="" alt="image" src="https://github.com/user-attachments/assets/f8b2e3a6-4a93-4c8b-bbc4-23210024f37a">|



