### PR TITLE
Fix inconsistent search label appearance

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -229,7 +229,7 @@ $large-input-size: 50px;
   }
 }
 
-.gem-c-search__label--white {
+.govuk-label.gem-c-search__label--white {
   color: govuk-colour("white");
 }
 

--- a/app/views/govuk_publishing_components/components/_search.html.erb
+++ b/app/views/govuk_publishing_components/components/_search.html.erb
@@ -1,5 +1,6 @@
 <%
   add_gem_component_stylesheet("search")
+  add_gem_component_stylesheet("label")
 
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
   heading_helper = GovukPublishingComponents::Presenters::HeadingHelper.new(local_assigns)
@@ -51,10 +52,8 @@
     end
   end
 %>
-
 <div class="<%= classes.join(" ") %>" data-module="gem-toggle-input-class-on-focus">
   <% if wrap_label_in_a_heading %>
-    <% add_gem_component_stylesheet("label") %>
     <%= content_tag(shared_helper.get_heading_level, class: "govuk-!-margin-0") do %>
       <%= tag_label %>
     <% end %>


### PR DESCRIPTION
## What
Fix the label styles in the search component. The label was appearing broken in some pages in the component guide, although still appearing correctly in the actual homepage.

- label stylesheet was only being included if wrap_label_in_a_heading was true
- custom gem label class for white on dark colour wasn't overriding standard govuk-frontend label class colour


## Why
Appearance of the component varied considerably within the component guide. I think this is because on some pages the label styles were already being included by other instances of the component on the page.

## Visual Changes
Fixes the following inconsistencies, so all pages now appear correctly (first one was correct already).

Component guide page | Appearance
----------------------- | ----------
Main page `/search` | ![Screenshot 2024-09-16 at 11 38 07](https://github.com/user-attachments/assets/64b75db6-3579-4959-9bb6-94e603a18152)
Preview all `/search/preview/` | ![Screenshot 2024-09-16 at 11 39 10](https://github.com/user-attachments/assets/7b60f656-8437-458e-9a07-76f711883fda)
Detail page `/search/homepage` | ![Screenshot 2024-09-16 at 11 39 48](https://github.com/user-attachments/assets/38a3ec0b-82dd-48c1-8a4c-fbce8c4bf504)
Detail preview page `/search/homepage/preview` | ![Screenshot 2024-09-16 at 11 40 19](https://github.com/user-attachments/assets/a3ab1a9f-098d-4b5f-bf1f-80ea84800c85)


