### PR TITLE
Add GA4 redaction to GWF and GB EORI numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Set aria-label text in govuk_logo.html to "GOV.UK" ([PR #4217](https://github.com/alphagov/govuk_publishing_components/pull/4217))
 * Fix cookie expiration date potentially relying on user's timezone ([PR #4219](https://github.com/alphagov/govuk_publishing_components/pull/4219))
 * Remove 100 character limit on search results ([PR #4230](https://github.com/alphagov/govuk_publishing_components/pull/4230))
+* Add GA4 redaction to GWF and GB EORI numbers ([PR #4227](https://github.com/alphagov/govuk_publishing_components/pull/4227))
 
 ## 43.1.1
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.js
@@ -27,6 +27,11 @@
   var UNLOCK_TOKEN_PATTERN = /unlock_token=[a-zA-Z0-9-]+/g
   var STATE_PATTERN = /state=.[^&]+/g
 
+  // some users mistakenly use GOV.UK to search for the status of their applications.
+  // e.g. GWF123456789 and GB123456789000
+  var VISA_PATTERN_GWF = /GWF\d{9}/g
+  var VISA_PATTERN_GB = /GB\d{12}/g
+
   function shouldStripDates () {
     var metas = document.querySelectorAll('meta[name="govuk:ga4-strip-dates"]')
     return metas.length > 0
@@ -97,6 +102,8 @@
     stripped = stripped.replace(RESET_PASSWORD_TOKEN_PATTERN, 'reset_password_token=[reset_password_token]')
     stripped = stripped.replace(UNLOCK_TOKEN_PATTERN, 'unlock_token=[unlock_token]')
     stripped = stripped.replace(STATE_PATTERN, 'state=[state]')
+    stripped = stripped.replace(VISA_PATTERN_GWF, '[gwf number]')
+    stripped = stripped.replace(VISA_PATTERN_GB, '[gb eori number]')
     stripped = this.stripQueryStringParameters(stripped)
 
     if (this.stripDatePII === true) {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.spec.js
@@ -55,6 +55,11 @@ describe('GOVUK.analyticsGa4.PIIRemover', function () {
       arr = pii.stripPII(arr)
       expect(arr).toEqual(strippedArr)
     })
+
+    it('strips visa application numbers', function () {
+      var string = pii.stripPII('my visa application numbers are GWF123456789 and GB123456789000')
+      expect(string).toEqual('my visa application numbers are [gwf number] and [gb eori number]')
+    })
   })
 
   describe('by default for account specific PII', function () {


### PR DESCRIPTION
## What
- Adds redaction to GWF+9 digits, and GB+12 digits. These are application IDs for visas.

## Why
<!-- What are the reasons behind this change being made? -->
- Some users mistakenly use GOV.UK to search for the status of their application (they were being redacted by our date redaction fortunately, so this change is more for accuracy of what's being redacted)
- https://trello.com/c/pk45odvO/833-add-redaction-to-gwf-visa-and-gb-eori-numbers

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
