### PR TITLE
Fix homepage super navigation buttons when text scale is increased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Add GA4 redaction to GWF and GB EORI numbers ([PR #4227](https://github.com/alphagov/govuk_publishing_components/pull/4227))
 * Add files for secondary navigation: ([PR #4229](https://github.com/alphagov/govuk_publishing_components/pull/4229))
 * New class to collapse columns for print ([PR #4224](https://github.com/alphagov/govuk_publishing_components/pull/4224))
+* Fix homepage super navigation buttons when text scale is increased ([PR #4232](https://github.com/alphagov/govuk_publishing_components/pull/4232))
 
 ## 43.1.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -290,6 +290,8 @@ $after-button-padding-left: govuk-spacing(4);
 // after it has been toggled closed if the blue background has
 // been enabled
 .gem-c-layout-super-navigation-header__navigation-top-toggle-button.gem-c-layout-super-navigation-header__navigation-top-toggle-button--blue-background {
+  background-color: $govuk-brand-colour;
+
   &:focus:not(:focus-visible) {
     &::after {
       background: none;
@@ -606,6 +608,10 @@ $after-button-padding-left: govuk-spacing(4);
 // Styles for search toggle button.
 .gem-c-layout-super-navigation-header__search-toggle-button {
   background: none;
+
+  &.gem-c-layout-super-navigation-header__search-toggle-button--blue-background {
+    background: $govuk-brand-colour;
+  }
   border: 0;
   color: govuk-colour("white");
   cursor: pointer;


### PR DESCRIPTION
## What / Why
<!-- What are the reasons behind this change being made? -->
- Add a blue background to the Menu / Search buttons, so they don't blend into the grey background for users that increase their text scale / have a screen resolution that is >= 300px in width (mobile users)
- Fixes https://github.com/alphagov/govuk_publishing_components/issues/4208

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

### Before
<img width="288" alt="image" src="https://github.com/user-attachments/assets/4fadaba5-7e1f-425b-9769-ac562cb68048">
<img width="288" alt="image" src="https://github.com/user-attachments/assets/532e3e96-6f8f-433d-8119-7be9dd1ef51e">


### After
<img width="288" alt="image" src="https://github.com/user-attachments/assets/322074ff-1237-4865-9a1b-3024d36e5848">
<img width="288" alt="image" src="https://github.com/user-attachments/assets/11381483-5a41-4064-a77a-def8b88625c5">
