### PR TITLE
Fix sortable table header issue on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Remove unused cookies from cookie category ([PR #4234](https://github.com/alphagov/govuk_publishing_components/pull/4234))
 * Allow custom name attribute on password input ([PR #4238](https://github.com/alphagov/govuk_publishing_components/pull/4238))
+* Fix sortable table header issue on mobile ([PR #4233](https://github.com/alphagov/govuk_publishing_components/pull/4233))
 
 ## 43.2.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_table.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_table.scss
@@ -33,6 +33,7 @@ $table-row-even-background-colour: govuk-colour("light-grey");
     }
 
     .app-table__sort-link {
+      display: inline-block;
       position: relative;
       padding-right: $sort-link-arrow-size;
       color: $govuk-link-colour;


### PR DESCRIPTION
## What

Fix sortable table header issue on mobile

## Why

The icon overlays the text when space is limited.

## Visual Changes

### Before (mobile)

<img src="https://github.com/user-attachments/assets/73313273-0214-4f37-9cc4-bc18766b46fc" width="330">

### After (mobile)

<img src="https://github.com/user-attachments/assets/f4e3ddb9-2b35-42de-a741-9b06ab267f3f" width="330">

### Before (>= tablet)

![components publishing service gov uk_component-guide_table_with_sortable_head_preview(iPad Pro)](https://github.com/user-attachments/assets/75827b2e-3e82-42b4-b5be-24d436a45227)

### After (>= tablet, no change)

![govuk-publishing-components dev gov uk_component-guide_table_with_sortable_head_preview(iPad Pro)](https://github.com/user-attachments/assets/3c8d03c4-d7d4-4489-b11f-2fb3375ce791)