### PR TITLE
removed unused cookies in cookie category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Remove unused cookies from cookie category ([PR #4234](https://github.com/alphagov/govuk_publishing_components/pull/4234))
+
 ## 43.2.0
 
 * Make deploying meta tags changes easier ([PR #4236](https://github.com/alphagov/govuk_publishing_components/pull/4236))

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
@@ -23,8 +23,6 @@
     multivariatetest_cohort_coronavirus_extremely_vulnerable_rate_limit: 'essential',
     dgu_beta_banner_dismissed: 'settings',
     global_bar_seen: 'settings',
-    govuk_browser_upgrade_dismisssed: 'settings',
-    govuk_not_first_visit: 'settings',
     user_nation: 'settings',
     'JS-Detection': 'usage',
     TLSversion: 'usage',


### PR DESCRIPTION
## What
 
To remove 'govuk_not_first_visit' and 'govuk_browser_upgrade_dismissed' 

## Why
These are no longer being used and we don’t actually present a banner of this nature any more. We should remove references to it from the govuk_publishing_components gem
https://trello.com/c/lR7DOoLn/341-we-refer-to-cookies-that-are-no-longer-in-use


## Visual Changes
Ensure that references to it are removed from [Details about cookies on GOV.UK](https://www.gov.uk/help/cookie-details)
