### PR TITLE
Remove left search variant of layout header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Remove left search variant of layout header ([PR #4239](https://github.com/alphagov/govuk_publishing_components/pull/4239))
+
 ## 43.3.0
 
 * Remove unused cookies from cookie category ([PR #4234](https://github.com/alphagov/govuk_publishing_components/pull/4234))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -608,10 +608,6 @@ $after-button-padding-left: govuk-spacing(4);
 // Styles for search toggle button.
 .gem-c-layout-super-navigation-header__search-toggle-button {
   background: none;
-
-  &.gem-c-layout-super-navigation-header__search-toggle-button--blue-background {
-    background: $govuk-brand-colour;
-  }
   border: 0;
   color: govuk-colour("white");
   cursor: pointer;
@@ -619,6 +615,11 @@ $after-button-padding-left: govuk-spacing(4);
   padding: govuk-spacing(3);
   position: relative;
   width: $search-width-or-height;
+
+  &.gem-c-layout-super-navigation-header__search-toggle-button--blue-background {
+    background: $govuk-brand-colour;
+  }
+
   @include govuk-font($size: 19, $weight: "bold", $line-height: 20px);
 
   @include focus-and-focus-visible {

--- a/app/views/govuk_publishing_components/components/_layout_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_header.html.erb
@@ -8,58 +8,34 @@
   product_name ||= nil
   remove_bottom_border ||= false
   search ||= false
-  search_left ||= false
   width_class = full_width ? "govuk-header__container--full-width" : "govuk-width-container"
   logo_link ||= "/"
 
   header_classes = %w[gem-c-layout-header govuk-header]
   header_classes << "gem-c-layout-header--#{environment}" if environment
   header_classes << "gem-c-layout-header--no-bottom-border" if remove_bottom_border
-  header_classes << "gem-c-layout-header--search-left" if search_left
 %>
 
 <header class="<%= header_classes.join(' ') %>"  role="banner" data-module="govuk-header">
   <div class="govuk-header__container <%= width_class %>">
-    <% if search_left %>
-      <div class="govuk-grid-row">
-        <div class="gem-c-layout-header__logo govuk-grid-column-one-third-from-desktop">
-          <%= render "govuk_publishing_components/components/layout_header/header_logo", {
-            environment: environment,
-            logo_link: logo_link,
-            product_name: product_name,
-          } %>
-        </div>
+    <div class="govuk-grid-row">
+      <div class="gem-c-layout-header__logo govuk-grid-column-one-half">
+        <%= render "govuk_publishing_components/components/layout_header/header_logo", {
+          environment: environment,
+          logo_link: logo_link,
+          product_name: product_name,
+        } %>
       </div>
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full govuk-grid-column-one-third-from-desktop gem-c-layout-header__search govuk-!-display-none-print">
+      <% if navigation_items.any? %>
+        <div class="govuk-header__content gem-c-header__content govuk-grid-column-full govuk-!-display-none-print">
+          <%= render "govuk_publishing_components/components/layout_header/navigation_items", navigation_items: navigation_items, navigation_aria_label: navigation_aria_label %>
+        </div>
+      <% end %>
+      <% if search %>
+        <div class="govuk-grid-column-one-half gem-c-layout-header__search govuk-!-display-none-print">
           <%= render "govuk_publishing_components/components/layout_header/search" %>
         </div>
-        <% if navigation_items.any? %>
-          <div class="govuk-header__content gem-c-header__content govuk-grid-column-full govuk-!-display-none-print">
-            <%= render "govuk_publishing_components/components/layout_header/navigation_items", navigation_items: navigation_items, navigation_aria_label: navigation_aria_label  %>
-          </div>
-        <% end %>
-      </div>
-    <% else %>
-      <div class="govuk-grid-row">
-        <div class="gem-c-layout-header__logo govuk-grid-column-one-half">
-          <%= render "govuk_publishing_components/components/layout_header/header_logo", {
-            environment: environment,
-            logo_link: logo_link,
-            product_name: product_name,
-          } %>
-        </div>
-        <% if navigation_items.any? %>
-          <div class="govuk-header__content gem-c-header__content govuk-grid-column-full govuk-!-display-none-print">
-            <%= render "govuk_publishing_components/components/layout_header/navigation_items", navigation_items: navigation_items, navigation_aria_label: navigation_aria_label %>
-          </div>
-        <% end %>
-        <% if search %>
-          <div class="govuk-grid-column-one-half gem-c-layout-header__search govuk-!-display-none-print">
-            <%= render "govuk_publishing_components/components/layout_header/search" %>
-          </div>
-        <% end %>
-      </div>
-    <% end %>
+      <% end %>
+    </div>
   </div>
 </header>

--- a/app/views/govuk_publishing_components/components/docs/layout_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_header.yml
@@ -41,47 +41,6 @@ examples:
       - text: Hidden on desktop
         href: "item-3"
         show_only_in_collapsed_menu: true
-  with_left_search_and_navigation:
-    description: This supports pages where the search appears on the left with multiple navigation links on the right, such as the [How government works](https://www.gov.uk/government/how-government-works) page
-    data:
-      search_left: true
-      navigation_items:
-      - text: Departments
-        href: "item-1"
-      - text: Worldwide
-        href: "item-2"
-      - text: How government works
-        href: "item-3"
-      - text: Get involved
-        href: "item-4"
-      - text: Consultations
-        href: "item-4"
-      - text: Statistics
-        href: "item-5"
-      - text: News and communications
-        href: "item-6"
-        active: true
-  with_custom_navigation_aria_label:
-    description: The navigation has `aria-label="Top level"` by default. This option is here for when the `aria-label` needs to be more descriptive than that.
-    data:
-      search_left: true
-      navigation_aria_label: "Departments and policy"
-      navigation_items:
-      - text: Departments
-        href: "item-1"
-      - text: Worldwide
-        href: "item-2"
-      - text: How government works
-        href: "item-3"
-      - text: Get involved
-        href: "item-4"
-      - text: Consultations
-        href: "item-4"
-      - text: Statistics
-        href: "item-5"
-      - text: News and communications
-        href: "item-6"
-        active: true
   with_navigation_link_data_attributes:
     description: Supports adding data attributes i.e for tracking
     data:

--- a/spec/components/layout_header_spec.rb
+++ b/spec/components/layout_header_spec.rb
@@ -120,12 +120,6 @@ describe "Layout header", type: :view do
     assert_select ".gem-c-layout-header .gem-c-search"
   end
 
-  it "renders the search bar on the left when requested" do
-    render_component(environment: "public", search: true, search_left: true)
-
-    assert_select ".gem-c-layout-header--search-left"
-  end
-
   it "has the default logo link when no logo_link is specified" do
     render_component({})
 


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Remove `search_left` variant of the layout header component
- Also fixes a SASS warning I introduced in a previous PR.

## Why
<!-- What are the reasons behind this change being made? -->
- Fixes https://github.com/alphagov/govuk_publishing_components/issues/4153

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

Removes the example in the docs.