### PR TITLE
Remove 'inverse' background style from phase banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Remove left search variant of layout header ([PR #4239](https://github.com/alphagov/govuk_publishing_components/pull/4239))
+* Remove 'inverse' background style from phase banner ([PR #4241](https://github.com/alphagov/govuk_publishing_components/pull/4241))
 
 ## 43.3.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_phase-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_phase-banner.scss
@@ -9,8 +9,6 @@
 }
 
 .gem-c-phase-banner--inverse {
-  background: $govuk-brand-colour;
-
   .govuk-phase-banner__content__tag {
     background: govuk-colour("white");
     color: $govuk-brand-colour;

--- a/app/views/govuk_publishing_components/components/docs/phase_banner.yml
+++ b/app/views/govuk_publishing_components/components/docs/phase_banner.yml
@@ -27,11 +27,15 @@ examples:
     data:
       phase: beta
       inverse: true
+    context:
+      dark_background: true
   inverse_for_blue_background_with_app_name:
     data:
       app_name: Skittles Maker
       phase: beta
       inverse: true
+    context:
+      dark_background: true
   without_ga4_tracking:
     description: |
       Disables GA4 tracking on the banner. Tracking is enabled by default. This includes link tracking on the component itself, and allows pageviews to record the presence of the banner on page load.


### PR DESCRIPTION
## What
Remove 'inverse' background style from phase banner

## Why

Components with an inverse option should not set a background colour as the inverse option is designed to work against a dark background, and we can't always know exactly what colour that background will be (it's usually GOV.UK dark blue, but it might be a dark green or something else in the future).

## Anything else

I've checked for instances where the banner is used with the inverse option [here](https://github.com/search?q=org%3Aalphagov+components%2Fcomponents%2Fphase_banner&type=Code). The only occurrence I found is in [Finder Frontend](https://github.com/alphagov/finder-frontend/blob/main/app/views/finders/_before_content.html.erb), which already applies a parent background style `app-before-content--inverse`, see [guidance and regulation](https://www.gov.uk/search/guidance-and-regulation?topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0&parent=foreign-commonwealth-office), so it won't cause any breaking changes.