### PR TITLE
Add `accessible-autocomplete` node_modules to gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add accessible-autocomplete node_modules to gemspec ([PR #4246](https://github.com/alphagov/govuk_publishing_components/pull/4246))
+
 ## 43.4.0
 
 * Remove left search variant of layout header ([PR #4239](https://github.com/alphagov/govuk_publishing_components/pull/4239))

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
   s.required_ruby_version = ">= 3.2"
 
-  s.files = Dir["{node_modules/govuk-frontend,node_modules/axe-core,node_modules/sortablejs,node_modules/govuk-single-consent,app,config,db,lib}/**/*", "LICENCE.md", "README.md"]
+  s.files = Dir["{node_modules/accessible-autocomplete,node_modules/govuk-frontend,node_modules/axe-core,node_modules/sortablejs,node_modules/govuk-single-consent,app,config,db,lib}/**/*", "LICENCE.md", "README.md"]
 
   s.add_dependency "govuk_app_config"
   s.add_dependency "govuk_personalisation", ">= 0.7.0"


### PR DESCRIPTION
This was missing from the gemspec's file allowlist, causing it to not be included in the gem archive published to Rubygems.