### PR TITLE
Allow visually hiding legend on `radio` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add `ostruct` as an explicit dependency ([PR #4251](https://github.com/alphagov/govuk_publishing_components/pull/4251))
+* Allow visually hiding legend on `radio` component ([PR #4252](https://github.com/alphagov/govuk_publishing_components/pull/4252))
 
 ## 43.4.1
 

--- a/app/views/govuk_publishing_components/components/_radio.html.erb
+++ b/app/views/govuk_publishing_components/components/_radio.html.erb
@@ -12,6 +12,7 @@
   heading ||= nil
   heading_caption ||= nil
   heading_size ||= nil
+  visually_hidden_heading ||= false
   small ||= false
   inline ||= false
   heading_level = shared_helper.get_heading_level
@@ -46,6 +47,7 @@
 
   legend_classes = %w(govuk-fieldset__legend)
   legend_classes << "govuk-fieldset__legend--#{size}"
+  legend_classes << "govuk-visually-hidden" if visually_hidden_heading
 
   aria = "#{hint_id} #{"#{error_id}" if has_error}".strip if hint or has_error
 

--- a/app/views/govuk_publishing_components/components/docs/radio.yml
+++ b/app/views/govuk_publishing_components/components/docs/radio.yml
@@ -160,6 +160,21 @@ examples:
         text: "Yes"
       - value: "no"
         text: "No"
+  with_visually_hidden_heading:
+    description: |
+      If the heading/legend on the radios is not required, it can be visually hidden using this
+      option. It will still be visible to screen readers.
+    data:
+      name: "radio-group-visually-hidden-heading"
+      heading: "What is your favourite colour?"
+      visually_hidden_heading: true
+      items:
+      - value: "red"
+        text: "Red"
+      - value: "green"
+        text: "Green"
+      - value: "blue"
+        text: "Blue"
   with_description:
     data:
       name: "radio-group-description"

--- a/spec/components/radio_spec.rb
+++ b/spec/components/radio_spec.rb
@@ -296,6 +296,17 @@ describe "Radio", type: :view do
     assert_select "h4.govuk-fieldset__heading", text: "What is your favourite skittle?"
   end
 
+  it "renders radio-group with a visually hidden heading if visually_hidden_heading is passed" do
+    render_component(
+      name: "favourite-skittle",
+      heading: "What is your favourite skittle?",
+      heading_level: 4,
+      visually_hidden_heading: true,
+    )
+
+    assert_select "legend.govuk-visually-hidden", "What is your favourite skittle?"
+  end
+
   it "renders radio-group with bold labels" do
     render_component(
       name: "radio-group-bold-labels",


### PR DESCRIPTION
## What
This adds a `visually_hidden_heading` option to the `radio` component complementing the already existing option of the same name on the `checkboxes` component.

## Why
This allows the heading/legend to be hidden for non-screenreader users, for example where the purpose of the radios is made visually obvious in another way.

We will use this on the new search filters UI to hide the heading on the sort options which is contained within a collapsible section that already has a heading of its own:
<img width="659" alt="image" src="https://github.com/user-attachments/assets/5fdc64be-7d27-4546-9dba-73fdb2c7e006">

## Visual Changes
<img width="987" alt="image" src="https://github.com/user-attachments/assets/354e4252-06ce-43f4-b9a7-365783d8ee19">