### PR TITLE
Remove incorrect search component example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Update accessibility criteria in component docs ([PR #4242](https://github.com/alphagov/govuk_publishing_components/pull/4242))
 * Show all big_number symbol types in our docs ([PR #4271](https://github.com/alphagov/govuk_publishing_components/pull/4271))
+* Remove incorrect search component example ([PR #4253](https://github.com/alphagov/govuk_publishing_components/pull/4253))
 
 ## 43.5.0
 

--- a/app/views/govuk_publishing_components/components/docs/search.yml
+++ b/app/views/govuk_publishing_components/components/docs/search.yml
@@ -16,10 +16,8 @@ accessibility_criteria: |
 examples:
   default:
     data: {}
-  apply_custom_styling_to_the_label_and_set_search_value:
+  set_search_value:
     data:
-      inline_label: false
-      label_text: "<h1>Search GOV.UK</h1>"
       value: "driving licence"
   stop_the_label_appearing_inline:
     data:


### PR DESCRIPTION
## What

Remove incorrect search component example

## Why

From MDN:
> Placing [heading elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) within a <label> interferes with many kinds of assistive technology

The correct approach, from https://design-system.service.gov.uk/patterns/question-pages/#page-headings, was implemented in this PR https://github.com/alphagov/govuk_publishing_components/pull/2462.