### PR TITLE
Add handling of for_static parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add component wrapper helper to radio component ([PR #4366](https://github.com/alphagov/govuk_publishing_components/pull/4366))
 * Add component wrapper to feedback component ([PR #4351](https://github.com/alphagov/govuk_publishing_components/pull/4351))
 * Add component wrapper helper to error message component ([PR #4359](https://github.com/alphagov/govuk_publishing_components/pull/4359))
+* Require layout_for_public will not render wrapper unless `for_static: true` is set. ([PR #4255](https://github.com/alphagov/govuk_publishing_components/pull/4255))
 
 ## 45.1.0
 

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -1,6 +1,7 @@
 <%
   add_gem_component_stylesheet("layout-for-public")
 
+  for_static ||= false
   emergency_banner ||= nil
   full_width ||= false
   blue_bar ||= local_assigns.include?(:blue_bar) ? local_assigns[:blue_bar] : !full_width
@@ -160,13 +161,15 @@
       <% end %>
     <% elsif custom_layout %>
       <%= yield %>
-    <% else %>
+    <% elsif for_static %>
       <div id="wrapper" class="<%= "govuk-width-container" unless full_width %>">
         <%= yield :before_content %>
         <main class="govuk-main-wrapper" id="content">
           <%= yield %>
         </main>
       </div>
+    <% else %>
+      <%= yield %>
     <% end %>
 
     <% unless omit_feedback_form %>

--- a/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
@@ -17,9 +17,19 @@ examples:
       title: 'Example layout'
       block: |
         <h1>Page content goes here</h1>
-  full_width:
-    description: By default, the layout applies the `govuk-width-container` class to the main element. We can remove this class by setting `full_width` to `true`
+  with_static_wrapper:
+    description: |
+      By default, the layout does not include the `div#wrapper` element, nor the `main` element within that.
+      This behaviour is peculiar to the one app that currently uses this layout - static. Static now sets the `for_static: true` flag,
+      which causes the wrapper to be included. Other apps in the future will not set that flag, but provide their own wrapper and main elements.
     data:
+      for_static: true
+      block: |
+        <h1>Page content goes here</h1>
+  full_width:
+    description: By default, the layout applies the `govuk-width-container` class to the main element. We can remove this class by setting `full_width` to `true`. Note this also requires the for_static flag, since that is needed for the main element.
+    data:
+      for_static: true
       full_width: true
       block: |
         <h1>Page content goes here</h1>
@@ -30,6 +40,7 @@ examples:
   blue_bar_background:
     description: For use when a page has a heading component with a background colour.
     data:
+      for_static: true
       full_width: true
       blue_bar: true
       blue_bar_background_colour: "no"

--- a/spec/components/layout_for_public_spec.rb
+++ b/spec/components/layout_for_public_spec.rb
@@ -29,14 +29,14 @@ describe "Layout for public", type: :view do
     assert_select "title", visible: false, text: "Custom GOV.UK Title"
   end
 
-  it "displays as a restricted width layout by default" do
-    render_component({})
+  it "displays as a restricted width layout when called with the for_static parameter" do
+    render_component(for_static: true)
 
     assert_select "#wrapper.govuk-width-container"
   end
 
-  it "can support full width layouts" do
-    render_component(full_width: true)
+  it "can support full width layouts when called with the for_static parameter" do
+    render_component(for_static: true, full_width: true)
 
     assert_select "#wrapper.govuk-width-container", false, "Should not apply govuk-width-container class when full width"
   end
@@ -327,12 +327,19 @@ describe "Layout for public", type: :view do
     assert page.has_no_selector?(".gem-c-layout-header")
   end
 
-  it "it can render a custom layout instead of the default one" do
+  it "can render a custom layout instead of the default one" do
     render_component({ custom_layout: true }) do
       content_tag(:main, "GOV.UK with a custom layout", id: "custom-layout")
     end
 
     assert_select "main#custom-layout"
+    assert page.has_no_selector?("div#wrapper")
+    assert page.has_no_selector?("main.govuk-main-wrapper")
+  end
+
+  it "renders without the wrapper if for_static is not explictly set to true" do
+    render_component({})
+
     assert page.has_no_selector?("div#wrapper")
     assert page.has_no_selector?("main.govuk-main-wrapper")
   end

--- a/spec/dummy/app/views/layouts/dummy_public_layout.html.erb
+++ b/spec/dummy/app/views/layouts/dummy_public_layout.html.erb
@@ -2,6 +2,7 @@
     emergency_banner: '<div class="govuk-width-container"><p class="govuk-body">This is the emergency banner slot.</p></div>',
     global_bar: '<div class="govuk-width-container govuk-!-margin-top-2"><p class="govuk-body">This is the global bar slot.</p></div>',
     title: "Example public page",
+    for_static: true,
     show_explore_header: true,
 } do %>
   <%= yield %>


### PR DESCRIPTION
- original behaviour was to always include wrapper class unless show_account_layout or custom_layout was present (custom layout is as of yet not used). Alter behaviour so that default is not to have the wrapper, and it's only included if for_static is true.

## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
layout_for_public does not behave like a standard layout - it's default is to include a wrapper element which is cut out by slimmer and replaced with the wrapper from the client app. If we try to use layout_for_public directly, this results in a double wrapper (or a single wrapper, but without the ability to add classes to it). Adding a parameter which maintains this behaviour (which can be added in Static: https://github.com/alphagov/static/pull/3440 ), but defaulting to not including the wrapper element allows other apps to use the layout component directly.

https://trello.com/c/COQYfYgn/347-allow-layoutforpublic-to-work-like-a-normal-layout

## Visual Changes

None expected