### PR TITLE
Center text and icons vertically in the option select component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Show all big_number symbol types in our docs ([PR #4271](https://github.com/alphagov/govuk_publishing_components/pull/4271))
 * Remove incorrect search component example ([PR #4253](https://github.com/alphagov/govuk_publishing_components/pull/4253))
 * Add component wrapper to contextual guidance component ([PR #4282](https://github.com/alphagov/govuk_publishing_components/pull/4277))
+* Center text and icons vertically in the option select component ([PR #4256](https://github.com/alphagov/govuk_publishing_components/pull/4256))
 
 ## 43.5.0
 

--- a/app/assets/javascripts/govuk_publishing_components/components/option-select.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/option-select.js
@@ -190,7 +190,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     var element = document.createElement('div')
     element.setAttribute('class', 'gem-c-option-select__selected-counter js-selected-counter')
     element.innerHTML = checkedString
-    this.$optionSelect.querySelector('.js-container-button').insertAdjacentElement('afterend', element)
+    this.$optionSelect.querySelector('.js-container-toggle').insertAdjacentElement('afterend', element)
   }
 
   OptionSelect.prototype.updateCheckedCount = function updateCheckedCount () {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_option-select.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_option-select.scss
@@ -76,11 +76,10 @@
 
 .gem-c-option-select__icon {
   display: none;
-  position: absolute;
-  top: 0;
-  left: 9px;
+  flex-shrink: 0;
   width: 30px;
   height: 40px;
+  margin-inline: 10px 4px;
   fill: govuk-colour("black");
 }
 
@@ -126,8 +125,14 @@
 .govuk-frontend-supported {
   .gem-c-option-select__heading {
     position: relative;
-    padding: 10px 8px 5px 43px;
-    margin: 0;
+    margin: 0 0 govuk-spacing(1);
+  }
+
+  .gem-c-option-select__toggle {
+    display: flex;
+    flex-direction: row-reverse;
+    justify-content: start;
+    align-items: center;
   }
 
   [aria-expanded="true"] ~ .gem-c-option-select__icon--up {
@@ -152,9 +157,9 @@
 }
 
 .gem-c-option-select__selected-counter {
+  margin-left: 44px;
   color: $govuk-text-colour;
-  margin-top: 3px;
-  @include govuk-font($size: 16);
+  @include govuk-font($size: 16, $line-height: 1);
 }
 
 .gem-c-option-select.js-closed {

--- a/app/views/govuk_publishing_components/components/_option_select.html.erb
+++ b/app/views/govuk_publishing_components/components/_option_select.html.erb
@@ -45,9 +45,11 @@
 
 <%= tag.div(**helper.all_attributes) do %>
   <h3 class="gem-c-option-select__heading js-container-heading">
-    <span class="gem-c-option-select__title js-container-button" id="<%= title_id %>"><%= title %></span>
-    <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" width="0" height="0" class="gem-c-option-select__icon gem-c-option-select__icon--up" aria-hidden="true" focusable="false"><path d="m798.16 609.84l-256-256c-16.683-16.683-43.691-16.683-60.331 0l-256 256c-16.683 16.683-16.683 43.691 0 60.331s43.691 16.683 60.331 0l225.84-225.84 225.84 225.84c16.683 16.683 43.691 16.683 60.331 0s16.683-43.691 0-60.331z"/></svg>
-    <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" width="0" height="0" class="gem-c-option-select__icon gem-c-option-select__icon--down" aria-hidden="true" focusable="false"><path d="m225.84 414.16l256 256c16.683 16.683 43.691 16.683 60.331 0l256-256c16.683-16.683 16.683-43.691 0-60.331s-43.691-16.683-60.331 0l-225.84 225.84-225.84-225.84c-16.683-16.683-43.691-16.683-60.331 0s-16.683 43.691 0 60.331z"/></svg>
+    <div class="gem-c-option-select__toggle js-container-toggle">
+      <span class="gem-c-option-select__title js-container-button" id="<%= title_id %>"><%= title %></span>
+      <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" width="0" height="0" class="gem-c-option-select__icon gem-c-option-select__icon--up" aria-hidden="true" focusable="false"><path d="m798.16 609.84l-256-256c-16.683-16.683-43.691-16.683-60.331 0l-256 256c-16.683 16.683-16.683 43.691 0 60.331s43.691 16.683 60.331 0l225.84-225.84 225.84 225.84c16.683 16.683 43.691 16.683 60.331 0s16.683-43.691 0-60.331z"/></svg>
+      <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" width="0" height="0" class="gem-c-option-select__icon gem-c-option-select__icon--down" aria-hidden="true" focusable="false"><path d="m225.84 414.16l256 256c16.683 16.683 43.691 16.683 60.331 0l256-256c16.683-16.683 16.683-43.691 0-60.331s-43.691-16.683-60.331 0l-225.84 225.84-225.84-225.84c-16.683-16.683-43.691-16.683-60.331 0s-16.683 43.691 0 60.331z"/></svg>
+    </div>
   </h3>
 
   <%= content_tag(:div, class: options_container_classes, id: options_container_id, tabindex: "-1") do %>


### PR DESCRIPTION
## What

Vertically centre align the toggle icons with the label in Option Selects. [Trello](https://trello.com/c/65zYsdtH/275-type-scale-finder-frontend-improve-spacing-and-alignment-in-search-filters-on-mobile)

## Why

The font size of this element increased with the typography changes deployed in a recent update to `govuk-frontend`. This means that the up/down icons no longer align vertically. This PR vertically centres the icons with the text for better vertical balance. A new container for the icon and button is also required so that the selected counter element can be styled independently.

This also supports the same change made in `finder-frontend` where search filter titles had the same tweak to icon positions. See the PR at https://github.com/alphagov/finder-frontend/pull/3334.

## Visual Changes

| Before    | After |
| -------- | ------- |
|<img width="" alt="image" src="https://github.com/user-attachments/assets/97c43d0c-8e95-442d-95ed-b4e2d4627b6a">|<img width="" alt="image" src="https://github.com/user-attachments/assets/33117139-5e25-46a2-80e7-fcf19e047d17">|

