### PR TITLE
Show all big_number symbol types in our docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Update accessibility criteria in component docs ([PR #4242](https://github.com/alphagov/govuk_publishing_components/pull/4242))
+* Show all big_number symbol types in our docs ([PR #4271](https://github.com/alphagov/govuk_publishing_components/pull/4271))
 
 ## 43.5.0
 

--- a/app/views/govuk_publishing_components/components/docs/big_number.yml
+++ b/app/views/govuk_publishing_components/components/docs/big_number.yml
@@ -18,11 +18,26 @@ examples:
     data:
       number: 119
       label: Open consultations
-  passing_extra_symbols:
-    description: "In some cases, we want to communicate more than just the flat numeric value eg: `400+`, `90%`, `-20`, `1M` etc. This is why we allow values to be passed as flat strings."
+  with_plus_symbol:
+    description: "In some cases, we want to communicate more than just the flat numeric value eg: `400+`. This is why we allow values to be passed as flat strings."
     data:
       number: "400+"
       label: Other agencies and public bodies
+  with_percentage_symbol:
+    description: "In some cases, we want to communicate more than just the flat numeric value eg: `90%`. This is why we allow values to be passed as flat strings."
+    data:
+      number: "90%"
+      label: is a large percentage of something
+  with_negative_symbol:
+    description: "In some cases, we want to communicate more than just the flat numeric value eg: `-20`. This is why we allow values to be passed as flat strings."
+    data:
+      number: "-20"
+      label: is a negative number
+  with_unit_symbol:
+    description: "In some cases, we want to communicate more than just the flat numeric value eg: `1M`. This is why we allow values to be passed as flat strings."
+    data:
+      number: "1M"
+      label: is a shorter way of saying one million
   with_link:
     data:
       number: 23


### PR DESCRIPTION
## What / Why
- [In the docs for the big number component](https://components.publishing.service.gov.uk/component-guide/big_number#passing_extra_symbols), we were only showing the `400+` example when demonstrating that symbols can be passed.
- This specific example contains extra styling compared to other symbol types, as we need to align the `+` symbol in the middle of the number. [See context here](https://github.com/alphagov/govuk_publishing_components/commit/1dd5cd1c3784f54cb04e3fec8034b63c6aed3165)
- As the other symbol types like `90%` weren't being shown in the docs, devs were then using `Inspect Element` to change the `400+` example to test the other symbol types like `90%`.
- However as the `400+` example has special styles on it, this led to [an issue](https://github.com/alphagov/govuk_publishing_components/issues/4159) being raised which suggested the styles are broken, when they aren't.
- Therefore, we should show more variations of the symbols in our examples, so that devs aren't using inspect element to look at the other symbols and then thinking there is a visual bug.
- Closes https://github.com/alphagov/govuk_publishing_components/issues/4159 which was raised due to [this PR discussion](https://github.com/alphagov/govuk_publishing_components/pull/4073#discussion_r1705614614)

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

Adds extra examples, so Percy will probably need to be approved as well.
