### PR TITLE
Global print link class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Remove instances of ga4_tracking ([PR #4282](https://github.com/alphagov/govuk_publishing_components/pull/4282))
 * Add component wrapper to cookie banner ([PR #4279](https://github.com/alphagov/govuk_publishing_components/pull/4279))
 * Update attachment link accessibility guidance ([PR #4278](https://github.com/alphagov/govuk_publishing_components/pull/4278))
+* Global print link class ([PR #4275](https://github.com/alphagov/govuk_publishing_components/pull/4275))
 
 ## 43.5.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
@@ -188,12 +188,5 @@
     &::before {
       display: none;
     }
-
-    .gem-c-action-link__link {
-      &::after {
-        display: block;
-        font-size: 12pt;
-      }
-    }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
@@ -155,7 +155,6 @@
   }
 }
 
-// stylelint-disable declaration-no-important
 @include govuk-media-query($media-type: print) {
   .gem-c-cards__list {
     display: block;
@@ -174,23 +173,12 @@
   }
 
   .gem-c-cards__link {
-    &,
-    &:link,
-    &:link:visited {
-      color: $govuk-print-text-colour !important;
-    }
-
     &::before {
       display: none;
     }
 
     &::after {
       position: static;
-      display: block;
-      margin: 1mm auto;
-      font-size: 12pt !important;
-      color: $govuk-print-text-colour;
     }
   }
 }
-// stylelint-enable declaration-no-important

--- a/app/assets/stylesheets/govuk_publishing_components/components/_contents-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_contents-list.scss
@@ -88,10 +88,4 @@
   .gem-c-contents-list__list-item--parent {
     list-style-type: none;
   }
-
-  .gem-c-contents-list__link {
-    &.govuk-link {
-      color: $govuk-print-text-colour;
-    }
-  }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_devolved-nations.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_devolved-nations.scss
@@ -11,25 +11,17 @@
   }
 }
 
-// stylelint-disable declaration-no-important
 @include govuk-media-query($media-type: print) {
   .gem-c-devolved-nations {
     border: 2pt solid $govuk-print-text-colour;
     margin: 0 0 5mm;
 
     * {
-      color: $govuk-print-text-colour !important;
+      color: $govuk-print-text-colour !important; // stylelint-disable-line declaration-no-important
     }
 
     .govuk-list li {
       margin-bottom: 2mm;
     }
-
-    .govuk-link::after {
-      display: block;
-      margin: 1mm auto;
-      font-size: 12pt;
-    }
   }
 }
-// stylelint-enable declaration-no-important

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -162,21 +162,16 @@
   }
 }
 
-// stylelint-disable declaration-no-important
 @include govuk-media-query($media-type: print) {
   .gem-c-document-list__item {
     break-inside: avoid;
+
+    * {
+      color: $govuk-print-text-colour;
+    }
   }
 
-  .gem-c-document-list__item-title {
-    .govuk-link {
-      color: $govuk-print-text-colour !important;
-    }
-
-    .govuk-link::after {
-      display: block;
-      margin: 1mm auto;
-    }
+  .gem-c-document-list__item-context {
+    display: block;
   }
 }
-// stylelint-enable declaration-no-important

--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -355,13 +355,8 @@
   }
 
   .gem-c-image-card__title-link {
-    color: $govuk-print-text-colour !important;
-
     &::after {
-      display: block;
       position: static;
-      margin-top: 2mm;
-      font-size: 12pt !important;
     }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_inset-text.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_inset-text.scss
@@ -1,25 +1,8 @@
 @import "govuk_publishing_components/individual_component_support";
 @import "govuk/components/inset-text/inset-text";
 
-// stylelint-disable declaration-no-important
 @include govuk-media-query($media-type: print) {
   .gem-c-inset-text {
     break-inside: avoid;
   }
-
-  .gem-c-inset-text .govuk-link {
-    &,
-    &:link,
-    &:link:visited {
-      color: $govuk-print-text-colour !important;
-    }
-
-    &::after {
-      display: block;
-      margin: 1mm auto;
-      font-size: 12pt !important;
-      color: $govuk-print-text-colour;
-    }
-  }
 }
-// stylelint-enable declaration-no-important

--- a/app/assets/stylesheets/govuk_publishing_components/components/_intervention.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_intervention.scss
@@ -22,7 +22,6 @@
   margin-bottom: -2px;
 }
 
-// stylelint-disable declaration-no-important
 @include govuk-media-query($media-type: print) {
   .gem-c-intervention {
     break-inside: avoid;
@@ -33,20 +32,4 @@
       margin: 0;
     }
   }
-
-  .gem-c-intervention .govuk-link {
-    &,
-    &:link,
-    &:link:visited {
-      color: $govuk-print-text-colour !important;
-    }
-
-    &::after {
-      display: block;
-      margin: 1mm auto;
-      font-size: 12pt !important;
-      color: $govuk-print-text-colour;
-    }
-  }
 }
-// stylelint-enable declaration-no-important

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-header.scss
@@ -32,17 +32,5 @@
 
   .gem-c-step-nav-header__title {
     @include govuk-font(24, $weight: bold);
-
-    &,
-    &:link,
-    &:link:visited {
-      color: $govuk-print-text-colour;
-    }
-
-    &::after {
-      display: block;
-      margin: 1mm auto;
-      font-size: 12pt !important; // stylelint-disable-line declaration-no-important
-    }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-related.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-related.scss
@@ -45,26 +45,9 @@
   margin-top: govuk-spacing(3);
 }
 
-// stylelint-disable declaration-no-important
 @include govuk-media-query($media-type: print) {
   .gem-c-step-nav-related {
     background: none;
     border-color: $govuk-print-text-colour;
   }
-
-  .gem-c-step-nav-related__heading,
-  .gem-c-step-nav-related__link-item {
-    .govuk-link,
-    .govuk-link:link,
-    .govuk-link:link:visited {
-      color: $govuk-print-text-colour !important;
-
-      &::after {
-        display: block;
-        margin: 1mm auto;
-        font-size: 12pt !important;
-      }
-    }
-  }
 }
-// stylelint-enable declaration-no-important

--- a/app/assets/stylesheets/govuk_publishing_components/lib/_print_support.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/lib/_print_support.scss
@@ -25,3 +25,48 @@
     }
   }
 }
+
+// Two helper classes to ensure that all printed links
+// receive consistent formatting. Most links inherit
+// styles from govuk-frontend, including the printing
+// of the href that a link contains. This makes printed
+// links more useful, but they can take up a lot of space
+// on the page in the default font size and will print
+// in blue by default. These helpers set the printed colour
+// to black, reduce the font size, and improve the layout
+// of the printed href.
+//
+// .gem-print-link
+// ----------------------------------------------------------
+// Typically this class will be applied to existing
+// elements that have the `govuk-link` class but it can
+// also be used on other link elements.
+//
+// .gem-print-links-within
+// ----------------------------------------------------------
+// A variation of the previous print style, to be used on
+// parent elements that contain links with the `govuk-link`
+// class. This is typically only required for views where
+// the `govuk-link` element is not exposed in the markup
+// of the view as it's coming from a self-contained helper.
+
+// stylelint-disable declaration-no-important
+@include govuk-media-query($media-type: print) {
+  .gem-print-link,
+  .gem-print-links-within .govuk-link {
+    &,
+    &:link,
+    &:visited {
+      color: $govuk-print-text-colour !important;
+    }
+
+    &::after {
+      display: block;
+      margin: 1mm auto;
+      font-size: 12pt;
+      font-weight: normal;
+      color: $govuk-print-text-colour !important;
+    }
+  }
+}
+// stylelint-enable declaration-no-important

--- a/app/views/govuk_publishing_components/components/_action_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_action_link.html.erb
@@ -28,7 +28,7 @@
   css_classes << "gem-c-action-link--mobile-subtext" if mobile_subtext
   css_classes << shared_helper.get_margin_bottom
 
-  link_classes = %w(govuk-link gem-c-action-link__link)
+  link_classes = %w(govuk-link gem-c-action-link__link gem-print-link)
   link_classes << "govuk-link--inverse" if light_text
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)

--- a/app/views/govuk_publishing_components/components/_cards.html.erb
+++ b/app/views/govuk_publishing_components/components/_cards.html.erb
@@ -38,7 +38,7 @@
             <%= content_tag("h#{sub_heading_level}", class: "gem-c-cards__sub-heading govuk-heading-s") do %>
               <%=
                 link_to link[:text], link[:path],
-                class: "govuk-link gem-c-cards__link",
+                class: "govuk-link gem-c-cards__link gem-print-link",
                 data: link[:data_attributes]
               %>
             <% end %>

--- a/app/views/govuk_publishing_components/components/_contents_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_contents_list.html.erb
@@ -8,7 +8,7 @@
   brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)
   title_fallback = t("components.contents_list.contents", locale: I18n.locale, fallback: false, default: "en")
   classes = %w[gem-c-contents-list]
-  link_classes = %w[gem-c-contents-list__link govuk-link]
+  link_classes = %w[gem-c-contents-list__link govuk-link gem-print-link]
   link_classes << brand_helper.color_class
   link_classes << "govuk-link--no-underline" unless underline_links
 

--- a/app/views/govuk_publishing_components/components/_devolved_nations.html.erb
+++ b/app/views/govuk_publishing_components/components/_devolved_nations.html.erb
@@ -31,7 +31,7 @@
     <% if devolved_nations_helper.nations_with_urls.any? %>
       <%= content_tag :ul, class: "govuk-list govuk-!-margin-top-1 govuk-!-margin-bottom-0" do -%>
         <% devolved_nations_helper.nations_with_urls.each do |k, v| %>
-          <%= content_tag(:li, link_to(devolved_nations_helper.alternative_content_text(k), v[:alternative_url], class: "govuk-link")) %>
+          <%= content_tag(:li, link_to(devolved_nations_helper.alternative_content_text(k), v[:alternative_url], class: "govuk-link gem-print-link")) %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/govuk_publishing_components/components/_document_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_document_list.html.erb
@@ -56,7 +56,7 @@
                 item[:link][:text],
                 item[:link][:path],
                 data: item[:link][:data_attributes],
-                class: "#{item_classes} govuk-link #{extra_link_classes}",
+                class: "#{item_classes} govuk-link gem-print-link #{extra_link_classes}",
                 lang: item[:link][:locale].presence,
                 rel: rel,
               )
@@ -117,7 +117,7 @@
                       part[:link][:text],
                       part[:link][:path],
                       data: part[:link][:data_attributes],
-                      class: "gem-c-document-list-child__heading gem-c-document-list-child__link #{brand_helper.color_class} govuk-link #{extra_link_classes}",
+                      class: "gem-c-document-list-child__heading gem-c-document-list-child__link #{brand_helper.color_class} govuk-link gem-print-link #{extra_link_classes}",
                     )
                   else
                     content_tag(

--- a/app/views/govuk_publishing_components/components/_image_card.html.erb
+++ b/app/views/govuk_publishing_components/components/_image_card.html.erb
@@ -25,12 +25,14 @@
   heading_link_classes = %w[
     gem-c-image-card__title-link
     govuk-link
+    gem-print-link
   ]
   heading_link_classes << brand_helper.color_class
   heading_link_classes << "gem-c-image-card__title-link--large-font-size-mobile" if card_helper.large_mobile_font_size?
   extra_link_classes = %w[
     gem-c-image-card__list-item-link
     govuk-link
+    gem-print-link
   ]
   extra_link_classes << brand_helper.color_class
 

--- a/app/views/govuk_publishing_components/components/_inset_text.html.erb
+++ b/app/views/govuk_publishing_components/components/_inset_text.html.erb
@@ -10,7 +10,7 @@
     margin_bottom: margin_bottom
   })
 
-  classes = %w[gem-c-inset-text govuk-inset-text]
+  classes = %w[gem-c-inset-text govuk-inset-text gem-print-links-within]
   classes << shared_helper.get_margin_top
   classes << shared_helper.get_margin_bottom
 %>

--- a/app/views/govuk_publishing_components/components/_intervention.html.erb
+++ b/app/views/govuk_publishing_components/components/_intervention.html.erb
@@ -38,7 +38,7 @@
   data_attributes[:ga4_intervention_banner] = "" unless disable_ga4 # Added to the parent element for the GA4 pageview object to use
 
   suggestion_tag_options = {
-    class: "govuk-link",
+    class: "govuk-link gem-print-link",
     href: suggestion_link_url,
     data: suggestion_data_attributes,
   }

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav_header.html.erb
@@ -35,7 +35,7 @@
     <strong class="gem-c-step-nav-header__part-of">Part of</strong>
     <% if path %>
       <a href="<%= path %>"
-        class="gem-c-step-nav-header__title govuk-link"
+        class="gem-c-step-nav-header__title govuk-link gem-print-link"
         <% unless disable_ga4 %>
           data-ga4-link='<%= ga4_data %>'
         <% end %>

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav_related.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav_related.html.erb
@@ -15,7 +15,7 @@
       <span class="gem-c-step-nav-related__pretitle"><%= pretitle %></span>
       <% if links.length == 1 && !always_display_as_list %>
           <a href="<%= links[0][:href] %>"
-            class="govuk-link"
+            class="govuk-link gem-print-link"
             <% unless disable_ga4
               ga4_attributes = {
                 event_name: "navigation",
@@ -37,7 +37,7 @@
           <% links.each_with_index do |link, index| %>
             <li class="gem-c-step-nav-related__link-item">
               <a href="<%= link[:href] %>"
-                class="govuk-link"
+                class="govuk-link gem-print-link"
                 <% unless disable_ga4
                   ga4_attributes = {
                     event_name: "navigation",


### PR DESCRIPTION
## What
Two new helper classes for applying consistent formatting to printed links. These classes replace the same repeated CSS previously created as part of the print improvement work. [Trello](https://trello.com/c/7opRx4sU/336-add-a-global-link-print-style)

## Why
Most links inherit styles from `govuk-frontend`, including printing the contents of the `href`. This makes printed links more useful, but they can take up a lot of space on the page in the default font size and will print in blue by default. These helper classes sets the printed colour to black, reduce the font size, and improve the layout of the printed href.

## Visual Changes
Not applicable as the visual output is the same as before.
