### PR TITLE
Update attachment link accessibility guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Center text and icons vertically in the option select component ([PR #4256](https://github.com/alphagov/govuk_publishing_components/pull/4256))
 * Remove instances of ga4_tracking ([PR #4282](https://github.com/alphagov/govuk_publishing_components/pull/4282))
 * Add component wrapper to cookie banner ([PR #4279](https://github.com/alphagov/govuk_publishing_components/pull/4279))
+* Update attachment link accessibility guidance ([PR #4278](https://github.com/alphagov/govuk_publishing_components/pull/4278))
 
 ## 43.5.0
 

--- a/app/views/govuk_publishing_components/components/docs/attachment_link.yml
+++ b/app/views/govuk_publishing_components/components/docs/attachment_link.yml
@@ -6,6 +6,12 @@ body: |
 
   It is expected to be embedded inside an element that provides text styles
   (such as `.govuk-body`) so does not provide its own text styling.
+accessibility_criteria: |
+    All touch targets (e.g the attachment link) must be 24px large, or leave sufficient space (target-size). See [Understanding Success Criterion 2.5.8: Target Size (Minimum))](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html).
+
+    To achieve this, you can embed the attachment link within another element that maintains sufficient space above and below the target. For instance, you can place individual links inside a paragraph element styled with a `.govuk-body` class, or as list items in the [list component](https://components.publishing.service.gov.uk/component-guide/list).
+
+    Attachment links within paragraphs of text do not need to meet the 24 by 24 CSS pixels requirements.    
 shared_accessibility_criteria:
 - link
 examples:


### PR DESCRIPTION
## What

Update attachment link accessibility guidance

## Why

See https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html. The Attachment link component might fail 2.5.8 Target Size (Minimum) if not used in the correct way. The last two examples ([with target blank
](https://components.publishing.service.gov.uk/component-guide/attachment_link/with_target_blank) and [with data attributes](https://components.publishing.service.gov.uk/component-guide/attachment_link/with_data_attributes)) show the component used without a containing element such as a paragraph tag or a list item element and the target height is only 20px high (24px is required for the success criterion).

This should be highlighted in the guidance.

## Anything else

I explored a few other approaches here:
- enable the Axe `target-size` rule, which is not enabled by default. Unfortunately, this doesn’t get flagged as a violation (because there are no intersecting 'targets' in the examples).
- embedding the final two examples within Govspeak or a paragraph element. However, I find this potentially confusing, as both examples demo usage with data attributes or the `target="_blank"` attribute. Including extra elements might mislead users into thinking these are necessary for the component to work. Additionally, the component can be implemented in various ways that would still meet the success criteria, such as within a list item.