### PR TITLE
Add component wrapper to cookie banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Add component wrapper to contextual guidance component ([PR #4277](https://github.com/alphagov/govuk_publishing_components/pull/4277))
 * Center text and icons vertically in the option select component ([PR #4256](https://github.com/alphagov/govuk_publishing_components/pull/4256))
 * Remove instances of ga4_tracking ([PR #4282](https://github.com/alphagov/govuk_publishing_components/pull/4282))
+* Add component wrapper to cookie banner ([PR #4279](https://github.com/alphagov/govuk_publishing_components/pull/4279))
 
 ## 43.5.0
 

--- a/app/models/govuk_publishing_components/component_wrapper_helper_options.rb
+++ b/app/models/govuk_publishing_components/component_wrapper_helper_options.rb
@@ -11,6 +11,7 @@ This component uses the component wrapper helper. It accepts the following optio
 - `role` - accepts a space separated string of roles
 - `lang` - accepts a language attribute value
 - `open` - accepts an open attribute value (true or false)
+- `hidden` - accepts an empty string, 'hidden', or 'until-found'
       "
     end
   end

--- a/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
@@ -23,13 +23,21 @@
                                   class: "govuk-link",
                                 )))
   services_cookies ||= nil
-  css_classes = %w(gem-c-cookie-banner govuk-clearfix govuk-cookie-banner js-banner-wrapper)
-  css_classes << "gem-c-cookie-banner--services" if services_cookies
+
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.set_id(id)
+  component_helper.add_class("gem-c-cookie-banner govuk-clearfix govuk-cookie-banner js-banner-wrapper")
+  component_helper.add_class("gem-c-cookie-banner--services") if services_cookies
+
+  component_helper.add_data_attribute({ module: "cookie-banner", nosnippet: "" })
+  component_helper.add_role("region")
+  component_helper.add_aria_attribute(label: title)
+  component_helper.set_hidden("hidden")
 
   disable_ga4 ||= false
 %>
 
-<div id="<%= id %>" class="<%= css_classes.join(' ') %>" data-module="cookie-banner" data-nosnippet role="region" aria-label="<%= title %>" hidden>
+<%= tag.div(**component_helper.all_attributes) do %>
   <div class="govuk-cookie-banner__message govuk-width-container">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
@@ -100,4 +108,4 @@
         </button>
     </div>
   </div>
-</div>
+<% end %>

--- a/lib/govuk_publishing_components/presenters/component_wrapper_helper.rb
+++ b/lib/govuk_publishing_components/presenters/component_wrapper_helper.rb
@@ -11,6 +11,7 @@ module GovukPublishingComponents
         check_role_is_valid(@options[:role]) if @options.include?(:role)
         check_lang_is_valid(@options[:lang]) if @options.include?(:lang)
         check_open_is_valid(@options[:open]) if @options.include?(:open)
+        check_hidden_is_valid(@options[:hidden]) if @options.include?(:hidden)
       end
 
       def all_attributes
@@ -23,6 +24,7 @@ module GovukPublishingComponents
         attributes[:role] = @options[:role] unless @options[:role].blank?
         attributes[:lang] = @options[:lang] unless @options[:lang].blank?
         attributes[:open] = @options[:open] unless @options[:open].blank?
+        attributes[:hidden] = @options[:hidden] unless @options[:hidden].nil?
 
         attributes
       end
@@ -60,6 +62,11 @@ module GovukPublishingComponents
       def set_open(open_attribute)
         check_open_is_valid(open_attribute)
         @options[:open] = open_attribute
+      end
+
+      def set_hidden(hidden_attribute)
+        check_hidden_is_valid(hidden_attribute)
+        @options[:hidden] = hidden_attribute
       end
 
     private
@@ -127,6 +134,15 @@ module GovukPublishingComponents
         options = [true, false]
         unless options.include? open_attribute
           raise(ArgumentError, "open attribute (#{open_attribute}) is not recognised")
+        end
+      end
+
+      def check_hidden_is_valid(hidden_attribute)
+        return if hidden_attribute.nil?
+
+        options = ["", "hidden", "until-found"]
+        unless options.include? hidden_attribute
+          raise(ArgumentError, "hidden attribute (#{hidden_attribute}) is not recognised")
         end
       end
 

--- a/spec/lib/govuk_publishing_components/components/component_wrapper_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/components/component_wrapper_helper_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe GovukPublishingComponents::Presenters::ComponentWrapperHelper do
         role: "navigation",
         lang: "en",
         open: true,
+        hidden: "",
       }
       component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(args)
       expected = {
@@ -25,6 +26,7 @@ RSpec.describe GovukPublishingComponents::Presenters::ComponentWrapperHelper do
         role: "navigation",
         lang: "en",
         open: true,
+        hidden: "",
       }
       expect(component_helper.all_attributes).to eql(expected)
     end
@@ -194,6 +196,27 @@ RSpec.describe GovukPublishingComponents::Presenters::ComponentWrapperHelper do
       expect {
         GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(open: "false")
       }.to raise_error(ArgumentError, error)
+    end
+
+    it "does not accept an invalid hidden value" do
+      error = "hidden attribute (false) is not recognised"
+      expect {
+        GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(hidden: "false")
+      }.to raise_error(ArgumentError, error)
+    end
+
+    it "accepts valid hidden attribute value" do
+      component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(hidden: "until-found")
+      expected = {
+        hidden: "until-found",
+      }
+      expect(component_helper.all_attributes).to eql(expected)
+    end
+
+    it "can set an hidden attribute, overriding a passed value" do
+      helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(hidden: "until-found")
+      helper.set_hidden("hidden")
+      expect(helper.all_attributes[:hidden]).to eql("hidden")
     end
   end
 end


### PR DESCRIPTION
## What / Why
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Adds the component wrapper to the cookie banner
- The cookie banner contains a `hidden` attribute, but the component wrapper didn't support this, so I've added that
- I can't seem to get `hidden` to work when passed with an empty string. I'm not sure if it's rails or the browser, but it automatically converts it to `<div hidden="hidden">` - I don't think this is a massive issue, as `hidden="hidden"` is still valid. Therefore if you have any tips to make `<div hidden>` alone work feel free to comment.

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->
None.
