### PR TITLE
add tracking to autocomplete suggestion selection

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.js
@@ -31,7 +31,9 @@
         percent_scrolled: this.undefined,
         video_current_time: this.undefined,
         length: this.undefined,
-        video_percent: this.undefined
+        video_percent: this.undefined,
+        autocomplete_input: this.undefined,
+        autocomplete_suggestions: this.undefined
       }
     }
   }

--- a/app/views/govuk_publishing_components/components/_search_with_autocomplete.html.erb
+++ b/app/views/govuk_publishing_components/components/_search_with_autocomplete.html.erb
@@ -21,7 +21,7 @@
 %>
 <%= tag.div(
   class: classes.join(" "),
-  data: { module: "gem-search-with-autocomplete", source_url:, source_key: }
+  data: { module: "gem-search-with-autocomplete ga4-event-tracker", source_url:, source_key: }
 ) do %>
   <%= render "govuk_publishing_components/components/search", search_component_options %>
 <% end %>

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.spec.js
@@ -41,7 +41,9 @@ describe('Google Analytics schemas', function () {
         percent_scrolled: undefined,
         video_current_time: undefined,
         length: undefined,
-        video_percent: undefined
+        video_percent: undefined,
+        autocomplete_input: this.undefined,
+        autocomplete_suggestions: this.undefined
       }
     }
     var returned = schemas.mergeProperties(data, 'example')
@@ -76,7 +78,9 @@ describe('Google Analytics schemas', function () {
         percent_scrolled: undefined,
         video_current_time: undefined,
         length: undefined,
-        video_percent: undefined
+        video_percent: undefined,
+        autocomplete_input: this.undefined,
+        autocomplete_suggestions: this.undefined
       }
     }
     var returned = schemas.mergeProperties(data, 'example')
@@ -111,7 +115,9 @@ describe('Google Analytics schemas', function () {
         percent_scrolled: undefined,
         video_current_time: undefined,
         length: undefined,
-        video_percent: undefined
+        video_percent: undefined,
+        autocomplete_input: this.undefined,
+        autocomplete_suggestions: this.undefined
       }
     }
     var returned = schemas.mergeProperties(data, 'example')
@@ -147,7 +153,9 @@ describe('Google Analytics schemas', function () {
         percent_scrolled: undefined,
         video_current_time: undefined,
         length: undefined,
-        video_percent: undefined
+        video_percent: undefined,
+        autocomplete_input: this.undefined,
+        autocomplete_suggestions: this.undefined
       }
     }
     var returned = schemas.mergeProperties(data, 'example')


### PR DESCRIPTION
Add ga4 tracking follow selection of an autocomplete suggestion as per requirements listed here:

https://docs.google.com/document/d/1X6vMjJpr8SiLegBGjnjL4-HSEScG-SWTgk2uy7bnWiM

- adds the new keys (`autocomplete_input` and `autocomplete_suggestions`) to the event schema.
- the data collection from the selection is then applied to the schema and event is fired before the form submits.
