### PR TITLE
Add component wrapper to devolved nations component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Add component wrapper to cookie banner ([PR #4279](https://github.com/alphagov/govuk_publishing_components/pull/4279))
 * Update attachment link accessibility guidance ([PR #4278](https://github.com/alphagov/govuk_publishing_components/pull/4278))
 * Global print link class ([PR #4275](https://github.com/alphagov/govuk_publishing_components/pull/4275))
+* Add component wrapper to devolved nations component ([PR #4281](https://github.com/alphagov/govuk_publishing_components/pull/4281))
 
 ## 43.5.0
 

--- a/app/views/govuk_publishing_components/components/_devolved_nations.html.erb
+++ b/app/views/govuk_publishing_components/components/_devolved_nations.html.erb
@@ -7,23 +7,27 @@
   applies_to ||= t("components.devolved_nations.applies_to")
   heading_level ||= 2
   disable_ga4 ||= false
-  data_attributes = {}
+
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("gem-c-devolved-nations")
 
   unless disable_ga4
-    data_attributes[:ga4_devolved_nations_banner] = devolved_nations_helper.ga4_applicable_nations_title_text(true)
-    data_attributes[:module] = "ga4-link-tracker"
-    data_attributes[:ga4_track_links_only] = ""
-    data_attributes[:ga4_set_indexes] = ""
-    data_attributes[:ga4_link] = {
-      event_name: "navigation",
-      type: "devolved nations banner",
-      section: t("components.devolved_nations.applies_to", locale: :en) + " " + devolved_nations_helper.ga4_applicable_nations_title_text,
-    }.to_json
+    component_helper.add_data_attribute({
+      ga4_devolved_nations_banner: devolved_nations_helper.ga4_applicable_nations_title_text(true),
+      module: "ga4-link-tracker",
+      ga4_track_links_only: "",
+      ga4_set_indexes: "",
+      ga4_link: {
+        event_name: "navigation",
+        type: "devolved nations banner",
+        section: t("components.devolved_nations.applies_to", locale: :en) + " " + devolved_nations_helper.ga4_applicable_nations_title_text,
+      }.to_json
+    })
   end
 %>
 
 <% if national_applicability.any? { |k,v| v[:applicable] == true } %>
-  <%= tag.section class: "gem-c-devolved-nations", data: data_attributes do %>
+  <%= tag.section(**component_helper.all_attributes) do %>
     <%= content_tag(shared_helper.get_heading_level, class: "govuk-heading-s govuk-!-margin-bottom-0") do %>
       <%= applies_to %> <%= devolved_nations_helper.applicable_nations_title_text %>
     <% end %>

--- a/app/views/govuk_publishing_components/components/docs/devolved_nations.yml
+++ b/app/views/govuk_publishing_components/components/docs/devolved_nations.yml
@@ -7,6 +7,7 @@ body: |
 
   * nations that the alternative content relates to
   * a list of alternative URLs where applicable
+uses_component_wrapper: true
 shared_accessibility_criteria:
   - link
 accessibility_criteria: |


### PR DESCRIPTION
## What / Why
- Adds the component wrapper to the `devolved_nations` component
- https://trello.com/c/qH4NyWJw/364-add-component-wrapper-to-more-components#comment-66fe6e7c9757203502c5ea6d

## Visual changes

None.