### PR TITLE
Standardise inverse for search component

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -82,6 +82,7 @@ $large-input-size: 50px;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+  border-right-width: 0;
   @include govuk-font($size: 19, $line-height: calc(28 / 19));
 
   // the .focus class is added by JS and ensures that the input remains above the label once clicked/filled in
@@ -91,6 +92,7 @@ $large-input-size: 50px;
   }
 
   &:focus {
+    border-right-width: 2px; // add the border once focused
     @include gem-c-search-input-focus;
   }
 
@@ -122,6 +124,12 @@ $large-input-size: 50px;
   height: $input-size;
   text-indent: -5000px;
   overflow: hidden;
+  background-color: govuk-colour("blue");
+  color: govuk-colour("white");
+
+  &:hover {
+    background-color: lighten(govuk-colour("blue"), 5%);
+  }
 
   .gem-c-search__icon {
     pointer-events: none;
@@ -164,7 +172,7 @@ $large-input-size: 50px;
   width: 1%;
 }
 
-.gem-c-search--on-govuk-blue {
+.gem-c-search--inverse {
   .gem-c-search__label {
     color: govuk-colour("white");
   }
@@ -205,26 +213,6 @@ $large-input-size: 50px;
 
     &:hover {
       background-color: lighten(#d2e2f1, 5%);
-    }
-  }
-}
-
-.gem-c-search--on-white {
-  .gem-c-search__submit {
-    background-color: govuk-colour("blue");
-    color: govuk-colour("white");
-
-    &:hover {
-      background-color: lighten(govuk-colour("blue"), 5%);
-    }
-  }
-
-  .gem-c-search__input[type="search"] {
-    border-right-width: 0;
-
-    // add the border once focused
-    &:focus {
-      border-right-width: 2px;
     }
   }
 }

--- a/app/views/govuk_publishing_components/components/_search.html.erb
+++ b/app/views/govuk_publishing_components/components/_search.html.erb
@@ -29,11 +29,7 @@
   classes << "gem-c-search--large-on-mobile" if size == "large-mobile"
   classes << "gem-c-search--homepage" if homepage
   classes << "gem-c-search--no-border" if no_border
-  if local_assigns[:on_govuk_blue].eql?(true)
-    classes << "gem-c-search--on-govuk-blue"
-  else
-    classes << "gem-c-search--on-white"
-  end
+  classes << "gem-c-search--inverse" if local_assigns[:inverse].eql?(true)
   classes << "gem-c-search--separate-label" if local_assigns.include?(:inline_label) or local_assigns.include?(:label_size)
 
   label_classes = []

--- a/app/views/govuk_publishing_components/components/docs/search.yml
+++ b/app/views/govuk_publishing_components/components/docs/search.yml
@@ -4,7 +4,7 @@ body: |
   A search box with label and attached submit button. The component must be used within an HTML form.
   The search input has a name="q" attribute and a customisable ID and NAME.
 
-  It can be used on white or on govuk-blue using the `on_govuk_blue` option.
+  It can be used on white or on govuk-blue using the `inverse` option.
 
   Markup such as heading tags can be included in the label using the label_text option. Styling is not included in the component for heading tags in labels, however this is what the search results page does.
 accessibility_criteria: |
@@ -28,9 +28,10 @@ examples:
       no_border: true
     context:
       black_background: true
-  for_use_on_govuk_blue_background:
+  inverse:
+    description: For use on a GOVUK blue or similar dark background.
     data:
-      on_govuk_blue: true
+      inverse: true
     context:
       dark_background: true
   homepage:
@@ -38,12 +39,12 @@ examples:
     data:
       label_text: "Search"
       inline_label: false
-      on_govuk_blue: true
+      inverse: true
       label_size: "s"
       homepage: true
       size: "large"
     context:
-      dark_background: true 
+      dark_background: true
   change_label_text:
     data:
       label_text: "Search"

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -7,18 +7,18 @@ describe "Search", type: :view do
 
   it "renders a search box with default options" do
     render_component({})
-    assert_select ".gem-c-search.gem-c-search--on-white"
+    assert_select ".gem-c-search"
     assert_select "label[class^='govuk-\!-margin-bottom-']", count: 0
   end
 
   it "renders a search box for a dark background" do
-    render_component(on_govuk_blue: true)
-    assert_select ".gem-c-search.gem-c-search--on-govuk-blue"
+    render_component(inverse: true)
+    assert_select ".gem-c-search.gem-c-search--inverse"
   end
 
   it "doesn't render a search box for a dark background if the parameter is invalid" do
-    render_component(on_govuk_blue: "dummy")
-    assert_select ".gem-c-search.gem-c-search--on-govuk-blue", false
+    render_component(inverse: "dummy")
+    assert_select ".gem-c-search.gem-c-search--inverse", false
   end
 
   it "renders a search box with a custom label text" do


### PR DESCRIPTION
## What
Update components that have an option for displaying them on a dark background to use `inverse` as the option name. Continues the work from https://github.com/alphagov/govuk_publishing_components/pull/4288

## Why
We're doing some unrelated work with the action link component and the fact that action link uses something other than `inverse` causes extra code to be required.

For reference, here are all the components I could find prior to starting this PR with an `inverse` option and what they called it:

- action link - **light_text**
- breadcrumbs - inverse
- contextual breadcrumbs - inverse
- govspeak - inverse
- heading - inverse
- lead paragraph - inverse
- metadata - inverse
- phase banner - inverse
- search with autocomplete - **on_govuk_blue**
- search - **on_govuk_blue**
- title - inverse
- translation nav - inverse

## Visual Changes
Should be no actual visual changes apart from some of the names of the examples in the component guide.
