### PR TITLE
Reskin tabs for the landing page

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_tabs.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_tabs.scss
@@ -32,6 +32,54 @@ li.govuk-tabs__list-item { // stylelint-disable-line selector-no-qualifying-type
   }
 }
 
+.gem-c-tabs--landing-page {
+  .govuk-tabs__list {
+    display: flex;
+    flex-wrap: nowrap;
+    justify-content: space-between;
+    border: 0;
+    margin: 0 -2px;
+  }
+
+  .govuk-tabs__list-item {
+    float: none;
+    flex: 1 1 0px;
+    background: govuk-colour("light-grey");
+    margin: 0 2px;
+    padding: govuk-spacing(4) govuk-spacing(2);
+    border: 0;
+    text-align: center;
+    font-weight: bold;
+  }
+
+  @include govuk-media-query($until: tablet) {
+    .govuk-tabs__title,
+    .govuk-tabs__list,
+    .govuk-tabs__list-item::before {
+      display: none;
+    }
+  }
+
+  .govuk-tabs__list-item--selected {
+    padding: govuk-spacing(4) govuk-spacing(2);
+    background: govuk-colour("blue");
+    border: 0;
+
+    .govuk-tabs__tab {
+      color: govuk-colour("white");
+
+      &:focus {
+        color: $govuk-focus-text-colour;
+      }
+    }
+  }
+
+  .govuk-tabs__panel {
+    border: 0;
+    padding: 0;
+  }
+}
+
 @include govuk-media-query($media-type: print) {
   .govuk-tabs__title {
     display: block !important; // stylelint-disable-line declaration-no-important

--- a/app/views/govuk_publishing_components/components/_tabs.html.erb
+++ b/app/views/govuk_publishing_components/components/_tabs.html.erb
@@ -9,9 +9,11 @@
 
   as_links ||= false
   disable_ga4 ||= false
+  landing_page ||= false
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("govuk-tabs gem-c-tabs")
+  component_helper.add_class("gem-c-tabs--landing-page") if landing_page
   component_helper.add_data_attribute({ module: "govuk-tabs" }) unless as_links
 
   unless disable_ga4

--- a/app/views/govuk_publishing_components/components/docs/tabs.yml
+++ b/app/views/govuk_publishing_components/components/docs/tabs.yml
@@ -122,3 +122,15 @@ examples:
         - href: "/page2"
           label: "Link 2"
           active: false
+  on_landing_page:
+    data:
+      landing_page: true
+      tabs:
+        - id: "landing-page1"
+          label: "Red Dwarf"
+          content: |
+            <p class="govuk-body-m">BBC</p>
+        - id: "landing-page2"
+          label: "Star Trek: The Next Generation"
+          content: |
+            <p class="govuk-body-m">NBC</p>

--- a/spec/components/tabs_spec.rb
+++ b/spec/components/tabs_spec.rb
@@ -146,4 +146,23 @@ describe "Tabs", type: :view do
     assert_select ".govuk-tabs[data-module='ga4-link-tracker']", false
     assert_select ".govuk-tabs__tab[data-ga4-link]", false
   end
+
+  it "renders tabs for the landing page" do
+    render_component(
+      landing_page: true,
+      tabs: [
+        {
+          id: "tab1",
+          label: "First section",
+          content: "<p>Fusce at dictum tellus.</p>",
+        },
+        {
+          id: "tab2",
+          label: "Second section",
+          content: "<p>Lorem ipsum.</p>",
+        },
+      ],
+    )
+    assert_select ".govuk-tabs.gem-c-tabs.gem-c-tabs--landing-page"
+  end
 end


### PR DESCRIPTION
## What
Adds a visual variant for the tabs component. This overrides a lot of the existing CSS on the tabs.

For mobile we're going to just hide the tabs themselves, and make all the tab content visible and stack it.

Note that the content of the tabs is going to be provided by the application, hence why there's no padding in the content.

## Why
Needed for the landing page.

## Visual Changes
New option looks like this:

![Screenshot 2024-10-08 at 15 00 20](https://github.com/user-attachments/assets/0ad3a58e-3b15-4d13-9894-d6ce6002cbcb)


Trello card: https://trello.com/c/YCUbimh9/50-build-featured
