### PR TITLE
Add variants required for square blue icon share links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add variants required for square blue icon share links ([PR #4292](https://github.com/alphagov/govuk_publishing_components/pull/4292))
+
 ## 44.2.0
 
 * Upgrade to version 5.7.0 of govuk-frontend ([PR #4298](https://github.com/alphagov/govuk_publishing_components/pull/4298))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_share-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_share-links.scss
@@ -83,3 +83,35 @@ $column-width: 9.5em;
     display: block;
   }
 }
+
+.gem-c-share-links--square-icons {
+  .gem-c-share-links__list-item {
+    padding-left: 60px;
+    padding-top: 12px;
+    margin-bottom: 30px;
+  }
+
+  .gem-c-share-links__link-icon {
+    background-color: govuk-colour("dark-blue");
+    color: govuk-colour("white");
+    padding: govuk-spacing(2);
+    margin-right: govuk-spacing(2);
+  }
+
+  .gem-c-share-links__link:hover {
+    .gem-c-share-links__link-icon {
+      background-color: govuk-colour("black");
+    }
+  }
+
+  .gem-c-share-links__link:focus {
+    .gem-c-share-links__link-icon {
+      background-color: govuk-colour("black");
+    }
+  }
+
+  .gem-c-share-links__label {
+    color: govuk-colour("black");
+    @include govuk-font(19, $weight: bold);
+  }
+}

--- a/app/views/govuk_publishing_components/components/_share_links.html.erb
+++ b/app/views/govuk_publishing_components/components/_share_links.html.erb
@@ -8,6 +8,7 @@
   ga4_extra_data ||= {}
   stacked ||= false
   columns ||= false
+  square_icons ||= false
 
   brand ||= false
   brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)
@@ -15,6 +16,8 @@
   classes = %w(gem-c-share-links govuk-!-display-none-print)
   classes << "gem-c-share-links--stacked" if stacked
   classes << "gem-c-share-links--columns" if columns
+  classes << "gem-c-share-links--square-icons" if square_icons
+
   classes << brand_helper.brand_class
 
   data_attributes ||= {}
@@ -110,7 +113,7 @@
                   <path fill="currentColor" d="M36.92,0A36.92,36.92,0,1,0,73.84,36.92,36.92,36.92,0,0,0,36.92,0ZM56.3,48.27a1.42,1.42,0,0,1-1.42,1.42h-19v9.18l-9.18-9.18H19a1.43,1.43,0,0,1-1.43-1.43V20.52A1.43,1.43,0,0,1,19,19.09H54.88a1.43,1.43,0,0,1,1.42,1.42Z"/>
                 </svg>
               <% end %>
-            </span><%= link_text %><% end %>
+            </span><%= tag.span(class: "gem-c-share-links__label") do %><%= link_text %><% end %><% end %>
         </li>
       <% end %>
     </ul>

--- a/app/views/govuk_publishing_components/components/docs/share_links.yml
+++ b/app/views/govuk_publishing_components/components/docs/share_links.yml
@@ -256,3 +256,39 @@ examples:
           icon: 'youtube'
         }
       ]
+  with_square_icons:
+    data:
+      square_icons: true
+      columns: true
+      links: [
+        {
+          href: '/twitter-share-link',
+          text: 'Twitter',
+          icon: 'twitter'
+        },
+        {
+          href: '/instagram-share-link',
+          text: 'Instagram',
+          icon: 'instagram'
+        },
+                {
+          href: '/flickr-share-link',
+          text: 'Flickr',
+          icon: 'flickr'
+        },
+        {
+          href: '/facebook-share-link',
+          text: 'Facebook',
+          icon: 'facebook'
+        },
+        {
+          href: '/youtube-share-link',
+          text: 'YouTube',
+          icon: 'youtube'
+        },
+        {
+          href: '/other-share-link',
+          text: 'Anything else that might be included that could have quite a long name',
+          icon: 'other'
+        },
+      ]

--- a/spec/components/share_links_spec.rb
+++ b/spec/components/share_links_spec.rb
@@ -124,4 +124,14 @@ describe "ShareLinks", type: :view do
     render_component(links:)
     assert_select ".gem-c-share-links .gem-c-share-links__link[href=\"/twitter\"] .govuk-visually-hidden", text: "Tweet to"
   end
+
+  it "adds the correct classes when square_icons is true" do
+    render_component(links:, square_icons: true)
+    assert_select ".gem-c-share-links--square-icons"
+  end
+
+  it "does not add extra classes when square_icons is false" do
+    render_component(links:, square_icons: false)
+    assert_select ".gem-c-share-links--square-icons", false
+  end
 end


### PR DESCRIPTION
## What / Why
<!-- What are the reasons behind this change being made? -->
- Add variants required for square blue icon share links
- Reasoning: https://trello.com/c/LNOqGMgZ/49-build-social-media-links
- The existing component styles use `position: absolute` for the icons, which doesn't work nicely when we need them square. This is because the absolutely positioned icons don't affect the width/height of the DOM, so adding square background styles just ended up in overlapping, fiddly overflows, and made it difficult to align the text in the centre of the icons.
- Therefore, I've used `display: flex` along with `inline-block` to get the styles we want.
- ~~I added a `min-width` at a certain breakpoint to make the reflow look nicer, but this is specific to the page we're going to put this variation on. (i.e. because we know the social icons / share link text that will be on the page, we can make the shorter sized social links look nicer when they stack next to longer social links by adding a `min-width`.) Of course that CSS rule is not very helpful if this variation was used on other pages that are using an arbitrary number of social links.~~

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

Multiple examples added, so will need a Percy review.

<img width="997" alt="image" src="https://github.com/user-attachments/assets/65780164-1c71-485d-8a3a-217ac08777ae">

<img width="997" alt="image" src="https://github.com/user-attachments/assets/640d5265-d4ca-40da-8090-1f9b348b7815">

<img width="997" alt="image" src="https://github.com/user-attachments/assets/53eca06d-998b-46f2-be72-4ef8ad558f7d">

<img width="997" alt="image" src="https://github.com/user-attachments/assets/a9662d58-725f-4a47-8a1a-c21180841069">

<img width="1007" alt="image" src="https://github.com/user-attachments/assets/ca4483be-8e3e-4e71-a812-05fed7d2e283">

