### PR TITLE
Add chartkick path to gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add chartkick path to gemspec ([PR #4312](https://github.com/alphagov/govuk_publishing_components/pull/4312))
+
 ## 44.4.0
 
 * Add chart component ([PR #4301](https://github.com/alphagov/govuk_publishing_components/pull/4301))

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
   s.required_ruby_version = ">= 3.2"
 
-  s.files = Dir["{node_modules/accessible-autocomplete,node_modules/govuk-frontend,node_modules/axe-core,node_modules/sortablejs,node_modules/govuk-single-consent,app,config,db,lib}/**/*", "LICENCE.md", "README.md"]
+  s.files = Dir["{node_modules/accessible-autocomplete,node_modules/govuk-frontend,node_modules/axe-core,node_modules/sortablejs,node_modules/govuk-single-consent,node_modules/chartkick,app,config,db,lib}/**/*", "LICENCE.md", "README.md"]
 
   s.add_dependency "chartkick"
   s.add_dependency "govuk_app_config"


### PR DESCRIPTION
## What

Adds the path to the `chartkick` JS explicitly into the gemspec.

## Why
Needed for the chart component. Installing in applications fails because the JS file can't be found.

## Visual Changes
None.
