### PR TITLE
Use flexbox for share links with square icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Use flexbox for share links with square icons ([PR #4316](https://github.com/alphagov/govuk_publishing_components/pull/4316))
+
 ## 44.5.0
 
 * Add component wrapper to error alert component ([PR #4287](https://github.com/alphagov/govuk_publishing_components/pull/4287))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_share-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_share-links.scss
@@ -84,18 +84,39 @@ $column-width: 9.5em;
   }
 }
 
-.gem-c-share-links--square-icons {
-  .gem-c-share-links__list-item {
-    padding-left: 60px;
-    padding-top: 12px;
-    margin-bottom: 30px;
+.gem-c-share-links--flexbox {
+  .gem-c-share-links__list {
+    display: flex;
+    flex-wrap: wrap;
   }
 
+  .gem-c-share-links__list-item {
+    padding-left: 0;
+    padding-right: 0;
+    min-width: 180px;
+  }
+
+  .gem-c-share-links__link-icon {
+    display: inline-flex;
+    position: relative;
+    vertical-align: middle;
+    margin-right: govuk-spacing(2);
+  }
+
+  .gem-c-share-links__label {
+    vertical-align: middle;
+  }
+
+  .gem-c-share-links__link {
+    display: inline-block;
+  }
+}
+
+.gem-c-share-links--square-icons {
   .gem-c-share-links__link-icon {
     background-color: govuk-colour("dark-blue");
     color: govuk-colour("white");
     padding: govuk-spacing(2);
-    margin-right: govuk-spacing(2);
   }
 
   .gem-c-share-links__link:hover {

--- a/app/views/govuk_publishing_components/components/_share_links.html.erb
+++ b/app/views/govuk_publishing_components/components/_share_links.html.erb
@@ -8,6 +8,7 @@
   ga4_extra_data ||= {}
   stacked ||= false
   columns ||= false
+  flexbox ||= false
   square_icons ||= false
 
   brand ||= false
@@ -16,6 +17,7 @@
   classes = %w(gem-c-share-links govuk-!-display-none-print)
   classes << "gem-c-share-links--stacked" if stacked
   classes << "gem-c-share-links--columns" if columns
+  classes << "gem-c-share-links--flexbox" if flexbox
   classes << "gem-c-share-links--square-icons" if square_icons
 
   classes << brand_helper.brand_class

--- a/app/views/govuk_publishing_components/components/docs/share_links.yml
+++ b/app/views/govuk_publishing_components/components/docs/share_links.yml
@@ -256,10 +256,45 @@ examples:
           icon: 'youtube'
         }
       ]
-  with_square_icons:
+  with_flexbox:
+    data:
+      flexbox: true
+      links: [
+        {
+          href: '/twitter-share-link',
+          text: 'Twitter',
+          icon: 'twitter'
+        },
+        {
+          href: '/instagram-share-link',
+          text: 'Instagram',
+          icon: 'instagram'
+        },
+                {
+          href: '/flickr-share-link',
+          text: 'Flickr',
+          icon: 'flickr'
+        },
+        {
+          href: '/facebook-share-link',
+          text: 'Facebook',
+          icon: 'facebook'
+        },
+        {
+          href: '/youtube-share-link',
+          text: 'YouTube',
+          icon: 'youtube'
+        },
+        {
+          href: '/other-share-link',
+          text: 'Anything else that might be included that could have quite a long name',
+          icon: 'other'
+        },
+      ]
+  with_square_icons_and_flexbox:
     data:
       square_icons: true
-      columns: true
+      flexbox: true
       links: [
         {
           href: '/twitter-share-link',

--- a/spec/components/share_links_spec.rb
+++ b/spec/components/share_links_spec.rb
@@ -125,6 +125,16 @@ describe "ShareLinks", type: :view do
     assert_select ".gem-c-share-links .gem-c-share-links__link[href=\"/twitter\"] .govuk-visually-hidden", text: "Tweet to"
   end
 
+  it "adds the correct classes when flexbox is true" do
+    render_component(links:, flexbox: true)
+    assert_select ".gem-c-share-links--flexbox"
+  end
+
+  it "does not add extra classes when flexbox is false" do
+    render_component(links:, flexbox: false)
+    assert_select ".gem-c-share-links--flexbox", false
+  end
+
   it "adds the correct classes when square_icons is true" do
     render_component(links:, square_icons: true)
     assert_select ".gem-c-share-links--square-icons"


### PR DESCRIPTION
## What / Why
<!-- What are the reasons behind this change being made? -->
- Stop using `columns: true` for our square icons as it doesn't give us the visual balance we want where we're using it.
- Therefore, use flexbox with a `min-width` for this variant instead. 
- The `min-width` is needed because alignment/stacking visual inconsistencies occur when the elements have varying widths. Therefore, if we ensure there is a minimum width for the elements, the alignment and flow when resizing is more visually pleasing. If you think of a component like our image cards, they stack and align nicely as they are all the same width, so we need some of that guarantee here, hence the `min-width`. It's also worth noting that `columns: true` was utilising a `min-width` for its balancing of links. I don't think we should be putting any max width type limitations though like `columns` does. (Mainly mentioning this as in the previous PR I originally used `min-width`, which was what led to back and forth conversation and alternatives being suggested.)
- Trello: https://trello.com/c/mK8f3WMQ/93-adjust-share-links

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

### Before
<img width="1274" alt="image" src="https://github.com/user-attachments/assets/fd162068-e5a2-49e0-9004-0a994cf0b6e5">

<img width="631" alt="image" src="https://github.com/user-attachments/assets/271b0665-87a3-48b9-ae70-7a46de298e31">


### After

<img width="1274" alt="image" src="https://github.com/user-attachments/assets/4a34af51-1925-4269-ae39-fe07d243dfbf">

<img width="631" alt="image" src="https://github.com/user-attachments/assets/bc6aed50-a8d2-4efe-80c6-e005e9a3b827">