### PR TITLE
Fix missing trailing quotes in chart component markup

### DIFF
--- a/app/views/govuk_publishing_components/components/_chart.html.erb
+++ b/app/views/govuk_publishing_components/components/_chart.html.erb
@@ -93,7 +93,7 @@
                 <tr class="govuk-table__row">
                   <td class="govuk-table__cell"></td>
                   <% keys.each do |key| %>
-                    <th class="govuk-table__header scope="col">
+                    <th class="govuk-table__header" scope="col">
                       <%= key %>
                     </th>
                   <% end %>
@@ -125,7 +125,7 @@
               <tbody class="govuk-table__body">
                 <% keys.each_with_index do |key, index| %>
                   <tr>
-                    <th class="govuk-table__header scope="row">
+                    <th class="govuk-table__header" scope="row">
                       <%= key %>
                     </th>
                     <% rows.each do |row| %>


### PR DESCRIPTION
## What
Fix incorrect markup in the chart component.

## Why
Has been causing a CI test failure.

## Visual Changes
None.
