### PR TITLE
Make it easier to find application level components in component guides

### DIFF
--- a/.github/workflows/visual-regression-tests.yml
+++ b/.github/workflows/visual-regression-tests.yml
@@ -53,3 +53,4 @@ jobs:
       - run: yarn run percy exec -- bundle exec rspec --tag visual_regression
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+          MAIN_COMPONENT_GUIDE: true

--- a/app/controllers/govuk_publishing_components/component_guide_controller.rb
+++ b/app/controllers/govuk_publishing_components/component_guide_controller.rb
@@ -9,7 +9,8 @@ module GovukPublishingComponents
       @component_gem_path = Gem.loaded_specs["govuk_publishing_components"].full_gem_path
       @component_docs = component_docs.all
       @gem_component_docs = gem_component_docs.all
-      @components_in_use_docs = components_in_use_docs.used_in_this_app
+      @used_components = used_components_names.get_component_docs
+      @unused_components = unused_components_names.get_component_docs
       @components_in_use_sass = components_in_use_sass
       @components_in_use_js = components_in_use_js
     end
@@ -47,7 +48,7 @@ module GovukPublishingComponents
       additional_files = "@import 'govuk_publishing_components/govuk_frontend_support';\n"
       additional_files << "@import 'govuk_publishing_components/component_support';\n"
 
-      components = find_all_partials_in(components_in_use)
+      components = find_all_partials_in(get_used_component_names)
 
       components.map { |component|
         "@import 'govuk_publishing_components/components/#{component.gsub('_', '-')}';" if component_has_sass_file(component.gsub("_", "-"))
@@ -57,7 +58,7 @@ module GovukPublishingComponents
     def components_in_use_js
       additional_files = "//= require govuk_publishing_components/lib\n"
 
-      components = find_all_partials_in(components_in_use)
+      components = find_all_partials_in(get_used_component_names)
 
       components.map { |component|
         "//= require govuk_publishing_components/components/#{component.gsub('_', '-')}" if component_has_js_file(component.gsub("_", "-"))
@@ -74,11 +75,15 @@ module GovukPublishingComponents
       @gem_component_docs ||= ComponentDocs.new(gem_components: true)
     end
 
-    def components_in_use_docs
-      @components_in_use_docs ||= ComponentDocs.new(gem_components: true, limit_to: components_in_use)
+    def used_components_names
+      @used_components_names ||= ComponentDocs.new(gem_components: true, limit_to: get_used_component_names)
     end
 
-    def components_in_use
+    def unused_components_names
+      @unused_components_names ||= ComponentDocs.new(gem_components: true, limit_to: get_unused_component_names)
+    end
+
+    def get_used_component_names
       matches = []
 
       files = Dir["#{@application_path}/app/views/**/*.erb"]
@@ -91,6 +96,11 @@ module GovukPublishingComponents
       end
 
       matches.flatten.uniq.map(&:to_s).sort
+    end
+
+    def get_unused_component_names
+      all_components = ComponentDocs.new(gem_components: true).all.map(&:id)
+      all_components - get_used_component_names
     end
 
     def find_all_partials_in(templates)

--- a/app/models/govuk_publishing_components/component_docs.rb
+++ b/app/models/govuk_publishing_components/component_docs.rb
@@ -12,11 +12,11 @@ module GovukPublishingComponents
     end
 
     def all
-      fetch_component_docs.map { |component| build(component) }.sort_by(&:name)
+      fetch_component_doc_files.map { |component| build(component) }.sort_by(&:name)
     end
 
-    def used_in_this_app
-      fetch_component_docs.map { |component| build(component) if component_in_use(component[:id]) }.compact.sort_by(&:name)
+    def get_component_docs
+      fetch_component_doc_files.map { |component| build(component) if component_in_use?(component[:id]) }.compact.sort_by(&:name)
     end
 
   private
@@ -25,13 +25,13 @@ module GovukPublishingComponents
       ComponentDoc.new(component)
     end
 
-    def fetch_component_docs
+    def fetch_component_doc_files
       doc_files = Rails.root.join(@documentation_directory, "*.yml")
       Dir[doc_files].sort.map { |file| parse_documentation(file) }
     end
 
-    def component_in_use(component)
-      true if @limit_to.include?(component)
+    def component_in_use?(component)
+      @limit_to.include?(component)
     end
 
     def fetch_component_doc(id)

--- a/app/views/govuk_publishing_components/component_guide/index.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/index.html.erb
@@ -15,7 +15,7 @@
   } %>
 </form>
 
-<% unless ENV["MAIN_COMPONENT_GUIDE"] %>
+<% if !ENV["MAIN_COMPONENT_GUIDE"] %>
   <h2 class="component-doc-h2">Components in this application (<%= @component_docs.length %>)</h2>
   <ul class="component-list" id="list-components-in-this-application">
     <% @component_docs.each do |component_doc| %>
@@ -28,7 +28,7 @@
     <% end %>
   </ul>
 
-  <h2 class="component-doc-h2">Gem components used by this app (<%= @components_in_use_docs.length %>)</h2>
+  <h2 class="component-doc-h2">Gem components used by this app (<%= @used_components.length %>)</h2>
 
   <%= render "govuk_publishing_components/components/details", {
     title: "Suggested imports for this application"
@@ -53,7 +53,7 @@
 </pre>
 
   <ul class="component-list">
-    <% @components_in_use_docs.each do |component_doc| %>
+    <% @used_components.each do |component_doc| %>
       <li>
         <%= link_to component_doc.name, component_doc_path(component_doc.id), class: "govuk-link" %>
         <p>
@@ -63,19 +63,30 @@
     <% end %>
   </ul>
 
-  <h2 class="component-doc-h2">All gem components (<%= @gem_component_docs.length %>)</h2>
-<% end %>
+  <h2 class="component-doc-h2">Gem components not used by this app (<%= @unused_components.length %>)</h2>
+  <ul class="component-list">
+    <% @unused_components.each do |component_doc| %>
+      <li>
+        <%= link_to component_doc.name, component_doc_path(component_doc.id), class: "govuk-link" %>
+        <p>
+          <%= component_doc.description %>
+        </p>
+      </li>
+    <% end %>
+  </ul>
 
-<ul class="component-list" id="list-all-components-in-the-gem">
-  <% @gem_component_docs.each do |component_doc| %>
-    <li>
-      <%= link_to component_doc.name, component_doc_path(component_doc.id), class: "govuk-link" %>
-      <p>
-        <%= component_doc.description %>
-      </p>
-    </li>
-  <% end %>
-</ul>
+<% else %>
+  <ul class="component-list" id="list-all-components-in-the-gem">
+    <% @gem_component_docs.each do |component_doc| %>
+      <li>
+        <%= link_to component_doc.name, component_doc_path(component_doc.id), class: "govuk-link" %>
+        <p>
+          <%= component_doc.description %>
+        </p>
+      </li>
+    <% end %>
+  </ul>
+<% end %>
 
 <div class="component-markdown">
   <p class="govuk-body">If you cannot find a suitable component consider extending an existing component or <a href="https://github.com/alphagov/govuk_publishing_components/blob/main/docs/generate-a-new-component.md">creating a new one</a>.</p>

--- a/app/views/govuk_publishing_components/component_guide/index.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/index.html.erb
@@ -16,6 +16,18 @@
 </form>
 
 <% unless ENV["MAIN_COMPONENT_GUIDE"] %>
+  <h2 class="component-doc-h2">Components in this application (<%= @component_docs.length %>)</h2>
+  <ul class="component-list" id="list-components-in-this-application">
+    <% @component_docs.each do |component_doc| %>
+      <li>
+        <%= link_to component_doc.name, component_doc_path(component_doc.id), class: "govuk-link" %>
+        <p>
+          <%= component_doc.description %>
+        </p>
+      </li>
+    <% end %>
+  </ul>
+
   <h2 class="component-doc-h2">Gem components used by this app (<%= @components_in_use_docs.length %>)</h2>
 
   <%= render "govuk_publishing_components/components/details", {
@@ -42,20 +54,6 @@
 
   <ul class="component-list">
     <% @components_in_use_docs.each do |component_doc| %>
-      <li>
-        <%= link_to component_doc.name, component_doc_path(component_doc.id), class: "govuk-link" %>
-        <p>
-          <%= component_doc.description %>
-        </p>
-      </li>
-    <% end %>
-  </ul>
-<% end %>
-
-<% unless ENV["MAIN_COMPONENT_GUIDE"] %>
-  <h2 class="component-doc-h2">Components in this application (<%= @component_docs.length %>)</h2>
-  <ul class="component-list" id="list-components-in-this-application">
-    <% @component_docs.each do |component_doc| %>
       <li>
         <%= link_to component_doc.name, component_doc_path(component_doc.id), class: "govuk-link" %>
         <p>


### PR DESCRIPTION
## What

Reorganise the list of components in the application component guides so that:
- App level components are presented first
- Instead of listing All gem component in an app component guide, list gem components NOT used by the app, to potentially help users identify gem components that could be utilised by the app

## Why
Application level components are always the fewest in number in each application. They are not easily visible when looking through the list of components, even though we are most likely interested in checking the documentation for the application level components. Listing “All gem components” in a component app guide can make it difficult to identify gem components available to this application that have not already been used, so instead list "Gem components not used by this app".

## Visual Changes

### Before in collections component guide

<img width="246" alt="Screenshot 2024-10-29 at 14 53 30" src="https://github.com/user-attachments/assets/e8735977-8b57-4c92-8f1d-45448b095042">


### After in collections component guide

<img width="269" alt="Screenshot 2024-10-29 at 14 52 29" src="https://github.com/user-attachments/assets/ed95c174-f2b6-4cc2-93fa-1e8a72cea827">


### Before in gem component guide 
<img width="500" alt="Screenshot 2024-10-29 at 14 54 30" src="https://github.com/user-attachments/assets/3d2bdb55-1ac4-4663-a4ff-9865e44f6759">


### After in gem component guide (No change)
<img width="500" alt="Screenshot 2024-10-29 at 14 54 55" src="https://github.com/user-attachments/assets/8a1c4e86-aafe-4801-9eb4-a4158a406eeb">

## To view examples

- [Gem component guide](https://components-gem-pr-4326.herokuapp.com/component-guide)
- To view an app component guide such as the collections component guide, pull down this gem branch and link to it from collections Gemfile (`gem "govuk_publishing_components", path: "../govuk_publishing_components"`). Navigate to`/component-guide/` in the frontend app eg. collections.

https://trello.com/c/twxnT667/2950-update-component-guide-in-applications
