### PR TITLE
Version 44.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 44.5.0
 
 * Add component wrapper to error alert component ([PR #4287](https://github.com/alphagov/govuk_publishing_components/pull/4287))
 * Add new chart component options ([PR #4318](https://github.com/alphagov/govuk_publishing_components/pull/4318))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (44.4.2)
+    govuk_publishing_components (44.5.0)
       chartkick
       govuk_app_config
       govuk_personalisation (>= 0.7.0)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "44.4.2".freeze
+  VERSION = "44.5.0".freeze
 end


### PR DESCRIPTION
## 44.5.0

* Add component wrapper to error alert component ([PR #4287](https://github.com/alphagov/govuk_publishing_components/pull/4287))
* Add new chart component options ([PR #4318](https://github.com/alphagov/govuk_publishing_components/pull/4318))
* Add shared helper and component wrapper helper to govspeak component ([PR #4325](https://github.com/alphagov/govuk_publishing_components/pull/4325))
* Add component wrapper to emergency banner component ([PR #4283](https://github.com/alphagov/govuk_publishing_components/pull/4283))
