### PR TITLE
Set default font for component guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Fix incorrect underline styles on share links ([PR #4337](https://github.com/alphagov/govuk_publishing_components/pull/4337))
+* Set default font for component guide ([PR #4330](https://github.com/alphagov/govuk_publishing_components/pull/4330))
 
 ## 44.7.0
 

--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -240,6 +240,7 @@ $gem-guide-border-width: 1px;
 // Preview Page Styling
 html {
   background: govuk-colour("white");
+  font-family: $govuk-font-family;
 }
 
 .hide-header-and-footer {


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

Some components do not set their default font, so they do not look right when presented in the component guide, as the component guide does not set the font either. This change fixes this problem by setting the default GDS Transport font for the components guide. By setting it, how the components look in the guide should better reflect how they look in pages, as pages also set the same default font.

This change is only related to component guides and how components look there.

## Why

This change was is a way to fix the issues described in this [Trello card](https://trello.com/c/PwSKwCN5/2949-the-government-frontend-component-guide-app-examples-dont-have-a-font-set)

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

### Before

Inverse header preview page:

![Screenshot 2024-10-23 at 12-29-51 Inverse header With paragraph and link preview - Component Guide](https://github.com/user-attachments/assets/f9cf3823-1e83-4db9-acf1-e7f8f56ba1dc)


In government-frontend's component guide:

![Screenshot 2024-10-23 at 11-58-15 Important metadata component - Government Frontend Component Guide](https://github.com/user-attachments/assets/a4ad3791-d2eb-41ff-be54-4b38a7a80169)


### After

Inverse header preview page:

![Screenshot 2024-10-23 at 12-30-04 Inverse header With paragraph and link preview - Component Guide](https://github.com/user-attachments/assets/22e272c6-1e38-4eb5-812c-45fb555bae82)


In government-frontend's component guide:

![Screenshot 2024-10-23 at 11-58-49 Important metadata component - Government Frontend Component Guide](https://github.com/user-attachments/assets/ba171dd7-ec9d-4398-9fd5-d31415a10148)
