### PR TITLE
Fix incorrect underline styles on share links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix incorrect underline styles on share links ([PR #4337](https://github.com/alphagov/govuk_publishing_components/pull/4337))
+
 ## 44.7.0
 
 * Contents list add margin_bottom option ([PR #4333](https://github.com/alphagov/govuk_publishing_components/pull/4333))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_share-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_share-links.scss
@@ -104,11 +104,25 @@ $column-width: 9.5em;
   }
 
   .gem-c-share-links__label {
+    display: inline-block;
     vertical-align: middle;
   }
 
   .gem-c-share-links__link {
     display: inline-block;
+  }
+
+  .gem-c-share-links__link:hover {
+    .gem-c-share-links__label {
+      text-decoration: underline;
+      text-decoration-thickness: 3px;
+    }
+  }
+
+  .gem-c-share-links__link:focus:hover {
+    .gem-c-share-links__label {
+      text-decoration: none;
+    }
   }
 }
 


### PR DESCRIPTION
## What / Why
<!-- What are the reasons behind this change being made? -->
- There's a hover underline visual issue when using the `flexbox` variant. 
- Looks like it was due to main label being a span (meaning it had `display: inline`).
- Switching to `inline-block` seems to have fixed it. This removed the default underline styles, so I reintroduced them via the CSS, which looks better anyway as there's now spacing between the line and the word.
- Not sure what's going on with the Percy visual change.

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

### Before
<img width="159" alt="image" src="https://github.com/user-attachments/assets/9da3fabb-64bf-4613-a5e3-786b7c9d644e">

<img width="198" alt="image" src="https://github.com/user-attachments/assets/f138c024-13ad-446a-9534-debbc3742ca8">


### After
<img width="198" alt="image" src="https://github.com/user-attachments/assets/1c0db5fc-14c7-4f38-bdef-ea6f424f69f3">

<img width="198" alt="image" src="https://github.com/user-attachments/assets/4b7c2904-e7ce-497d-83e9-3c0dea1ec452">
