### PR TITLE
Layout super nav header: Correct URL for search form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Layout super nav header: Correct URL for search form ([PR #4341](https://github.com/alphagov/govuk_publishing_components/pull/4341))
+
 ## 44.8.0
 
 * Adjust chart component options ([PR #4342](https://github.com/alphagov/govuk_publishing_components/pull/4342))

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -299,29 +299,30 @@
           </h3>
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
-              <%
-                form_attributes = {
-                  event_name: "search",
-                  type: "header menu bar",
-                  section: "Search GOV.UK",
-                  action: "search",
-                  url: "/search/all",
-                  index_section: 3,
-                  index_section_count: 3,
-                }.to_json
-              %>
-              <form
-                class="gem-c-layout-super-navigation-header__search-form"
-                id="search"
-                data-module="ga4-form-tracker"
-                data-ga4-form="<%= form_attributes %>"
-                data-ga4-form-include-text
-                data-ga4-form-no-answer-undefined
-                action="<%= absolute_links_helper.make_url_absolute('/search') %>"
-                method="get"
-                role="search"
-                aria-label="Site-wide"
-              >
+              <%= tag.form(
+                class: "gem-c-layout-super-navigation-header__search-form",
+                id: "search",
+                data: {
+                  module: "ga4-form-tracker",
+                  ga4_form: {
+                    event_name: "search",
+                    type: "header menu bar",
+                    section: "Search GOV.UK",
+                    action: "search",
+                    url: "/search/all",
+                    index_section: 3,
+                    index_section_count: 3,
+                  },
+                  ga4_form_include_text: "",
+                  ga4_form_no_answer_undefined: "",
+                },
+                action: absolute_links_helper.make_url_absolute("/search/all"),
+                method: "get",
+                role: "search",
+                aria: {
+                  label: "Site-wide",
+                }
+              ) do %>
                 <%= render "govuk_publishing_components/components/search", {
                   inline_label: false,
                   label_size: "m",
@@ -331,7 +332,7 @@
                   margin_bottom: 0,
                   disable_corrections: true,
                 } %>
-              </form>
+              <% end %>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## What
- Point form at `/search/all` instead of `/search` to avoid most users going through an unnecessary 301 redirect
- Use Rails's tag helper for more concise form code (in particular data attributes)

## Why
Users currently get taken through an additional, unnecessary redirection when performing a search through the layout super nav's search form, as this points to the `/search` landing page instead of the actual site search page at `/search/all`. The former will just redirect to the latter if keywords are given:
<img width="885" alt="image" src="https://github.com/user-attachments/assets/7e6b6203-0228-4c5f-a96a-be0508067708">

While I was already here, using Rails's tag helper for the form tag means we have more concise and readable data attributes and don't have to manually convert to JSON.