### PR TITLE
Version 44.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## 44.7.1
+## 44.8.0
 
 * Adjust chart component options ([PR #4342](https://github.com/alphagov/govuk_publishing_components/pull/4342))
+
+## 44.7.1
+
 * Fix incorrect underline styles on share links ([PR #4337](https://github.com/alphagov/govuk_publishing_components/pull/4337))
 * Set default font for component guide ([PR #4330](https://github.com/alphagov/govuk_publishing_components/pull/4330))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (44.7.1)
+    govuk_publishing_components (44.8.0)
       chartkick
       govuk_app_config
       govuk_personalisation (>= 0.7.0)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "44.7.1".freeze
+  VERSION = "44.8.0".freeze
 end


### PR DESCRIPTION
## 44.8.0

* Adjust chart component options ([PR #4342](https://github.com/alphagov/govuk_publishing_components/pull/4342))

Needed to make https://github.com/alphagov/frontend/pull/4341 work.

Also fixes the CHANGELOG entry that I did wrong in https://github.com/alphagov/govuk_publishing_components/pull/4342