### PR TITLE
Chart component accessibility improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Chart component accessibility improvements ([PR #4344](https://github.com/alphagov/govuk_publishing_components/pull/4344))
+
 ## 44.9.1
 
 * Layout super nav header: Correct name for search input ([PR #4347](https://github.com/alphagov/govuk_publishing_components/pull/4347))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_chart.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_chart.scss
@@ -47,3 +47,18 @@
     padding: 0 govuk-spacing(4);
   }
 }
+
+.gem-c-chart .gem-c-chart__a11y-note-link {
+  display: none;
+  margin-bottom: govuk-spacing(2);
+}
+
+.js-enabled {
+  .gem-c-chart .gem-c-chart__a11y-note-link {
+    display: inline;
+  }
+
+  .gem-c-chart .gem-c-chart__a11y-note-link:focus-within {
+    display: inline-block;
+  }
+}

--- a/app/views/govuk_publishing_components/components/_chart.html.erb
+++ b/app/views/govuk_publishing_components/components/_chart.html.erb
@@ -3,6 +3,7 @@
   add_gem_component_stylesheet("table")
   add_gem_component_stylesheet("details")
   add_gem_component_stylesheet("heading")
+  add_gem_component_stylesheet("skip-link")
 
   chart_heading ||= nil
   chart_heading_level ||= 2
@@ -97,8 +98,14 @@
       <% unless minimal %>
         <div class="govuk-visually-hidden">
           <%= content_tag :div, chart_overview, class: "gem-c-chart__a11y-note-1" if chart_overview %>
-          <%= content_tag :div, t("components.chart.accessibility_html", table_id: table_id), class: "gem-c-chart__a11y-note-2" %>
+          <%= content_tag :div, t("components.chart.accessibility_html"), class: "gem-c-chart__a11y-note-2" %>
         </div>
+        <span class="gem-c-chart__a11y-note-link">
+          <%= render "govuk_publishing_components/components/skip_link", {
+            text: t("components.chart.accessibility_link", chart_heading: chart_heading),
+            href: "##{table_id}"
+          } %>
+        </span>
       <% end %>
 
       <%= line_chart(chart_format_data, library: chart_library_options) %>

--- a/app/views/govuk_publishing_components/components/_chart.html.erb
+++ b/app/views/govuk_publishing_components/components/_chart.html.erb
@@ -119,6 +119,9 @@
           ) do %>
             <div tabindex="0" class="gem-c-chart__table-wrapper">
               <table class="govuk-table">
+                <caption class="govuk-visually-hidden" id="<%= "data-table-caption-#{SecureRandom.hex(4)}" %>">
+                  <%= t("components.chart.accessibility_heading", chart_heading: chart_heading) %>
+                </caption>
                 <% if table_direction == "horizontal" %>
                   <thead class="govuk-table__head">
                     <tr class="govuk-table__row">

--- a/app/views/govuk_publishing_components/components/_chart.html.erb
+++ b/app/views/govuk_publishing_components/components/_chart.html.erb
@@ -45,6 +45,10 @@
   textPosition = nil
   textPosition = 'none' if minimal
 
+  if !minimal && !chart_heading
+    raise ArgumentError, "A chart heading must be provided for accessibility purposes."
+  end
+
   chart_library_options = {
     chartArea: { width: '80%', height: '60%' },
     crosshair: { orientation: 'vertical', trigger: 'both', color: '#ccc' },

--- a/app/views/govuk_publishing_components/components/docs/chart.yml
+++ b/app/views/govuk_publishing_components/components/docs/chart.yml
@@ -11,6 +11,7 @@ accessibility_criteria: |
   Charts must:
 
     - use line colours with a contrast ratio higher than 4.5:1 against the background colour to meet WCAG AA
+    - contain a `chart_heading` option if `minimal` is not set to true, so that skip links and visually hidden headings are accurate
 shared_accessibility_criteria:
   - link
 uses_component_wrapper_helper: true

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -37,7 +37,9 @@ ar:
         characters: أحرف
         words: كلمات
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -33,7 +33,9 @@ az:
         characters: simvol
         words: söz
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -35,7 +35,9 @@ be:
         characters: знакаў
         words: словаў
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -33,7 +33,9 @@ bg:
         characters: символа
         words: думи
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -33,7 +33,9 @@ bn:
         characters: ক্যারেক্টার
         words: শব্দসমষ্টি
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -34,7 +34,9 @@ cs:
         characters: znaky
         words: slova
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -37,7 +37,9 @@ cy:
         characters: nodau
         words: geiriau
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -33,7 +33,9 @@ da:
         characters: Tegn
         words: ord
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -33,7 +33,9 @@ de:
         characters: Zeichen
         words: Wörter
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -36,7 +36,9 @@ dr:
         characters: ارقام
         words: کلمات
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -33,7 +33,9 @@ el:
         characters: χαρακτήρες
         words: λέξεις
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,7 @@ en:
       table_dropdown: Data table
       accessibility_html: This chart is a visual representation of the data available in the table.
       accessibility_link: Skip to "%{chart_heading}" data table
+      accessibility_heading: Data table for "%{chart_heading}"
     chat_entry:
       heading: Try GOV.UK Chat
       description: Sign up to GOV.UK’s experimental new AI tool and find answers to your business questions

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,7 +34,8 @@ en:
         words: words
     chart:
       table_dropdown: Data table
-      accessibility_html: This chart is a visual representation of the data available in the <a href='#%{table_id}'>table</a>.
+      accessibility_html: This chart is a visual representation of the data available in the table.
+      accessibility_link: Skip to "%{chart_heading}" data table
     chat_entry:
       heading: Try GOV.UK Chat
       description: Sign up to GOV.UK’s experimental new AI tool and find answers to your business questions

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -33,7 +33,9 @@ es-419:
         characters: caracteres
         words: palabras
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -33,7 +33,9 @@ es:
         characters: caracteres
         words: palabras
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -33,7 +33,9 @@ et:
         characters: tähemärki
         words: sõnu
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -33,7 +33,9 @@ fa:
         characters: کاراکتر
         words: کلمه
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -33,7 +33,9 @@ fi:
         characters: merkkejä
         words: sanoja
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -33,7 +33,9 @@ fr:
         characters: caractères
         words: mots
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -35,7 +35,9 @@ gd:
         characters: Figiúr
         words: Carachtar
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -33,7 +33,9 @@ gu:
         characters: અક્ષરો
         words: શબ્દો
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -33,7 +33,9 @@ he:
         characters: תווים
         words: מילים
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -33,7 +33,9 @@ hi:
         characters: अक्षर
         words: शब्द
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -34,7 +34,9 @@ hr:
         characters: znakova
         words: riječi
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -33,7 +33,9 @@ hu:
         characters: karakterek
         words: szavak
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -35,7 +35,9 @@ hy:
         characters: նիշ
         words: բառ
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -32,7 +32,9 @@ id:
         characters: karakter
         words: kata
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -33,7 +33,9 @@ is:
         characters: stafi
         words: orð
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -33,7 +33,9 @@ it:
         characters: caratteri
         words: parole
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -32,7 +32,9 @@ ja:
         characters: 文字
         words: 単語
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -33,7 +33,9 @@ ka:
         characters: სიმბოლოები
         words: სიტყვები
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -33,7 +33,9 @@ kk:
         characters: таңба
         words: сөз
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -32,7 +32,9 @@ ko:
         characters:
         words:
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -34,7 +34,9 @@ lt:
         characters: spaudos ženklų
         words: žodžių
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -33,7 +33,9 @@ lv:
         characters: rakstzīmes
         words: vārdi
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -32,7 +32,9 @@ ms:
         characters: aksara
         words: perkataan
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -35,7 +35,9 @@ mt:
         characters: karattri
         words: kliem
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -33,7 +33,9 @@ nl:
         characters: karakters
         words: woorden
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -33,7 +33,9 @@
         characters: tegn
         words: ord
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -33,7 +33,9 @@ pa-pk:
         characters: کردار
         words: الفاظ
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -33,7 +33,9 @@ pa:
         characters: ਅੱਖਰ
         words: ਸ਼ਬਦ
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -35,7 +35,9 @@ pl:
         characters: znaków
         words: słów
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -33,7 +33,9 @@ ps:
         characters: کرکټرونه
         words: ټکي
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -33,7 +33,9 @@ pt:
         characters: carateres
         words: palavras
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -34,7 +34,9 @@ ro:
         characters: caractere
         words: cuvinte
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -35,7 +35,9 @@ ru:
         characters: символов
         words: слов
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -33,7 +33,9 @@ si:
         characters: අක්ෂර
         words: වචන
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -34,7 +34,9 @@ sk:
         characters: znakov
         words: slov
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -37,7 +37,9 @@ sl:
         characters: znaki
         words: besede
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -33,7 +33,9 @@ so:
         characters: dabeecadaha
         words: kalmadaha
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -33,7 +33,9 @@ sq:
         characters: karaktere
         words: fjalë
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -34,7 +34,9 @@ sr:
         characters: znakova
         words: reči
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -33,7 +33,9 @@ sv:
         characters: tecken
         words: ord
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -33,7 +33,9 @@ sw:
         characters: herufi
         words: maneno
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -33,7 +33,9 @@ ta:
         characters: எழுத்துருக்கள்
         words: சொற்கள்
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -32,7 +32,9 @@ th:
         characters: ตัวอักษร
         words: คำ
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -33,7 +33,9 @@ tk:
         characters: şekiller
         words: sözler
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -33,7 +33,9 @@ tr:
         characters: karakter
         words: kelime
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -35,7 +35,9 @@ uk:
         characters: символів
         words: слів
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -33,7 +33,9 @@ ur:
         characters: حروف
         words: الفاظ
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -33,7 +33,9 @@ uz:
         characters: белгилар
         words: сўзлар
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -32,7 +32,9 @@ vi:
         characters: ký tự
         words: từ
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -32,7 +32,9 @@ zh-hk:
         characters: 字元
         words: 字彙
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -32,7 +32,9 @@ zh-tw:
         characters: 字元
         words: 字
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -32,7 +32,9 @@ zh:
         characters: 字符
         words: 单词
     chart:
+      accessibility_heading:
       accessibility_html:
+      accessibility_link:
       table_dropdown:
     chat_entry:
       description:

--- a/spec/components/chart_spec.rb
+++ b/spec/components/chart_spec.rb
@@ -9,8 +9,7 @@ describe "Chart", type: :view do
 
   let(:data) do
     {
-      chart_label: "Page views chart",
-      table_label: "Page views table",
+      chart_heading: "Page views chart",
       keys: (Date.new(2017, 12, 1)..Date.new(2017, 12, 12)).to_a,
       rows: [
         {
@@ -26,7 +25,7 @@ describe "Chart", type: :view do
   end
 
   it "does not render when no data is given" do
-    assert_empty render_component({})
+    assert_empty render_component({ chart_heading: "" })
   end
 
   it "does not render if keys are missing" do
@@ -89,7 +88,6 @@ describe "Chart", type: :view do
   it "can include an overview" do
     overview = "This chart shows a gradual decline in the numbers of hedgehogs using social media since 2008."
     data[:chart_overview] = overview
-    data[:chart_heading] = "Page views chart"
     render_component(data)
     assert_select ".gem-c-chart__a11y-note-1", text: overview
     assert_select ".gem-c-chart__a11y-note-2", text: "This chart is a visual representation of the data available in the table."
@@ -140,5 +138,20 @@ describe "Chart", type: :view do
     render_component(data)
 
     assert_select ".gem-c-chart.gem-c-chart--padding"
+  end
+
+  it "throws an error if a heading is not supplied" do
+    data[:chart_heading] = nil
+    expect {
+      render_component(data)
+    }.to raise_error("A chart heading must be provided for accessibility purposes.")
+  end
+
+  it "does not throw an error if a heading is not supplied in minimal mode" do
+    data[:chart_heading] = nil
+    data[:minimal] = true
+    expect {
+      render_component(data)
+    }.not_to raise_error("A chart heading must be provided for accessibility purposes.")
   end
 end

--- a/spec/components/chart_spec.rb
+++ b/spec/components/chart_spec.rb
@@ -96,6 +96,11 @@ describe "Chart", type: :view do
     assert_select ".gem-c-chart__a11y-note-link a[href='#table-id-1234']", text: "Skip to \"Page views chart\" data table"
   end
 
+  it "includes an accessible caption for data tables" do
+    render_component(data)
+    assert_select "#data-table-caption-1234", text: "Data table for \"Page views chart\""
+  end
+
   it "can include a download link" do
     data[:link] = "https://www.gov.uk"
     render_component(data)

--- a/spec/components/chart_spec.rb
+++ b/spec/components/chart_spec.rb
@@ -5,6 +5,8 @@ describe "Chart", type: :view do
     "chart"
   end
 
+  before { allow(SecureRandom).to receive(:hex).and_return("1234") }
+
   let(:data) do
     {
       chart_label: "Page views chart",
@@ -87,9 +89,11 @@ describe "Chart", type: :view do
   it "can include an overview" do
     overview = "This chart shows a gradual decline in the numbers of hedgehogs using social media since 2008."
     data[:chart_overview] = overview
+    data[:chart_heading] = "Page views chart"
     render_component(data)
     assert_select ".gem-c-chart__a11y-note-1", text: overview
     assert_select ".gem-c-chart__a11y-note-2", text: "This chart is a visual representation of the data available in the table."
+    assert_select ".gem-c-chart__a11y-note-link a[href='#table-id-1234']", text: "Skip to \"Page views chart\" data table"
   end
 
   it "can include a download link" do


### PR DESCRIPTION
## What / Why
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- In the chart component, there is a "Skip to table" link that was visually hidden, but still focusable. This caused an accessibility issue as the link was focusable but had no focus styles. Therefore, I have used the [existing skip link component](https://components.publishing.service.gov.uk/component-guide/skip_link) in order to ensure the link has styles when focused on.
    - I had to add a couple custom styles to the parent element of the component, so that the skip link didn't appear when JavaScript was disabled, as it isn't needed when JS is disabled.
    - I also moved the link out of the `<div>` it was originally in, as that `<div>` uses `govuk-visually-hidden`, which clashes with how the skip link component works.
- Additionally, the data tables also did not have a caption, which was a separate accessibility issue. Therefore I have added a visually hidden caption to the data tables.
- Both of these accessibility improvements rely on a `chart_heading` existing. Therefore I have added some validation to ensure `chart_heading` text is passed through, unless the chart is in `minimal` mode.
- Fixes these two trello cards: [Chart focus not visible](https://trello.com/c/Nz6SSyIc) and [Chart tables without caption or heading](https://trello.com/c/ybFOZLr7)
- I've had the accessibility fixes checked by our accessibility specialist.

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

### This skip link now appears when focused

<img width="973" alt="image" src="https://github.com/user-attachments/assets/761c3cac-e506-4768-bc44-1d897620d17a">

