### PR TITLE
Layout super nav header: Correct name for search input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Layout super nav header: Correct name for search input ([PR #4347](https://github.com/alphagov/govuk_publishing_components/pull/4347))
+
 ## 44.9.0
 
 * Layout super nav header: Correct URL for search form ([PR #4341](https://github.com/alphagov/govuk_publishing_components/pull/4341))

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -324,6 +324,7 @@
                 }
               ) do %>
                 <%= render "govuk_publishing_components/components/search", {
+                  name: "keywords",
                   inline_label: false,
                   label_size: "m",
                   label_text: search_text,


### PR DESCRIPTION
## What
Sets an explicit field name (`keywords`) for the search input on the layout super navigation header, as this is coming through into Finder Frontend as the default name of `q`.

## Why
Finder Frontend implicitly converts this param so it's not actually causing problems for users, but it's causing issues with our analytics tracking.