### PR TITLE
Add component wrapper to feedback component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add component wrapper helper to radio component ([PR #4366](https://github.com/alphagov/govuk_publishing_components/pull/4366))
+* Add component wrapper to feedback component ([PR #4351](https://github.com/alphagov/govuk_publishing_components/pull/4351))
 
 ## 45.1.0
 

--- a/app/views/govuk_publishing_components/components/_feedback.html.erb
+++ b/app/views/govuk_publishing_components/components/_feedback.html.erb
@@ -11,12 +11,15 @@
   path_without_pii = utf_encode(request.fullpath.gsub(email_regex, '[email]'))
 
   disable_ga4 ||= false
-  data_module = "feedback"
-  data_module << " ga4-event-tracker" unless disable_ga4
+
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("gem-c-feedback govuk-!-display-none-print")
+  component_helper.add_data_attribute({ module: "feedback" })
+  component_helper.add_data_attribute({ module: "ga4-event-tracker" }) unless disable_ga4
 %>
 
-<div class="gem-c-feedback govuk-!-display-none-print" data-module="<%= data_module %>">
+<%= tag.div(**component_helper.all_attributes) do %>
   <%= render "govuk_publishing_components/components/feedback/yes_no_banner", disable_ga4: %>
   <%= render "govuk_publishing_components/components/feedback/problem_form", url_without_pii: url_without_pii, disable_ga4: %>
   <%= render "govuk_publishing_components/components/feedback/survey_signup_form", path_without_pii: path_without_pii, disable_ga4: %>
-</div>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/feedback.yml
+++ b/app/views/govuk_publishing_components/components/docs/feedback.yml
@@ -4,6 +4,7 @@ body: |
   This component is designed to sit at the bottom of pages on GOV.UK to allow users to submit feedback on that page.
 
   This component uses JavaScript for expanding and collapsing and also for submitting form responses. This code is not compatible with Internet Explorer, so IE11 and down do not use JavaScript to submit the forms, instead falling back to a normal form submission.
+uses_component_wrapper_helper: true
 accessibility_criteria: |
   The form must:
 


### PR DESCRIPTION
## What
- Adds the component wrapper helper to the `feedback` component.
- Sidenote: I noticed some IE11 references while working on this component, so I've logged that here: https://github.com/alphagov/govuk_publishing_components/issues/4350

## Why
As the [trello card](https://trello.com/c/qH4NyWJw/364-add-component-wrapper-to-more-components) states:

> Standardising our components to use the component wrapper helper will reduce code, increase standardisation, and improve future feature implementation speed.

## Visual changes

None.