### PR TITLE
[WIP] **BREAKING** Add component wrapper to character count component

### DIFF
--- a/app/views/govuk_publishing_components/components/_character_count.html.erb
+++ b/app/views/govuk_publishing_components/components/_character_count.html.erb
@@ -4,17 +4,19 @@
   maxwords ||= nil
   threshold ||= nil
   textarea ||= {}
-%>
-<% if maxlength || maxwords %>
-  <%= content_tag :div,
-    class: "gem-c-character-count govuk-character-count",
-    data: {
+
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("gem-c-character-count govuk-character-count")
+  component_helper.add_data_attribute({
       module: "govuk-character-count",
       maxlength: maxlength,
       maxwords: maxwords,
       threshold: threshold
-    } do %>
+    })
 
+%>
+<% if maxlength || maxwords %>
+  <%= tag.div(**component_helper.all_attributes) do %>
     <%= render "govuk_publishing_components/components/textarea", { id: id, character_count: true }.merge(textarea.symbolize_keys) %>
 
     <div id="<%= id %>-info" class="govuk-hint govuk-character-count__message">

--- a/app/views/govuk_publishing_components/components/docs/character_count.yml
+++ b/app/views/govuk_publishing_components/components/docs/character_count.yml
@@ -2,6 +2,7 @@ name: Form character count
 description: Help users enter text when there is a limit on the number of characters they can type
 govuk_frontend_components:
   - character-count
+uses_component_wrapper_helper: true
 accessibility_criteria: |
   The component must:
 


### PR DESCRIPTION
## What
- Adds the component wrapper helper to the `Form character count` component.

## Why
As the [trello card](https://trello.com/c/qH4NyWJw/364-add-component-wrapper-to-more-components) states:

> Standardising our components to use the component wrapper helper will reduce code, increase standardisation, and improve future feature implementation speed.

## Visual changes

None.