### PR TITLE
Version 44.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 44.11.0
 
 * Extend chart component to allow headings to be removed from the DOM ([PR #4362](https://github.com/alphagov/govuk_publishing_components/pull/4362))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (44.10.0)
+    govuk_publishing_components (44.11.0)
       chartkick
       govuk_app_config
       govuk_personalisation (>= 0.7.0)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "44.10.0".freeze
+  VERSION = "44.11.0".freeze
 end


### PR DESCRIPTION
## 44.11.0

* Extend chart component to allow headings to be removed from the DOM ([PR #4362](https://github.com/alphagov/govuk_publishing_components/pull/4362))