### PR TITLE
Add component wrapper helper to label component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add the component wrapper to the lead paragraph component ([PR #4434](https://github.com/alphagov/govuk_publishing_components/pull/4434))
+* Add component wrapper helper to label component ([PR #4364](https://github.com/alphagov/govuk_publishing_components/pull/4364))
 
 ## 45.7.0
 

--- a/app/views/govuk_publishing_components/components/_label.html.erb
+++ b/app/views/govuk_publishing_components/components/_label.html.erb
@@ -4,25 +4,26 @@
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
 
   hint_text ||= ""
-  id ||= nil
   is_radio_label ||= false
   bold ||= false
   heading_size = false unless shared_helper.valid_heading_size?(heading_size)
   is_page_heading ||= false
   right_to_left ||= false
 
-  css_classes = %w[gem-c-label govuk-label]
-  css_classes << "govuk-label--s" if bold
-  css_classes << "govuk-radios__label" if is_radio_label
-  css_classes << "govuk-label--#{heading_size}" if heading_size
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("gem-c-label govuk-label")
+  component_helper.add_class("govuk-label--s") if bold
+  component_helper.add_class("govuk-radios__label") if is_radio_label
+  component_helper.add_class("govuk-label--#{heading_size}") if heading_size
+  component_helper.set_dir("rtl") if right_to_left
 %>
 
 <% if is_page_heading %>
   <%= tag.h1 text, class: "govuk-label-wrapper" do %>
-    <%= tag.label text, id: id, for: html_for, class: css_classes, dir: right_to_left ? "rtl" : nil %>
+    <%= tag.label text, for: html_for, **component_helper.all_attributes %>
   <% end %>
 <% else %>
-  <%= tag.label text, id: id, for: html_for, class: css_classes, dir: right_to_left ? "rtl" : nil %>
+  <%= tag.label text, for: html_for, **component_helper.all_attributes %>
 <% end %>
 
 <% if hint_text.present? %>

--- a/app/views/govuk_publishing_components/components/docs/label.yml
+++ b/app/views/govuk_publishing_components/components/docs/label.yml
@@ -2,6 +2,7 @@ name: Form label
 description: Use labels for all form fields.
 body: |
   For use with other form inputs e.g. [Radio buttons](/component-guide/radio)
+uses_component_wrapper_helper: true
 accessibility_criteria: |
   All text must have a contrast ratio higher than 4.5:1 against the background colour to meet [WCAG AA](https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast)
 


### PR DESCRIPTION
## What
- Adds the component wrapper helper to the `form label` component.

## Why
As the [trello card](https://trello.com/c/qH4NyWJw/364-add-component-wrapper-to-more-components) states:

> Standardising our components to use the component wrapper helper will reduce code, increase standardisation, and improve future feature implementation speed.

## Visual changes

None.