### PR TITLE
Improve metadata component to support RTL print styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Use component wrapper on contextual sidebar ([PR #4561](https://github.com/alphagov/govuk_publishing_components/pull/4561))
 * Correctly translate 'Published' word to Arabic ([PR #4563](https://github.com/alphagov/govuk_publishing_components/pull/4563))
 * Style breadcrumbs in RTL (right-to-left) writing mode ([PR #4559](https://github.com/alphagov/govuk_publishing_components/pull/4559))
+* Improve metadata component to support RTL print styles ([PR #4365](https://github.com/alphagov/govuk_publishing_components/pull/4365))
 
 ## 49.0.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_metadata.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_metadata.scss
@@ -17,6 +17,7 @@
   }
 }
 
+.direction-rtl .gem-c-metadata,
 .gem-c-metadata.direction-rtl {
   direction: rtl;
   text-align: start;
@@ -63,9 +64,10 @@
   }
 }
 
+.direction-rtl .gem-c-metadata .gem-c-metadata__term,
 .gem-c-metadata.direction-rtl .gem-c-metadata__term {
-  float: right;
-  clear: right;
+  float: inline-start;
+  clear: inline-start;
 
   @include govuk-media-query($from: tablet) {
     padding-left: govuk-spacing(1);
@@ -83,8 +85,9 @@
   }
 }
 
+.direction-rtl .gem-c-metadata .gem-c-metadata__definition,
 .gem-c-metadata.direction-rtl .gem-c-metadata__definition {
-  float: right;
+  float: inline-start;
 }
 
 .gem-c-metadata__toggle-wrap {


### PR DESCRIPTION
## What
Improvements to the metadata component to improve RTL print styles.

This is part of the work to improve print styles more generally. [Trello](https://trello.com/c/6E5UoTiK/335-rtl-print-styles-have-been-considered-and-implemented-where-required)

_Note: This is a dependency of https://github.com/alphagov/government-frontend/pull/3404_

## Why
Some pages are broken for foreign languages that read right to left, with styles not set correctly for the changed direction.

## Visual Changes

| Before    | After |
| -------- | ------- |
| ![image](https://github.com/user-attachments/assets/8972f8bf-b926-448c-a79a-6600ef7f9865)  |![image](https://github.com/user-attachments/assets/6b91ba5f-2812-4cbb-a5a2-c061c75d1c50)  |
