### PR TITLE
Add component wrapper helper to radio component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add component wrapper helper to radio component ([PR #4366](https://github.com/alphagov/govuk_publishing_components/pull/4366))
+
 ## 45.1.0
 
 * Add GA4 tracking for search autocomplete ([PR #4371](https://github.com/alphagov/govuk_publishing_components/pull/4371))

--- a/app/views/govuk_publishing_components/components/_radio.html.erb
+++ b/app/views/govuk_publishing_components/components/_radio.html.erb
@@ -37,9 +37,11 @@
   hint_id = "hint-#{SecureRandom.hex(4)}" if hint
   error_id = "error-#{SecureRandom.hex(4)}"
 
-  form_group_css_classes = %w(govuk-form-group)
-  form_group_css_classes << "govuk-form-group--error" if has_error
-  form_group_css_classes << shared_helper.get_margin_bottom
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("govuk-form-group")
+  component_helper.add_class("govuk-form-group--error") if has_error
+  component_helper.add_class(shared_helper.get_margin_bottom)
+  component_helper.set_id(id)
 
   radio_classes = %w(govuk-radios)
   radio_classes << "govuk-radios--small" if small
@@ -54,7 +56,7 @@
   # check if any item is set as being conditional
   has_conditional = items.any? { |item| item.is_a?(Hash) && item[:conditional] }
 %>
-<%= tag.div id: id, class: form_group_css_classes do %>
+<%= tag.div(**component_helper.all_attributes) do %>
   <%= tag.fieldset class: "govuk-fieldset", "aria-describedby": aria do %>
     <% if heading.present? %>
       <%= tag.legend class: legend_classes do %>

--- a/app/views/govuk_publishing_components/components/docs/radio.yml
+++ b/app/views/govuk_publishing_components/components/docs/radio.yml
@@ -4,6 +4,7 @@ body: |
   You can also use 'or' as an item to break up radios.
 
   If JavaScript is disabled a conditionally revealed content expands fully. All of the functionality (including aria attributes) are added using JavaScript.
+uses_component_wrapper_helper: true
 accessibility_criteria: |
   Radio buttons should
 


### PR DESCRIPTION
## What
- Adds the component wrapper helper to the `radio button` component.

## Why
As the [trello card](https://trello.com/c/qH4NyWJw/364-add-component-wrapper-to-more-components) states:

> Standardising our components to use the component wrapper helper will reduce code, increase standardisation, and improve future feature implementation speed.

## Visual changes

None.