### PR TITLE
Search with autocomplete: Work around Enter edge case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Add GA4 tracking for search autocomplete ([PR #4371](https://github.com/alphagov/govuk_publishing_components/pull/4371))
 * Append no-actions class to rows without actions in Summary Cards ([PR #4368](https://github.com/alphagov/govuk_publishing_components/pull/4368))
+* Search with autocomplete: Work around Enter edge case ([PR #4372](https://github.com/alphagov/govuk_publishing_components/pull/4372))
 
 ## 45.0.0
 

--- a/spec/javascripts/components/search-with-autocomplete-spec.js
+++ b/spec/javascripts/components/search-with-autocomplete-spec.js
@@ -1,5 +1,5 @@
 /* eslint-env jasmine */
-/* global GOVUK, Event, FormData */
+/* global GOVUK, Event, FormData, KeyboardEvent */
 
 describe('Search with autocomplete component', () => {
   let autocomplete, fixture
@@ -209,11 +209,30 @@ describe('Search with autocomplete component', () => {
     const form = fixture.querySelector('form')
     const submitSpy = spyOn(form, 'requestSubmit')
 
-    autocomplete.submitContainingForm('updated value')
+    autocomplete.onConfirm('updated value')
 
     const formData = new FormData(form)
     expect(formData.get('q')).toEqual('updated value')
     expect(submitSpy).toHaveBeenCalled()
+  })
+
+  it('triggers a requestSubmit if Enter is pressed in the search field to work around library bug', (done) => {
+    const form = fixture.querySelector('form')
+    const input = fixture.querySelector('input')
+    const submitSpy = spyOn(form, 'requestSubmit')
+
+    stubSuccessfulFetch(['i am an undesirable result'])
+    performInput(input, 'i just want to search the old-fashioned way', () => {
+      const enterEvent = new KeyboardEvent('keydown', {
+        key: 'Enter',
+        bubbles: true,
+        cancelable: true
+      })
+      input.dispatchEvent(enterEvent)
+
+      expect(submitSpy).toHaveBeenCalled()
+      done()
+    })
   })
 
   describe('analytics data attributes', () => {


### PR DESCRIPTION
## What
The `accessible-autocomplete` component has an edge case where when the menu is visible, [it `preventDefault()`s on the Enter key event](https://github.com/alphagov/accessible-autocomplete/blob/b8369d037fd5d26d30a831ed73baa3dd566293ef/src/autocomplete.js#L361), even if the user hasn't yet put keyboard focus on a suggestion. This results in a scenario where the user types something, does _not_ interact with the autocomplete menu at all, and then hits Enter to try to submit the form - but it isn't submitted.

This implements a workaround that adds our own event listener and ensures `requestSubmit` is run for the form if it hasn't been already.

- Add event listener for `keydown` event and submit the containing form ourselves if the key is `Enter`
- Split out code meant to run on accepting a suggestion (`onConfirm`) from form submission logic (`submitContainingForm`) so we can reuse the latter
- Add a check to `submitContainingForm` that it hasn't already been called for the component anyway

## Why
This is not something we can fix upstream as it is usually desirable behaviour for the library.