### PR TITLE
Add a content block component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Add component wrapper to feedback component ([PR #4351](https://github.com/alphagov/govuk_publishing_components/pull/4351))
 * Add component wrapper helper to error message component ([PR #4359](https://github.com/alphagov/govuk_publishing_components/pull/4359))
 * Require layout_for_public will not render wrapper unless `for_static: true` is set. ([PR #4255](https://github.com/alphagov/govuk_publishing_components/pull/4255))
+* Add a Content Block component ([PR #4376](https://github.com/alphagov/govuk_publishing_components/pull/4376))
 
 ## 45.1.0
 

--- a/app/views/govuk_publishing_components/components/_content_block.html.erb
+++ b/app/views/govuk_publishing_components/components/_content_block.html.erb
@@ -1,0 +1,8 @@
+<%=
+  render(
+      "govuk_publishing_components/components/content_blocks/#{document_type}",
+      wrapper_args: { class: "gem-c-content-block", data: { "content-id": content_id, "document-type": document_type } },
+      title:,
+      details:,
+    )
+%>

--- a/app/views/govuk_publishing_components/components/content_blocks/_contact.html.erb
+++ b/app/views/govuk_publishing_components/components/content_blocks/_contact.html.erb
@@ -1,0 +1,3 @@
+<%= content_tag(:span, **wrapper_args) do %>
+  <%= title %>
+<% end %>

--- a/app/views/govuk_publishing_components/components/content_blocks/_content_block_email_address.html.erb
+++ b/app/views/govuk_publishing_components/components/content_blocks/_content_block_email_address.html.erb
@@ -1,0 +1,3 @@
+<%= content_tag(:span, **wrapper_args) do %>
+  <%= details[:email_address] %>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/content_block.yml
+++ b/app/views/govuk_publishing_components/components/docs/content_block.yml
@@ -1,0 +1,28 @@
+name: Content block
+description: Renders a GOV.UK Content Block
+body: |
+  This allows the rendering of a Content Block generated using the GOV.UK Content Block Manager
+accessibility_criteria: |
+  - text should have a text contrast ratio higher than 4.5:1 against the background colour to meet WCAG AA
+examples:
+  default:
+    data:
+      document_type: "content_block_email_address"
+      content_id: "47b62ede-c89c-42c5-8c05-9727e7bd16e5"
+      title: "GDS Email Address"
+      details: { email_address: "foo@example.com" }
+    description: "Display an email address content block"
+  email_address:
+    data:
+      document_type: "content_block_email_address"
+      content_id: "47b62ede-c89c-42c5-8c05-9727e7bd16e5"
+      title: "GDS Email Address"
+      details: { email_address: "foo@example.com" }
+    description: "Display an email address content block"
+  contact_block:
+    data:
+      document_type: "contact"
+      content_id: "47b62ede-c89c-42c5-8c05-9727e7bd16e5"
+      title: "Contact us"
+      details: { some: "details" }
+    description: "Display an contact content block"

--- a/spec/components/all_components_spec.rb
+++ b/spec/components/all_components_spec.rb
@@ -24,7 +24,7 @@ describe "All components" do
       end
 
       it "has the correct class in the ERB template",
-         skip: component_name.in?(%w[step_by_step_nav_related step_by_step_nav_header step_by_step_nav previous_and_next_navigation]),
+         skip: component_name.in?(%w[step_by_step_nav_related step_by_step_nav_header step_by_step_nav previous_and_next_navigation content_block]),
          not_applicable: component_name.in?(%w[meta_tags machine_readable_metadata google_tag_manager_script table]) do
         erb = File.read(filename)
 
@@ -45,7 +45,7 @@ describe "All components" do
         expect(File).to exist(rspec_file)
       end
 
-      it "has a correctly named SCSS file", not_applicable: component_name.in?(%w[contextual_breadcrumbs contextual_footer contextual_sidebar google_tag_manager_script list machine_readable_metadata meta_tags]) do
+      it "has a correctly named SCSS file", not_applicable: component_name.in?(%w[contextual_breadcrumbs contextual_footer contextual_sidebar google_tag_manager_script list machine_readable_metadata meta_tags content_block]) do
         css_file = "#{__dir__}/../../app/assets/stylesheets/govuk_publishing_components/components/_#{component_name.tr('_', '-')}.scss"
 
         expect(File).to exist(css_file)

--- a/spec/components/content_block_spec.rb
+++ b/spec/components/content_block_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+describe "Content Block", type: :view do
+  def component_name
+    "content_block"
+  end
+
+  let(:content_id) { SecureRandom.uuid }
+
+  it "renders a contact block" do
+    render_component(
+      title: "Something",
+      details: { some: "details" },
+      document_type: "contact",
+      content_id:,
+    )
+
+    assert_select "span.gem-c-content-block[data-content-id='#{content_id}'][data-document-type='contact']", text: "Something"
+  end
+
+  it "renders an email address correctly" do
+    render_component(
+      title: "Something",
+      details: { email_address: "foo@example.com" },
+      document_type: "content_block_email_address",
+      content_id:,
+    )
+
+    assert_select "span.gem-c-content-block[data-content-id='#{content_id}'][data-document-type='content_block_email_address']", text: "foo@example.com"
+  end
+end


### PR DESCRIPTION
Currently, the logic for rendering content blocks logic is locked up in the Publishing API. The Content Modelling team has need to use this logic in multiple places outside the Publishing API, so rather than have to create an API endpoint to render a content block, we decided we should have one source of truth.

We initially looked at incorporating this into Govspeak, but the initial rendering of content blocks when a content block changes has to take place in the Publishing API, and currently, there are some publishing apps (e.g. Whitehall) that render Govspeak _before_ sending content to the Publishing API, and this is too difficult to unpick without a lot of work. 

Additionally, this will give us a degree of futureproofing for the longer term, when we start to move away from using the Content Store towards rendering content directly in frontend apps via the (currently in development) GraphQL API.

After some discussing with our team and @richardTowers, we decided that this gem was the best place for this logic to live. More context is in a draft ADR here - https://github.com/alphagov/publishing-api/pull/2974

Once this is in, we’ll call this component when rendering content blocks in Publishing API, so the Publishing Components gem becomes the source of truth.

Currently some of the blocks look a little bare bones, but we will be expanding on this in the near future, especially when it comes to the contact block.