### PR TITLE
Add component wrapper helper to the inverse header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Rename gem-print-link and gem-print-links-within ([PR #4375](https://github.com/alphagov/govuk_publishing_components/pull/4375))
 * Fix unwanted additional yield in textareas inside the problem form partial of the feedback component ([PR #4394](https://github.com/alphagov/govuk_publishing_components/pull/4394))
+* Add component wrapper helper to the inverse header ([PR #4379](https://github.com/alphagov/govuk_publishing_components/pull/4379))
 
 ## 45.2.0
 

--- a/app/views/govuk_publishing_components/components/_inverse_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_inverse_header.html.erb
@@ -1,13 +1,14 @@
 <%
   add_gem_component_stylesheet("inverse-header")
 
-  css_classes = []
-  css_classes << " gem-c-inverse-header--full-width" if local_assigns[:full_width]
-  css_classes << " gem-c-inverse-header--padding-top" unless local_assigns[:padding_top].eql?(false)
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("gem-c-inverse-header")
+  component_helper.add_class("gem-c-inverse-header--full-width") if local_assigns[:full_width]
+  component_helper.add_class("gem-c-inverse-header--padding-top") unless local_assigns[:padding_top].eql?(false)
 %>
 <% block = yield %>
 <% unless block.empty? %>
-  <header class="gem-c-inverse-header <%= css_classes.join(' ') %> ">
+  <%= tag.header(**component_helper.all_attributes) do %>
     <%= block %>
-  </header>
+  <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/inverse_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/inverse_header.yml
@@ -4,6 +4,7 @@ body: |
   This component can be passed a block of template code and will wrap it in a blue header. This is as light-touch as possible and doesn't attempt to deal with the margins and paddings of its content. White text is enforced on content and would need to be overridden where unwanted. Implemented to accommodate topic and list page headings but unopinionated about its contents.
 
   If passing links to the block make sure to add [the inverse modifier](https://design-system.service.gov.uk/styles/typography/#links-on-dark-backgrounds).
+uses_component_wrapper_helper: true
 accessibility_criteria: |
   The component must:
 


### PR DESCRIPTION
## What
- Adds the component wrapper helper to the `inverse header` component.

## Why
As the [trello card](https://trello.com/c/qH4NyWJw/364-add-component-wrapper-to-more-components) states:

> Standardising our components to use the component wrapper helper will reduce code, increase standardisation, and improve future feature implementation speed.

## Visual changes

None.