### PR TITLE
Add component wrapper helper to the footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add component wrapper helper to the footer ([PR #4380](https://github.com/alphagov/govuk_publishing_components/pull/4380))
 * Add component wrapper to the inset text component ([PR #4387](https://github.com/alphagov/govuk_publishing_components/pull/4387))
 * Rename gem-print-link and gem-print-links-within ([PR #4375](https://github.com/alphagov/govuk_publishing_components/pull/4375))
 * Fix unwanted additional yield in textareas inside the problem form partial of the feedback component ([PR #4394](https://github.com/alphagov/govuk_publishing_components/pull/4394))

--- a/app/views/govuk_publishing_components/components/_layout_footer.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_footer.html.erb
@@ -4,12 +4,16 @@
   meta ||= []
   navigation ||= []
   with_border ||= false
-  classes = %w(gem-c-layout-footer govuk-footer)
-  classes << "gem-c-layout-footer--border" if with_border
   layout_footer_helper = GovukPublishingComponents::Presenters::LayoutFooterHelper.new(navigation, meta)
   absolute_links_helper = GovukPublishingComponents::Presenters::AbsoluteLinksHelper.new()
+
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("gem-c-layout-footer govuk-footer")
+  component_helper.add_class("gem-c-layout-footer--border") if with_border
+  component_helper.add_role("contentinfo")
+  component_helper.add_data_attribute({ module: "ga4-link-tracker" })
 %>
-<%= tag.footer class: classes, role: "contentinfo", 'data-module': "ga4-link-tracker" do %>
+<%= tag.footer(**component_helper.all_attributes) do %>
   <div class="govuk-width-container">
     <% if navigation.any? %>
       <div class="govuk-footer__navigation">

--- a/app/views/govuk_publishing_components/components/docs/layout_footer.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_footer.yml
@@ -2,6 +2,7 @@ name: Layout footer
 description: The footer provides copyright, licensing and other information
 govuk_frontend_components:
   - footer
+uses_component_wrapper_helper: true
 accessibility_criteria: |
   Text and links in the Footer must:
 


### PR DESCRIPTION
## What
- Adds the component wrapper helper to the `layout_footer` component.

## Why
As the [trello card](https://trello.com/c/qH4NyWJw/364-add-component-wrapper-to-more-components) states:

> Standardising our components to use the component wrapper helper will reduce code, increase standardisation, and improve future feature implementation speed.

## Visual changes

None.