### PR TITLE
Search with autocomplete: Set minimum query length

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/components/search-with-autocomplete.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/search-with-autocomplete.js
@@ -28,6 +28,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         defaultValue: this.$originalInput.value,
         cssNamespace: 'gem-c-search-with-autocomplete',
         confirmOnBlur: false,
+        minLength: 3,
         showNoOptionsFound: false,
         source: this.getResults.bind(this),
         onConfirm: this.onConfirm.bind(this),


### PR DESCRIPTION
## What
This stops the `search_with_autocomplete` component from wasting requests trying to fetch suggestions when our backend won't provide any for query lengths < 3.

## Why
Fewer pointless requests is better!

Note that I've not bothered making this configurable - it's unlikely for the time being that this component will be used with a different source/backend, so there isn't much point in adding a configuration option. I've also not added a changelog option as that felt over the top 😄 