### PR TITLE
Add heading option to metadata component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Add component wrapper helper to the inverse header ([PR #4379](https://github.com/alphagov/govuk_publishing_components/pull/4379))
 * Mark events as "tracked" to prevent double tracking ([PR #4395](https://github.com/alphagov/govuk_publishing_components/pull/4395))
 * Search with autocomplete: track non-empty suggestions ([PR #4400](https://github.com/alphagov/govuk_publishing_components/pull/4400))
+* Add heading option to metadata component ([PR #4383](https://github.com/alphagov/govuk_publishing_components/pull/4383))
 
 ## 45.2.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_metadata.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_metadata.scss
@@ -33,6 +33,10 @@
 .gem-c-metadata--inverse-padded {
   padding: govuk-spacing(2);
 
+  .gem-c-metadata__title {
+    padding: 0 govuk-spacing(3);
+  }
+
   .gem-c-metadata__list {
     margin: govuk-spacing(2);
 

--- a/app/views/govuk_publishing_components/components/_metadata.html.erb
+++ b/app/views/govuk_publishing_components/components/_metadata.html.erb
@@ -1,6 +1,8 @@
 <%
   add_gem_component_stylesheet("metadata")
 
+  title ||= ""
+
   from ||= []
   from = Array(from)
 
@@ -34,6 +36,16 @@
   }.to_json unless disable_ga4
 %>
 <%= content_tag :div, class: classes, data: { module: "gem-toggle metadata" } do %>
+  <% if title.present? %>
+    <%= content_tag :div, class: "gem-c-metadata__title" do %>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: sanitize(title),
+        font_size: "m",
+        inverse:,
+        margin_bottom: 0,
+      } %>
+    <% end %>
+  <% end %>
   <dl class="gem-c-metadata__list">
     <% if from.any? %>
       <dt class="gem-c-metadata__term"><%= t("components.metadata.from") %>:</dt>

--- a/app/views/govuk_publishing_components/components/docs/metadata.yml
+++ b/app/views/govuk_publishing_components/components/docs/metadata.yml
@@ -393,3 +393,17 @@ examples:
       last_updated: 10 September 2015
       see_updates_link: true
       disable_ga4: true
+  with_title:
+    data:
+      last_updated: 10 September 2015
+      see_updates_link: true
+      title: Title
+  on_a_dark_background_with_title:
+    data:
+      inverse: true
+      other:
+        Release date: 23 August 2018 9:30am
+        Reason for change: Date of release brought forward from 23 August 2018 to 21 August 2018 as data in its final form is now available to be published on this new date.
+      title: The release date has been changed
+    context:
+      dark_background: true

--- a/spec/components/metadata_spec.rb
+++ b/spec/components/metadata_spec.rb
@@ -237,6 +237,12 @@ describe "Metadata", type: :view do
     assert_select ".gem-c-metadata__definition:nth-of-type(2)[data-ga4-track-links-only]", false
   end
 
+  it "renders the component with a title" do
+    render_component(from: "<a href='/link'>Department</a>", title: "my title")
+
+    assert_select ".gem-c-metadata__title", text: "my title"
+  end
+
   def assert_truncation(length, limit)
     assert_select ".gem-c-metadata__toggle-items", count: 1
     assert_select ".gem-c-metadata__definition > a", count: limit


### PR DESCRIPTION
## What
Add heading option to metadata component.

## Why

The important metadata block component, used in Government Frontend e.g. https://www.gov.uk/government/statistics/announcements/core-statistics-book-august-2018, can be replaced with the metadata block component. However, some block instances include a title so we should provide a heading option and we can then replace the app variant with this component.

## Visual Changes

![govuk-publishing-components dev gov uk_component-guide_metadata_with_title_preview](https://github.com/user-attachments/assets/63a15188-1dec-4ffd-9186-93a679318efd)

![govuk-publishing-components dev gov uk_component-guide_metadata_on_a_dark_background_with_title_preview](https://github.com/user-attachments/assets/b040ef56-8cf5-4987-904f-9387a26fcac7)

## Anything else

- https://github.com/alphagov/govuk_publishing_components/issues/3482
- https://github.com/alphagov/government-frontend/pull/3414