### PR TITLE
Add component wrapper to the inset text component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add component wrapper to the inset text component ([PR #4387](https://github.com/alphagov/govuk_publishing_components/pull/4387))
 * Rename gem-print-link and gem-print-links-within ([PR #4375](https://github.com/alphagov/govuk_publishing_components/pull/4375))
 
 ## 45.2.0

--- a/app/views/govuk_publishing_components/components/_inset_text.html.erb
+++ b/app/views/govuk_publishing_components/components/_inset_text.html.erb
@@ -10,11 +10,13 @@
     margin_bottom: margin_bottom
   })
 
-  classes = %w[gem-c-inset-text govuk-inset-text gem-c-print-links-within]
-  classes << shared_helper.get_margin_top
-  classes << shared_helper.get_margin_bottom
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("gem-c-inset-text govuk-inset-text gem-c-print-links-within")
+  component_helper.add_class(shared_helper.get_margin_top)
+  component_helper.add_class(shared_helper.get_margin_bottom)
+  component_helper.set_id(id)
 %>
-<%= tag.div id: id, class: classes do %>
+<%= tag.div(**component_helper.all_attributes) do %>
   <% if defined? text %>
     <%= text %>
   <% elsif block_given? %>

--- a/app/views/govuk_publishing_components/components/docs/inset_text.yml
+++ b/app/views/govuk_publishing_components/components/docs/inset_text.yml
@@ -2,6 +2,7 @@ name: Inset text
 description: Use the inset text component to differentiate a block of text from the content that surrounds it.
 govuk_frontend_components:
   - inset-text
+uses_component_wrapper_helper: true
 accessibility_criteria: |
   All text must have a contrast ratio higher than 4.5:1 against the background colour to meet [WCAG AA](https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast)
 examples:


### PR DESCRIPTION
## What
- Adds the component wrapper helper to the `inset_text` component.

## Why
As the [trello card](https://trello.com/c/qH4NyWJw/364-add-component-wrapper-to-more-components) states:

> Standardising our components to use the component wrapper helper will reduce code, increase standardisation, and improve future feature implementation speed.

## Visual changes

None.