### PR TITLE
Add empty blocks to prevent double-yielding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Rename gem-print-link and gem-print-links-within ([PR #4375](https://github.com/alphagov/govuk_publishing_components/pull/4375))
+* Fix unwanted additional yield in textareas inside the problem form partial of the feedback component ([PR #4394](https://github.com/alphagov/govuk_publishing_components/pull/4394))
 
 ## 45.2.0
 

--- a/app/views/govuk_publishing_components/components/feedback/_problem_form.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_problem_form.html.erb
@@ -30,7 +30,7 @@
         name: "what_doing",
         rows: 3,
         describedby: "feedback_explanation"
-      } %>
+      } do %> <% end %>
 
       <%= render "govuk_publishing_components/components/textarea", {
         label: {
@@ -38,7 +38,7 @@
         },
         name: "what_wrong",
         rows: 3
-      } %>
+      } do %> <% end %>
 
       <%
         unless disable_ga4


### PR DESCRIPTION
## What
When called through the public layout, the feedback component's problem form passes on the block that's been passed to the public layout and implicitly passes it on to the two textarea components, which yield to it, resulting in the page contents passed to the component being rendered three times in the page (once where it's supposed to be, and then once more under each textarea component). Since we don't want blocks passed to these particular textareas, we add an explicit empty block to each one.

## Why
When using layout_for_public directly in an app, any yield block passed to that component gets repeated three times.

## Visual Changes
None
