### PR TITLE
Mark events as "tracked" to prevent double tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Rename gem-print-link and gem-print-links-within ([PR #4375](https://github.com/alphagov/govuk_publishing_components/pull/4375))
 * Fix unwanted additional yield in textareas inside the problem form partial of the feedback component ([PR #4394](https://github.com/alphagov/govuk_publishing_components/pull/4394))
 * Add component wrapper helper to the inverse header ([PR #4379](https://github.com/alphagov/govuk_publishing_components/pull/4379))
+* Mark events as "tracked" to prevent double tracking ([PR #4395](https://github.com/alphagov/govuk_publishing_components/pull/4395))
 
 ## 45.2.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.js
@@ -29,6 +29,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   }
 
   Ga4EventTracker.prototype.trackClick = function (event) {
+    if (event.tracked) return
     var target = window.GOVUK.analyticsGa4.core.trackFunctions.findTrackingAttributes(event.target, this.trackingTrigger)
     if (target) {
       try {
@@ -76,6 +77,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         }
       }
       window.GOVUK.analyticsGa4.core.applySchemaAndSendData(data, 'event_data')
+      event.tracked = true
     }
   }
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.spec.js
@@ -135,6 +135,36 @@ describe('Google Analytics event tracker', function () {
     })
   })
 
+  describe('doing simple tracking on a nested tracked elements', function () {
+    var child
+
+    beforeEach(function () {
+      element.setAttribute('data-ga4-event', JSON.stringify({}))
+      child = document.createElement('div')
+      child.setAttribute('data-ga4-event', JSON.stringify({}))
+      element.appendChild(child)
+      document.body.appendChild(element)
+      new GOVUK.Modules.Ga4EventTracker(element).init()
+      new GOVUK.Modules.Ga4EventTracker(child).init()
+    })
+
+    it('pushes a single event when the parent is clicked', function () {
+      element.click()
+      expect(window.dataLayer.length).toEqual(1)
+    })
+
+    it('pushes a single event when the child is clicked', function () {
+      child.click()
+      expect(window.dataLayer.length).toEqual(1)
+    })
+
+    it('pushes two events when the child is clicked twice', function () {
+      child.click()
+      child.click()
+      expect(window.dataLayer.length).toEqual(2)
+    })
+  })
+
   describe('doing tracking on the text of the element', function () {
     var attributes
 


### PR DESCRIPTION
## What
- Mark events as tracked in the `ga4-event-tracker`
- Ensure that an event has not already been tracked before tracking it

## Why
- When nested (such as in the case of details in a tab component) the event tracker was causing multiple pushes to the data layer to occur
- This resulted in some events being tracked twice
- https://trello.com/c/Mt7YXtIc/3040-bugs-double-tracking-in-some-events

## TODO
- CHANGELOG
- Add test case to `ga4-event-tracker.spec.js`
