### PR TITLE
Only apply the tracker to the `ul` in tabs

### DIFF
--- a/app/views/govuk_publishing_components/components/_tabs.html.erb
+++ b/app/views/govuk_publishing_components/components/_tabs.html.erb
@@ -14,9 +14,9 @@
   component_helper.add_class("govuk-tabs gem-c-tabs")
   component_helper.add_data_attribute({ module: "govuk-tabs" }) unless as_links
 
+  tracking_module = ""
   unless disable_ga4
-    component_helper.add_data_attribute({ module: "ga4-event-tracker" }) unless as_links
-    component_helper.add_data_attribute({ module: "ga4-link-tracker" }) if as_links
+    tracking_module = as_links ? "ga4-link-tracker" : "ga4-event-tracker"
   end
 %>
 <% if tabs.count > 1 %>
@@ -24,7 +24,7 @@
     <h2 class="govuk-tabs__title">
       <%= t("components.tabs.contents") %>
     </h2>
-    <ul class="govuk-tabs__list">
+    <ul class="govuk-tabs__list" data-module="<%= tracking_module %>">
       <% tabs.each_with_index do |tab, index| %>
       <li class="govuk-tabs__list-item <%= "govuk-tabs__list-item--selected" if tab[:active] %>">
         <%


### PR DESCRIPTION
## What
- Remove tracking module from the tabs container
- Apply the appropriate tracking module (`ga4-event-tracker` or `ga4-link-tracker`) only to the `ul` containing the tabs

## Why
- Adding `ga4-event-tracker` on the container element meant that any tracking would apply not just to the tabs, but also the content of any of the tabs
- Consequently any component that had tracking built in such as details would result in double tracking
- A developer also needed to remember not to any other event trackers to the contents of the tab else double tracking would result
- https://trello.com/c/Mt7YXtIc/3040-bugs-double-tracking-in-some-events


## TODO
- Update failing tests
- Update CHANGELOG