### PR TITLE
Search with autocomplete: track non-empty suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fix unwanted additional yield in textareas inside the problem form partial of the feedback component ([PR #4394](https://github.com/alphagov/govuk_publishing_components/pull/4394))
 * Add component wrapper helper to the inverse header ([PR #4379](https://github.com/alphagov/govuk_publishing_components/pull/4379))
 * Mark events as "tracked" to prevent double tracking ([PR #4395](https://github.com/alphagov/govuk_publishing_components/pull/4395))
+* Search with autocomplete: track non-empty suggestions ([PR #4400](https://github.com/alphagov/govuk_publishing_components/pull/4400))
 
 ## 45.2.0
 

--- a/app/assets/javascripts/govuk_publishing_components/components/search-with-autocomplete.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/search-with-autocomplete.js
@@ -114,10 +114,15 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     // Set tracking attributes on the input field. These can be used by the containing form's
     // analytics module to track the user's interaction with the autocomplete component.
     setTrackingAttributes (query, results) {
-      const formattedResults = results.slice(0, 5).join('|')
+      // Only set the suggestions attribute when results actually come back (so this attribute
+      // tracks the last seen non-empty suggestions, even if the user then amends their query to one
+      // that doesn't generate any)
+      if (results.length > 0) {
+        const formattedResults = results.slice(0, 5).join('|')
+        this.$autocompleteInput.dataset.autocompleteSuggestions = formattedResults
+      }
 
       this.$autocompleteInput.dataset.autocompleteTriggerInput = query
-      this.$autocompleteInput.dataset.autocompleteSuggestions = formattedResults
       this.$autocompleteInput.dataset.autocompleteSuggestionsCount = results.length
       this.$autocompleteInput.dataset.autocompleteAccepted = false
     }

--- a/spec/javascripts/components/search-with-autocomplete-spec.js
+++ b/spec/javascripts/components/search-with-autocomplete-spec.js
@@ -258,6 +258,31 @@ describe('Search with autocomplete component', () => {
     })
   })
 
+  it('keeps the suggestions (but not the count) in the data attribute when subsequent requests return empty results', (done) => {
+    // Allows us to override the spy on fetch to be able to stub out a subsequent request
+    jasmine.getEnv().allowRespy(true)
+
+    const input = fixture.querySelector('input')
+
+    stubSuccessfulFetch([
+      'my favourite song is red',
+      'my favourite song is karma',
+      'my favourite song is death by a thousand cuts'
+    ])
+    performInput(input, 'my favourite song is', () => {
+      stubSuccessfulFetch([])
+      performInput(input, 'my favourite song is espresso', () => {
+        expect(input.dataset.autocompleteSuggestions).toEqual(
+          'my favourite song is red|' +
+          'my favourite song is karma|' +
+          'my favourite song is death by a thousand cuts'
+        )
+        expect(input.dataset.autocompleteSuggestionsCount).toEqual('0')
+        done()
+      })
+    })
+  })
+
   it('limits the number of suggestions included in the data to 5', (done) => {
     const input = fixture.querySelector('input')
 


### PR DESCRIPTION
## What
This amends the `search_with_autocomplete` component's tracking attributes to track the last non-empty set of suggestions the user has seen, rather than the last set of suggestions regardless of if there were any.

## Why
This allows us to track and evaluate why a user doesn't accept any of the suggestions they were offered, choosing instead to type in their own query.
