### PR TITLE
Release 45.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Unreleased
 
+## 45.3.0
+
 * Enhance Youtube without cookies ([PR #4388](https://github.com/alphagov/govuk_publishing_components/pull/4388))
 * Add component wrapper helper to the header ([PR #4385](https://github.com/alphagov/govuk_publishing_components/pull/4385))
 * Add component wrapper helper to the footer ([PR #4380](https://github.com/alphagov/govuk_publishing_components/pull/4380))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (45.2.0)
+    govuk_publishing_components (45.3.0)
       chartkick
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
@@ -511,7 +511,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     rexml (3.3.8)
-    rouge (4.5.0)
+    rouge (4.5.1)
     rspec-core (3.13.1)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.2)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "45.2.0".freeze
+  VERSION = "45.3.0".freeze
 end


### PR DESCRIPTION
## CHANGELOG

* Enhance Youtube without cookies ([PR #4388](https://github.com/alphagov/govuk_publishing_components/pull/4388))
* Add component wrapper helper to the header ([PR #4385](https://github.com/alphagov/govuk_publishing_components/pull/4385))
* Add component wrapper helper to the footer ([PR #4380](https://github.com/alphagov/govuk_publishing_components/pull/4380))
* Add component wrapper to the inset text component ([PR #4387](https://github.com/alphagov/govuk_publishing_components/pull/4387))
* Rename gem-print-link and gem-print-links-within ([PR #4375](https://github.com/alphagov/govuk_publishing_components/pull/4375))
* Fix unwanted additional yield in textareas inside the problem form partial of the feedback component ([PR #4394](https://github.com/alphagov/govuk_publishing_components/pull/4394))
* Add component wrapper helper to the inverse header ([PR #4379](https://github.com/alphagov/govuk_publishing_components/pull/4379))
* Mark events as "tracked" to prevent double tracking ([PR #4395](https://github.com/alphagov/govuk_publishing_components/pull/4395))
* Search with autocomplete: track non-empty suggestions ([PR #4400](https://github.com/alphagov/govuk_publishing_components/pull/4400))
* Add heading option to metadata component ([PR #4383](https://github.com/alphagov/govuk_publishing_components/pull/4383))
* Track autocomplete acceptance in session storage ([PR #4381](https://github.com/alphagov/govuk_publishing_components/pull/4381))