### PR TITLE
Rename print link classes to fix conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Rename print link classes to fix conflict ([PR #4407](https://github.com/alphagov/govuk_publishing_components/pull/4407))
+
 ## 45.4.0
 
 * Chat entry component design changes ([PR #4399](https://github.com/alphagov/govuk_publishing_components/pull/4399))

--- a/app/assets/stylesheets/govuk_publishing_components/lib/_print_support.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/lib/_print_support.scss
@@ -36,13 +36,13 @@
 // to black, reduce the font size, and improve the layout
 // of the printed href.
 //
-// .gem-c-print-link
+// .gem-c-force-print-link-styles
 // ----------------------------------------------------------
 // Typically this class will be applied to existing
 // elements that have the `govuk-link` class but it can
 // also be used on other link elements.
 //
-// .gem-c-print-links-within
+// .gem-c-force-print-link-styles-within
 // ----------------------------------------------------------
 // A variation of the previous print style, to be used on
 // parent elements that contain links with the `govuk-link`
@@ -52,8 +52,8 @@
 
 // stylelint-disable declaration-no-important
 @include govuk-media-query($media-type: print) {
-  .gem-c-print-link,
-  .gem-c-print-links-within .govuk-link {
+  .gem-c-force-print-link-styles,
+  .gem-c-force-print-link-styles-within .govuk-link {
     &,
     &:link,
     &:visited {

--- a/app/views/govuk_publishing_components/components/_action_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_action_link.html.erb
@@ -28,7 +28,7 @@
   css_classes << "gem-c-action-link--mobile-subtext" if mobile_subtext
   css_classes << shared_helper.get_margin_bottom
 
-  link_classes = %w(govuk-link gem-c-action-link__link gem-c-print-link)
+  link_classes = %w(govuk-link gem-c-action-link__link gem-c-force-print-link-styles)
   link_classes << "govuk-link--inverse" if inverse
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)

--- a/app/views/govuk_publishing_components/components/_cards.html.erb
+++ b/app/views/govuk_publishing_components/components/_cards.html.erb
@@ -38,7 +38,7 @@
             <%= content_tag("h#{sub_heading_level}", class: "gem-c-cards__sub-heading govuk-heading-s") do %>
               <%=
                 link_to link[:text], link[:path],
-                class: "govuk-link gem-c-cards__link gem-c-print-link",
+                class: "govuk-link gem-c-cards__link gem-c-force-print-link-styles",
                 data: link[:data_attributes]
               %>
             <% end %>

--- a/app/views/govuk_publishing_components/components/_contents_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_contents_list.html.erb
@@ -13,7 +13,7 @@
   cl_helper = GovukPublishingComponents::Presenters::ContentsListHelper.new(local_assigns)
   brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)
 
-  link_classes = %w[gem-c-contents-list__link govuk-link gem-c-print-link]
+  link_classes = %w[gem-c-contents-list__link govuk-link gem-c-force-print-link-styles]
   link_classes << brand_helper.color_class
   link_classes << "govuk-link--no-underline" unless underline_links
 

--- a/app/views/govuk_publishing_components/components/_devolved_nations.html.erb
+++ b/app/views/govuk_publishing_components/components/_devolved_nations.html.erb
@@ -35,7 +35,7 @@
     <% if devolved_nations_helper.nations_with_urls.any? %>
       <%= content_tag :ul, class: "govuk-list govuk-!-margin-top-1 govuk-!-margin-bottom-0" do -%>
         <% devolved_nations_helper.nations_with_urls.each do |k, v| %>
-          <%= content_tag(:li, link_to(devolved_nations_helper.alternative_content_text(k), v[:alternative_url], class: "govuk-link gem-c-print-link")) %>
+          <%= content_tag(:li, link_to(devolved_nations_helper.alternative_content_text(k), v[:alternative_url], class: "govuk-link gem-c-force-print-link-styles")) %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/govuk_publishing_components/components/_document_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_document_list.html.erb
@@ -57,7 +57,7 @@
                 item[:link][:text],
                 item[:link][:path],
                 data: item[:link][:data_attributes],
-                class: "#{item_classes} govuk-link gem-c-print-link #{extra_link_classes}",
+                class: "#{item_classes} govuk-link gem-c-force-print-link-styles #{extra_link_classes}",
                 lang: item[:link][:locale].presence,
                 rel: rel,
               )
@@ -118,7 +118,7 @@
                       part[:link][:text],
                       part[:link][:path],
                       data: part[:link][:data_attributes],
-                      class: "gem-c-document-list-child__heading gem-c-document-list-child__link #{brand_helper.color_class} govuk-link gem-c-print-link #{extra_link_classes}",
+                      class: "gem-c-document-list-child__heading gem-c-document-list-child__link #{brand_helper.color_class} govuk-link gem-c-force-print-link-styles #{extra_link_classes}",
                     )
                   else
                     content_tag(

--- a/app/views/govuk_publishing_components/components/_image_card.html.erb
+++ b/app/views/govuk_publishing_components/components/_image_card.html.erb
@@ -25,14 +25,14 @@
   heading_link_classes = %w[
     gem-c-image-card__title-link
     govuk-link
-    gem-c-print-link
+    gem-c-force-print-link-styles
   ]
   heading_link_classes << brand_helper.color_class
   heading_link_classes << "gem-c-image-card__title-link--large-font-size-mobile" if card_helper.large_mobile_font_size?
   extra_link_classes = %w[
     gem-c-image-card__list-item-link
     govuk-link
-    gem-c-print-link
+    gem-c-force-print-link-styles
   ]
   extra_link_classes << brand_helper.color_class
 

--- a/app/views/govuk_publishing_components/components/_inset_text.html.erb
+++ b/app/views/govuk_publishing_components/components/_inset_text.html.erb
@@ -11,7 +11,7 @@
   })
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
-  component_helper.add_class("gem-c-inset-text govuk-inset-text gem-c-print-links-within")
+  component_helper.add_class("gem-c-inset-text govuk-inset-text gem-c-force-print-link-styles-within")
   component_helper.add_class(shared_helper.get_margin_top)
   component_helper.add_class(shared_helper.get_margin_bottom)
   component_helper.set_id(id)

--- a/app/views/govuk_publishing_components/components/_intervention.html.erb
+++ b/app/views/govuk_publishing_components/components/_intervention.html.erb
@@ -38,7 +38,7 @@
   data_attributes[:ga4_intervention_banner] = "" unless disable_ga4 # Added to the parent element for the GA4 pageview object to use
 
   suggestion_tag_options = {
-    class: "govuk-link gem-c-print-link",
+    class: "govuk-link gem-c-force-print-link-styles",
     href: suggestion_link_url,
     data: suggestion_data_attributes,
   }

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav_header.html.erb
@@ -35,7 +35,7 @@
     <strong class="gem-c-step-nav-header__part-of">Part of</strong>
     <% if path %>
       <a href="<%= path %>"
-        class="gem-c-step-nav-header__title govuk-link gem-c-print-link"
+        class="gem-c-step-nav-header__title govuk-link gem-c-force-print-link-styles"
         <% unless disable_ga4 %>
           data-ga4-link='<%= ga4_data %>'
         <% end %>

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav_related.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav_related.html.erb
@@ -15,7 +15,7 @@
       <span class="gem-c-step-nav-related__pretitle"><%= pretitle %></span>
       <% if links.length == 1 && !always_display_as_list %>
           <a href="<%= links[0][:href] %>"
-            class="govuk-link gem-c-print-link"
+            class="govuk-link gem-c-force-print-link-styles"
             <% unless disable_ga4
               ga4_attributes = {
                 event_name: "navigation",
@@ -37,7 +37,7 @@
           <% links.each_with_index do |link, index| %>
             <li class="gem-c-step-nav-related__link-item">
               <a href="<%= link[:href] %>"
-                class="govuk-link gem-c-print-link"
+                class="govuk-link gem-c-force-print-link-styles"
                 <% unless disable_ga4
                   ga4_attributes = {
                     event_name: "navigation",


### PR DESCRIPTION
## What / Why
<!-- What are the reasons behind this change being made? -->
- In https://github.com/alphagov/govuk_publishing_components/pull/4375, `gem-print-link` and `gem-print-link-within` were renamed to `gem-c-print-link` and `gem-c-print-link-within` to comply with validation set by the component wrapper helper. 
- However, the class name `gem-c-print-link` conflicted with an existing print link class in the print link component. The name change was mistakenly merged without the class being checked to ensure it was unique. The issue was only surfaced when devs were trying to deploy the gem.
- This PR fixes this by giving the class a new name, that is also more descriptive.

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
