### PR TITLE
Change icon and link colours on square option for share links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Change colours on square option for share links ([PR #4409](https://github.com/alphagov/govuk_publishing_components/pull/4409))
+
 ## 45.4.1
 
 * Rename print link classes to fix conflict ([PR #4407](https://github.com/alphagov/govuk_publishing_components/pull/4407))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_share-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_share-links.scss
@@ -128,25 +128,12 @@ $column-width: 9.5em;
 
 .gem-c-share-links--square-icons {
   .gem-c-share-links__link-icon {
-    background-color: govuk-colour("dark-blue");
-    color: govuk-colour("white");
+    background-color: govuk-colour("light-grey");
+    color: govuk-colour("black");
     padding: govuk-spacing(2);
   }
 
-  .gem-c-share-links__link:hover {
-    .gem-c-share-links__link-icon {
-      background-color: govuk-colour("black");
-    }
-  }
-
-  .gem-c-share-links__link:focus {
-    .gem-c-share-links__link-icon {
-      background-color: govuk-colour("black");
-    }
-  }
-
   .gem-c-share-links__label {
-    color: govuk-colour("black");
     @include govuk-font(19, $weight: bold);
   }
 }


### PR DESCRIPTION
## What
Updates the colour of the share links in square option to meet design updates

Trello: https://trello.com/c/37SyRmUF/150-rework-share-links


## Visual Changes

### Before
<img width="1118" alt="image" src="https://github.com/user-attachments/assets/df939a0c-0997-442b-ab0a-bf55e3ceb2f5">

### After

<img width="933" alt="image" src="https://github.com/user-attachments/assets/19e3a991-0c52-46e8-9f7d-80744b74c527">

