### PR TITLE
Add margin_top_until_tablet option to chat entry component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Fix yellow focus colour overspill ([PR #4418](https://github.com/alphagov/govuk_publishing_components/pull/4418))
+* Add margin_top_until_tablet option to chat entry component ([PR #4417](https://github.com/alphagov/govuk_publishing_components/pull/4417))
 
 ## 45.5.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_chat-entry.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_chat-entry.scss
@@ -7,6 +7,12 @@
   padding: govuk-spacing(4);
 }
 
+.gem-c-chat-entry--margin-top-until-tablet {
+  @include govuk-media-query($until: tablet) {
+    margin-top: 35px;
+  }
+}
+
 .gem-c-chat-entry--border-top {
   border-top: 2px solid govuk-colour("blue");
   padding-top: govuk-spacing(5);

--- a/app/views/govuk_publishing_components/components/_chat_entry.html.erb
+++ b/app/views/govuk_publishing_components/components/_chat_entry.html.erb
@@ -8,11 +8,13 @@
   border_top ||= false
   border_bottom ||= false
   disable_ga4 ||= false
+  margin_top_until_tablet ||= false
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-chat-entry")
   component_helper.add_class("gem-c-chat-entry--border-top") if border_top
   component_helper.add_class("gem-c-chat-entry--border-bottom") if border_bottom
+  component_helper.add_class("gem-c-chat-entry--margin-top-until-tablet") if margin_top_until_tablet
   component_helper.add_class(shared_helper.get_margin_bottom)
   component_helper.add_data_attribute({ module: "ga4-link-tracker" }) unless disable_ga4
 

--- a/app/views/govuk_publishing_components/components/docs/chat_entry.yml
+++ b/app/views/govuk_publishing_components/components/docs/chat_entry.yml
@@ -34,6 +34,10 @@ examples:
   with_margin_bottom:
     data:
       margin_bottom: 3
+  with_margin_top_until_tablet:
+    description: Adds a `.gem-c-chat-entry--margin-top-until-tablet` class that applies `margin-top:35px` on smaller screen sizes (i.e. tablets and below)
+    data:
+      margin_top_until_tablet: true
   without_ga4_tracking:
     description: |
       Disables GA4 tracking on the component. Tracking is enabled by default. This adds a data module and data-attributes with JSON data. See the [ga4-link-tracker documentation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-link-tracker.md) for more information.

--- a/spec/components/chat_entry_spec.rb
+++ b/spec/components/chat_entry_spec.rb
@@ -73,4 +73,12 @@ describe "Chat entry", type: :view do
     assert_select '.gem-c-chat-entry[data-module="ga4-link-tracker"]', false
     assert_select ".gem-c-chat-entry[data-ga4-link]", false
   end
+
+  it "renders the chat entry component with a margin-top-until-tablet class" do
+    render_component({
+      margin_top_until_tablet: true,
+    })
+
+    assert_select ".gem-c-chat-entry.gem-c-chat-entry--margin-top-until-tablet"
+  end
 end


### PR DESCRIPTION
## What
This PR adds a `margin_top_until_tablet` option to the chat entry component, which adds `margin-top: 35px` on smaller screen sizes (i.e. <= tablet). I've opted for applying this via a `.gem-c-chat-entry--margin-top-until-tablet` rather than using the `margin_top` helper as 1). it should only be applied at certain screen sizes and 2). the specific amount of margin required isn't supported by the helper.

## Why
Design requirements - [trello card](https://trello.com/c/iOuUw0vs/2157-entry-banner-tweaks).

## Visual Changes
N/A
