### PR TITLE
Fix yellow focus colour overspill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix yellow focus colour overspill ([PR #4418](https://github.com/alphagov/govuk_publishing_components/pull/4418))
+
 ## 45.5.0
 
 * Adjust chart options and settings ([PR #4405](https://github.com/alphagov/govuk_publishing_components/pull/4405))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_share-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_share-links.scss
@@ -136,6 +136,10 @@ $column-width: 9.5em;
   .gem-c-share-links__label {
     @include govuk-font(19, $weight: bold);
   }
+
+  .gem-c-share-links__link:focus {
+    box-shadow: 0 0 $govuk-focus-colour, 0 4px govuk-colour("black");
+  }
 }
 
 .gem-c-share-links--black-icons {


### PR DESCRIPTION
## What / Why
<!-- What are the reasons behind this change being made? -->
- On the share links with square icons, the focus styles overspilled by a few pixels over the top of the element
- I showed this to our designer, he agreed that we should get rid of this few pixel overspill
- See screenshots

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

### Before

<img width="181" alt="image" src="https://github.com/user-attachments/assets/91e33447-35ab-4cb9-aaf6-51230803858e">

### After

<img width="181" alt="image" src="https://github.com/user-attachments/assets/295fab52-1487-42bf-aa0d-506fa9488fcd">

