### PR TITLE
Introduce "add another" component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Add 'toggle' module to each expandable region in metadata component ([PR #4397](https://github.com/alphagov/govuk_publishing_components/pull/4397))
 * Add a description for the metadata block 'see_updates_link' example ([PR #4447](https://github.com/alphagov/govuk_publishing_components/pull/4447))
+* Add the component wrapper to the fieldset component ([PR #4420](https://github.com/alphagov/govuk_publishing_components/pull/4434))
 
 ## 45.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add 'toggle' module to each expandable region in metadata component ([PR #4397](https://github.com/alphagov/govuk_publishing_components/pull/4397))
 * Add a description for the metadata block 'see_updates_link' example ([PR #4447](https://github.com/alphagov/govuk_publishing_components/pull/4447))
 * Add the component wrapper to the fieldset component ([PR #4420](https://github.com/alphagov/govuk_publishing_components/pull/4434))
+* Introduce "add another" component ([PR #4420](https://github.com/alphagov/govuk_publishing_components/pull/4434))
 
 ## 45.9.0
 

--- a/app/assets/javascripts/govuk_publishing_components/components/add-another.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/add-another.js
@@ -1,0 +1,124 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  function AddAnother (module) {
+    this.module = module
+    this.emptyFieldset = undefined
+    this.addAnotherButton = undefined
+  }
+
+  function createButton (textContent, additionalClass = '') {
+    var button = document.createElement('button')
+    button.className = 'gem-c-button govuk-button ' + additionalClass
+    button.type = 'button'
+    button.textContent = textContent
+    return button
+  }
+
+  AddAnother.prototype.init = function () {
+    this.createAddAnotherButton()
+    this.createRemoveButtons()
+    this.removeEmptyFieldset()
+    this.updateFieldsetsAndButtons()
+  }
+
+  AddAnother.prototype.createAddAnotherButton = function () {
+    this.addAnotherButton =
+      createButton(
+        this.module.dataset.addButtonText,
+        'js-add-another__add-button govuk-button--secondary'
+      )
+    this.addAnotherButton.addEventListener('click', this.addNewFieldset.bind(this))
+    this.module.appendChild(this.addAnotherButton)
+  }
+
+  AddAnother.prototype.createRemoveButton = function (fieldset, removeFunction) {
+    var removeButton =
+      createButton(
+        'Delete',
+        'js-add-another__remove-button gem-c-add-another__remove-button govuk-button--warning'
+      )
+    removeButton.addEventListener('click', function (event) {
+      removeFunction(event)
+      this.updateFieldsetsAndButtons()
+      this.addAnotherButton.focus()
+    }.bind(this))
+    fieldset.appendChild(removeButton)
+  }
+
+  AddAnother.prototype.createRemoveButtons = function () {
+    var fieldsets =
+      document.querySelectorAll('.js-add-another__fieldset')
+    fieldsets.forEach(function (fieldset) {
+      this.createRemoveButton(fieldset, this.removeExistingFieldset.bind(this))
+      fieldset.querySelector('.js-add-another__destroy-checkbox').hidden = true
+    }.bind(this))
+  }
+
+  AddAnother.prototype.removeEmptyFieldset = function () {
+    this.emptyFieldset = this.module.querySelector('.js-add-another__empty')
+    this.emptyFieldset.remove()
+  }
+
+  AddAnother.prototype.updateFieldsetsAndButtons = function () {
+    this.module.querySelectorAll('.js-add-another__fieldset:not([hidden]) > fieldset > legend')
+      .forEach(function (legend, index) {
+        legend.textContent = this.module.dataset.fieldsetLegend + ' ' + (index + 1)
+      }.bind(this))
+
+    this.module.querySelector('.js-add-another__remove-button').classList.toggle(
+      'js-add-another__remove-button--hidden',
+      this.module.querySelectorAll('.js-add-another__fieldset:not([hidden])').length === 1
+    )
+  }
+
+  AddAnother.prototype.addNewFieldset = function (event) {
+    var button = event.target
+    var newFieldset = this.emptyFieldset.cloneNode(true)
+    newFieldset.classList.remove('js-add-another__empty')
+    newFieldset.classList.add('js-add-another__fieldset')
+    this.createRemoveButton(newFieldset, this.removeNewFieldset.bind(this))
+    button.before(newFieldset)
+
+    this.incrementAttributes(this.emptyFieldset)
+    this.updateFieldsetsAndButtons()
+
+    // Move focus to first visible field in new set
+    newFieldset
+      .querySelector('input:not([type="hidden"]), select, textarea')
+      .focus()
+  }
+
+  AddAnother.prototype.removeExistingFieldset = function (event) {
+    var fieldset = event.target.parentNode
+    var destroyCheckbox =
+      fieldset.querySelector('.js-add-another__destroy-checkbox input')
+
+    destroyCheckbox.checked = true
+    fieldset.hidden = true
+  }
+
+  AddAnother.prototype.removeNewFieldset = function (event) {
+    var fieldset = event.target.parentNode
+    fieldset.remove()
+  }
+
+  // Set attribute values for id, for and name of supplied fieldset
+  AddAnother.prototype.incrementAttributes = function (fieldset) {
+    var matcher = /(.*[_[])([0-9]+)([_\]].*?)$/
+    fieldset
+      .querySelectorAll('label, input, select, textarea')
+      .forEach(function (element) {
+        ['name', 'id', 'for'].forEach(function (attribute) {
+          var value = element.getAttribute(attribute)
+          var matched = matcher.exec(value)
+          if (!matched) return
+          var index = parseInt(matched[2], 10) + 1
+          element.setAttribute(attribute, matched[1] + index + matched[3])
+        })
+      })
+  }
+
+  Modules.AddAnother = AddAnother
+})(window.GOVUK.Modules)

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -10,6 +10,7 @@
 // components
 @import "components/accordion";
 @import "components/action-link";
+@import "components/add-another";
 @import "components/attachment";
 @import "components/attachment-link";
 @import "components/back-link";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_add-another.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_add-another.scss
@@ -1,0 +1,12 @@
+@import "govuk_publishing_components/individual_component_support";
+@import "govuk/components/button/button";
+@import "govuk/components/fieldset/fieldset";
+
+.gem-c-add-another__remove-button {
+  margin-top: govuk-spacing(6);
+  margin-bottom: 0;
+}
+
+.js-add-another__remove-button--hidden {
+  display: none;
+}

--- a/app/views/govuk_publishing_components/components/_add_another.html.erb
+++ b/app/views/govuk_publishing_components/components/_add_another.html.erb
@@ -1,0 +1,29 @@
+<%
+  add_gem_component_stylesheet("add-another")
+  items ||= []
+  empty ||= ""
+  fieldset_legend ||= ""
+  add_button_text ||= "Add another"
+%>
+
+<div data-module="add-another" class="gem-c-add-another" data-add-button-text="<%= add_button_text %>" data-fieldset-legend="<%= fieldset_legend %>">
+  <% items.each_with_index do |item, index| %>
+    <%= render "govuk_publishing_components/components/fieldset", {
+      classes: "js-add-another__fieldset",
+      legend_text: "#{fieldset_legend} #{index + 1}",
+      heading_size: "m"
+    } do %>
+      <div class="js-add-another__destroy-checkbox">
+        <%= item[:destroy_checkbox] %>
+      </div>
+      <%= item[:fields] %>
+    <% end %>
+  <% end %>
+  <%= render "govuk_publishing_components/components/fieldset", {
+    classes: "js-add-another__empty",
+    legend_text: "#{fieldset_legend} #{items.length + 1}",
+    heading_size: "m"
+  } do %>
+    <%= empty %>
+  <% end %>
+</div>

--- a/app/views/govuk_publishing_components/components/_fieldset.html.erb
+++ b/app/views/govuk_publishing_components/components/_fieldset.html.erb
@@ -17,15 +17,16 @@
     describedby = error_id
   end
 
-  css_classes = %w(gem-c-fieldset govuk-form-group)
-  css_classes << "govuk-form-group--error" if error_message
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("gem-c-fieldset govuk-form-group")
+  component_helper.add_class("govuk-form-group--error") if error_message
 
   fieldset_classes = %w(govuk-fieldset)
 
   legend_classes = %w(govuk-fieldset__legend)
   legend_classes << "govuk-fieldset__legend--#{heading_size}" if heading_size
 %>
-<%= tag.div class: css_classes do %>
+<%= tag.div(**component_helper.all_attributes) do %>
   <%= tag.fieldset class: fieldset_classes, aria: { describedby: describedby }, role: role, id: id do %>
     <% if heading_level %>
       <%= tag.legend class: legend_classes do %>

--- a/app/views/govuk_publishing_components/components/docs/add_another.yml
+++ b/app/views/govuk_publishing_components/components/docs/add_another.yml
@@ -1,0 +1,48 @@
+name: Add another (experimental)
+description: |
+  The "add another" component lets users input multiple values for a set of form
+  fields.
+body: |
+  This component is currently experimental because more research is needed to
+  validate it.
+  
+  Applications using this component must include a deletion checkbox in addtion
+  to the rendered repeating items as well as an empty field. The checkboxes and
+  empty field are required to allow users without javascript to add new items
+  and remove existing items from the list. See the examples below for how to do
+  this.
+
+  The example here passes HTML in to the component due to limitations in the
+  format of this documentation. In applications it is expected that the caller
+  will render other components instead. See Whitehall for
+  [examples of this approach](https://github.com/alphagov/whitehall/pull/9644).
+
+accessibility_criteria: |
+  The form controls within the fieldsets must be fully accessible as per the
+  design system guidance for each of the form control components.
+uses_component_wrapper_helper: false
+govuk_frontend_components:
+  - button
+examples:
+  default:
+    data:
+      fieldset_legend: "Person"
+      add_button_text: "Add another person"
+      items:
+        - fields: >
+            <div class="govuk-form-group">
+              <label for="person_0_name" class="gem-c-label govuk-label">Full name</label>
+              <input class="gem-c-input govuk-input" id="person_0_name" name="person[0]name">
+            </div>
+          destroy_checkbox: >
+            <div class="govuk-checkboxes" data-module="govuk-checkboxes" data-govuk-checkboxes-init="">
+              <div class="govuk-checkboxes__item">
+                <input type="checkbox" name="person[0][_destroy]" id="person_0__destroy" class="govuk-checkboxes__input">
+                <label for="person_0__destroy" class="govuk-label govuk-checkboxes__label">Delete</label>
+              </div>
+            </div>
+      empty:
+        <div class="govuk-form-group">
+          <label for="person_1_name" class="gem-c-label govuk-label">Full name</label>
+          <input class="gem-c-input govuk-input" id="person_1_name" name="person[1]name">
+        </div>

--- a/spec/components/add_another_spec.rb
+++ b/spec/components/add_another_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+describe "Add another", type: :view do
+  def component_name
+    "add_another"
+  end
+
+  def default_items
+    [
+      {
+        fields: sanitize("<div class=\"item1\">item1</div>"),
+        destroy_checkbox: sanitize("<input type=\"checkbox\" />"),
+      },
+      {
+        fields: sanitize("<div class=\"item2\">item2</div>"),
+        destroy_checkbox: sanitize("<input type=\"checkbox\" />"),
+      },
+    ]
+  end
+
+  it "renders a wrapper element" do
+    render_component(items: default_items)
+
+    assert_select "div.gem-c-add-another[data-module='add-another']"
+  end
+
+  it "renders the items provided" do
+    empty = ""
+    render_component({ items: default_items, empty: })
+
+    assert_select "div.js-add-another__fieldset .item1"
+    assert_select "div.js-add-another__fieldset .item2"
+  end
+
+  it "renders a destroy checkbox for each item" do
+    empty = ""
+    render_component({ items: default_items, empty: })
+
+    assert_select "div.js-add-another__fieldset .js-add-another__destroy-checkbox", count: 2
+  end
+
+  it "renders the empty item" do
+    empty = sanitize("<div class=\"empty\">empty</div>")
+    render_component({ items: default_items, empty: })
+
+    assert_select ".js-add-another__empty div.empty"
+  end
+end

--- a/spec/javascripts/components/add-another-spec.js
+++ b/spec/javascripts/components/add-another-spec.js
@@ -1,0 +1,230 @@
+/* eslint-env jasmine, jquery */
+/* global GOVUK */
+describe('GOVUK.Modules.AddAnother', function () {
+  var fixture, addAnother, addButton, fieldset, fieldset0, fieldset1, fieldset2, fieldset3
+
+  beforeEach(function () {
+    fixture = document.createElement('form')
+    fixture.setAttribute('data-module', 'AddAnother')
+    fixture.setAttribute('data-fieldset-legend', 'Thing')
+    fixture.setAttribute('data-add-button-text', 'Add another thing')
+    fixture.innerHTML = `
+      <div>
+        <div class="js-add-another__fieldset">
+          <fieldset>
+            <legend>Thing 1</legend>
+            <input type="hidden" name="test[0][id]" value="test_id" />
+            <label for="test_0_foo">Foo</label>
+            <input type="text" id="test_0_foo" name="test[0][foo]" value="test foo" />
+            <label for="test_0_bar"></label>
+            <textarea id="test_0_bar" name="test[0][bar]">test bar</textarea>
+            <label for="test_0__destroy">Delete</label>
+            <div class="js-add-another__destroy-checkbox">
+              <input type="checkbox" id="test_0_destroy" name="test[0][_destroy]" />
+            </div>
+          </fieldset>
+        </div>
+        <div class="js-add-another__fieldset">
+          <fieldset>
+            <legend>Thing 2</legend>
+            <input type="hidden" name="test[1][id]" value="test_id" />
+            <label for="test_1_foo">Foo</label>
+            <input type="text" id="test_1_foo" name="test[1][foo]" value="test foo" />
+            <label for="test_1_bar"></label>
+            <textarea id="test_1_bar" name="test[1][bar]">test bar</textarea>
+            <label for="test_1__destroy">Delete</label>
+            <div class="js-add-another__destroy-checkbox">
+              <input type="checkbox" id="test_1_destroy" name="test[1][_destroy]" />
+            </div>
+          </fieldset>
+        </div>
+        <div class="js-add-another__empty">
+          <fieldset>
+            <legend>Thing 3</legend>
+            <input type="hidden" name="test[2][id]" value="test_id" />
+            <label for="test_2_foo">Foo</label>
+            <input type="text" id="test_2_foo" name="test[2][foo]" value="" />
+            <label for="test_2_bar"></label>
+            <textarea id="test_2_bar" name="test[2][bar]"></textarea>
+            <label for="test_2__destroy">Delete</label>
+          </fieldset>
+        </div>
+      </div>
+    `
+    document.body.append(fixture)
+
+    addAnother = new GOVUK.Modules.AddAnother(fixture)
+    addAnother.init()
+
+    addButton = document.querySelector('.js-add-another__add-button')
+  })
+
+  afterEach(function () {
+    document.body.removeChild(fixture)
+  })
+
+  it('should add an "Add" button to the container when the component is initialised', function () {
+    expect(addButton).toBeTruthy()
+    expect(addButton.textContent).toBe('Add another thing')
+  })
+
+  it('should add a "Remove" button to each repeated fieldset when the component is initialised', function () {
+    var removeButtons = document.querySelectorAll('.js-add-another__remove-button')
+    expect(removeButtons).toHaveSize(2)
+    expect(removeButtons[0].textContent).toBe('Delete')
+  })
+
+  it('should hide the destroy checkbox for each repeated fieldset when the component is initialised', function () {
+    var destroyCheckboxes = document.querySelectorAll('.js-add-another__destroy-checkbox')
+    destroyCheckboxes.forEach(function (checkbox) {
+      expect(checkbox).toBeHidden()
+    })
+  })
+
+  it('should remove the empty fieldset when the component is initialised', function () {
+    expect(document.querySelectorAll('.js-add-another__empty')).toHaveSize(0)
+  })
+
+  it('should add new fields with the correct values when the "Add" button is clicked', function () {
+    window.GOVUK.triggerEvent(addButton, 'click')
+
+    fieldset0 = document.querySelectorAll('.js-add-another__fieldset')[0]
+    fieldset2 = document.querySelectorAll('.js-add-another__fieldset')[2]
+
+    expect(document.querySelectorAll('.js-add-another__fieldset').length).toBe(3)
+    expect(fieldset0.querySelector('input[type="hidden"]').value).toBe('test_id')
+    expect(fieldset0.querySelector('input[type="text"]').value).toBe('test foo')
+    expect(fieldset2.querySelector('input[type="text"]').value).toBe('')
+    expect(fieldset0.querySelector('textarea').value).toBe('test bar')
+    expect(fieldset2.querySelector('textarea').value).toBe('')
+    expect(fieldset0.querySelector('legend').textContent).toBe('Thing 1')
+    expect(fieldset2.querySelector('legend').textContent).toBe('Thing 3')
+  })
+
+  it('should move focus to the first relevant field in the new set when the "Add" button is clicked', function () {
+    window.GOVUK.triggerEvent(addButton, 'click')
+
+    expect(document.activeElement).toBe(
+      document.querySelector('input[name="test[2][foo]"]')
+    )
+  })
+
+  it('should increment the id/name/for values of the added fields', function () {
+    window.GOVUK.triggerEvent(addButton, 'click')
+    window.GOVUK.triggerEvent(addButton, 'click')
+
+    fieldset1 = document.querySelectorAll('.js-add-another__fieldset')[1]
+    fieldset2 = document.querySelectorAll('.js-add-another__fieldset')[2]
+    fieldset3 = document.querySelectorAll('.js-add-another__fieldset')[3]
+
+    expect(
+      fieldset1.querySelector('input[type="hidden"]').getAttribute('name')
+    ).toBe('test[1][id]')
+    expect(
+      fieldset2.querySelector('input[type="hidden"]').getAttribute('name')
+    ).toBe('test[2][id]')
+    expect(
+      fieldset3.querySelector('input[type="hidden"]').getAttribute('name')
+    ).toBe('test[3][id]')
+    expect(fieldset1.querySelectorAll('label')[0].getAttribute('for')).toBe(
+      'test_1_foo'
+    )
+    expect(fieldset2.querySelectorAll('label')[0].getAttribute('for')).toBe(
+      'test_2_foo'
+    )
+    expect(fieldset3.querySelectorAll('label')[0].getAttribute('for')).toBe(
+      'test_3_foo'
+    )
+    expect(fieldset1.querySelector('input[type="text"]').getAttribute('id')).toBe(
+      'test_1_foo'
+    )
+    expect(fieldset2.querySelector('input[type="text"]').getAttribute('id')).toBe(
+      'test_2_foo'
+    )
+    expect(fieldset3.querySelector('input[type="text"]').getAttribute('id')).toBe(
+      'test_3_foo'
+    )
+    expect(
+      fieldset1.querySelector('input[type="text"]').getAttribute('name')
+    ).toBe('test[1][foo]')
+    expect(
+      fieldset2.querySelector('input[type="text"]').getAttribute('name')
+    ).toBe('test[2][foo]')
+    expect(
+      fieldset3.querySelector('input[type="text"]').getAttribute('name')
+    ).toBe('test[3][foo]')
+    expect(fieldset1.querySelectorAll('label')[1].getAttribute('for')).toBe(
+      'test_1_bar'
+    )
+    expect(fieldset2.querySelectorAll('label')[1].getAttribute('for')).toBe(
+      'test_2_bar'
+    )
+    expect(fieldset3.querySelectorAll('label')[1].getAttribute('for')).toBe(
+      'test_3_bar'
+    )
+    expect(fieldset1.querySelector('textarea').getAttribute('id')).toBe('test_1_bar')
+    expect(fieldset2.querySelector('textarea').getAttribute('id')).toBe('test_2_bar')
+    expect(fieldset3.querySelector('textarea').getAttribute('id')).toBe('test_3_bar')
+    expect(fieldset1.querySelector('textarea').getAttribute('name')).toBe(
+      'test[1][bar]'
+    )
+    expect(fieldset2.querySelector('textarea').getAttribute('name')).toBe(
+      'test[2][bar]'
+    )
+    expect(fieldset3.querySelector('textarea').getAttribute('name')).toBe(
+      'test[3][bar]'
+    )
+  })
+
+  it('should hide and check the destroy checkbox for an existing field when its "Remove" button is clicked', function () {
+    fieldset = document.querySelector('.js-add-another__fieldset')
+
+    var removeButton = fieldset.querySelector('.js-add-another__remove-button')
+    window.GOVUK.triggerEvent(removeButton, 'click')
+
+    var destroyCheckbox = fieldset.querySelector('.js-add-another__destroy-checkbox input')
+    expect(destroyCheckbox).toBeTruthy()
+    expect(fieldset).toBeHidden()
+  })
+
+  it('should remove a new fieldset when its "Remove" button is clicked', function () {
+    window.GOVUK.triggerEvent(addButton, 'click')
+
+    fieldset = document.querySelectorAll('.js-add-another__fieldset')[2]
+
+    var removeButton = fieldset.querySelector('.js-add-another__remove-button')
+    window.GOVUK.triggerEvent(removeButton, 'click')
+
+    expect(document.querySelectorAll('.js-add-another__fieldset').length).toBe(2)
+  })
+
+  it('should update the fieldset legends when an entry is removed', function () {
+    window.GOVUK.triggerEvent(addButton, 'click')
+
+    fieldset0 = document.querySelector('.js-add-another__fieldset')
+    fieldset1 = document.querySelectorAll('.js-add-another__fieldset')[1]
+    fieldset2 = document.querySelectorAll('.js-add-another__fieldset')[2]
+
+    expect(fieldset0.querySelector('legend').textContent).toBe('Thing 1')
+    expect(fieldset1.querySelector('legend').textContent).toBe('Thing 2')
+    expect(fieldset2.querySelector('legend').textContent).toBe('Thing 3')
+
+    var removeButton = fieldset0.querySelector('.js-add-another__remove-button')
+    window.GOVUK.triggerEvent(removeButton, 'click')
+
+    expect(fieldset1.querySelector('legend').textContent).toBe('Thing 1')
+    expect(fieldset2.querySelector('legend').textContent).toBe('Thing 2')
+  })
+
+  it('should move focus to the add another button when any "Remove" button is clicked', function () {
+    window.GOVUK.triggerEvent(addButton, 'click')
+    window.GOVUK.triggerEvent(addButton, 'click')
+
+    var removeButton = document.querySelectorAll('.js-add-another__remove-button')[0]
+    window.GOVUK.triggerEvent(removeButton, 'click')
+
+    expect(document.activeElement).toBe(
+      document.querySelector('.js-add-another__add-button')
+    )
+  })
+})

--- a/spec/lib/govuk_publishing_components/app_helpers/asset_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/app_helpers/asset_helper_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe GovukPublishingComponents::AppHelpers::AssetHelper do
     end
 
     it "detect the total number of stylesheet paths" do
-      expect(get_component_css_paths.count).to eql(80)
+      expect(get_component_css_paths.count).to eql(81)
     end
 
     it "initialize empty asset helper" do


### PR DESCRIPTION
## What
- Add the component wrapper helper to fieldsets
- Introduce the add another component based on the [MoJ design system](https://design-patterns.service.justice.gov.uk/components/add-another/) and [existing component in Whitehall](https://github.com/alphagov/whitehall/blob/main/app/assets/javascripts/admin/modules/add-another.js). 
- An empty field and destroy checkboxes for the existing fields are required and displayed to the user when javascript is disabled in keeping with rails conventions.
- When Javascript is enabled, an "add another" button is introduced to allow users to add copies of the empty field and the checkboxes replaced with "Delete" buttons which hide the fields and checks the appropriate checkbox.

## Why
 - This component is to be used when users need to add similar information a couple of times, such as several featured links for an organisation.
 - The current implementation in Whitehall requires JavaScript to work correctly
 - We want to use the pattern in Specialist Publisher and Mainstream.
 - https://trello.com/c/BIfsF9pP/3139-move-add-another-pattern-to-govukpublishingcomponents


## Screenshots
To see further examples of usage, the [migration PR for Whitehall](https://github.com/alphagov/whitehall/pull/9644) can be looked at.
> The screenshots are taken with `input` and `checkbox` styles added to the page.
> This are not present in the code in the PR.
### With Javascript
<img width="976" alt="Screenshot 2024-11-25 at 17 45 43" src="https://github.com/user-attachments/assets/e7ca3cac-992e-4de0-9208-26f767c000b8">
<img width="974" alt="Screenshot 2024-11-25 at 17 45 55" src="https://github.com/user-attachments/assets/725aba99-ba41-4d22-9a98-c7329cba3137">


### Without Javascript
<img width="977" alt="Screenshot 2024-11-25 at 17 46 56" src="https://github.com/user-attachments/assets/3701a5b2-4962-4e54-83b9-d6d8743244fd">
