### PR TITLE
Fix "sticky" GA4 search tracker `tool_name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix "sticky" GA4 search tracker `tool_name` ([PR #4422](https://github.com/alphagov/govuk_publishing_components/pull/4422))
+
 ## 45.6.0
 
 * Fix yellow focus colour overspill ([PR #4418](https://github.com/alphagov/govuk_publishing_components/pull/4418))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-search-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-search-tracker.js
@@ -65,6 +65,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
           // part of the `page_view` event on the subsequent page load
           window.sessionStorage &&
             window.sessionStorage.setItem('searchAutocompleteAccepted', 'true')
+        } else {
+          // Explicitly set `tool_name` to `null` if the user has not accepted a suggestion, as
+          // `undefined` will not overwrite the current value in the analytics state (meaning a
+          // previously set value would be used if there was one)
+          data.tool_name = null
         }
 
         data.length = Number(this.$searchInput.dataset.autocompleteSuggestionsCount)

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-search-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-search-tracker.spec.js
@@ -145,7 +145,7 @@ describe('Google Analytics search tracking', () => {
       expect(setItemSpy).toHaveBeenCalledWith('searchAutocompleteAccepted', 'true')
     })
 
-    it('does not set tool_name if the user has not accepted a suggestion', () => {
+    it('sets tool_name to null if the user has not accepted a suggestion', () => {
       input.dataset.autocompleteTriggerInput = 'i want to'
       input.dataset.autocompleteSuggestions = 'i want to fish|i want to dance|i want to sleep'
       input.dataset.autocompleteSuggestionsCount = '3'
@@ -153,7 +153,7 @@ describe('Google Analytics search tracking', () => {
       input.value = 'i want to fish'
       GOVUK.triggerEvent(form, 'submit')
 
-      expect(sendSpy.calls.mostRecent().args[0].tool_name).toBeUndefined()
+      expect(sendSpy.calls.mostRecent().args[0].tool_name).toBeNull()
     })
   })
 


### PR DESCRIPTION
## What
The GA4 search tracker was only setting the `tool_name` on its `search` event in case the user had accepted an autocomplete suggestion. Now that we persist the `tool_name` in the page's analytics state, this meant that if the user had accepted a suggestion on a previous search, the `tool_name` would continue to be set for subsequent searches regardless of whether they've actually _used_ autocomplete.

## Why
Avoiding incorrect analytics data.