### PR TITLE
Fix chart minimal option

### DIFF
--- a/app/views/govuk_publishing_components/components/_chart.html.erb
+++ b/app/views/govuk_publishing_components/components/_chart.html.erb
@@ -13,7 +13,6 @@
   chart_type ||= "line"
   minimal ||= false
   hide_heading ||= minimal
-  hide_legend ||= minimal
   link ||= false
   padding ||= false
 

--- a/lib/govuk_publishing_components/presenters/chart_helper.rb
+++ b/lib/govuk_publishing_components/presenters/chart_helper.rb
@@ -5,9 +5,12 @@ module GovukPublishingComponents
         @rows = options[:rows]
         @keys = options[:keys]
         @minimal = options[:minimal]
+        @enable_interactivity = false
         @enable_interactivity = true unless @minimal
         @hide_legend = options[:hide_legend]
+        @hide_legend = true if @minimal
         @point_size = options[:point_size] ||= 10
+        @point_size = 0 if @minimal
         @height = options[:height] || 400
         @h_axis_title = options[:h_axis_title]
         @v_axis_title = options[:v_axis_title]

--- a/spec/lib/govuk_publishing_components/components/chart_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/components/chart_helper_spec.rb
@@ -50,9 +50,11 @@ RSpec.describe GovukPublishingComponents::Presenters::ChartHelper do
 
     it "returns expected chart options when minimal is true" do
       required_params[:minimal] = true
-      expected[:enableInteractivity] = nil
+      expected[:enableInteractivity] = false
       expected[:hAxis][:textPosition] = "none"
       expected[:vAxis][:textPosition] = "none"
+      expected[:legend] = "none"
+      expected[:pointSize] = 0
 
       chart_helper = GovukPublishingComponents::Presenters::ChartHelper.new(required_params)
       options = chart_helper.chart_options


### PR DESCRIPTION
## What
Fixes the `minimal` option in the chart component, because it wasn't hiding the legend, removing interactivity, or reducing point size automatically, as it should have been.

## Why
Managed to break this as part of https://github.com/alphagov/govuk_publishing_components/pull/4424

## Visual Changes
None (except to fix minimal mode back to what it should be).