### PR TITLE
`search_with_autocomplete`: Change trigger input tracking

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/components/search-with-autocomplete.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/search-with-autocomplete.js
@@ -116,15 +116,15 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     // Set tracking attributes on the input field. These can be used by the containing form's
     // analytics module to track the user's interaction with the autocomplete component.
     setTrackingAttributes (query, results) {
-      // Only set the suggestions attribute when results actually come back (so this attribute
-      // tracks the last seen non-empty suggestions, even if the user then amends their query to one
-      // that doesn't generate any)
+      // Only set the suggestions and trigger input attributes when results actually come back (so
+      // these attributes track the last seen non-empty suggestions and input used to trigger them,
+      // even if the user then amends their query to one that doesn't generate any)
       if (results.length > 0) {
         const formattedResults = results.slice(0, 5).join('|')
         this.$autocompleteInput.dataset.autocompleteSuggestions = formattedResults
+        this.$autocompleteInput.dataset.autocompleteTriggerInput = query
       }
 
-      this.$autocompleteInput.dataset.autocompleteTriggerInput = query
       this.$autocompleteInput.dataset.autocompleteSuggestionsCount = results.length
       this.$autocompleteInput.dataset.autocompleteAccepted = false
     }

--- a/spec/javascripts/components/search-with-autocomplete-spec.js
+++ b/spec/javascripts/components/search-with-autocomplete-spec.js
@@ -277,7 +277,7 @@ describe('Search with autocomplete component', () => {
     })
   })
 
-  it('keeps the suggestions (but not the count) in the data attribute when subsequent requests return empty results', (done) => {
+  it('keeps the suggestions and input (but not the count) in the data attribute when subsequent requests return empty results', (done) => {
     // Allows us to override the spy on fetch to be able to stub out a subsequent request
     jasmine.getEnv().allowRespy(true)
 
@@ -296,6 +296,7 @@ describe('Search with autocomplete component', () => {
           'my favourite song is karma|' +
           'my favourite song is death by a thousand cuts'
         )
+        expect(input.dataset.autocompleteTriggerInput).toEqual('my favourite song is')
         expect(input.dataset.autocompleteSuggestionsCount).toEqual('0')
         done()
       })


### PR DESCRIPTION
## What
The analytics tracking on the `search_with_autocomplete` component currently tracks whatever the user last entered into the search field, regardless of whether that actually led to any suggestions being displayed.

This changes the logic to instead track the _last_ thing the user entered into the search field that produced suggestions.

## Why
This helps us better understand what input leads to suggestions being shown, and why users might not interact with the offered suggestions.