### PR TITLE
search_with_autocomplete: Standardise trigger input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* search_with_autocomplete: Change trigger input tracking ([PR #4428](https://github.com/alphagov/govuk_publishing_components/pull/4428))
+* search_with_autocomplete: Standardise trigger input ([PR #4429](https://github.com/alphagov/govuk_publishing_components/pull/4429))
+
 ## 45.7.0
 
 * Extend chart component options ([PR #4424](https://github.com/alphagov/govuk_publishing_components/pull/4424))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-search-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-search-tracker.js
@@ -51,7 +51,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         url: this.url,
         index_section: this.indexSection,
         index_section_count: this.indexSectionCount,
-        text: this.searchTerm()
+        text: this.standardiseInput(this.$searchInput.value)
       }
 
       if (this.$searchInput.dataset.autocompleteTriggerInput) {
@@ -73,7 +73,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         }
 
         data.length = Number(this.$searchInput.dataset.autocompleteSuggestionsCount)
-        data.autocomplete_input = this.$searchInput.dataset.autocompleteTriggerInput
+        data.autocomplete_input = this.standardiseInput(
+          this.$searchInput.dataset.autocompleteTriggerInput
+        )
         data.autocomplete_suggestions = this.$searchInput.dataset.autocompleteSuggestions
       }
 
@@ -83,16 +85,16 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     skipTracking () {
       // Skip tracking for those events that we do not want to track: where the search term is
       // present, but has not changed from its initial value
-      return this.searchTerm() !== '' && this.searchTerm() === this.initialKeywords
+      return this.$searchInput.value !== '' && this.$searchInput.value === this.initialKeywords
     }
 
-    searchTerm () {
+    standardiseInput (value) {
       const { standardiseSearchTerm } = window.GOVUK.analyticsGa4.core.trackFunctions
 
       // `standardiseSearchTerm` returns undefined for empty strings, whereas we actively want an
       // empty string as part of search events (undefined would not overwrite the current value in
       // the analytics state)
-      return standardiseSearchTerm(this.$searchInput.value) || ''
+      return standardiseSearchTerm(value) || ''
     }
   }
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-search-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-search-tracker.spec.js
@@ -3,7 +3,7 @@
 describe('Google Analytics search tracking', () => {
   'use strict'
 
-  let fixture, form, input, sendSpy, setItemSpy, ga4SearchTracker
+  let fixture, form, input, sendSpy, standardiseSpy, setItemSpy, ga4SearchTracker
   const GOVUK = window.GOVUK
 
   const html = `
@@ -40,6 +40,7 @@ describe('Google Analytics search tracking', () => {
 
     sendSpy = spyOn(GOVUK.analyticsGa4.core, 'applySchemaAndSendData')
     setItemSpy = spyOn(window.sessionStorage, 'setItem')
+    standardiseSpy = spyOn(GOVUK.analyticsGa4.core.trackFunctions, 'standardiseSearchTerm').and.callThrough()
 
     ga4SearchTracker = new GOVUK.Modules.Ga4SearchTracker(form)
   })
@@ -154,6 +155,15 @@ describe('Google Analytics search tracking', () => {
       GOVUK.triggerEvent(form, 'submit')
 
       expect(sendSpy.calls.mostRecent().args[0].tool_name).toBeNull()
+    })
+
+    it('standardises both the text and autocomplete_input values', () => {
+      input.dataset.autocompleteTriggerInput = 'i want to'
+      input.value = 'I want to fish'
+
+      GOVUK.triggerEvent(form, 'submit')
+      expect(standardiseSpy).toHaveBeenCalledTimes(2)
+      expect(standardiseSpy.calls.allArgs()).toEqual([['I want to fish'], ['i want to']])
     })
   })
 


### PR DESCRIPTION
## What
We want to apply the search input standardisation for the search event not just on the search term itself, but also on the (partial) user input that led to the autocomplete suggestions being triggered.

- Refactor `Ga4SearchTracker.searchTerm()` into a more generic `.standardiseInput()` that we can use for both search term and trigger input value
- Standardise search term for both using this new function
- Add missing changelog entry for a previous PR (sorry!)

## Why
This will make our search events more consistently sanitised for analytics purposes.