### PR TITLE
Version 45.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 45.7.1
 
 * search_with_autocomplete: Change trigger input tracking ([PR #4428](https://github.com/alphagov/govuk_publishing_components/pull/4428))
 * search_with_autocomplete: Standardise trigger input ([PR #4429](https://github.com/alphagov/govuk_publishing_components/pull/4429))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (45.7.0)
+    govuk_publishing_components (45.7.1)
       chartkick
       govuk_app_config
       govuk_personalisation (>= 0.7.0)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "45.7.0".freeze
+  VERSION = "45.7.1".freeze
 end


### PR DESCRIPTION
* search_with_autocomplete: Change trigger input tracking ([PR #4428](https://github.com/alphagov/govuk_publishing_components/pull/4428))
* search_with_autocomplete: Standardise trigger input ([PR #4429](https://github.com/alphagov/govuk_publishing_components/pull/4429))