### PR TITLE
Revert "search_with_autocomplete: Standardise trigger input"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,6 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
-
-* search_with_autocomplete: Change trigger input tracking ([PR #4428](https://github.com/alphagov/govuk_publishing_components/pull/4428))
-* search_with_autocomplete: Standardise trigger input ([PR #4429](https://github.com/alphagov/govuk_publishing_components/pull/4429))
-
 ## 45.7.0
 
 * Extend chart component options ([PR #4424](https://github.com/alphagov/govuk_publishing_components/pull/4424))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-search-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-search-tracker.js
@@ -51,7 +51,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         url: this.url,
         index_section: this.indexSection,
         index_section_count: this.indexSectionCount,
-        text: this.standardiseInput(this.$searchInput.value)
+        text: this.searchTerm()
       }
 
       if (this.$searchInput.dataset.autocompleteTriggerInput) {
@@ -73,9 +73,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         }
 
         data.length = Number(this.$searchInput.dataset.autocompleteSuggestionsCount)
-        data.autocomplete_input = this.standardiseInput(
-          this.$searchInput.dataset.autocompleteTriggerInput
-        )
+        data.autocomplete_input = this.$searchInput.dataset.autocompleteTriggerInput
         data.autocomplete_suggestions = this.$searchInput.dataset.autocompleteSuggestions
       }
 
@@ -85,16 +83,16 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     skipTracking () {
       // Skip tracking for those events that we do not want to track: where the search term is
       // present, but has not changed from its initial value
-      return this.$searchInput.value !== '' && this.$searchInput.value === this.initialKeywords
+      return this.searchTerm() !== '' && this.searchTerm() === this.initialKeywords
     }
 
-    standardiseInput (value) {
+    searchTerm () {
       const { standardiseSearchTerm } = window.GOVUK.analyticsGa4.core.trackFunctions
 
       // `standardiseSearchTerm` returns undefined for empty strings, whereas we actively want an
       // empty string as part of search events (undefined would not overwrite the current value in
       // the analytics state)
-      return standardiseSearchTerm(value) || ''
+      return standardiseSearchTerm(this.$searchInput.value) || ''
     }
   }
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-search-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-search-tracker.spec.js
@@ -3,7 +3,7 @@
 describe('Google Analytics search tracking', () => {
   'use strict'
 
-  let fixture, form, input, sendSpy, standardiseSpy, setItemSpy, ga4SearchTracker
+  let fixture, form, input, sendSpy, setItemSpy, ga4SearchTracker
   const GOVUK = window.GOVUK
 
   const html = `
@@ -40,7 +40,6 @@ describe('Google Analytics search tracking', () => {
 
     sendSpy = spyOn(GOVUK.analyticsGa4.core, 'applySchemaAndSendData')
     setItemSpy = spyOn(window.sessionStorage, 'setItem')
-    standardiseSpy = spyOn(GOVUK.analyticsGa4.core.trackFunctions, 'standardiseSearchTerm').and.callThrough()
 
     ga4SearchTracker = new GOVUK.Modules.Ga4SearchTracker(form)
   })
@@ -155,15 +154,6 @@ describe('Google Analytics search tracking', () => {
       GOVUK.triggerEvent(form, 'submit')
 
       expect(sendSpy.calls.mostRecent().args[0].tool_name).toBeNull()
-    })
-
-    it('standardises both the text and autocomplete_input values', () => {
-      input.dataset.autocompleteTriggerInput = 'i want to'
-      input.value = 'I want to fish'
-
-      GOVUK.triggerEvent(form, 'submit')
-      expect(standardiseSpy).toHaveBeenCalledTimes(2)
-      expect(standardiseSpy.calls.allArgs()).toEqual([['I want to fish'], ['i want to']])
     })
   })
 


### PR DESCRIPTION
Reverts alphagov/govuk_publishing_components#4429

Having discussed this again in the team, we actually _don't_ want to do this after all 🥴

While standardising the search terms has some value for consistent analytics data, we trade off being able to determine if users e.g. put in extra spaces causing autocomplete to fail. PII is also not a concern as the input is only set for suggestions matching the input that come back, which are already clean of PII.