### PR TITLE
Allow licence details in footer to be hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Allow the licence details to be hidden ([PR #4438](https://github.com/alphagov/govuk_publishing_components/pull/4438))
+
 ## 45.8.0
 
 * Add the component wrapper to the lead paragraph component ([PR #4434](https://github.com/alphagov/govuk_publishing_components/pull/4434))

--- a/app/views/govuk_publishing_components/components/_layout_footer.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_footer.html.erb
@@ -4,6 +4,7 @@
   meta ||= []
   navigation ||= []
   with_border ||= false
+  hide_licence ||= false
   layout_footer_helper = GovukPublishingComponents::Presenters::LayoutFooterHelper.new(navigation, meta)
   absolute_links_helper = GovukPublishingComponents::Presenters::AbsoluteLinksHelper.new()
 
@@ -95,29 +96,31 @@
             <% end %>
           </ul>
         <% end %>
-        <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
-          <path
-            fill="currentColor"
-            d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
-          />
-        </svg>
-        <% # this is to avoid having hardcoded data attributes in locale files %>
-        <span
-          class="govuk-footer__licence-description"
-          data-ga4-track-links-only
-          data-ga4-link="<%= {
-            "event_name": "navigation",
-            "section": "Licence",
-            "index_section": layout_footer_helper.ga4_ogl_link_index_section.to_s,
-            "index_link": "1",
-            "index_section_count": layout_footer_helper.ga4_index_section_count.to_s,
-            "text": "Open Government Licence v3.0",
-            "index_total": "1",
-            "type": "footer",
-          }.to_json %>"
-        >
-          <%= t("components.layout_footer.licence_html") %>
-        </span>
+        <% unless hide_licence %>
+          <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
+            <path
+              fill="currentColor"
+              d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
+            />
+          </svg>
+          <% # this is to avoid having hardcoded data attributes in locale files %>
+          <span
+            class="govuk-footer__licence-description"
+            data-ga4-track-links-only
+            data-ga4-link="<%= {
+              "event_name": "navigation",
+              "section": "Licence",
+              "index_section": layout_footer_helper.ga4_ogl_link_index_section.to_s,
+              "index_link": "1",
+              "index_section_count": layout_footer_helper.ga4_index_section_count.to_s,
+              "text": "Open Government Licence v3.0",
+              "index_total": "1",
+              "type": "footer",
+            }.to_json %>"
+          >
+            <%= t("components.layout_footer.licence_html") %>
+          </span>
+        <% end %>
       </div>
       <% # this is to avoid having hardcoded data attributes in locale files %>
       <div

--- a/app/views/govuk_publishing_components/components/docs/layout_footer.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_footer.yml
@@ -169,3 +169,10 @@ examples:
             text: Rhestr o Wasanaethau Cymraeg
           - href: '/government/organisations/government-digital-service'
             text: Government Digital Service
+
+  without_licence_details:
+    description: |
+      In some limited circumstances (for example, in backend-facing admin systems) it doesn't make
+      sense to show the licence information. This can be hidden by setting `hide_licence` to `true`.
+    data:
+      hide_licence: true

--- a/spec/components/layout_footer_spec.rb
+++ b/spec/components/layout_footer_spec.rb
@@ -402,4 +402,25 @@ describe "Layout footer", type: :view do
       expect(link_parent.attr("data-ga4-link").to_s).to eq '{"event_name":"navigation","section":"Copyright","index_section":"5","index_link":"1","index_section_count":"5","text":"© Crown copyright","index_total":"1","type":"footer"}'
     end
   end
+
+  it "shows the licence by default" do
+    render_component({})
+
+    assert_select ".govuk-footer__licence-logo"
+    assert_select ".govuk-footer__licence-description"
+  end
+
+  it "allows the licence to be hidden" do
+    render_component({ hide_licence: true })
+
+    assert_no_selector ".govuk-footer__licence-logo"
+    assert_no_selector ".govuk-footer__licence-description"
+  end
+
+  it "shows the licence if hide_licence is set to false" do
+    render_component({ hide_licence: false })
+
+    assert_select ".govuk-footer__licence-logo"
+    assert_select ".govuk-footer__licence-description"
+  end
 end


### PR DESCRIPTION
The layout footer component is used quite a lot by internal services, where it doesn’t make sense to show licence details. This adds a `show_licence` option to allow users to hide the licence if they want/need to. This will always default to `true`, unless the option is specifically set to `false`.