### PR TITLE
Allow the devolved nations component to work properly on Welsh pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Support Welsh devolved nations component ([PR #4440](https://github.com/alphagov/govuk_publishing_components/pull/4440))
 * Use component wrapper on previous and next component ([PR #4463](https://github.com/alphagov/govuk_publishing_components/pull/4463))
 
 ## 46.1.0

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -70,9 +70,9 @@ cy:
     devolved_nations:
       applies_to: Yn berthnasol i
       connectors:
-        last_word:
-        two_words:
-      england:
+        last_word: " a "
+        two_words: " a "
+      england: Loegr
       northern_ireland:
       scotland:
       type:


### PR DESCRIPTION
## What
Allow the devolved administration component to work properly on Welsh pages.

## Why
Trello card: https://trello.com/c/EFcpWfY2/3071-allow-devolved-administration-component-to-support-welsh-m

## Visual Changes
### Before
<img width="680" alt="Screenshot 2024-11-27 at 17 06 03" src="https://github.com/user-attachments/assets/42ed89a9-819c-4edd-a1f8-7f4be25d64b3">

### After
<img width="678" alt="Screenshot 2024-12-02 at 16 09 45" src="https://github.com/user-attachments/assets/712c1490-e344-4709-9a78-77e9084333f6">



