### PR TITLE
**BREAKING** Add component wrapper helper to the list component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 ## Unreleased
 
 * **BREAKING** Change devolved nations component type option ([PR #4535](https://github.com/alphagov/govuk_publishing_components/pull/4535))
+* **BREAKING** Add component wrapper helper to intervention component ([PR #4378](https://github.com/alphagov/govuk_publishing_components/pull/4378))
+* **BREAKING** Add component wrapper helper to the list component ([PR #4441](https://github.com/alphagov/govuk_publishing_components/pull/4441))
 * Use component wrapper on subscription links ([PR #4525](https://github.com/alphagov/govuk_publishing_components/pull/4525))
 * Use component wrapper on success alert component ([PR #4527](https://github.com/alphagov/govuk_publishing_components/pull/4527))
 * Use component wrapper on summary card component ([PR #4528](https://github.com/alphagov/govuk_publishing_components/pull/4528))
@@ -17,7 +19,6 @@
 * Use component wrapper on translation nav component ([PR #4530](https://github.com/alphagov/govuk_publishing_components/pull/4530))
 * Use component wrapper on warning text component ([PR #4351](https://github.com/alphagov/govuk_publishing_components/pull/4531))
 * Remove govspeak advisory component ([PR #4349](https://github.com/alphagov/govuk_publishing_components/pull/4349))
-* **BREAKING**: Add component wrapper helper to intervention component ([PR #4378](https://github.com/alphagov/govuk_publishing_components/pull/4378))
 * Use component wrapper on super navigation header ([PR #4534](https://github.com/alphagov/govuk_publishing_components/pull/4534))
 
 ## 47.0.0

--- a/app/views/govuk_publishing_components/components/_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_list.html.erb
@@ -1,20 +1,14 @@
 <%
-  aria_label ||= nil
   extra_spacing ||= nil
-  id ||= nil
   items ||= []
   list_type ||= "unordered"
   visible_counters ||= nil
 
-  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
-
-  classes = %w[gem-c-list govuk-list]
-  classes << "govuk-list--bullet" if visible_counters and list_type === "unordered"
-  classes << "govuk-list--number" if visible_counters and list_type === "number"
-  classes << "govuk-list--spaced" if extra_spacing
-  # Setting the  `margin_bottom` to 4 is the same as the default margin - so we
-  # can omit the override class. To do this we leave out `4` from the array:
-  classes << shared_helper.get_margin_bottom if [0,1,2,3,5,6,7,8,9].include?(local_assigns[:margin_bottom])
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("gem-c-list govuk-list")
+  component_helper.add_class("govuk-list--bullet") if visible_counters and list_type === "unordered"
+  component_helper.add_class("govuk-list--number") if visible_counters and list_type === "number"
+  component_helper.add_class("govuk-list--spaced") if extra_spacing
 
   # Default list type is unordered list.
   list_tag = "ul"
@@ -23,7 +17,7 @@
   list_tag = "ol" if list_type === "number"
 %>
 <% if items.any? %>
-  <%= content_tag list_tag, class: classes, id: id, "aria-label": aria_label do %>
+  <%= content_tag list_tag, **component_helper.all_attributes do %>
     <% items.each do |item| %>
       <li><%= raw(item) %></li>
     <% end %>

--- a/app/views/govuk_publishing_components/components/docs/list.yml
+++ b/app/views/govuk_publishing_components/components/docs/list.yml
@@ -5,6 +5,7 @@ body: |
 
   The `items` parameter can include HTML to display - such as links or another
   list. This HTML can either be directly coded or come from another component.
+uses_component_wrapper_helper: true
 accessibility_criteria: |
   The list must:
 
@@ -31,7 +32,8 @@ examples:
   unordered_list_with_aria-label:
     description: "A list with an aria-label"
     data:
-      aria_label: "A list of delicious chocolate bars."
+      aria:
+        label: "A list of delicious chocolate bars."
       <<: *default-example-data
   unordered_list_with_bullet_points:
     description: "An unordered list with visible bullet points."

--- a/spec/components/list_spec.rb
+++ b/spec/components/list_spec.rb
@@ -28,7 +28,9 @@ describe "List", type: :view do
 
   it "adds an aria-label" do
     render_component(
-      aria_label: "An aria-label to give this context.",
+      aria: {
+        label: "An aria-label to give this context.",
+      },
       items: ["Test item", "Another test item"],
     )
 
@@ -122,17 +124,6 @@ describe "List", type: :view do
       ],
     )
     assert_select '.gem-c-list.govuk-\!-margin-bottom-7'
-  end
-
-  it "defaults to no bottom margin if an incorrect value is passed" do
-    render_component(
-      margin_bottom: 20,
-      items: [
-        "<a href='https://example.com/'>Test item</a>",
-        "<a href='https://example.com/'>Another test item</a>",
-      ],
-    )
-    assert_select "[class^='govuk-\!-margin-bottom-']", false
   end
 
   it "has no margin class added by default" do


### PR DESCRIPTION
## What
- Adds the component wrapper helper to the `list` component.
- Breaking as this component was using `aria_label` to set its label, but now it should use the component wrapper functionality.
- Should only affect one template: https://github.com/search?q=org%3Aalphagov+govuk_publishing_components%2Fcomponents%2Flist+AND+aria_label&type=code

## Why
As the [trello card](https://trello.com/c/ro4UhaAa/423-add-component-wrapper-helper-to-list-component) states:

> Standardising our components to use the component wrapper helper will reduce code, increase standardisation, and improve future feature implementation speed.

## Visual changes

None.