### PR TITLE
Add component wrapper to the metadata component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Add a `glance_metric` component ([PR #4452](https://github.com/alphagov/govuk_publishing_components/pull/4452))
 * Use component wrapper on org logo component ([PR #4458](https://github.com/alphagov/govuk_publishing_components/pull/4458))
 * Use component wrapper on notice component ([PR #4444](https://github.com/alphagov/govuk_publishing_components/pull/4444))
+* Add component wrapper to the metadata component ([PR #4442](https://github.com/alphagov/govuk_publishing_components/pull/4442))
 
 ## 46.0.0
 

--- a/app/views/govuk_publishing_components/components/_metadata.html.erb
+++ b/app/views/govuk_publishing_components/components/_metadata.html.erb
@@ -17,16 +17,18 @@
   direction_class = " direction-#{direction}" if local_assigns.include?(:direction)
 
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
-  classes = %w(gem-c-metadata)
-  classes << "direction-#{direction}" if local_assigns.include?(:direction)
 
-  if inverse && inverse_compress
-    classes << "gem-c-metadata--inverse"
-  elsif inverse
-    classes << "gem-c-metadata--inverse gem-c-metadata--inverse-padded"
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("gem-c-metadata")
+  component_helper.add_class("direction-#{direction}") if local_assigns.include?(:direction)
+
+  if inverse
+    component_helper.add_class("gem-c-metadata--inverse")
+    component_helper.add_class("gem-c-metadata--inverse-padded") unless inverse_compress
   end
 
-  classes << shared_helper.get_margin_bottom if local_assigns[:margin_bottom]
+  component_helper.add_class(shared_helper.get_margin_bottom) if local_assigns[:margin_bottom]
+  component_helper.add_data_attribute({ module: "metadata" })
 
   disable_ga4 ||= false
   ga4_object = {
@@ -35,7 +37,7 @@
     section: "Top",
   }.to_json unless disable_ga4
 %>
-<%= content_tag :div, class: classes, data: { module: "metadata" } do %>
+<%= tag.div(**component_helper.all_attributes) do %>
   <% if title.present? %>
     <%= content_tag :div, class: "gem-c-metadata__title" do %>
       <%= render "govuk_publishing_components/components/heading", {

--- a/app/views/govuk_publishing_components/components/docs/metadata.yml
+++ b/app/views/govuk_publishing_components/components/docs/metadata.yml
@@ -7,6 +7,7 @@ accessibility_criteria: |
   - indicate the initial state of expandable content
   - indicate where the state of expandable content has changed
 
+uses_component_wrapper_helper: true
 shared_accessibility_criteria:
   - link
 accessibility_excluded_rules:

--- a/docs/component-wrapper-helper.md
+++ b/docs/component-wrapper-helper.md
@@ -33,7 +33,7 @@ These options can be passed to any component that uses the component wrapper.
 - `lang` - accepts a language attribute value
 - `open` - accepts an open attribute value (true or false)
 
-To prevent breaking [component isolation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/component_principles.md#a-component-is-isolated-when), passed classes should only be used for JavaScript hooks and not styling. All component styling should be included only in the component itself. Any passed classes should be prefixed with `js-`. To allow for extending this option, classes prefixed with `gem-c-`, `app-c-` or `govuk-` are also permitted, but should only be used within the component and not passed to it.
+To prevent breaking [component isolation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/component_principles.md#a-component-is-isolated-when), passed classes should only be used for JavaScript hooks and not styling. All component styling should be included only in the component itself. Any passed classes should be prefixed with `js-`. To allow for extending this option, classes prefixed with `gem-c-`, `govuk-`, `app-c-`, `brand--`, or `brand__` are also permitted, as well as an exact match of `direction-rtl`, but these classes should only be used within the component and not passed to it.
 
 The helper checks that any passed `id` attribute is valid, specifically that it does not start with a number or contain whitespace or contain any characters other than letters, numbers, and `_` or `-`. It also checks that role and lang attribute values are valid, along with some other checks detailed below.
 

--- a/lib/govuk_publishing_components/presenters/component_wrapper_helper.rb
+++ b/lib/govuk_publishing_components/presenters/component_wrapper_helper.rb
@@ -104,7 +104,7 @@ module GovukPublishingComponents
         return if classes.blank?
 
         class_array = classes.split(" ")
-        unless class_array.all? { |c| c.start_with?("js-", "gem-c-", "govuk-", "app-c-", "brand--", "brand__") }
+        unless class_array.all? { |c| c.start_with?("js-", "gem-c-", "govuk-", "app-c-", "brand--", "brand__") || c == "direction-rtl" }
           raise(ArgumentError, "Classes (#{classes}) must be prefixed with `js-`")
         end
       end

--- a/spec/lib/govuk_publishing_components/components/component_wrapper_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/components/component_wrapper_helper_spec.rb
@@ -34,15 +34,22 @@ RSpec.describe GovukPublishingComponents::Presenters::ComponentWrapperHelper do
     end
 
     it "accepts valid class names" do
-      component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(classes: "gem-c-component govuk-component app-c-component brand--thing brand__thing")
+      component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(classes: "gem-c-component govuk-component app-c-component brand--thing brand__thing direction-rtl")
       expected = {
-        class: "gem-c-component govuk-component app-c-component brand--thing brand__thing",
+        class: "gem-c-component govuk-component app-c-component brand--thing brand__thing direction-rtl",
       }
       expect(component_helper.all_attributes).to eql(expected)
     end
 
     it "rejects invalid class names" do
       classes = "js-okay not-cool-man"
+      expect {
+        GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(classes:)
+      }.to raise_error(ArgumentError, "Classes (#{classes}) must be prefixed with `js-`")
+    end
+
+    it "rejects classes that aren't an exact match of 'direction-rtl'" do
+      classes = "direction-rtll"
       expect {
         GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(classes:)
       }.to raise_error(ArgumentError, "Classes (#{classes}) must be prefixed with `js-`")


### PR DESCRIPTION
## What
- Adds the component wrapper helper to the `metadata` component.
- **Note:** I added `direction-rtl` to the permitted classes, as it's used across multiple components, but if you think I should do something else, let me know.

## Why
As the [trello card](https://trello.com/c/qH4NyWJw/364-add-component-wrapper-to-more-components) states:

> Standardising our components to use the component wrapper helper will reduce code, increase standardisation, and improve future feature implementation speed.

## Visual changes

None.