### PR TITLE
Version 45.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,13 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 45.8.0
 
+* Limit chart heading width ([PR #4435](https://github.com/alphagov/govuk_publishing_components/pull/4435))
 * Allow the licence details to be hidden ([PR #4438](https://github.com/alphagov/govuk_publishing_components/pull/4438))
 
 ## 45.8.0
 
-* Limit chart heading width ([PR #4435](https://github.com/alphagov/govuk_publishing_components/pull/4435))
 * Add the component wrapper to the lead paragraph component ([PR #4434](https://github.com/alphagov/govuk_publishing_components/pull/4434))
 * Add component wrapper helper to label component ([PR #4364](https://github.com/alphagov/govuk_publishing_components/pull/4364))
 * `search_with_autocomplete`: Change trigger input tracking ([PR #4428](https://github.com/alphagov/govuk_publishing_components/pull/4428))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (45.8.0)
+    govuk_publishing_components (45.9.0)
       chartkick
       govuk_app_config
       govuk_personalisation (>= 0.7.0)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "45.8.0".freeze
+  VERSION = "45.9.0".freeze
 end


### PR DESCRIPTION
## 45.8.0

* Limit chart heading width ([PR #4435](https://github.com/alphagov/govuk_publishing_components/pull/4435))
* Allow the licence details to be hidden ([PR #4438](https://github.com/alphagov/govuk_publishing_components/pull/4438))