### PR TITLE
Add a description for the metadata block 'see_updates_link' example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add 'toggle' module to each expandable region in metadata component ([PR #4397](https://github.com/alphagov/govuk_publishing_components/pull/4397))
+* Add a description for the metadata block 'see_updates_link' example ([PR #4447](https://github.com/alphagov/govuk_publishing_components/pull/4447))
 
 ## 45.9.0
 

--- a/app/views/govuk_publishing_components/components/docs/metadata.yml
+++ b/app/views/govuk_publishing_components/components/docs/metadata.yml
@@ -26,6 +26,9 @@ examples:
       first_published: 14 June 2014
       last_updated: 10 September 2015
   updated_with_links_to_see_details:
+    description: If a `last_updated` value exists and `see_updates_link` is set to true,
+      a "See all updates" link will be shown. The link's href will be set to `#full-publication-update-history`,
+      taking users to the change history on the same page and expanding the section, if expandable, for example, [changes to the rates of capital gains tax](https://www.gov.uk/government/publications/changes-to-the-rates-of-capital-gains-tax)
     data:
       last_updated: 10 September 2015
       see_updates_link: true


### PR DESCRIPTION
## What

Add a description for the metadata block `see_updates_link` example

https://components-gem-pr-4447.herokuapp.com/component-guide/metadata/updated_with_links_to_see_details

## Why

To provide more information on what these options do, including a link to an example page.