### PR TITLE
[DO NOT MERGE] Layout super nav header: Add search autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add search autocomplete to layout super navigation header ([PR #4451](https://github.com/alphagov/govuk_publishing_components/pull/4451))
 * Use component wrapper on reorderable list component ([PR #4474](https://github.com/alphagov/govuk_publishing_components/pull/4474))
 * Use "button" button type for copy to clipboard component ([PR #4480](https://github.com/alphagov/govuk_publishing_components/pull/4480))
 * Use component wrapper on signup link component ([PR #4481](https://github.com/alphagov/govuk_publishing_components/pull/4481))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     chartkick (5.1.2)
+    climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
@@ -614,6 +615,7 @@ PLATFORMS
 
 DEPENDENCIES
   capybara
+  climate_control
   dartsass-rails
   faker
   gds-api-adapters

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -317,7 +317,7 @@
                   label: "Site-wide",
                 }
               ) do %>
-                <%= render "govuk_publishing_components/components/search", {
+                <%= render "govuk_publishing_components/components/search_with_autocomplete", {
                   name: "keywords",
                   inline_label: false,
                   label_size: "m",
@@ -326,6 +326,8 @@
                   size: "large",
                   margin_bottom: 0,
                   disable_corrections: true,
+                  source_url: [Plek.new.website_root, "/api/search/autocomplete.json"].join,
+                  source_key: "suggestions"
                 } %>
               <% end %>
             </div>

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -317,7 +317,7 @@
                   label: "Site-wide",
                 }
               ) do %>
-                <%= render "govuk_publishing_components/components/search_with_autocomplete", {
+                <% search_options = {
                   name: "keywords",
                   inline_label: false,
                   label_size: "m",
@@ -326,9 +326,15 @@
                   size: "large",
                   margin_bottom: 0,
                   disable_corrections: true,
-                  source_url: [Plek.new.website_root, "/api/search/autocomplete.json"].join,
-                  source_key: "suggestions"
                 } %>
+                <% if ENV["GOVUK_DISABLE_SEARCH_AUTOCOMPLETE"] %>
+                  <%= render "govuk_publishing_components/components/search", search_options %>
+                <% else %>
+                  <%= render "govuk_publishing_components/components/search_with_autocomplete", search_options.merge({
+                    source_url: [Plek.new.website_root, "/api/search/autocomplete.json"].join,
+                    source_key: "suggestions",
+                  }) %>
+                <% end %>
               <% end %>
             </div>
           </div>

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency "sprockets-rails"
 
   s.add_development_dependency "capybara"
+  s.add_development_dependency "climate_control"
   s.add_development_dependency "dartsass-rails"
   s.add_development_dependency "faker"
   s.add_development_dependency "gds-api-adapters"

--- a/spec/component_guide/component_index_spec.rb
+++ b/spec/component_guide/component_index_spec.rb
@@ -71,6 +71,7 @@ describe "Component guide index", :capybara do
 @import 'govuk_publishing_components/components/print-link';
 @import 'govuk_publishing_components/components/related-navigation';
 @import 'govuk_publishing_components/components/search';
+@import 'govuk_publishing_components/components/search-with-autocomplete';
 @import 'govuk_publishing_components/components/skip-link';
 @import 'govuk_publishing_components/components/step-by-step-nav';
 @import 'govuk_publishing_components/components/step-by-step-nav-header';
@@ -98,6 +99,7 @@ describe "Component guide index", :capybara do
 //= require govuk_publishing_components/components/layout-header
 //= require govuk_publishing_components/components/layout-super-navigation-header
 //= require govuk_publishing_components/components/print-link
+//= require govuk_publishing_components/components/search-with-autocomplete
 //= require govuk_publishing_components/components/skip-link
 //= require govuk_publishing_components/components/step-by-step-nav
 //= require govuk_publishing_components/components/tabs"

--- a/spec/components/layout_super_navigation_header_spec.rb
+++ b/spec/components/layout_super_navigation_header_spec.rb
@@ -163,6 +163,11 @@ describe "Super navigation header", type: :view do
     assert_select ".js-module-initialised[data-module=\"super-navigation-mega-menu\"]", false
   end
 
+  it "includes the search_with_autocomplete component with correct URL" do
+    render_component({})
+    assert_select ".gem-c-search-with-autocomplete[data-source-url='http://www.dev.gov.uk/api/search/autocomplete.json']"
+  end
+
   it "adds GA4 tracking" do
     render_component({})
 

--- a/spec/components/layout_super_navigation_header_spec.rb
+++ b/spec/components/layout_super_navigation_header_spec.rb
@@ -163,11 +163,6 @@ describe "Super navigation header", type: :view do
     assert_select ".js-module-initialised[data-module=\"super-navigation-mega-menu\"]", false
   end
 
-  it "includes the search_with_autocomplete component with correct URL" do
-    render_component({})
-    assert_select ".gem-c-search-with-autocomplete[data-source-url='http://www.dev.gov.uk/api/search/autocomplete.json']"
-  end
-
   it "adds GA4 tracking" do
     render_component({})
 
@@ -179,5 +174,20 @@ describe "Super navigation header", type: :view do
     assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index_section":2,"index_link":1,"index_section_count":3,"index_total":6,"section":"Government activity"}\']'
     assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index_section":2,"index_link":6,"index_section_count":3,"index_total":6,"section":"Government activity"}\']'
     assert_select "form[data-module='ga4-search-tracker']"
+  end
+
+  describe "search autocomplete" do
+    it "includes the search_with_autocomplete component by default" do
+      render_component({})
+      assert_select ".gem-c-search-with-autocomplete[data-source-url='http://www.dev.gov.uk/api/search/autocomplete.json']"
+    end
+
+    it "allows the GOVUK_DISABLE_SEARCH_AUTOCOMPLETE env var presence to fallback to search without autocomplete" do
+      ClimateControl.modify GOVUK_DISABLE_SEARCH_AUTOCOMPLETE: "1" do
+        render_component({})
+        assert_select ".gem-c-search-autocomplete", false
+        assert_select ".gem-c-search"
+      end
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require "rspec/rails"
 require "capybara/rails"
 require "govuk_test"
+require "climate_control"
 
 GovukTest.configure
 Selenium::WebDriver::Options.chrome(loggingPrefs: { browser: "ALL" })


### PR DESCRIPTION
## What
This changes the layout super navigation header to use the new `search_with_autocomplete` component instead of the vanilla `search` one.

## Why
So users can enjoy the same autocompleting experience as on the homepage and search page.

## Visual Changes
<img width="941" alt="image" src="https://github.com/user-attachments/assets/64ea6b48-f552-41c4-921a-61d195075977">
