### PR TITLE
Apply helper to `fieldset` instead of parent `div`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Apply the component wrapper helper to the fieldset instead of parent div ([PR #4453](https://github.com/alphagov/govuk_publishing_components/pull/4453))
+
 ## 45.10.0
 
 * Add 'toggle' module to each expandable region in metadata component ([PR #4397](https://github.com/alphagov/govuk_publishing_components/pull/4397))

--- a/app/assets/javascripts/govuk_publishing_components/components/add-another.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/add-another.js
@@ -62,7 +62,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   }
 
   AddAnother.prototype.updateFieldsetsAndButtons = function () {
-    this.module.querySelectorAll('.js-add-another__fieldset:not([hidden]) > fieldset > legend')
+    this.module.querySelectorAll('.js-add-another__fieldset:not([hidden]) > legend')
       .forEach(function (legend, index) {
         legend.textContent = this.module.dataset.fieldsetLegend + ' ' + (index + 1)
       }.bind(this))

--- a/app/views/govuk_publishing_components/components/_fieldset.html.erb
+++ b/app/views/govuk_publishing_components/components/_fieldset.html.erb
@@ -5,12 +5,10 @@
 
   text = text || yield
   describedby ||= nil
-  role ||= nil
   heading_level ||= nil
   heading_size = false unless shared_helper.valid_heading_size?(heading_size)
   error_message ||= nil
   error_id ||= nil
-  id ||= nil
 
   if error_message
     error_id = "error-#{SecureRandom.hex(4)}" unless error_id
@@ -18,16 +16,17 @@
   end
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
-  component_helper.add_class("gem-c-fieldset govuk-form-group")
-  component_helper.add_class("govuk-form-group--error") if error_message
+  component_helper.add_class("govuk-fieldset")
+  component_helper.add_aria_attribute({ describedby: describedby }) if describedby
 
-  fieldset_classes = %w(govuk-fieldset)
+  css_classes = %w(gem-c-fieldset govuk-form-group)
+  css_classes << "govuk-form-group--error" if error_message
 
   legend_classes = %w(govuk-fieldset__legend)
   legend_classes << "govuk-fieldset__legend--#{heading_size}" if heading_size
 %>
-<%= tag.div(**component_helper.all_attributes) do %>
-  <%= tag.fieldset class: fieldset_classes, aria: { describedby: describedby }, role: role, id: id do %>
+<%= tag.div class: css_classes do %>
+  <%= tag.fieldset(**component_helper.all_attributes) do %>
     <% if heading_level %>
       <%= tag.legend class: legend_classes do %>
         <%= content_tag(

--- a/spec/javascripts/components/add-another-spec.js
+++ b/spec/javascripts/components/add-another-spec.js
@@ -10,8 +10,8 @@ describe('GOVUK.Modules.AddAnother', function () {
     fixture.setAttribute('data-add-button-text', 'Add another thing')
     fixture.innerHTML = `
       <div>
-        <div class="js-add-another__fieldset">
-          <fieldset>
+        <div>
+          <fieldset class="js-add-another__fieldset">
             <legend>Thing 1</legend>
             <input type="hidden" name="test[0][id]" value="test_id" />
             <label for="test_0_foo">Foo</label>
@@ -24,8 +24,8 @@ describe('GOVUK.Modules.AddAnother', function () {
             </div>
           </fieldset>
         </div>
-        <div class="js-add-another__fieldset">
-          <fieldset>
+        <div>
+          <fieldset class="js-add-another__fieldset">
             <legend>Thing 2</legend>
             <input type="hidden" name="test[1][id]" value="test_id" />
             <label for="test_1_foo">Foo</label>
@@ -38,8 +38,8 @@ describe('GOVUK.Modules.AddAnother', function () {
             </div>
           </fieldset>
         </div>
-        <div class="js-add-another__empty">
-          <fieldset>
+        <div>
+          <fieldset class="js-add-another__empty">
             <legend>Thing 3</legend>
             <input type="hidden" name="test[2][id]" value="test_id" />
             <label for="test_2_foo">Foo</label>


### PR DESCRIPTION
## What
- Apply the Component Wrapper Helper to the `fieldset` instead of parent `div`

## Why
- Its introduction in #4420 was causing `id` to be set on both the parent and fieldset.
