### PR TITLE
Use component wrapper on panel component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Use component wrapper on panel component ([PR #4459](https://github.com/alphagov/govuk_publishing_components/pull/4459))
 * Add a `glance_metric` component ([PR #4452](https://github.com/alphagov/govuk_publishing_components/pull/4452))
 
 ## 46.0.0

--- a/app/views/govuk_publishing_components/components/_panel.html.erb
+++ b/app/views/govuk_publishing_components/components/_panel.html.erb
@@ -6,8 +6,10 @@
   append ||= false
 
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("gem-c-panel govuk-panel govuk-panel--confirmation")
 %>
-<div class="gem-c-panel govuk-panel govuk-panel--confirmation">
+<%= tag.div(**component_helper.all_attributes) do %>
   <%= content_tag(shared_helper.get_heading_level, class: "govuk-panel__title") do %>
     <% if prepend %>
       <span class="gem-c-panel__prepend">
@@ -29,4 +31,4 @@
       <%= description %>
     </div>
   <% end %>
-</div>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/panel.yml
+++ b/app/views/govuk_publishing_components/components/docs/panel.yml
@@ -2,6 +2,7 @@ name: Panel
 description: Used on confirmation or results pages to highlight important content.
 govuk_frontend_components:
   - panel
+uses_component_wrapper_helper: true
 accessibility_criteria: |
   - have a text colour contrast ratio of more than 4.5:1 with its background to be visually distinct
 examples:


### PR DESCRIPTION
## What
- Adds the component wrapper helper to the `panel` component.

## Why
As the [trello card](https://trello.com/c/qH4NyWJw/364-add-component-wrapper-to-more-components) states:

> Standardising our components to use the component wrapper helper will reduce code, increase standardisation, and improve future feature implementation speed.

## Visual changes

None.