### PR TITLE
Add large_font_size option to govspeak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Use component wrapper on org logo component ([PR #4458](https://github.com/alphagov/govuk_publishing_components/pull/4458))
 * Use component wrapper on notice component ([PR #4444](https://github.com/alphagov/govuk_publishing_components/pull/4444))
 * Add component wrapper to the metadata component ([PR #4442](https://github.com/alphagov/govuk_publishing_components/pull/4442))
+* Add a `font_size` option to the govspeak component ([PR #4461](https://github.com/alphagov/govuk_publishing_components/pull/4461))
 
 ## 46.0.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
@@ -15,6 +15,10 @@
 .gem-c-govspeak {
   @include markdown-typography;
 
+  &.gem-c-govspeak--font-size-l {
+    @include markdown-typography($base_font_size: 19, $font_size: 24, $heading_font_size: 36);
+  }
+
   &.gem-c-govspeak--direction-rtl ol,
   &.gem-c-govspeak--direction-rtl ul {
     margin-left: 0;

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_markdown-typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_markdown-typography.scss
@@ -1,7 +1,7 @@
-@mixin markdown-typography {
+@mixin markdown-typography($base_font_size: 16, $font_size: 19, $heading_font_size: 27) {
   @include govuk-text-colour;
 
-  @include govuk-font($size: 16);
+  @include govuk-font($size: $base_font_size);
 
   $gutter-two-thirds: $govuk-gutter - calc($govuk-gutter / 3);
 
@@ -10,7 +10,7 @@
   p {
     margin-top: $govuk-gutter-half;
     margin-bottom: $govuk-gutter-half;
-    @include govuk-font($size: 19);
+    @include govuk-font($size: $font_size);
 
     @include govuk-media-query($from: tablet) {
       margin-top: $gutter-two-thirds;
@@ -26,13 +26,13 @@
   h1 {
     margin: 0;
     padding: 0;
-    @include govuk-font($size: 19);
+    @include govuk-font($size: $font_size);
   }
 
   h2 {
     margin-top: $govuk-gutter;
     margin-bottom: 0;
-    @include govuk-font($size: 27, $weight: bold);
+    @include govuk-font($size: $heading_font_size, $weight: bold);
 
     @include govuk-media-query($from: desktop) {
       margin-top: $govuk-gutter * 1.5;
@@ -43,7 +43,7 @@
   h3 {
     margin-top: $govuk-gutter + 5px;
     margin-bottom: 0;
-    @include govuk-font($size: 19, $weight: bold);
+    @include govuk-font($size: $font_size, $weight: bold);
   }
 
   // H4, H5 and H6 are discouraged and thus styled the same
@@ -53,7 +53,7 @@
   h6 {
     margin-top: $govuk-gutter + 5px;
     margin-bottom: 0;
-    @include govuk-font($size: 19, $weight: bold);
+    @include govuk-font($size: $font_size, $weight: bold);
 
     + p {
       margin-top: 5px;

--- a/app/views/govuk_publishing_components/components/_govspeak.html.erb
+++ b/app/views/govuk_publishing_components/components/_govspeak.html.erb
@@ -5,7 +5,7 @@
   local_assigns[:margin_bottom] ||= 0
   direction_class = "gem-c-govspeak--direction-#{direction}" if local_assigns.include?(:direction)
   disable_youtube_expansions = local_assigns.fetch(:disable_youtube_expansions) if local_assigns.include?(:disable_youtube_expansions)
-  font_size_class = local_assigns.fetch(:font_size, "m").then { |font_size| "gem-c-govspeak--font-size-#{font_size}" }
+  large_font_size = local_assigns.fetch(:large_font_size, false)
 
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
@@ -14,7 +14,7 @@
   component_helper.add_class("js-disable-youtube") if disable_youtube_expansions
   component_helper.add_class("gem-c-govspeak--inverse") if inverse
   component_helper.add_class(shared_helper.get_margin_bottom)
-  component_helper.add_class(font_size_class)
+  component_helper.add_class("gem-c-govspeak--font-size-l") if large_font_size
   component_helper.add_data_attribute({ module: "govspeak" })
 %>
 <%= tag.div(**component_helper.all_attributes) do %>

--- a/app/views/govuk_publishing_components/components/_govspeak.html.erb
+++ b/app/views/govuk_publishing_components/components/_govspeak.html.erb
@@ -5,6 +5,7 @@
   local_assigns[:margin_bottom] ||= 0
   direction_class = "gem-c-govspeak--direction-#{direction}" if local_assigns.include?(:direction)
   disable_youtube_expansions = local_assigns.fetch(:disable_youtube_expansions) if local_assigns.include?(:disable_youtube_expansions)
+  font_size_class = local_assigns.fetch(:font_size, "m").then { |font_size| "gem-c-govspeak--font-size-#{font_size}" }
 
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
@@ -13,6 +14,7 @@
   component_helper.add_class("js-disable-youtube") if disable_youtube_expansions
   component_helper.add_class("gem-c-govspeak--inverse") if inverse
   component_helper.add_class(shared_helper.get_margin_bottom)
+  component_helper.add_class(font_size_class)
   component_helper.add_data_attribute({ module: "govspeak" })
 %>
 <%= tag.div(**component_helper.all_attributes) do %>

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -19,7 +19,7 @@ shared_accessibility_criteria:
   - link
 accessibility_excluded_rules:
   - landmark-complementary-is-top-level # Statistic headlines are generating an aside element which can not be a top level in the examples
-  - different_font_sizes # Example includes headings, which don't conform with the document structure
+  - large_font_size # Example includes headings, which don't conform with the document structure
 uses_component_wrapper_helper: true
 examples:
   basic_content:
@@ -912,9 +912,9 @@ examples:
             <p>Deforested area. Credit: Blue Ventures-Garth Cripps</p>
           </figcaption>
         </figure>
-  different_font_sizes:
+  large_font_size:
     description: |
-      Set a different font size for the govspeak. The only valid option is `l`.
+      Set a different font size for the govspeak. The valid options are true or false (the default).
       
       This option should be used rarely, in cases where the design calls for a short
       piece of large rich text (for example, in the content of a hero block).
@@ -936,4 +936,4 @@ examples:
         <h4>Heading 4</h4>
         <h5>Heading 5</h5>
         <h6>Heading 6</h6>
-      font_size: "l"
+      large_font_size: true

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -911,3 +911,22 @@ examples:
             <p>Deforested area. Credit: Blue Ventures-Garth Cripps</p>
           </figcaption>
         </figure>
+  different_font_sizes:
+    description: |
+      Set a different font size for the govspeak. The only valid option is `l`.
+      
+      This option should be used rarely, in cases where the design calls for a short
+      piece of large rich text (for example, in the content of a hero block).
+    data:
+      block: |
+        <p>This is large govspeak</p>
+        <p>It is:</p>
+        <ul>
+          <li>Bigger than normal govspeak</li>
+          <li>Intended to be used rarely</li>
+          <li>A way to include large rich text when the design calls for it</li>
+        </ul>
+        <div class="call-to-action">
+          <p>It should support all the usual govspeak features, such as calls to action.</p>
+        </div>
+      font_size: "l"

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -930,7 +930,6 @@ examples:
         <div class="call-to-action">
           <p>It should support all the usual govspeak features, such as calls to action.</p>
         </div>
-        <h1>Heading 1</h1>
         <h2>Heading 2</h2>
         <h3>Heading 3</h3>
         <h4>Heading 4</h4>

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -19,6 +19,7 @@ shared_accessibility_criteria:
   - link
 accessibility_excluded_rules:
   - landmark-complementary-is-top-level # Statistic headlines are generating an aside element which can not be a top level in the examples
+  - different_font_sizes # Example includes headings, which don't conform with the document structure
 uses_component_wrapper_helper: true
 examples:
   basic_content:
@@ -929,4 +930,10 @@ examples:
         <div class="call-to-action">
           <p>It should support all the usual govspeak features, such as calls to action.</p>
         </div>
+        <h1>Heading 1</h1>
+        <h2>Heading 2</h2>
+        <h3>Heading 3</h3>
+        <h4>Heading 4</h4>
+        <h5>Heading 5</h5>
+        <h6>Heading 6</h6>
       font_size: "l"

--- a/spec/components/govspeak_spec.rb
+++ b/spec/components/govspeak_spec.rb
@@ -54,6 +54,23 @@ describe "Govspeak", type: :view do
     assert_select ".js-disable-youtube h2", text: "youtube"
   end
 
+  it "renders with font-size m by default" do
+    render_component(
+      content: "".html_safe,
+    )
+
+    assert_select ".gem-c-govspeak--font-size-m"
+  end
+
+  it "renders with font-size l when the font_size option is used" do
+    render_component(
+      font_size: "l",
+      content: "".html_safe,
+    )
+
+    assert_select ".gem-c-govspeak--font-size-l"
+  end
+
   it "accepts a block" do
     render "govuk_publishing_components/components/#{component_name}" do
       "content-via-block"

--- a/spec/components/govspeak_spec.rb
+++ b/spec/components/govspeak_spec.rb
@@ -54,17 +54,17 @@ describe "Govspeak", type: :view do
     assert_select ".js-disable-youtube h2", text: "youtube"
   end
 
-  it "renders with font-size m by default" do
+  it "does not render with font-size l by default" do
     render_component(
       content: "".html_safe,
     )
 
-    assert_select ".gem-c-govspeak--font-size-m"
+    assert_select ".gem-c-govspeak--font-size-l", false
   end
 
-  it "renders with font-size l when the font_size option is used" do
+  it "renders with font-size l when the large_font_size option is used" do
     render_component(
-      font_size: "l",
+      large_font_size: true,
       content: "".html_safe,
     )
 


### PR DESCRIPTION
## What

We want big govspeak for our hero blocks, and although we can do this with CSS, it breaks component isolation, so we're adding a font_size option to the govspeak component instead.

## Why

In rare cases, we want to use govspeak to render rich text, but the design calls for a larger font size. We want to support this.

[Trello card](https://trello.com/c/vxoiwFba/191-make-headings-and-text-in-main-hero-blocks-bigger)

## How

If the large_font_size option is set to true we'll add a gem-c-govspeak--font-size-l modifier class.

This is used to increase the default font sizes one step on the type scale, so 16 -> 19, 19 -> 24 and 27 -> 36.

## Visual Changes

![image](https://github.com/user-attachments/assets/91b843cb-1056-441a-a7b9-3015282bdb6c)

