### PR TITLE
Use component wrapper on previous and next component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Unreleased
 
+* Use component wrapper on previous and next component ([PR #4463](https://github.com/alphagov/govuk_publishing_components/pull/4463))
+
 ## 46.1.0
 
 * Use component wrapper on panel component ([PR #4459](https://github.com/alphagov/govuk_publishing_components/pull/4459))

--- a/app/views/govuk_publishing_components/components/_previous_and_next_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_previous_and_next_navigation.html.erb
@@ -2,16 +2,15 @@
   add_gem_component_stylesheet("previous-and-next-navigation")
   disable_ga4 ||= false
 
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("govuk-pagination govuk-pagination--block")
+  component_helper.add_role("navigation")
+  component_helper.add_aria_attribute({ label: t("components.previous_and_next_navigation.pagination") })
+  component_helper.add_data_attribute({ module: "ga4-link-tracker" }) unless disable_ga4
+
   if local_assigns.include?(:next_page) || local_assigns.include?(:previous_page)
 %>
-  <nav
-    class="govuk-pagination govuk-pagination--block"
-    role="navigation"
-    aria-label="<%= t("components.previous_and_next_navigation.pagination") %>"
-    <% unless disable_ga4 %>
-      data-module="ga4-link-tracker"
-    <% end %>
-  >
+  <%= tag.nav(**component_helper.all_attributes) do %>
     <% if local_assigns.include?(:previous_page) %>
       <%
         title = previous_page[:title] || t("components.previous_and_next_navigation.previous")
@@ -73,5 +72,5 @@
         </a>
       </div>
     <% end %>
-  </nav>
+  <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/previous_and_next_navigation.yml
+++ b/app/views/govuk_publishing_components/components/docs/previous_and_next_navigation.yml
@@ -19,6 +19,7 @@ accessibility_criteria: |
   - identify itself as pagination navigation
   - provide a distinction between the navigation text and label text of the links both visually and for screenreaders
 
+uses_component_wrapper_helper: true
 shared_accessibility_criteria:
   - link
 accessibility_excluded_rules:


### PR DESCRIPTION
## What
- Adds the component wrapper helper to the `previous and next` component.

## Why
As the [trello card](https://trello.com/c/qH4NyWJw/364-add-component-wrapper-to-more-components) states:

> Standardising our components to use the component wrapper helper will reduce code, increase standardisation, and improve future feature implementation speed.

## Visual changes

None.