### PR TITLE
Version 46.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Unreleased
 
+## 46.1.0
+
 * Use component wrapper on panel component ([PR #4459](https://github.com/alphagov/govuk_publishing_components/pull/4459))
 * Use the component wrapper on the phase banner component ([PR #4460](https://github.com/alphagov/govuk_publishing_components/pull/4460))
 * Add a `glance_metric` component ([PR #4452](https://github.com/alphagov/govuk_publishing_components/pull/4452))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (46.0.0)
+    govuk_publishing_components (46.1.0)
       chartkick
       govuk_app_config
       govuk_personalisation (>= 0.7.0)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "46.0.0".freeze
+  VERSION = "46.1.0".freeze
 end


### PR DESCRIPTION
* Use component wrapper on panel component ([PR #4459](https://github.com/alphagov/govuk_publishing_components/pull/4459))
* Use the component wrapper on the phase banner component ([PR #4460](https://github.com/alphagov/govuk_publishing_components/pull/4460))
* Add a `glance_metric` component ([PR #4452](https://github.com/alphagov/govuk_publishing_components/pull/4452))
* Use component wrapper on org logo component ([PR #4458](https://github.com/alphagov/govuk_publishing_components/pull/4458))
* Use component wrapper on notice component ([PR #4444](https://github.com/alphagov/govuk_publishing_components/pull/4444))
* Add component wrapper to the metadata component ([PR #4442](https://github.com/alphagov/govuk_publishing_components/pull/4442))