### PR TITLE
Remove heading helper from search component

### DIFF
--- a/app/models/govuk_publishing_components/audit_components.rb
+++ b/app/models/govuk_publishing_components/audit_components.rb
@@ -263,12 +263,6 @@ module GovukPublishingComponents
           used_by: [],
         },
         {
-          name: "Heading helper",
-          link: "lib/govuk_publishing_components/presenters/heading_helper.rb",
-          match: /(GovukPublishingComponents::Presenters::HeadingHelper.new)/,
-          used_by: [],
-        },
-        {
           name: "Shared helper",
           link: "lib/govuk_publishing_components/presenters/shared_helper.rb",
           match: /(GovukPublishingComponents::Presenters::SharedHelper.new)/,

--- a/app/views/govuk_publishing_components/components/_search.html.erb
+++ b/app/views/govuk_publishing_components/components/_search.html.erb
@@ -3,7 +3,6 @@
   add_gem_component_stylesheet("label")
 
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
-  heading_helper = GovukPublishingComponents::Presenters::HeadingHelper.new(local_assigns)
 
   aria_controls ||= nil
   button_text ||= t("components.search_box.search_button")

--- a/spec/component_guide/audit_components_spec.rb
+++ b/spec/component_guide/audit_components_spec.rb
@@ -105,12 +105,6 @@ describe "Auditing the components in the gem" do
           ],
         },
         {
-          link: "lib/govuk_publishing_components/presenters/heading_helper.rb",
-          match: /(GovukPublishingComponents::Presenters::HeadingHelper.new)/,
-          name: "Heading helper",
-          used_by: [],
-        },
-        {
           link: "lib/govuk_publishing_components/presenters/shared_helper.rb",
           match: /(GovukPublishingComponents::Presenters::SharedHelper.new)/,
           name: "Shared helper",


### PR DESCRIPTION
## What / why
Removes the heading helper from the search component.

- not used
- also remove it from the auditing tools, because it's only used by one other component (the heading component) and we only need to audit helpers that are used by multiple components, lots of components already have their own individual helpers

## Visual Changes
None.
