### PR TITLE
[WIP] Move margin_bottom option into component wrapper helper

### DIFF
--- a/app/models/govuk_publishing_components/component_wrapper_helper_options.rb
+++ b/app/models/govuk_publishing_components/component_wrapper_helper_options.rb
@@ -8,6 +8,7 @@ This component uses the component wrapper helper. It accepts the following optio
 - `data_attributes` - accepts a hash of data attributes
 - `aria` - accepts a hash of aria attributes
 - `classes` - accepts a space separated string of classes, these should not be used for styling and must be prefixed with `js-`
+- `margin_bottom` - accepts a number from `0` to `9` (`0px` to `60px`) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale) (defaults to no margin)
 - `role` - accepts a space separated string of roles
 - `lang` - accepts a language attribute value
 - `open` - accepts an open attribute value (true or false)

--- a/app/views/govuk_publishing_components/components/_accordion.html.erb
+++ b/app/views/govuk_publishing_components/components/_accordion.html.erb
@@ -13,7 +13,6 @@
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.set_id(id)
   component_helper.add_class("gem-c-accordion govuk-accordion")
-  component_helper.add_class(shared_helper.get_margin_bottom)
 
   component_helper.add_data_attribute({ module: "govuk-accordion gem-accordion" })
   component_helper.add_data_attribute({ module: "ga4-event-tracker" }) unless disable_ga4

--- a/app/views/govuk_publishing_components/components/_action_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_action_link.html.erb
@@ -2,7 +2,6 @@
   add_gem_component_stylesheet("action-link")
 
   local_assigns[:margin_bottom] ||= 0
-  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
 
   text ||= false
   nowrap_text ||= false
@@ -26,7 +25,6 @@
   css_classes << "gem-c-action-link--simple-light" if simple_light
   css_classes << "gem-c-action-link--with-subtext" if subtext
   css_classes << "gem-c-action-link--mobile-subtext" if mobile_subtext
-  css_classes << shared_helper.get_margin_bottom
 
   link_classes = %w(govuk-link gem-c-action-link__link gem-c-force-print-link-styles)
   link_classes << "govuk-link--inverse" if inverse

--- a/app/views/govuk_publishing_components/components/_chart.html.erb
+++ b/app/views/govuk_publishing_components/components/_chart.html.erb
@@ -14,6 +14,7 @@
   minimal ||= false
   hide_heading ||= minimal
   link ||= false
+  local_assigns[:margin_bottom] ||= 3
 
   chart_id = "chart-id-#{SecureRandom.hex(4)}"
   table_id = "table-id-#{SecureRandom.hex(4)}"
@@ -21,10 +22,8 @@
   @external_script[:loaded] += 1
 
   chart_helper = GovukPublishingComponents::Presenters::ChartHelper.new(local_assigns)
-  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-chart")
-  component_helper.add_class(shared_helper.get_margin_bottom)
   component_helper.add_class("gem-c-chart--minimal") if minimal
 
   require "chartkick"

--- a/app/views/govuk_publishing_components/components/_chat_entry.html.erb
+++ b/app/views/govuk_publishing_components/components/_chat_entry.html.erb
@@ -9,13 +9,13 @@
   border_bottom ||= false
   disable_ga4 ||= false
   margin_top_until_tablet ||= false
+  local_assigns[:margin_bottom] ||= 6
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-chat-entry")
   component_helper.add_class("gem-c-chat-entry--border-top") if border_top
   component_helper.add_class("gem-c-chat-entry--border-bottom") if border_bottom
   component_helper.add_class("gem-c-chat-entry--margin-top-until-tablet") if margin_top_until_tablet
-  component_helper.add_class(shared_helper.get_margin_bottom)
   component_helper.add_data_attribute({ module: "ga4-link-tracker" }) unless disable_ga4
 
   unless disable_ga4

--- a/app/views/govuk_publishing_components/components/_contents_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_contents_list.html.erb
@@ -9,7 +9,6 @@
   local_assigns[:aria] ||= {}
   local_assigns[:margin_bottom] ||= 4
 
-  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
   cl_helper = GovukPublishingComponents::Presenters::ContentsListHelper.new(local_assigns)
   brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)
 
@@ -29,7 +28,6 @@
   component_helper.add_class("gem-c-contents-list #{brand_helper.brand_class}")
   component_helper.add_class("gem-c-contents-list--alternative-line-style") if alternative_line_style
   component_helper.add_class("gem-c-contents-list--custom-title") if title
-  component_helper.add_class(shared_helper.get_margin_bottom)
   component_helper.add_data_attribute({ module: "ga4-link-tracker" }) unless disable_ga4
   component_helper.add_aria_attribute({ label: t("components.contents_list.contents") }) unless local_assigns[:aria][:label]
   component_helper.add_role("navigation")

--- a/docs/component-wrapper-helper.md
+++ b/docs/component-wrapper-helper.md
@@ -29,6 +29,7 @@ These options can be passed to any component that uses the component wrapper.
 - `data_attributes` - accepts a hash of data attributes
 - `aria` - accepts a hash of aria attributes
 - `classes` - accepts a space separated string of classes, these should not be used for styling and must be prefixed with `js-`
+- `margin_bottom` - accepts a number from `0` to `9` (`0px` to `60px`) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale) (defaults to no margin)
 - `role` - accepts a space separated string of roles
 - `lang` - accepts a language attribute value
 - `open` - accepts an open attribute value (true or false)
@@ -64,6 +65,9 @@ The component wrapper includes several methods to make managing options easier, 
   data_attributes ||= {}
   aria_attributes ||= {}
   role ||= nil
+
+  # margin_bottom will default to no margin, use this line to set a different default
+  local_assigns[:margin_bottom] ||= 6
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-example govuk-example") # combines the given class with any passed classes

--- a/lib/govuk_publishing_components/presenters/component_wrapper_helper.rb
+++ b/lib/govuk_publishing_components/presenters/component_wrapper_helper.rb
@@ -19,7 +19,6 @@ module GovukPublishingComponents
 
       def all_attributes
         attributes = {}
-
         attributes[:id] = @options[:id] unless @options[:id].blank?
         attributes[:data] = @options[:data_attributes] unless @options[:data_attributes].blank?
         attributes[:aria] = @options[:aria] unless @options[:aria].blank?

--- a/lib/govuk_publishing_components/presenters/component_wrapper_helper.rb
+++ b/lib/govuk_publishing_components/presenters/component_wrapper_helper.rb
@@ -14,6 +14,7 @@ module GovukPublishingComponents
         check_hidden_is_valid(@options[:hidden]) if @options.include?(:hidden)
         check_tabindex_is_valid(@options[:tabindex]) if @options.include?(:tabindex)
         check_dir_is_valid(@options[:dir]) if @options.include?(:dir)
+        get_margin_bottom(@options[:margin_bottom]) if @options.include?(:margin_bottom)
       end
 
       def all_attributes
@@ -81,6 +82,10 @@ module GovukPublishingComponents
       def set_dir(dir_attribute)
         check_dir_is_valid(dir_attribute)
         @options[:dir] = dir_attribute
+      end
+
+      def get_margin_bottom(margin_bottom)
+        add_class("govuk-!-margin-bottom-#{margin_bottom}") if [*0..9].include?(margin_bottom)
       end
 
     private

--- a/spec/lib/govuk_publishing_components/components/component_wrapper_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/components/component_wrapper_helper_spec.rb
@@ -33,79 +33,6 @@ RSpec.describe GovukPublishingComponents::Presenters::ComponentWrapperHelper do
       expect(component_helper.all_attributes).to eql(expected)
     end
 
-    it "accepts valid class names" do
-      component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(classes: "gem-c-component govuk-component app-c-component brand--thing brand__thing direction-rtl")
-      expected = {
-        class: "gem-c-component govuk-component app-c-component brand--thing brand__thing direction-rtl",
-      }
-      expect(component_helper.all_attributes).to eql(expected)
-    end
-
-    it "rejects invalid class names" do
-      classes = "js-okay not-cool-man"
-      expect {
-        GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(classes:)
-      }.to raise_error(ArgumentError, "Classes (#{classes}) must be prefixed with `js-`")
-    end
-
-    it "rejects classes that aren't an exact match of 'direction-rtl'" do
-      classes = "direction-rtll"
-      expect {
-        GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(classes:)
-      }.to raise_error(ArgumentError, "Classes (#{classes}) must be prefixed with `js-`")
-    end
-
-    it "accepts bottom margin" do
-      component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(margin_bottom: 1)
-      expected = {
-        class: "govuk-!-margin-bottom-1",
-      }
-      expect(component_helper.all_attributes).to eql(expected)
-    end
-
-    it "accepts valid class names and bottom margin" do
-      component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(classes: "gem-c-component", margin_bottom: 5)
-      expected = {
-        class: "gem-c-component govuk-!-margin-bottom-5",
-      }
-      expect(component_helper.all_attributes).to eql(expected)
-    end
-
-    it "can set an id, overriding a passed value" do
-      helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(id: "original")
-      helper.set_id("override")
-      expect(helper.all_attributes[:id]).to eql("override")
-    end
-
-    it "does not accept invalid ids" do
-      ["1dstartingwithnumber", "id with spaces", "idwith.dot", "id\nwithnewline"].each do |id|
-        expect {
-          GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(id:)
-        }.to raise_error(ArgumentError, / contain/)
-      end
-    end
-
-    it "does not accept invalid ids when passed" do
-      expect {
-        helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(id: "valid")
-        helper.set_id("not. a. valid. id")
-      }.to raise_error(ArgumentError)
-    end
-
-    it "can add a class to already passed classes" do
-      helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(classes: "js-original")
-      helper.add_class("gem-c-extra")
-      expect(helper.all_attributes[:class]).to eql("js-original gem-c-extra")
-    end
-
-    it "will error if trying to add an invalid class to already passed classes" do
-      classes = "gem-c-extra something-invalid"
-      expect {
-        helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(classes: "js-original")
-        helper.add_class(classes)
-      }.to raise_error(ArgumentError, "Classes (#{classes}) must be prefixed with `js-`")
-    end
-
     it "does not error if passed blank values" do
       component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(
         id: nil,
@@ -128,66 +55,151 @@ RSpec.describe GovukPublishingComponents::Presenters::ComponentWrapperHelper do
       expect(component_helper.all_attributes).to eql({})
     end
 
-    it "does not accept invalid data attributes" do
-      invalid_data = { module: "ok", xml_something: "notok", "XML_something": "notok", "has space": "notok", "has:colon": "notok", normal: "ok" }
-      error = "Data attributes (xml_something, XML_something, has space, has:colon) cannot contain capitals, spaces or colons, or start with 'xml'"
-      expect {
-        GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(data_attributes: invalid_data)
-      }.to raise_error(ArgumentError, error)
+    describe "classes" do
+      it "accepts valid class names" do
+        component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(classes: "gem-c-component govuk-component app-c-component brand--thing brand__thing direction-rtl")
+        expected = {
+          class: "gem-c-component govuk-component app-c-component brand--thing brand__thing direction-rtl",
+        }
+        expect(component_helper.all_attributes).to eql(expected)
+      end
 
-      expect {
-        helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(data_attributes: { module: "something" })
-        helper.add_data_attribute(invalid_data)
-      }.to raise_error(ArgumentError, error)
+      it "rejects invalid class names" do
+        classes = "js-okay not-cool-man"
+        expect {
+          GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(classes:)
+        }.to raise_error(ArgumentError, "Classes (#{classes}) must be prefixed with `js-`")
+      end
+
+      it "rejects classes that aren't an exact match of 'direction-rtl'" do
+        classes = "direction-rtll"
+        expect {
+          GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(classes:)
+        }.to raise_error(ArgumentError, "Classes (#{classes}) must be prefixed with `js-`")
+      end
+
+      it "can add a class to already passed classes" do
+        helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(classes: "js-original")
+        helper.add_class("gem-c-extra")
+        expect(helper.all_attributes[:class]).to eql("js-original gem-c-extra")
+      end
+
+      it "will error if trying to add an invalid class to already passed classes" do
+        classes = "gem-c-extra something-invalid"
+        expect {
+          helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(classes: "js-original")
+          helper.add_class(classes)
+        }.to raise_error(ArgumentError, "Classes (#{classes}) must be prefixed with `js-`")
+      end
     end
 
-    it "can add data attributes to already passed data attributes" do
-      helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(data_attributes: { module: "original-module", other: "other" })
-      helper.add_data_attribute({ module: "extra-module", another: "another" })
-      expect(helper.all_attributes[:data]).to eql({ module: "original-module extra-module", other: "other", another: "another" })
+    describe "margin bottom" do
+      it "accepts bottom margin" do
+        component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(margin_bottom: 1)
+        expected = {
+          class: "govuk-!-margin-bottom-1",
+        }
+        expect(component_helper.all_attributes).to eql(expected)
+      end
+
+      it "accepts valid class names and bottom margin" do
+        component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(classes: "gem-c-component", margin_bottom: 5)
+        expected = {
+          class: "gem-c-component govuk-!-margin-bottom-5",
+        }
+        expect(component_helper.all_attributes).to eql(expected)
+      end
     end
 
-    it "can add aria attributes to already passed aria attributes" do
-      helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(aria: { label: "original-label", describedby: "other" })
-      helper.add_aria_attribute({ label: "extra-label", controls: "something" })
-      expect(helper.all_attributes[:aria]).to eql({ label: "original-label extra-label", describedby: "other", controls: "something" })
+    describe "id" do
+      it "can set an id, overriding a passed value" do
+        helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(id: "original")
+        helper.set_id("override")
+        expect(helper.all_attributes[:id]).to eql("override")
+      end
+
+      it "does not accept invalid ids" do
+        ["1dstartingwithnumber", "id with spaces", "idwith.dot", "id\nwithnewline"].each do |id|
+          expect {
+            GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(id:)
+          }.to raise_error(ArgumentError, / contain/)
+        end
+      end
+
+      it "does not accept invalid ids when passed" do
+        expect {
+          helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(id: "valid")
+          helper.set_id("not. a. valid. id")
+        }.to raise_error(ArgumentError)
+      end
     end
 
-    it "does not accept invalid aria attributes" do
-      invalid_aria = { potato: "salad", label: "something", spoon: "invalid" }
-      error = "Aria attribute (potato, spoon) not recognised"
-      expect {
-        GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(aria: invalid_aria)
-      }.to raise_error(ArgumentError, error)
+    describe "data attributes" do
+      it "does not accept invalid data attributes" do
+        invalid_data = { module: "ok", xml_something: "notok", "XML_something": "notok", "has space": "notok", "has:colon": "notok", normal: "ok" }
+        error = "Data attributes (xml_something, XML_something, has space, has:colon) cannot contain capitals, spaces or colons, or start with 'xml'"
+        expect {
+          GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(data_attributes: invalid_data)
+        }.to raise_error(ArgumentError, error)
 
-      expect {
-        helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(aria: { label: "something" })
-        helper.add_aria_attribute(invalid_aria)
-      }.to raise_error(ArgumentError, error)
+        expect {
+          helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(data_attributes: { module: "something" })
+          helper.add_data_attribute(invalid_data)
+        }.to raise_error(ArgumentError, error)
+      end
+
+      it "can add data attributes to already passed data attributes" do
+        helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(data_attributes: { module: "original-module", other: "other" })
+        helper.add_data_attribute({ module: "extra-module", another: "another" })
+        expect(helper.all_attributes[:data]).to eql({ module: "original-module extra-module", other: "other", another: "another" })
+      end
     end
 
-    it "does not accept an invalid role" do
-      error = "Role attribute (custarddoughnuts, moose) is not recognised"
-      expect {
-        GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(role: "custarddoughnuts moose")
-      }.to raise_error(ArgumentError, error)
+    describe "aria attributes" do
+      it "can add aria attributes to already passed aria attributes" do
+        helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(aria: { label: "original-label", describedby: "other" })
+        helper.add_aria_attribute({ label: "extra-label", controls: "something" })
+        expect(helper.all_attributes[:aria]).to eql({ label: "original-label extra-label", describedby: "other", controls: "something" })
+      end
 
-      expect {
-        GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(role: "navigation custarddoughnuts moose")
-      }.to raise_error(ArgumentError, error)
+      it "does not accept invalid aria attributes" do
+        invalid_aria = { potato: "salad", label: "something", spoon: "invalid" }
+        error = "Aria attribute (potato, spoon) not recognised"
+        expect {
+          GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(aria: invalid_aria)
+        }.to raise_error(ArgumentError, error)
+
+        expect {
+          helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(aria: { label: "something" })
+          helper.add_aria_attribute(invalid_aria)
+        }.to raise_error(ArgumentError, error)
+      end
     end
 
-    it "does not accept an invalid role when passed" do
-      error = "Role attribute (custarddoughnuts, moose) is not recognised"
-      expect {
-        helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(role: "navigation")
-        helper.add_role("custarddoughnuts moose")
-      }.to raise_error(ArgumentError, error)
+    describe "roles" do
+      it "does not accept an invalid role" do
+        error = "Role attribute (custarddoughnuts, moose) is not recognised"
+        expect {
+          GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(role: "custarddoughnuts moose")
+        }.to raise_error(ArgumentError, error)
 
-      expect {
-        helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(role: "navigation")
-        helper.add_role("alert custarddoughnuts moose")
-      }.to raise_error(ArgumentError, error)
+        expect {
+          GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(role: "navigation custarddoughnuts moose")
+        }.to raise_error(ArgumentError, error)
+      end
+
+      it "does not accept an invalid role when passed" do
+        error = "Role attribute (custarddoughnuts, moose) is not recognised"
+        expect {
+          helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(role: "navigation")
+          helper.add_role("custarddoughnuts moose")
+        }.to raise_error(ArgumentError, error)
+
+        expect {
+          helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(role: "navigation")
+          helper.add_role("alert custarddoughnuts moose")
+        }.to raise_error(ArgumentError, error)
+      end
     end
 
     it "does not accept an invalid lang" do
@@ -197,72 +209,78 @@ RSpec.describe GovukPublishingComponents::Presenters::ComponentWrapperHelper do
       }.to raise_error(ArgumentError, error)
     end
 
-    it "accepts valid open attribute value" do
-      component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(open: true)
-      expected = {
-        open: true,
-      }
-      expect(component_helper.all_attributes).to eql(expected)
+    describe "open" do
+      it "accepts valid open attribute value" do
+        component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(open: true)
+        expected = {
+          open: true,
+        }
+        expect(component_helper.all_attributes).to eql(expected)
+      end
+
+      it "can set an open attribute, overriding a passed value" do
+        helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(open: true)
+        helper.set_open(false)
+        expect(helper.all_attributes[:open]).to eql(nil)
+      end
+
+      it "does not include an open attribute if the option is false" do
+        component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(open: false)
+        expect(component_helper.all_attributes).to eql({})
+      end
+
+      it "does not accept an invalid open value" do
+        error = "open attribute (false) is not recognised"
+        expect {
+          GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(open: "false")
+        }.to raise_error(ArgumentError, error)
+      end
     end
 
-    it "can set an open attribute, overriding a passed value" do
-      helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(open: true)
-      helper.set_open(false)
-      expect(helper.all_attributes[:open]).to eql(nil)
+    describe "hidden" do
+      it "does not accept an invalid hidden value" do
+        error = "hidden attribute (false) is not recognised"
+        expect {
+          GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(hidden: "false")
+        }.to raise_error(ArgumentError, error)
+      end
+
+      it "accepts valid hidden attribute value" do
+        component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(hidden: "until-found")
+        expected = {
+          hidden: "until-found",
+        }
+        expect(component_helper.all_attributes).to eql(expected)
+      end
+
+      it "can set an hidden attribute, overriding a passed value" do
+        helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(hidden: "until-found")
+        helper.set_hidden("hidden")
+        expect(helper.all_attributes[:hidden]).to eql("hidden")
+      end
     end
 
-    it "does not include an open attribute if the option is false" do
-      component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(open: false)
-      expect(component_helper.all_attributes).to eql({})
-    end
+    describe "dir" do
+      it "does not accept an invalid dir value" do
+        error = "dir attribute (false) is not recognised"
+        expect {
+          GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(dir: "false")
+        }.to raise_error(ArgumentError, error)
+      end
 
-    it "does not accept an invalid open value" do
-      error = "open attribute (false) is not recognised"
-      expect {
-        GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(open: "false")
-      }.to raise_error(ArgumentError, error)
-    end
+      it "accepts valid dir attribute value" do
+        component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(dir: "rtl")
+        expected = {
+          dir: "rtl",
+        }
+        expect(component_helper.all_attributes).to eql(expected)
+      end
 
-    it "does not accept an invalid hidden value" do
-      error = "hidden attribute (false) is not recognised"
-      expect {
-        GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(hidden: "false")
-      }.to raise_error(ArgumentError, error)
-    end
-
-    it "accepts valid hidden attribute value" do
-      component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(hidden: "until-found")
-      expected = {
-        hidden: "until-found",
-      }
-      expect(component_helper.all_attributes).to eql(expected)
-    end
-
-    it "does not accept an invalid dir value" do
-      error = "dir attribute (false) is not recognised"
-      expect {
-        GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(dir: "false")
-      }.to raise_error(ArgumentError, error)
-    end
-
-    it "accepts valid dir attribute value" do
-      component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(dir: "rtl")
-      expected = {
-        dir: "rtl",
-      }
-      expect(component_helper.all_attributes).to eql(expected)
-    end
-
-    it "can set an dir attribute, overriding a passed value" do
-      helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(dir: "rtl")
-      helper.set_dir("ltr")
-      expect(helper.all_attributes[:dir]).to eql("ltr")
-    end
-
-    it "can set an hidden attribute, overriding a passed value" do
-      helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(hidden: "until-found")
-      helper.set_hidden("hidden")
-      expect(helper.all_attributes[:hidden]).to eql("hidden")
+      it "can set an dir attribute, overriding a passed value" do
+        helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(dir: "rtl")
+        helper.set_dir("ltr")
+        expect(helper.all_attributes[:dir]).to eql("ltr")
+      end
     end
 
     it "can set an tabindex attribute, overriding a passed value" do

--- a/spec/lib/govuk_publishing_components/components/component_wrapper_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/components/component_wrapper_helper_spec.rb
@@ -55,6 +55,22 @@ RSpec.describe GovukPublishingComponents::Presenters::ComponentWrapperHelper do
       }.to raise_error(ArgumentError, "Classes (#{classes}) must be prefixed with `js-`")
     end
 
+    it "accepts bottom margin" do
+      component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(margin_bottom: 1)
+      expected = {
+        class: "govuk-!-margin-bottom-1",
+      }
+      expect(component_helper.all_attributes).to eql(expected)
+    end
+
+    it "accepts valid class names and bottom margin" do
+      component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(classes: "gem-c-component", margin_bottom: 5)
+      expected = {
+        class: "gem-c-component govuk-!-margin-bottom-5",
+      }
+      expect(component_helper.all_attributes).to eql(expected)
+    end
+
     it "can set an id, overriding a passed value" do
       helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(id: "original")
       helper.set_id("override")


### PR DESCRIPTION
## What
Moves the code to handle margin bottom on components from the shared helper to the component wrapper helper, and updates components that depend on it.

This PR may not entirely remove the margin bottom code from the shared helper, as this would probably be a breaking change. We'll see how it goes.

## Why
The component wrapper helper seems like the more logical place for the margin bottom option to live, as it (should be) applied exclusively to the wrapping element of a component.

This work will also smooth the path for a forthcoming look at standardising component margins.

## Visual Changes
None.

Trello card: https://trello.com/c/Y0pDWbHw/242-move-some-shared-helper-options-into-component-wrapper