### PR TITLE
Translate "and" connective in metadata component for some languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add /media/ path to GA4 download link tracking ([PR #4491](https://github.com/alphagov/govuk_publishing_components/pull/4491/))
+* Translate "and" connective in metadata component for some languages ([PR #4477](https://github.com/alphagov/govuk_publishing_components/pull/4477))
 
 ## 46.3.0
 

--- a/app/views/govuk_publishing_components/components/metadata/_sentence.html.erb
+++ b/app/views/govuk_publishing_components/components/metadata/_sentence.html.erb
@@ -5,9 +5,10 @@
     remaining = items[list_limit..items.length]
     items = items[0...list_limit]
   end
+  connector = " #{t("components.metadata.and")} "
 %>
+<%= items.to_sentence(two_words_connector: connector, last_word_connector: connector).html_safe %>
 <% if remaining.any? %>
-  <%= items.to_sentence(last_word_connector: ' and ').html_safe %>
   <div class="gem-c-metadata__toggle-wrap govuk-!-display-none-print">
     <a href="#"
        class="gem-c-metadata__definition-link govuk-!-display-none-print"
@@ -20,6 +21,4 @@
     </a>
   </div>
   <span id="toggle-<%= toggle_id %>" class="gem-c-metadata__toggle-items js-hidden"><%= remaining.to_sentence.html_safe %></span>
-<% else %>
-  <%= items.to_sentence(last_word_connector: ' and ').html_safe %>
 <% end %>

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -137,7 +137,7 @@ ar:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: و
+      and:
       from: من
       history: المحفوظات
       last_updated: التحديث الأخير

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -137,6 +137,7 @@ ar:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: و
       from: من
       history: المحفوظات
       last_updated: التحديث الأخير

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -134,7 +134,7 @@ az:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: və
+      and:
       from: "...dan (dən)"
       history: Tarix
       last_updated: Son yenilənmə

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -134,6 +134,7 @@ az:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: və
       from: "...dan (dən)"
       history: Tarix
       last_updated: Son yenilənmə

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -140,7 +140,7 @@ be:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: і
+      and:
       from: З
       history: Гiсторыя
       last_updated: Апошняе абнаўленне

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -140,6 +140,7 @@ be:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: і
       from: З
       history: Гiсторыя
       last_updated: Апошняе абнаўленне

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -138,6 +138,7 @@ bg:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: и
       from: От
       history: История
       last_updated: Последно актуализирани

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -138,7 +138,7 @@ bg:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: и
+      and:
       from: От
       history: История
       last_updated: Последно актуализирани

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -135,6 +135,7 @@ bn:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: এবং
       from: থেকে
       history: ইতিহাস
       last_updated: সর্বশেষ আপডেট করা হয়েছে

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -135,7 +135,7 @@ bn:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: এবং
+      and:
       from: থেকে
       history: ইতিহাস
       last_updated: সর্বশেষ আপডেট করা হয়েছে

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -139,6 +139,7 @@ cs:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: a
       from: 'Komu I:'
       history: Historie
       last_updated: 'Poslední aktualizace:'

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -139,7 +139,7 @@ cs:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: a
+      and:
       from: 'Komu I:'
       history: Historie
       last_updated: 'Poslední aktualizace:'

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -138,7 +138,7 @@ cy:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: a
+      and:
       from: Gan
       history: Hanes
       last_updated: Diweddarwyd ddiwethaf

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -138,6 +138,7 @@ cy:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: a
       from: Gan
       history: Hanes
       last_updated: Diweddarwyd ddiwethaf

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -135,6 +135,7 @@ da:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: og
       from: Fra
       history: Historie
       last_updated: Sidst opdateret

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -135,7 +135,7 @@ da:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: og
+      and:
       from: Fra
       history: Historie
       last_updated: Sidst opdateret

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -138,6 +138,7 @@ de:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: und
       from: Von
       history: Geschichte
       last_updated: Zuletzt aktualisiert

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -136,7 +136,7 @@ dr:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: و
+      and:
       from: از
       history: پیشینهء جستجو
       last_updated: آخرین آپدیت

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -136,6 +136,7 @@ dr:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: و
       from: از
       history: پیشینهء جستجو
       last_updated: آخرین آپدیت

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -134,6 +134,7 @@ el:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: και
       from: Από
       history: Ιστορικό
       last_updated: Τελευταία ενημέρωση

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -134,7 +134,7 @@ el:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: και
+      and:
       from: Από
       history: Ιστορικό
       last_updated: Τελευταία ενημέρωση

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -241,6 +241,7 @@ en:
       navigation_search_subheading: Search
       search_text: Search GOV.UK
     metadata:
+      and: and
       from: From
       history: History
       last_updated: Last updated

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -134,6 +134,7 @@ es-419:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: y
       from: Desde
       history: Historial
       last_updated: Última actualización

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -134,6 +134,7 @@ es:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: y
       from: Desde
       history: Historial
       last_updated: Última actualización

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -137,6 +137,7 @@ et:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: ja
       from: Alates
       history: Ajalugu
       last_updated: Viimati värskendatud

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -137,7 +137,7 @@ et:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: ja
+      and:
       from: Alates
       history: Ajalugu
       last_updated: Viimati värskendatud

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -133,6 +133,7 @@ fa:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: و
       from: از
       history: تاریخچه
       last_updated: آخرین بروزرسانی

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -133,7 +133,7 @@ fa:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: و
+      and:
       from: از
       history: تاریخچه
       last_updated: آخرین بروزرسانی

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -136,7 +136,7 @@ fi:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: ja
+      and:
       from: Alkaen
       history: Historia
       last_updated: Viimeksi päivitetty

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -136,6 +136,7 @@ fi:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: ja
       from: Alkaen
       history: Historia
       last_updated: Viimeksi päivitetty

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -134,6 +134,7 @@ fr:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: et
       from: De
       history: Historique
       last_updated: Dernière mise à jour

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -136,6 +136,7 @@ gd:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: agus
       from: De
       history: Stairiúil
       last_updated: Nuashonrú deireanach

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -136,7 +136,7 @@ gd:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: agus
+      and:
       from: De
       history: Stairiúil
       last_updated: Nuashonrú deireanach

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -134,6 +134,7 @@ gu:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: અને
       from: થી
       history: હિસ્ટરી
       last_updated: છેલ્લે અપડેટ કરવામાં આવ્યું

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -134,7 +134,7 @@ gu:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: અને
+      and:
       from: થી
       history: હિસ્ટરી
       last_updated: છેલ્લે અપડેટ કરવામાં આવ્યું

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -134,6 +134,7 @@ he:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: ו
       from: מ-
       history: היסטוריה
       last_updated: עדכון אחרון

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -134,7 +134,7 @@ he:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: ו
+      and:
       from: מ-
       history: היסטוריה
       last_updated: עדכון אחרון

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -134,7 +134,7 @@ hi:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: और
+      and:
       from: से
       history: इतिहास
       last_updated: आखरी अपडेट

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -134,6 +134,7 @@ hi:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: और
       from: से
       history: इतिहास
       last_updated: आखरी अपडेट

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -135,7 +135,7 @@ hr:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: i
+      and:
       from: Iz
       history: Istorija
       last_updated: Posljednji put ažurirano

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -135,6 +135,7 @@ hr:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: i
       from: Iz
       history: Istorija
       last_updated: Posljednji put ažurirano

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -137,6 +137,7 @@ hu:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: és
       from: Feladó
       history: Előzmények
       last_updated: Utolsó frissítés

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -137,7 +137,7 @@ hu:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: és
+      and:
       from: Feladó
       history: Előzmények
       last_updated: Utolsó frissítés

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -138,6 +138,7 @@ hy:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: և
       from: Ումից՝
       history: Պատմություն
       last_updated: Վերջին անգամ թարմացվել է

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -138,7 +138,7 @@ hy:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: և
+      and:
       from: Ումից՝
       history: Պատմություն
       last_updated: Վերջին անգամ թարմացվել է

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -134,7 +134,7 @@ id:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: dan
+      and:
       from: Dari
       history: Riwayat
       last_updated: Terakhir diperbarui

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -134,6 +134,7 @@ id:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: dan
       from: Dari
       history: Riwayat
       last_updated: Terakhir diperbarui

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -134,6 +134,7 @@ is:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: og
       from: Frá
       history: Saga
       last_updated: Síðast uppfært

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -134,7 +134,7 @@ is:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: og
+      and:
       from: Frá
       history: Saga
       last_updated: Síðast uppfært

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -134,6 +134,7 @@ it:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: e
       from: Da
       history: Cronologia
       last_updated: Ultimo aggiornamento

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -134,7 +134,7 @@ it:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: e
+      and:
       from: Da
       history: Cronologia
       last_updated: Ultimo aggiornamento

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -130,6 +130,7 @@ ja:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: および
       from: から
       history: 歴史
       last_updated: 最終更新

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -130,7 +130,7 @@ ja:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: および
+      and:
       from: から
       history: 歴史
       last_updated: 最終更新

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -137,7 +137,7 @@ ka:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: და
+      and:
       from: დან
       history: ისტორია
       last_updated: ბოლო განახლება

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -137,6 +137,7 @@ ka:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: და
       from: დან
       history: ისტორია
       last_updated: ბოლო განახლება

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -134,6 +134,7 @@ kk:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: және
       from: Кімнен
       history: Журнал
       last_updated: Соңғы рет жаңартылды

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -134,7 +134,7 @@ kk:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: және
+      and:
       from: Кімнен
       history: Журнал
       last_updated: Соңғы рет жаңартылды

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -129,7 +129,7 @@ ko:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: 그리고
+      and:
       from:
       history:
       last_updated:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -129,6 +129,7 @@ ko:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: 그리고
       from:
       history:
       last_updated:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -139,7 +139,7 @@ lt:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: ir
+      and:
       from: Nuo
       history: Istorija
       last_updated: Paskutinį kartą naujinta

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -139,6 +139,7 @@ lt:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: ir
       from: Nuo
       history: Istorija
       last_updated: Paskutinį kartą naujinta

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -138,7 +138,7 @@ lv:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: un
+      and:
       from: 'No'
       history: Vēsture
       last_updated: Pēdējoreiz atjaunināts

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -138,6 +138,7 @@ lv:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: un
       from: 'No'
       history: Vēsture
       last_updated: Pēdējoreiz atjaunināts

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -133,6 +133,7 @@ ms:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: dan
       from: Daripada
       history: Sejarah
       last_updated: Kali terakhir dikemas kini

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -133,7 +133,7 @@ ms:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: dan
+      and:
       from: Daripada
       history: Sejarah
       last_updated: Kali terakhir dikemas kini

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -136,6 +136,7 @@ mt:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: u
       from: Minn
       history: Storja
       last_updated: Aġġornat l-aħħar

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -136,7 +136,7 @@ mt:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: u
+      and:
       from: Minn
       history: Storja
       last_updated: Aġġornat l-aħħar

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -134,6 +134,7 @@ nl:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: en
       from: Van
       history: Geschiedenis
       last_updated: Laatst bijgewerkt

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -134,7 +134,7 @@ nl:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: en
+      and:
       from: Van
       history: Geschiedenis
       last_updated: Laatst bijgewerkt

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -134,7 +134,7 @@
       navigation_search_subheading:
       search_text:
     metadata:
-      and: og
+      and:
       from: Fra
       history: Historie
       last_updated: Sist oppdatert

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -134,6 +134,7 @@
       navigation_search_subheading:
       search_text:
     metadata:
+      and: og
       from: Fra
       history: Historie
       last_updated: Sist oppdatert

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -130,6 +130,7 @@ pa-pk:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: ہور
       from: ایتھوں
       history: پچھلا کم
       last_updated: آخری دفعہ کدوں نویں گل دسی سی

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -130,7 +130,7 @@ pa-pk:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: ہور
+      and:
       from: ایتھوں
       history: پچھلا کم
       last_updated: آخری دفعہ کدوں نویں گل دسی سی

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -134,7 +134,7 @@ pa:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: ਅਤੇ
+      and:
       from: ਤੋਂ
       history: ਇਤਿਹਾਸ
       last_updated: ਪਿਛਲੀ ਵਾਰ ਅਪਡੇਟ ਕੀਤਾ ਗਿਆ

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -134,6 +134,7 @@ pa:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: ਅਤੇ
       from: ਤੋਂ
       history: ਇਤਿਹਾਸ
       last_updated: ਪਿਛਲੀ ਵਾਰ ਅਪਡੇਟ ਕੀਤਾ ਗਿਆ

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -138,6 +138,7 @@ pl:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: i
       from: Od
       history: Historia
       last_updated: Ostatnio zaktualizowano

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -131,6 +131,7 @@ ps:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: او
       from: له
       history: تاریخ
       last_updated: وروستی تازه شوی

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -131,7 +131,7 @@ ps:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: او
+      and:
       from: له
       history: تاریخ
       last_updated: وروستی تازه شوی

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -134,6 +134,7 @@ pt:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: e
       from: De
       history: Histórico
       last_updated: Última atualização

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -134,7 +134,7 @@ pt:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: e
+      and:
       from: De
       history: Histórico
       last_updated: Última atualização

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -135,7 +135,7 @@ ro:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: și
+      and:
       from: De la
       history: Istoric
       last_updated: Ultima actualizare

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -135,6 +135,7 @@ ro:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: și
       from: De la
       history: Istoric
       last_updated: Ultima actualizare

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -138,6 +138,7 @@ ru:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: и
       from: Из
       history: История
       last_updated: Последнее обновление

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -138,7 +138,7 @@ ru:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: и
+      and:
       from: Из
       history: История
       last_updated: Последнее обновление

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -134,7 +134,7 @@ si:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: සහ
+      and:
       from: සිට
       history: ඉතිහාසය
       last_updated: අවසන් වරට යාවත්කාලීන කළේ

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -134,6 +134,7 @@ si:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: සහ
       from: සිට
       history: ඉතිහාසය
       last_updated: අවසන් වරට යාවත්කාලීන කළේ

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -139,7 +139,7 @@ sk:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: a
+      and:
       from: Od
       history: História
       last_updated: Posledná aktualizácia

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -139,6 +139,7 @@ sk:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: a
       from: Od
       history: História
       last_updated: Posledná aktualizácia

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -141,7 +141,7 @@ sl:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: in
+      and:
       from: Od
       history: Zgodovina
       last_updated: Nazadnje posodobljeno

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -141,6 +141,7 @@ sl:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: in
       from: Od
       history: Zgodovina
       last_updated: Nazadnje posodobljeno

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -134,6 +134,7 @@ so:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: iyo
       from: Laga bilaabo
       history: Taariikhda
       last_updated: Cusboonaysiintii ugu dambaysay

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -134,7 +134,7 @@ so:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: iyo
+      and:
       from: Laga bilaabo
       history: Taariikhda
       last_updated: Cusboonaysiintii ugu dambaysay

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -134,6 +134,7 @@ sq:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: dhe
       from: Nga
       history: Historia
       last_updated: Përditësuar së fundmi

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -134,7 +134,7 @@ sq:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: dhe
+      and:
       from: Nga
       history: Historia
       last_updated: Përditësuar së fundmi

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -135,6 +135,7 @@ sr:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: i
       from: Od
       history: Istorija
       last_updated: Poslednje ažuriranje

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -135,7 +135,7 @@ sr:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: i
+      and:
       from: Od
       history: Istorija
       last_updated: Poslednje ažuriranje

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -134,6 +134,7 @@ sv:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: och
       from: Från
       history: Historia
       last_updated: Senast uppdaterad

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -134,7 +134,7 @@ sv:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: och
+      and:
       from: Från
       history: Historia
       last_updated: Senast uppdaterad

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -134,7 +134,7 @@ sw:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: na
+      and:
       from: Kuanzia
       history: Kumbukumbu
       last_updated: Ilisasishwa mara ya mwisho

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -134,6 +134,7 @@ sw:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: na
       from: Kuanzia
       history: Kumbukumbu
       last_updated: Ilisasishwa mara ya mwisho

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -135,6 +135,7 @@ ta:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: மற்றும்
       from: இதிலிருந்து
       history: வரலாறு
       last_updated: கடைசியாகப் புதுப்பிக்கப்பட்டது

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -135,7 +135,7 @@ ta:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: மற்றும்
+      and:
       from: இதிலிருந்து
       history: வரலாறு
       last_updated: கடைசியாகப் புதுப்பிக்கப்பட்டது

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -132,7 +132,7 @@ th:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: และ
+      and:
       from: จาก
       history: ประวัติ
       last_updated: อัปเดตล่าสุด

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -132,6 +132,7 @@ th:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: และ
       from: จาก
       history: ประวัติ
       last_updated: อัปเดตล่าสุด

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -135,6 +135,7 @@ tk:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: we
       from: "-dan"
       history: Taryh
       last_updated: Iň soňky täzelenme

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -135,7 +135,7 @@ tk:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: we
+      and:
       from: "-dan"
       history: Taryh
       last_updated: Iň soňky täzelenme

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -135,6 +135,7 @@ tr:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: ve
       from: Şuradan
       history: Geçmiş
       last_updated: Son güncelleme

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -135,7 +135,7 @@ tr:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: ve
+      and:
       from: Şuradan
       history: Geçmiş
       last_updated: Son güncelleme

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -141,6 +141,7 @@ uk:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: та
       from: Від
       history: Історія
       last_updated: Останнє оновлення

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -141,7 +141,7 @@ uk:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: та
+      and:
       from: Від
       history: Історія
       last_updated: Останнє оновлення

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -131,6 +131,7 @@ ur:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: اور
       from: از
       history: ہسٹری
       last_updated: آخری بار اپ ڈیٹ کردہ

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -131,7 +131,7 @@ ur:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: اور
+      and:
       from: از
       history: ہسٹری
       last_updated: آخری بار اپ ڈیٹ کردہ

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -136,6 +136,7 @@ uz:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: ва
       from: дан
       history: Тарих
       last_updated: Сўнгги янгиланиш

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -136,7 +136,7 @@ uz:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: ва
+      and:
       from: дан
       history: Тарих
       last_updated: Сўнгги янгиланиш

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -133,7 +133,7 @@ vi:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: và
+      and:
       from: Từ
       history: Lịch sử
       last_updated: Lần cập nhật gần đây nhất

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -133,6 +133,7 @@ vi:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: và
       from: Từ
       history: Lịch sử
       last_updated: Lần cập nhật gần đây nhất

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -132,7 +132,7 @@ zh-hk:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: 及
+      and:
       from: 來自
       history: 過往記錄
       last_updated: 最近更新

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -132,6 +132,7 @@ zh-hk:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: 及
       from: 來自
       history: 過往記錄
       last_updated: 最近更新

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -132,6 +132,7 @@ zh-tw:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: 以及
       from: 從
       history: 歷史
       last_updated: 最新更新

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -132,7 +132,7 @@ zh-tw:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: 以及
+      and:
       from: 從
       history: 歷史
       last_updated: 最新更新

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -132,7 +132,7 @@ zh:
       navigation_search_subheading:
       search_text:
     metadata:
-      and: 和
+      and:
       from: 从
       history: 历史
       last_updated: 上次更新

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -132,6 +132,7 @@ zh:
       navigation_search_subheading:
       search_text:
     metadata:
+      and: 和
       from: 从
       history: 历史
       last_updated: 上次更新

--- a/spec/components/metadata_spec.rb
+++ b/spec/components/metadata_spec.rb
@@ -78,6 +78,22 @@ describe "Metadata", type: :view do
     end
   end
 
+  it "renders multiples as a single sentence (except history) in foreign language without translation of \"and\"" do
+    I18n.with_locale("ja") do
+      render_component(
+        from: %w[一 二],
+        part_of: %w[此れ 彼],
+        other: {
+          "関連項目": %w[a b c],
+        },
+      )
+
+      assert_definition("から:", "一 and 二")
+      assert_definition("一部の:", "此れ and 彼")
+      assert_definition("関連項目:", "a, b and c")
+    end
+  end
+
   it "long lists of metadata are truncated and the remainder hidden behind a toggle for from" do
     links = [
       "<a href=\"/government/organisations/ministry-of-defence\">Ministry of Defence</a>",

--- a/spec/components/metadata_spec.rb
+++ b/spec/components/metadata_spec.rb
@@ -62,6 +62,22 @@ describe "Metadata", type: :view do
     assert_definition("Related topics:", "a, b and c")
   end
 
+  it "renders multiples as a single sentence (except history) with translations applied" do
+    I18n.with_locale("pl") do
+      render_component(
+        from: %w[pierwszy drugi],
+        part_of: %w[to tamto],
+        other: {
+          "Powiązane tematy": %w[a b c],
+        },
+      )
+
+      assert_definition("Od:", "pierwszy i drugi")
+      assert_definition("Część:", "to i tamto")
+      assert_definition("Powiązane tematy:", "a, b i c")
+    end
+  end
+
   it "long lists of metadata are truncated and the remainder hidden behind a toggle for from" do
     links = [
       "<a href=\"/government/organisations/ministry-of-defence\">Ministry of Defence</a>",


### PR DESCRIPTION
## What

Fix the following issue:

The `From` section on documents is missing translations for the word `and` see [https://www.gov.uk/government/publications/uk-candidate-for-the-international-court-of-justice-election-2026-professor-dapo-akande-election-brochure.fr](https://www.gov.uk/government/publications/uk-candidate-for-the-international-court-of-justice-election-2026-professor-dapo-akande-election-brochure.fr "smartCard-inline")

The original ticket is about French and Spanish, as the authors are not sure which languages use "and" in the same way and which don't. I've extended the number of languages to the languages I know use "and" in the same way, namely Polish and German.

## Why

[Trello ticket](https://trello.com/c/EMWvRao0/3082-add-the-translation-for-and-in-the-metadata-component-for-french-and-spanish-m)

## Visual Changes

### Before

![Screenshot 2024-12-05 at 14-01-03 Candidat du Royaume-Uni aux élections 2026 de la Cour internationale de justice brochure électorale du professeur Dapo Akande - GOV UK](https://github.com/user-attachments/assets/95ff436d-e5b1-4277-b67b-c4536b1ff5fe)

### After

![Screenshot 2024-12-05 at 14-00-37 Candidat du Royaume-Uni aux élections 2026 de la Cour internationale de justice brochure électorale du professeur Dapo Akande - GOV UK](https://github.com/user-attachments/assets/d5073a4f-9c2c-40f7-a1c3-431f419fc9cf)

