### PR TITLE
Use component wrapper on share links component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Use component wrapper on reorderable list component ([PR #4474](https://github.com/alphagov/govuk_publishing_components/pull/4474))
+* Use component wrapper on share links component ([PR #4479](https://github.com/alphagov/govuk_publishing_components/pull/4479))
 
 ## 46.2.0
 


### PR DESCRIPTION
## What
- Adds the component wrapper helper to the `share links` component.

## Why
As the [trello card](https://trello.com/c/qH4NyWJw/364-add-component-wrapper-to-more-components) states:

> Standardising our components to use the component wrapper helper will reduce code, increase standardisation, and improve future feature implementation speed.

## Visual changes

None.