### PR TITLE
Use correct button type for copy to clipboard component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Use component wrapper on reorderable list component ([PR #4474](https://github.com/alphagov/govuk_publishing_components/pull/4474))
+* Use "button" button type for copy to clipboard component ([PR 4480](https://github.com/alphagov/govuk_publishing_components/pull/4480))
 
 ## 46.2.0
 

--- a/app/views/govuk_publishing_components/components/_copy_to_clipboard.html.erb
+++ b/app/views/govuk_publishing_components/components/_copy_to_clipboard.html.erb
@@ -15,6 +15,7 @@
 
   <%= render "govuk_publishing_components/components/button", {
     text: button_text,
+    type: "button",
     data_attributes: button_data_attributes,
     secondary_quiet: true,
   } %>

--- a/spec/components/copy_to_clipboard_spec.rb
+++ b/spec/components/copy_to_clipboard_spec.rb
@@ -14,6 +14,6 @@ describe "Copy to clipboard", type: :view do
 
     assert_select "label", text: "Some label"
     assert_select "input", value: "https://www.example.org"
-    assert_select "button", value: "Copy link"
+    assert_select "button[type=\"button\"]", value: "Copy link"
   end
 end


### PR DESCRIPTION
## What
Use the "button" button type for the copy to clipboard button

## Why
The copy to clipboard component is not used as a form submit button, and therefore should have the "button" button type instead of the "submit" button type.

This affects the tracking implementation in Whitehall ([related Trello](https://trello.com/c/mVJGdWsZ))
