### PR TITLE
Use component wrapper on signup link component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 ## Unreleased
 
 * Use component wrapper on reorderable list component ([PR #4474](https://github.com/alphagov/govuk_publishing_components/pull/4474))
-* Use "button" button type for copy to clipboard component ([PR 4480](https://github.com/alphagov/govuk_publishing_components/pull/4480))
+* Use "button" button type for copy to clipboard component ([PR #4480](https://github.com/alphagov/govuk_publishing_components/pull/4480))
+* Use component wrapper on signup link component ([PR #4481](https://github.com/alphagov/govuk_publishing_components/pull/4481))
 
 ## 46.2.0
 

--- a/app/views/govuk_publishing_components/components/_signup_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_signup_link.html.erb
@@ -10,14 +10,14 @@
   data ||= false
 
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
-
-  classes = %w(gem-c-signup-link govuk-!-display-none-print)
-  classes << shared_helper.get_margin_bottom
-  classes << "gem-c-signup-link--link-only" unless heading
-  classes << "gem-c-signup-link--with-background-and-border" if background
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("gem-c-signup-link govuk-!-display-none-print")
+  component_helper.add_class(shared_helper.get_margin_bottom)
+  component_helper.add_class("gem-c-signup-link--link-only") unless heading
+  component_helper.add_class("gem-c-signup-link--with-background-and-border") if background
 %>
 <% if link_text && link_href %>
-  <div class="<%= classes.join(' ') %>">
+  <%= tag.div(**component_helper.all_attributes) do %>
     <div class="gem-c-signup-link__inner govuk-width-container">
       <svg  class="gem-c-signup-link__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" height="18" width="18" viewBox="0 0 459.334 459.334">
         <path fill="black" d="M177.216 404.514c-.001.12-.009.239-.009.359 0 30.078 24.383 54.461 54.461 54.461s54.461-24.383 54.461-54.461c0-.12-.008-.239-.009-.359H175.216zM403.549 336.438l-49.015-72.002v-89.83c0-60.581-43.144-111.079-100.381-122.459V24.485C254.152 10.963 243.19 0 229.667 0s-24.485 10.963-24.485 24.485v27.663c-57.237 11.381-100.381 61.879-100.381 122.459v89.83l-49.015 72.002a24.76 24.76 0 0 0 20.468 38.693H383.08a24.761 24.761 0 0 0 20.469-38.694z"/>
@@ -28,5 +28,5 @@
         data: data
       }) %>
     </div>
-  </div>
+  <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/signup_link.yml
+++ b/app/views/govuk_publishing_components/components/docs/signup_link.yml
@@ -4,6 +4,7 @@ accessibility_criteria: |
   - the component must use the correct heading level for the page
   - text should have a text contrast ratio higher than 4.5:1 against the background colour to meet WCAG AA
   - the icon must not be focusable or shown to screenreaders
+uses_component_wrapper_helper: true
 shared_accessibility_criteria:
   - link
 examples:


### PR DESCRIPTION
## What
- Adds the component wrapper helper to the `signup link` component.

## Why
As the [trello card](https://trello.com/c/qH4NyWJw/364-add-component-wrapper-to-more-components) states:

> Standardising our components to use the component wrapper helper will reduce code, increase standardisation, and improve future feature implementation speed.

## Visual changes

None.