### PR TITLE
Fix broken spec assertions

### DIFF
--- a/spec/component_guide/component_audit_spec.rb
+++ b/spec/component_guide/component_audit_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Component audit page" do
+describe "Component audit page", :capybara do
   it "renders the audit page" do
     visit "/component-guide/audit"
     expect(page).to have_title "Component audit - Component Guide"

--- a/spec/component_guide/component_example_accessibility_criteria_spec.rb
+++ b/spec/component_guide/component_example_accessibility_criteria_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Component examples with accessibility criteria" do
+describe "Component examples with accessibility criteria", :capybara do
   it "shows the accessibility acceptance criteria as HTML" do
     visit "/component-guide/test_component"
 

--- a/spec/component_guide/component_example_accessibility_testing_spec.rb
+++ b/spec/component_guide/component_example_accessibility_testing_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Component example with automated testing", js: true do
+describe "Component example with automated testing", :capybara, js: true do
   it "has accessibility testing hooks" do
     visit "/component-guide/test_component"
     expect(page).to have_selector('[data-module="test-a11y"]')

--- a/spec/component_guide/component_example_spec.rb
+++ b/spec/component_guide/component_example_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Component example" do
+describe "Component example", :capybara do
   it "illustrates how to use the component" do
     visit "/component-guide/test_component"
 

--- a/spec/component_guide/component_index_spec.rb
+++ b/spec/component_guide/component_index_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Component guide index" do
+describe "Component guide index", :capybara do
   # Load ordering test can only fail if run as the first test in suite
   # https://github.com/rails/rails/issues/12168
   it "renders using gem layout not app layout after viewing a page on the application" do

--- a/spec/component_guide/component_preview_spec.rb
+++ b/spec/component_guide/component_preview_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Component preview" do
+describe "Component preview", :capybara do
   it "shows all component examples on a page without header or footer" do
     visit "/component-guide/test_component_with_params/preview"
     expect(page).to have_selector(".hide-header-and-footer")

--- a/spec/components/contextual_breadcrumbs_spec.rb
+++ b/spec/components/contextual_breadcrumbs_spec.rb
@@ -57,7 +57,7 @@ describe "ContextualBreadcrumbs", type: :view do
 
   it "renders parent-based breadcrumbs if the content_item is tagged to mainstream browse and there is a parent" do
     render_component(content_item: example_document_for("place", "find-regional-passport-office"))
-    assert_no_selector(".gem-c-step-nav-header")
+    assert_select(".gem-c-step-nav-header", false)
     assert_select "a", text: "Home"
     assert_select "a", text: "Passports, travel and living abroad"
     assert_select "a", text: "Passports"
@@ -72,7 +72,7 @@ describe "ContextualBreadcrumbs", type: :view do
     content_item = example_document_for("licence", "licence_without_continuation_link")
     content_item = remove_mainstream_browse(content_item)
     render_component(content_item:)
-    assert_no_selector(".gem-c-step-nav-header")
+    assert_select(".gem-c-step-nav-header", false)
     assert_select "a", text: "Home"
     assert_select "a", text: "Business and self-employed"
     assert_select "a", text: "Licences and licence applications"
@@ -82,7 +82,7 @@ describe "ContextualBreadcrumbs", type: :view do
     content_item = example_document_for("guide", "guide-with-no-parent")
     content_item = set_live_taxons(content_item)
     render_component(content_item:)
-    assert_no_selector(".gem-c-step-nav-header")
+    assert_select(".gem-c-step-nav-header", false)
     assert_select "a", text: "Home"
     assert_select "a", text: "School curriculum"
     assert_select "a", text: "Education, training and skills"
@@ -118,8 +118,8 @@ describe "ContextualBreadcrumbs", type: :view do
     content_item = remove_mainstream_browse(content_item)
     content_item = remove_curated_related_item(content_item)
     content_item["links"]["taxons"].each { |taxon| taxon["phase"] = "draft" }
-    assert_no_selector(".gem-c-step-nav-header")
-    assert_no_selector(".gem-c-breadcrumbs")
+    assert_select(".gem-c-step-nav-header", false)
+    assert_select(".gem-c-breadcrumbs", false)
   end
 
   it "renders parent finder breadcrumb if content schema is a specialist document" do
@@ -177,8 +177,8 @@ describe "ContextualBreadcrumbs", type: :view do
     content_item = remove_mainstream_browse(content_item)
     content_item = remove_curated_related_item(content_item)
     content_item["links"]["taxons"] = nil
-    assert_no_selector(".gem-c-step-nav-header")
-    assert_no_selector(".gem-c-breadcrumbs")
+    assert_select(".gem-c-step-nav-header", false)
+    assert_select(".gem-c-breadcrumbs", false)
   end
 
   it "renders taxon breadcrumbs even if there are mainstream browse pages if prioritise_taxon_breadcrumbs is true" do
@@ -187,8 +187,8 @@ describe "ContextualBreadcrumbs", type: :view do
     content_item = set_live_taxons(content_item)
     render_component(content_item:, prioritise_taxon_breadcrumbs: true)
     assert_select "a", text: "Home"
-    assert_no_selector "a", text: "Business and self-employed"
-    assert_no_selector "a", text: "Licences and licence applications"
+    assert_select "a", text: "Business and self-employed", count: 0
+    assert_select "a", text: "Licences and licence applications", count: 0
     assert_select "a", text: "School curriculum"
     assert_select "a", text: "Education, training and skills"
   end
@@ -201,8 +201,8 @@ describe "ContextualBreadcrumbs", type: :view do
     assert_select "a", text: "Home"
     assert_select "a", text: "Business and self-employed"
     assert_select "a", text: "Licences and licence applications"
-    assert_no_selector "a", text: "School curriculum"
-    assert_no_selector "a", text: "Education, training and skills"
+    assert_select "a", text: "School curriculum", count: 0
+    assert_select "a", text: "Education, training and skills", count: 0
   end
 
   it "renders mainstream browse pages if prioritise_taxon_breadcrumbs is not passed and are live taxons" do
@@ -213,7 +213,7 @@ describe "ContextualBreadcrumbs", type: :view do
     assert_select "a", text: "Home"
     assert_select "a", text: "Business and self-employed"
     assert_select "a", text: "Licences and licence applications"
-    assert_no_selector "a", text: "School curriculum"
-    assert_no_selector "a", text: "Education, training and skills"
+    assert_select "a", text: "School curriculum", count: 0
+    assert_select "a", text: "Education, training and skills", count: 0
   end
 end

--- a/spec/components/contextual_footer_spec.rb
+++ b/spec/components/contextual_footer_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Contextual footer", type: :view do
 
     render_component(content_item:)
 
-    has_selector? ".gem-c-contextual-footer"
+    assert_select ".gem-c-contextual-footer"
   end
 
   context "part of a step by step" do

--- a/spec/components/contextual_footer_spec.rb
+++ b/spec/components/contextual_footer_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Contextual footer", type: :view do
         content_item: GovukSchemas::RandomExample.for_schema(frontend_schema: "step_by_step_nav"),
       )
 
-      assert_no_selector ".gem-c-contextual-footer"
+      assert_select ".gem-c-contextual-footer", false
     end
   end
 

--- a/spec/components/contextual_footer_spec.rb
+++ b/spec/components/contextual_footer_spec.rb
@@ -20,9 +20,18 @@ RSpec.describe "Contextual footer", type: :view do
 
   context "part of a step by step" do
     it "does not renders the footer" do
-      render_component(
-        content_item: GovukSchemas::RandomExample.for_schema(frontend_schema: "step_by_step_nav"),
-      )
+      content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: "speech") do |payload|
+        payload["links"].merge!("part_of_step_navs" => [{
+          "title" => "Step by Step",
+          "content_id" => SecureRandom.uuid,
+          "base_path" => "/step-by-step",
+          "locale" => "en",
+        }])
+
+        payload
+      end
+
+      render_component(content_item:)
 
       assert_select ".gem-c-contextual-footer", false
     end

--- a/spec/components/input_spec.rb
+++ b/spec/components/input_spec.rb
@@ -141,7 +141,8 @@ describe "Input", type: :view do
       name: "email-address",
       width: 11,
     )
-    expect(page).to have_no_css(".govuk-input--width-10")
+
+    assert_select ".govuk-input--width-10", false
   end
 
   context "when a hint is provided" do

--- a/spec/components/input_spec.rb
+++ b/spec/components/input_spec.rb
@@ -283,7 +283,7 @@ describe "Input", type: :view do
       enterkeyhint: "chocolate",
     )
 
-    assert_no_selector ".govuk-input[enterkeyhint='chocolate']"
+    assert_select ".govuk-input[enterkeyhint='chocolate']", false
   end
 
   it "renders the input and label with the correct `dir` attribute when the input is set to 'right_to_left: true'" do
@@ -314,8 +314,8 @@ describe "Input", type: :view do
     )
 
     assert_select ".govuk-input[dir='rtl']"
-    assert_no_selector ".govuk-label[dir='rtl']"
-    assert_no_selector ".govuk-hint[dir='rtl']"
-    assert_no_selector ".govuk-error-message[dir='rtl']"
+    assert_select ".govuk-label[dir='rtl']", false
+    assert_select ".govuk-hint[dir='rtl']", false
+    assert_select ".govuk-error-message[dir='rtl']", false
   end
 end

--- a/spec/components/layout_footer_spec.rb
+++ b/spec/components/layout_footer_spec.rb
@@ -413,8 +413,8 @@ describe "Layout footer", type: :view do
   it "allows the licence to be hidden" do
     render_component({ hide_licence: true })
 
-    assert_no_selector ".govuk-footer__licence-logo"
-    assert_no_selector ".govuk-footer__licence-description"
+    assert_select ".govuk-footer__licence-logo", false
+    assert_select ".govuk-footer__licence-description", false
   end
 
   it "shows the licence if hide_licence is set to false" do

--- a/spec/components/layout_for_public_spec.rb
+++ b/spec/components/layout_for_public_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Layout for public", type: :view do
+describe "Layout for public", :capybara, type: :view do
   def component_name
     "layout_for_public"
   end

--- a/spec/components/radio_spec.rb
+++ b/spec/components/radio_spec.rb
@@ -650,7 +650,7 @@ describe "Radio", type: :view do
 end
 
 # This component can be interacted with, so use integration tests for these cases.
-describe "Radio (integration)" do
+describe "Radio (integration)", :capybara do
   def input_visible
     false # our inputs are hidden with CSS, and rely on the label.
   end

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -111,18 +111,18 @@ describe "Search", type: :view do
   it "renders the correct label size" do
     render_component(label_size: "xl")
     assert_select ".govuk-label.govuk-label--xl", text: "Search on GOV.UK"
-    assert_no_selector ".gem-c-search__label"
+    assert_select ".gem-c-search__label", false
   end
 
   it "renders the default label when given an incorrect t-shirt size" do
     render_component(label_size: "super-massive-size")
-    assert_no_selector ".govuk-label"
+    assert_select ".govuk-label", false
     assert_select ".gem-c-search__label", text: "Search on GOV.UK"
   end
 
   it "renders the default label when given no label size" do
     render_component({})
-    assert_no_selector ".govuk-label"
+    assert_select ".govuk-label", false
     assert_select ".gem-c-search__label", text: "Search on GOV.UK"
   end
 

--- a/spec/components/textarea_spec.rb
+++ b/spec/components/textarea_spec.rb
@@ -227,8 +227,8 @@ describe "Textarea", type: :view do
     )
 
     assert_select ".govuk-textarea[dir='rtl']"
-    assert_no_selector ".govuk-label[dir='rtl']"
-    assert_no_selector ".govuk-hint[dir='rtl']"
-    assert_no_selector ".govuk-error-message[dir='rtl']"
+    assert_select ".govuk-label[dir='rtl']", false
+    assert_select ".govuk-hint[dir='rtl']", false
+    assert_select ".govuk-error-message[dir='rtl']", false
   end
 end

--- a/spec/features/accordion_spec.rb
+++ b/spec/features/accordion_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Accordion", js: true, type: :view do
+describe "Accordion", :js, :capybara do
   scenario "There is a page with the accordion rendered" do
     given_i_visit_a_page_with_the_accordion_component
     then_the_accordion_loads

--- a/spec/features/asset_helper_spec.rb
+++ b/spec/features/asset_helper_spec.rb
@@ -1,4 +1,4 @@
-describe "When the asset helper is configured", type: :view do
+describe "When the asset helper is configured", :capybara do
   scenario "go to page with multiple GOV.UK publishing components only" do
     GovukPublishingComponents.configure do |config|
       config.exclude_css_from_static = true

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Contextual navigation" do
+describe "Contextual navigation", :capybara do
   scenario "There's a step by step list" do
     given_theres_a_page_with_a_step_by_step
     and_i_visit_that_page

--- a/spec/features/step_nav_helper_spec.rb
+++ b/spec/features/step_nav_helper_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Specimen usage of step by step navigation helpers" do
+describe "Specimen usage of step by step navigation helpers", :capybara do
   include GdsApi::TestHelpers::ContentStore
 
   context "no related step by step navigation journeys" do

--- a/spec/features/tabs_spec.rb
+++ b/spec/features/tabs_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Tabs component", js: true do
+describe "Tabs component", :js, :capybara do
   scenario "Tabs load" do
     given_i_visit_a_page_with_the_tabs_component
     then_the_tabs_load

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,7 +10,7 @@ GovukTest.configure
 Selenium::WebDriver::Options.chrome(loggingPrefs: { browser: "ALL" })
 
 RSpec.configure do |config|
-  config.include Capybara::DSL, capybara: true
+  config.include Capybara::DSL, capybara: true, visual_regression: true
   config.include Helpers::Components, type: :view
   config.include ActiveSupport::Testing::TimeHelpers
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,7 +10,7 @@ GovukTest.configure
 Selenium::WebDriver::Options.chrome(loggingPrefs: { browser: "ALL" })
 
 RSpec.configure do |config|
-  config.include Capybara::DSL
+  config.include Capybara::DSL, capybara: true
   config.include Helpers::Components, type: :view
   config.include ActiveSupport::Testing::TimeHelpers
 end

--- a/spec/visual_regression_tests/all_components_spec.rb
+++ b/spec/visual_regression_tests/all_components_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 require "percy/capybara"
 require "uri"
 
-describe "visual regression test runner Percy", visual_regression: true do
+describe "visual regression test runner Percy", :visual_regression do
   it "takes a screenshot of each component" do
     # Freeze time for consistency
     travel_to Time.zone.local(2020, 12, 1, 6, 0, 0)


### PR DESCRIPTION
This PR was prompted after discovering in https://github.com/alphagov/govuk_publishing_components/pull/4451 that the commonly used `assert_no_selector` test assertion in view specs didn't actually assert anything and would pass even if given `assert_no_selector("*")`

The reason this non-assertion was available was because it is using a Capybara assertion (from the [Capybara::DSL](https://github.com/alphagov/govuk_publishing_components/blob/52b5260d4809c31015aee8806c21833e99237f4a/spec/rails_helper.rb#L13)) - however these assertions only have an impact if you have run `visit(url)` and have a `page` variable.

To remedy this I have taken 2 steps: 

1. I have replaced all usages of `assert_no_selector(selector)` to be `assert_select(selector, false)` to confirm when a selector isn't available for a view spec (unfortunately `assert_no_select` isn't available [yet](https://github.com/rails/rails-dom-testing/blob/da0d96bc872e7e9b2656bc17ef3467bdf4bd9d48/CHANGELOG.md#next--unreleased))
2. I have added a `capybara` tag so that only specs that are tagged with capybara will have access to the Capybara DSL - to prevent using assertions that have no impact. Ideally we'd only have these scoped to a type of test (i.e. feature) but the ship has sailed on that for this project.

No changelog as this is only an internal change.