### PR TITLE
Update Govspeak "Warning Text" component styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@
 * Use component wrapper on reorderable list component ([PR #4474](https://github.com/alphagov/govuk_publishing_components/pull/4474))
 * Use "button" button type for copy to clipboard component ([PR #4480](https://github.com/alphagov/govuk_publishing_components/pull/4480))
 * Use component wrapper on signup link component ([PR #4481](https://github.com/alphagov/govuk_publishing_components/pull/4481))
+* Update Govspeak "Warning Text" component styles ([PR #4487](https://github.com/alphagov/govuk_publishing_components/pull/4487))
 
 ## 46.2.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_warning-callout.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_warning-callout.scss
@@ -8,29 +8,23 @@
 
 .govspeak, // Legacy class name that's still used in some content items - needs to be kept until `.govspeak` is removed from the content items.
 .gem-c-govspeak {
+  @import "govuk/components/warning-text/warning-text";
+
   .help-notice {
     $icon-size: 35px;
-    $line-height-mobile: 20px;
-    $line-height-tablet: 25px;
+    $icon-spacing: 10px;
 
     margin: 2em 0;
+    padding-left: calc($icon-size + $icon-spacing);
+    position: relative;
 
-    // Add '!' icon
-    background-image: url("govuk_publishing_components/icon-important.svg");
-    background-size: $icon-size $icon-size;
-    background-repeat: no-repeat;
-    min-height: $icon-size;
-    padding-left: $icon-size;
-
-    // Center the icon around the baseline
-    padding-top: calc(($icon-size - $line-height-mobile) / 2);
-
-    @include govuk-media-query($from: tablet) {
-      padding-top: calc(($icon-size - $line-height-tablet) / 2);
+    &::before {
+      content: "!";
+      @include govuk-typography-weight-bold($important: false);
+      @extend .govuk-warning-text__icon; // stylelint-disable-line scss/at-extend-no-missing-placeholder
     }
 
     p {
-      margin-left: 1em;
       @include govuk-font($size: 19, $weight: bold);
     }
   }


### PR DESCRIPTION
## What

Update Govspeak "Warning Text" component styles to extend the GOV.UK Frontend `govuk-warning-text__icon` styles.

See https://components-gem-pr-4487.herokuapp.com/component-guide/govspeak/warning_callout/preview

## Why

The left spacing between the icon and text appears to be excessive compared to both the [Warning Text component](https://components.publishing.service.gov.uk/component-guide/warning_text/default/preview) and its [Design System](https://design-system.service.gov.uk/components/warning-text/) equivalent

## Visual Changes

### Before (mobile)

<img src="https://github.com/user-attachments/assets/f8640d14-695f-49b7-8c33-d0066d4240bf" width=330>

### After (mobile)

<img src="https://github.com/user-attachments/assets/7690f142-1454-41e8-a579-c1d4e0e9e908" width=330>

### Before (tablet)

![components publishing service gov uk_component-guide_govspeak_warning_callout_preview](https://github.com/user-attachments/assets/27b41384-31ff-4fa0-805c-d539b51e5cd2)

### After (tablet)

![components-gem-pr-4487 herokuapp com_component-guide_govspeak_warning_callout_preview (1)](https://github.com/user-attachments/assets/250ae347-2446-479b-b3d5-4bb02007fd1d)

### Before (travel advice page - mobile)

<img src="https://github.com/user-attachments/assets/cb31bc40-ae4e-4a52-a136-0c40b8c7ef08" width=330>

### After (travel advice page - mobile)

<img src="https://github.com/user-attachments/assets/14cd7f14-dff8-4e9c-b8e7-7d24ae1706b8" width=330>

### Before (travel advice page - tablet)

![www gov uk_foreign-travel-advice_algeria(iPad Pro) (2)](https://github.com/user-attachments/assets/9822e779-a2ae-4eb6-bd59-1b1c00433d3c)

### After (travel advice page - tablet)

![www gov uk_foreign-travel-advice_algeria(iPad Pro) (1)](https://github.com/user-attachments/assets/69db66f8-b1ae-4615-b831-9b4e2896f276)