### PR TITLE
Remove min-width from share links flexbox variant list-items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Remove min-width from share links flexbox variant list-items ([PR #4488](https://github.com/alphagov/govuk_publishing_components/pull/4488))
 * Add search autocomplete to layout super navigation header ([PR #4451](https://github.com/alphagov/govuk_publishing_components/pull/4451))
 * Use component wrapper on reorderable list component ([PR #4474](https://github.com/alphagov/govuk_publishing_components/pull/4474))
 * Use "button" button type for copy to clipboard component ([PR #4480](https://github.com/alphagov/govuk_publishing_components/pull/4480))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_share-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_share-links.scss
@@ -93,7 +93,10 @@ $column-width: 9.5em;
   .gem-c-share-links__list-item {
     padding-left: 0;
     padding-right: 0;
-    min-width: 180px;
+
+    @include govuk-media-query($until: tablet) {
+      min-width: 100%;
+    }
   }
 
   .gem-c-share-links__link-icon {


### PR DESCRIPTION
## What
Remove min-width from share links flexbox variant list-items

## Why
Current share items look odd with very small text content (eg X)

## Visual Changes

(screenshots from frontend, but also compare: https://components.publishing.service.gov.uk/component-guide/share_links/with_flexbox/preview with https://components-gem-pr-4488.herokuapp.com/component-guide/share_links/with_flexbox/preview)

### Before

<img width="1073" alt="Screenshot 2024-12-10 at 15 00 44" src="https://github.com/user-attachments/assets/db899f82-52e4-4bbc-b005-b9f1a4907cfb">


### After

<img width="1048" alt="Screenshot 2024-12-10 at 11 47 46" src="https://github.com/user-attachments/assets/b16e3c32-2f6e-4423-bf8d-e0adc5594d97">
