### PR TITLE
Add /media/ path to GA4 download link tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add /media/ path to GA4 download link tracking ([PR #4491](https://github.com/alphagov/govuk_publishing_components/pull/4491/))
+
 ## 46.3.0
 
 * Remove min-width from share links flexbox variant list-items ([PR #4488](https://github.com/alphagov/govuk_publishing_components/pull/4488))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.js
@@ -9,7 +9,7 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
     init: function (config) {
       if (window.dataLayer) {
         config = config || {}
-        this.internalDownloadPaths = config.internalDownloadPaths || ['/government/uploads/']
+        this.internalDownloadPaths = config.internalDownloadPaths || ['/government/uploads/', '/media/']
         this.dedicatedDownloadDomains = config.dedicatedDownloadDomains || ['assets.publishing.service.gov.uk']
         window.GOVUK.analyticsGa4.core.trackFunctions.appendDomainsWithoutWWW(this.dedicatedDownloadDomains)
         this.handleClick = this.handleClick.bind(this)

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.spec.js
@@ -371,10 +371,12 @@ describe('A specialist link tracker', function () {
           '<div class="preview-download-links">' +
             '<a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/moj-hq.csv/preview" path="/government/uploads/system/uploads/attachment_data/file/444468/moj-hq.csv/preview" link_domain="https://assets.publishing.service.gov.uk">Preview link</a>' +
             '<a href="http://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/moj-hq.csv/preview" path="/government/uploads/system/uploads/attachment_data/file/444468/moj-hq.csv/preview" link_domain="http://assets.publishing.service.gov.uk">Relative Spreadsheet link</a>' +
+            '<a href="https://www.gov.uk/media/66866f8d4a94d44125d9ccc1/Management_information_-_initial_teacher_education___in_year_inspection_outcomes_1_September_2023_to_30_April_2024.csv/preview" path="/media/66866f8d4a94d44125d9ccc1/Management_information_-_initial_teacher_education___in_year_inspection_outcomes_1_September_2023_to_30_April_2024.csv/preview" link_domain="https://www.gov.uk">Relative csv link</a>' +
           '</div>' +
           '<div class="not-a-preview-link">' +
             '<a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/preview.mp4" path="/government/uploads/system/uploads/attachment_data/file/444468/preview.mp4" link_domain="https://assets.publishing.service.gov.uk">Preview link</a>' +
             '<a href="http://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/preview.jpg&preview=false" path="/government/uploads/system/uploads/attachment_data/file/444468/preview.jpg&preview=false" link_domain="http://assets.publishing.service.gov.uk">Relative Spreadsheet link</a>' +
+'<a href="https://www.gov.uk/media/66866f8d4a94d44125d9ccc1/preview.csv" link_domain="https://www.gov.uk">Relative csv link</a>' +
           '</div>'
 
       body.appendChild(links)
@@ -509,7 +511,7 @@ describe('A specialist link tracker', function () {
 
     it('detects preview clicks on gov.uk download preview links', function () {
       var linksToTest = document.querySelectorAll('.preview-download-links a')
-
+      var external = ['true', 'true', 'false']
       for (var i = 0; i < linksToTest.length; i++) {
         window.dataLayer = []
         var link = linksToTest[i]
@@ -518,7 +520,7 @@ describe('A specialist link tracker', function () {
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.type = 'preview'
         expected.event_data.text = link.innerText.trim()
-        expected.event_data.external = 'true'
+        expected.event_data.external = external[i]
 
         expect(window.dataLayer[0]).toEqual(expected)
       }
@@ -526,7 +528,7 @@ describe('A specialist link tracker', function () {
 
     it('detects files with preview in their filename as download links instead of preview links', function () {
       var linksToTest = document.querySelectorAll('.not-a-preview-link a')
-
+      var external = ['true', 'true', 'false']
       for (var i = 0; i < linksToTest.length; i++) {
         window.dataLayer = []
         var link = linksToTest[i]
@@ -535,7 +537,7 @@ describe('A specialist link tracker', function () {
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.type = 'generic download'
         expected.event_data.text = link.innerText.trim()
-        expected.event_data.external = 'true'
+        expected.event_data.external = external[i]
 
         expect(window.dataLayer[0]).toEqual(expected)
       }


### PR DESCRIPTION
## What / Why
- Ensure links starting with `https://www.gov.uk/media/` are tracked as download links
- We either missed tracking these, or these links were recently reintroduced after an issue with attachments. Therefore the 'View Online' links were not being tracked if they used this old type of link.
- Example link: https://www.gov.uk/government/statistical-data-sets/management-information-ofsteds-initial-teacher-education-ite-inspections-outcomes
- https://trello.com/c/SlmI0kKL/847-attachment-navigation-link-clicks-not-firing-on-certain-links-view-online-links
## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
