### PR TITLE
[WIP] Try adding a search-autocomplete to super nav header

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/components/layout-super-navigation-header.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/layout-super-navigation-header.js
@@ -1,3 +1,4 @@
+// = require ./search-with-autocomplete.js
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -69,6 +69,7 @@
 @import "components/related-navigation";
 @import "components/reorderable-list";
 @import "components/search";
+@import "components/search-with-autocomplete";
 @import "components/secondary-navigation";
 @import "components/select";
 @import "components/share-links";


### PR DESCRIPTION
Attempt 1
----------

Tested locally using static and collections and get the following error:

Access to fetch at 'http://www.dev.gov.uk/api/search/autocomplete.json?q=test' from origin 'http://localhost:3070' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.

## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
<!-- What are the reasons behind this change being made? -->

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

### Before


### After
