### PR TITLE
Add search-with-autocomplete to stylesheets served by static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add search-with-autocomplete to stylesheets served by static ([PR #4495](https://github.com/alphagov/govuk_publishing_components/pull/4495))
 * Add /media/ path to GA4 download link tracking ([PR #4491](https://github.com/alphagov/govuk_publishing_components/pull/4491/))
 
 ## 46.3.0

--- a/lib/govuk_publishing_components/app_helpers/asset_helper.rb
+++ b/lib/govuk_publishing_components/app_helpers/asset_helper.rb
@@ -23,6 +23,7 @@ module GovukPublishingComponents
         govuk_publishing_components/components/_input.css
         govuk_publishing_components/components/_label.css
         govuk_publishing_components/components/_search.css
+        govuk_publishing_components/components/_search-with-autocomplete.css
         govuk_publishing_components/components/_skip-link.css
         govuk_publishing_components/components/_textarea.css
         govuk_publishing_components/components/_title.css


### PR DESCRIPTION
## What

This adds the search-with-autocomplete component to the list of those served by static.

## Why

We are adding this to static in: https://github.com/alphagov/static/pull/3532 and want to avoid serving this stylesheet unnecessarily to users.

## Visual Changes

None
