### PR TITLE
Limit GA4 search term tracking to 500 characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Limit GA4 search term tracking to 500 characters ([PR #4496](https://github.com/alphagov/govuk_publishing_components/pull/4496))
+
 ## 46.3.1
 
 * Add search-with-autocomplete to stylesheets served by static ([PR #4495](https://github.com/alphagov/govuk_publishing_components/pull/4495))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -340,6 +340,11 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
 
         if (isSearchResult) {
           var searchQuery = window.GOVUK.analyticsGa4.core.trackFunctions.standardiseSearchTerm(element.getAttribute('data-ga4-search-query'))
+
+          // Limit tracked search term to 500 characters
+          if (searchQuery) {
+            searchQuery = searchQuery.substring(0, 500)
+          }
           var variant = element.getAttribute('data-ga4-ecommerce-variant')
           DEFAULT_LIST_TITLE = 'Site search results'
         }

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
@@ -644,6 +644,25 @@ describe('GA4 core', function () {
         expect(builtEcommerceObject).toEqual(expectedEcommerceObject)
       })
 
+      it('limits ecommerce search term tracking to 500 characters', function () {
+        var veryLongString = ''
+
+        for (var i = 0; i < 600; i++) {
+          veryLongString = veryLongString + 'a'
+        }
+
+        resultsParentEl.setAttribute('data-ga4-search-query', veryLongString)
+
+        expectedEcommerceObject.search_results.term = veryLongString.substring(0, 500)
+
+        var builtEcommerceObject = GOVUK.analyticsGa4.core.ecommerceHelperFunctions.populateEcommerceSchema({
+          element: resultsParentEl,
+          resultsId: 'result-count'
+        })
+
+        expect(builtEcommerceObject).toEqual(expectedEcommerceObject)
+      })
+
       it('tracks variant and term for search results even when query is blank', function () {
         resultsParentEl.setAttribute('data-ga4-search-query', '')
         resultsParentEl.setAttribute('data-ga4-ecommerce-variant', 'upside-down')


### PR DESCRIPTION
## What / Why
<!-- What are the reasons behind this change being made? -->
- Limit the search term sent to GA4 to 500 characters
- Request by PAs, to reduce the amount of data collected
- https://trello.com/c/ZQbreFrw/856-add-500-character-limit-to-ecommerce-searchterm-tracking

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.