### PR TITLE
Add canonical_url value to GA4 page view tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add canonical_url value to GA4 page view tracking ([PR #4500](https://github.com/alphagov/govuk_publishing_components/pull/4500))
 * Add margin_bottom option to component wrapper helper ([PR #4494](https://github.com/alphagov/govuk_publishing_components/pull/4494))
 * Limit GA4 search term tracking to 500 characters ([PR #4496](https://github.com/alphagov/govuk_publishing_components/pull/4496))
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
@@ -66,7 +66,8 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
             search_term: this.getSearchTerm(),
             tool_name: this.getToolName(),
             spelling_suggestion: this.getMetaContent('spelling-suggestion'),
-            discovery_engine_attribution_token: this.getMetaContent('discovery-engine-attribution-token')
+            discovery_engine_attribution_token: this.getMetaContent('discovery-engine-attribution-token'),
+            canonical_url: this.getCanonicalHref()
           }
         }
         window.GOVUK.analyticsGa4.core.sendData(data)
@@ -76,6 +77,14 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
     removeHyphensAndDowncase: function (text) {
       if (text) {
         return text.replace(/-/g, ' ').toLowerCase()
+      }
+    },
+
+    getCanonicalHref: function () {
+      var link = document.querySelector('link[rel=canonical]')
+
+      if (link) {
+        return link.href
       }
     },
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
@@ -63,7 +63,8 @@ describe('Google Tag Manager page view tracking', function () {
         search_term: undefined,
         tool_name: undefined,
         spelling_suggestion: undefined,
-        discovery_engine_attribution_token: undefined
+        discovery_engine_attribution_token: undefined,
+        canonical_url: undefined
       }
     }
     spyOn(GOVUK.analyticsGa4.core, 'getTimestamp').and.returnValue('123456')
@@ -716,5 +717,21 @@ describe('Google Tag Manager page view tracking', function () {
 
       expect(window.dataLayer[0].page_view.tool_name).toEqual('autocomplete')
     })
+  })
+
+  it('returns a canonical_url', function () {
+    var link = document.createElement('link')
+    var head = document.getElementsByTagName('head')[0]
+
+    link.setAttribute('rel', 'canonical')
+    link.setAttribute('href', 'https://www.gov.uk/benefits-calculators/')
+
+    head.appendChild(link)
+
+    expected.page_view.canonical_url = 'https://www.gov.uk/benefits-calculators/'
+    GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
+    expect(window.dataLayer[0]).toEqual(expected)
+
+    head.removeChild(link)
   })
 })


### PR DESCRIPTION
## What / Why
<!-- What are the reasons behind this change being made? -->
- Adds a `canonical_url` attribute to the GA4 page view tracker.
- https://trello.com/b/rm8pjAAk/ga4-gtm-implementation-ga4-team-user-experience-govuk

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.