### PR TITLE
Refactor single page notification component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Refactor single page notification component ([PR #4501](https://github.com/alphagov/govuk_publishing_components/pull/4501))
 * Remove shared helper from button component ([PR #4569](https://github.com/alphagov/govuk_publishing_components/pull/4569))
 * Remove shared helper from inset text component ([PR #4571](https://github.com/alphagov/govuk_publishing_components/pull/4571))
 * Use component wrapper on contextual footer ([PR #4562](https://github.com/alphagov/govuk_publishing_components/pull/4562))

--- a/app/views/govuk_publishing_components/components/_single_page_notification_button.html.erb
+++ b/app/views/govuk_publishing_components/components/_single_page_notification_button.html.erb
@@ -2,10 +2,16 @@
   add_gem_component_stylesheet("single-page-notification-button")
 
   local_assigns[:margin_bottom] ||= 3
+  js_enhancement ||= false
 
   spnb_helper = GovukPublishingComponents::Presenters::SinglePageNotificationButtonHelper.new(local_assigns)
-  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("gem-c-single-page-notification-button")
+  component_helper.add_class("js-personalisation-enhancement") if local_assigns[:js_enhancement]
+  component_helper.add_data_attribute({ module: "single-page-notification-button" }) if js_enhancement
+  component_helper.add_data_attribute({ button_location: spnb_helper.button_location })
+  component_helper.add_data_attribute({ button_text_subscribe: spnb_helper.button_text_subscribe })
+  component_helper.add_data_attribute({ button_text_unsubscribe: spnb_helper.button_text_unsubscribe })
 
   ga4_data_attributes = ga4_data_attributes ||= nil
   ga4_link_data_attributes = ga4_data_attributes[:ga4_link] if ga4_data_attributes
@@ -18,7 +24,7 @@
   <svg class="gem-c-single-page-notification-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" height="18" width="18" viewBox="0 0 459.334 459.334"><path fill="currentColor" d="M177.216 404.514c-.001.12-.009.239-.009.359 0 30.078 24.383 54.461 54.461 54.461s54.461-24.383 54.461-54.461c0-.12-.008-.239-.009-.359H175.216zM403.549 336.438l-49.015-72.002v-89.83c0-60.581-43.144-111.079-100.381-122.459V24.485C254.152 10.963 243.19 0 229.667 0s-24.485 10.963-24.485 24.485v27.663c-57.237 11.381-100.381 61.879-100.381 122.459v89.83l-49.015 72.002a24.76 24.76 0 0 0 20.468 38.693H383.08a24.761 24.761 0 0 0 20.469-38.694z"/></svg><span class="gem-c-single-page-notication-button__text"><%= spnb_helper.button_text %></span>
 <% end %>
 <%= tag.div(**component_helper.all_attributes) do %>
-  <%= tag.form class: spnb_helper.classes, action: spnb_helper.form_action, method: "POST", data: spnb_helper.data do %>
+  <%= tag.form action: spnb_helper.form_action, method: "POST" do %>
     <input type="hidden" name="base_path" value="<%= spnb_helper.base_path %>">
     <% if spnb_helper.skip_the_gov_uk_account? %>
       <input type="hidden" name="<%= spnb_helper.skip_account_param %>" value="true">

--- a/lib/govuk_publishing_components/presenters/single_page_notification_button_helper.rb
+++ b/lib/govuk_publishing_components/presenters/single_page_notification_button_helper.rb
@@ -1,30 +1,18 @@
 module GovukPublishingComponents
   module Presenters
     class SinglePageNotificationButtonHelper
-      attr_reader :already_subscribed, :data_attributes, :base_path, :js_enhancement, :button_type, :button_location, :classes, :skip_account
+      attr_reader :already_subscribed, :data_attributes, :base_path, :button_type, :button_location, :skip_account, :button_text_subscribe, :button_text_unsubscribe
 
       def initialize(local_assigns)
         @local_assigns = local_assigns
         @data_attributes = @local_assigns[:data_attributes] || {}
-        @js_enhancement = @local_assigns[:js_enhancement] || false
         @already_subscribed = @local_assigns[:already_subscribed] || false
         @base_path = @local_assigns[:base_path] || nil
         @button_location = button_location_is_valid? ? @local_assigns[:button_location] : nil
         @button_type = @local_assigns[:already_subscribed] ? "Unsubscribe" : "Subscribe"
-        @classes = %w[gem-c-single-page-notification-button]
-        @classes << "js-personalisation-enhancement" if js_enhancement
         @button_text_subscribe = custom_button_text_is_valid? ? custom_subscribe_text : default_subscribe_text
         @button_text_unsubscribe = custom_button_text_is_valid? ? custom_unsubscribe_text : default_unsubscribe_text
         @skip_account = @local_assigns[:skip_account] || nil
-      end
-
-      def data
-        @data_attributes[:module] = "single-page-notification-button" if js_enhancement
-        # This attribute is passed through to the personalisation API to ensure when a new button is returned from the API, it has the same button_location
-        @data_attributes[:button_location] = button_location
-        @data_attributes[:button_text_subscribe] = @button_text_subscribe
-        @data_attributes[:button_text_unsubscribe] = @button_text_unsubscribe
-        @data_attributes
       end
 
       def button_location_is_valid?

--- a/spec/components/single_page_notification_button_spec.rb
+++ b/spec/components/single_page_notification_button_spec.rb
@@ -11,7 +11,7 @@ describe "Single page notification button", type: :view do
 
   it "renders with the correct markup if base path is present" do
     render_component({ base_path: "/the-current-page" })
-    assert_select "form.gem-c-single-page-notification-button"
+    assert_select ".gem-c-single-page-notification-button form"
     assert_select "input[type='hidden']", value: "/the-current-page"
     assert_select ".gem-c-single-page-notification-button button.gem-c-single-page-notification-button__submit[type='submit']"
   end
@@ -90,12 +90,12 @@ describe "Single page notification button", type: :view do
 
   it "sets a default bottom margin to its wrapper" do
     render_component({ base_path: "/the-current-page" })
-    assert_select 'div.govuk-\!-margin-bottom-3 .gem-c-single-page-notification-button'
+    assert_select '.gem-c-single-page-notification-button.govuk-\!-margin-bottom-3'
   end
 
   it "adds bottom margin to its wrapper if margin_bottom is specified" do
     render_component({ base_path: "/the-current-page", margin_bottom: 9 })
-    assert_select 'div.govuk-\!-margin-bottom-9 .gem-c-single-page-notification-button'
+    assert_select '.gem-c-single-page-notification-button.govuk-\!-margin-bottom-9'
   end
 
   it "has a js-enhancement class and a data-module attribute if the js-enhancement flag is present" do

--- a/spec/javascripts/components/single-page-notification-button-spec.js
+++ b/spec/javascripts/components/single-page-notification-button-spec.js
@@ -5,11 +5,16 @@ describe('Single page notification component', function () {
   var FIXTURE
 
   beforeEach(function () {
-    FIXTURE =
-      '<form class="gem-c-single-page-notification-button js-personalisation-enhancement" action="/email/subscriptions/single-page/new" method="POST" data-module="single-page-notification-button">' +
-        '<input type="hidden" name="base_path" value="/current-page-path">' +
-        '<button class="gem-c-single-page-notification-button__submit" type="submit"><span class="gem-c-single-page-notication-button__text">Get emails about this page</span></button>' +
-    '</form>'
+    FIXTURE = `
+      <div data-button-text-subscribe="Get emails about this page" data-button-text-unsubscribe="Stop getting emails about this page" class="gem-c-single-page-notification-button govuk-!-display-none-print govuk-!-margin-bottom-3" data-module="single-page-notification-button">
+        <form action="/email/subscriptions/single-page/new" method="POST">
+          <input type="hidden" name="base_path" value="/current-page-path">
+          <button class="govuk-body-s gem-c-single-page-notification-button__submit" type="submit">
+            <span class="gem-c-single-page-notication-button__text">Get emails about this page</span>
+        </button>
+        </form>
+      </div>
+    `
     window.setFixtures(FIXTURE)
     jasmine.Ajax.install()
   })
@@ -48,7 +53,7 @@ describe('Single page notification component', function () {
       responseText: '{\n    "base_path": "/current-page-path",\n    "active": false\n }'
     })
 
-    var button = document.querySelector('form.gem-c-single-page-notification-button')
+    var button = document.querySelector('.gem-c-single-page-notification-button')
     expect(button).toHaveClass('gem-c-single-page-notification-button--visible')
   })
 
@@ -102,7 +107,7 @@ describe('Single page notification component', function () {
       responseText: responseText
     })
 
-    var button = document.querySelector('form.gem-c-single-page-notification-button.gem-c-single-page-notification-button--visible button')
+    var button = document.querySelector('.gem-c-single-page-notification-button.gem-c-single-page-notification-button--visible .gem-c-single-page-notification-button__submit')
     expect(button).toHaveText('Get emails about this page')
     expect(GOVUK.Modules.SinglePageNotificationButton.prototype.responseIsJSON(responseText)).toBe(false)
   })
@@ -117,7 +122,7 @@ describe('Single page notification component', function () {
       responseText: responseText
     })
 
-    var button = document.querySelector('form.gem-c-single-page-notification-button.gem-c-single-page-notification-button--visible button')
+    var button = document.querySelector('.gem-c-single-page-notification-button.gem-c-single-page-notification-button--visible .gem-c-single-page-notification-button__submit')
     expect(button).toHaveText('Get emails about this page')
     expect(GOVUK.Modules.SinglePageNotificationButton.prototype.responseIsJSON(responseText)).toBe(false)
   })
@@ -131,7 +136,7 @@ describe('Single page notification component', function () {
       responseText: ''
     })
 
-    var button = document.querySelector('form.gem-c-single-page-notification-button.gem-c-single-page-notification-button--visible button')
+    var button = document.querySelector('.gem-c-single-page-notification-button.gem-c-single-page-notification-button--visible .gem-c-single-page-notification-button__submit')
     expect(button).toHaveText('Get emails about this page')
   })
 
@@ -140,7 +145,7 @@ describe('Single page notification component', function () {
     initButton()
     jasmine.Ajax.requests.mostRecent().responseTimeout()
 
-    var button = document.querySelector('form.gem-c-single-page-notification-button.gem-c-single-page-notification-button--visible button')
+    var button = document.querySelector('.gem-c-single-page-notification-button.gem-c-single-page-notification-button--visible .gem-c-single-page-notification-button__submit')
     expect(button).toHaveText('Get emails about this page')
     jasmine.clock().uninstall()
   })


### PR DESCRIPTION
## What
Refactor the markup of the single page notification button component slightly...

- move most of the component attributes (class, data attributes) to be handled by the component wrapper on the parent element
- remove the shared helper as not being used
- update the helper and tests to reflect this change

I've tested this with a branch on integration for https://www.gov.uk/guidance/check-if-an-email-youve-received-from-hmrc-is-genuine and it seems to behave as it did before, but it could use another pair of eyes (particularly from someone more familiar with this component).

## Why
This component was inconsistent because it was using the component wrapper helper but had its parent class (`gem-c-single-page-notification-button`) on a child element, rather than the parent. There seems to be no need for this, but it was causing a problem in some unrelated work, so thought I'd fix it.

## Visual Changes
None, hopefully.

Trello card: https://trello.com/c/Y0pDWbHw/390-move-some-shared-helper-options-into-component-wrapper
