### PR TITLE
Remove title component margin_top option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Remove title component margin_top option ([PR #4508](https://github.com/alphagov/govuk_publishing_components/pull/4508))
 * **BREAKING** Add global bar component from static ([PR #4538](https://github.com/alphagov/govuk_publishing_components/pull/4538))
 * Add custom padding to inverse header ([PR #4590](https://github.com/alphagov/govuk_publishing_components/pull/4590))
 * Add another: fix problem in createRemoveButtons method ([PR #11719](https://github.com/alphagov/govuk_publishing_components/pull/4586))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_title.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_title.scss
@@ -1,5 +1,11 @@
 @import "govuk_publishing_components/individual_component_support";
 
+.gem-c-title {
+  @include govuk-media-query($from: tablet) {
+    padding-top: govuk-spacing(8);
+  }
+}
+
 .gem-c-title--inverse {
   color: govuk-colour("white");
 

--- a/app/views/govuk_publishing_components/components/_title.html.erb
+++ b/app/views/govuk_publishing_components/components/_title.html.erb
@@ -8,20 +8,17 @@
   context_inside ||= false
 
   inverse ||= false
-  local_assigns[:margin_top] ||= 8
   local_assigns[:margin_bottom] ||= 8
 
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
 
   classes = %w[gem-c-title]
   classes << "gem-c-title--inverse" if inverse
-  classes << shared_helper.get_margin_top
   classes << shared_helper.get_margin_bottom
 
   heading_classes = %w[gem-c-title__text]
   heading_classes << (average_title_length.present? ? 'govuk-heading-l' : 'govuk-heading-xl')
 %>
-
 <% @context_block = capture do %>
   <span class="govuk-caption-xl gem-c-title__context" <%= "lang=#{context_locale}" if context_locale.present? %>>
     <%= context %>

--- a/spec/components/title_spec.rb
+++ b/spec/components/title_spec.rb
@@ -71,26 +71,6 @@ describe "Title", type: :view do
     assert_select "[class^='govuk-\!-margin-bottom-']", false
   end
 
-  it "has a default margin top of 8" do
-    render_component(title: "Margin default")
-    assert_select '.gem-c-title.govuk-\!-margin-top-8'
-  end
-
-  it "applies a margin top of 0" do
-    render_component(title: "Margin 0", margin_top: 0)
-    assert_select '.gem-c-title.govuk-\!-margin-top-0'
-  end
-
-  it "applies a valid margin top" do
-    render_component(title: "Margin 4", margin_top: 4)
-    assert_select '.gem-c-title.govuk-\!-margin-top-4'
-  end
-
-  it "ignores an invalid margin top" do
-    render_component(title: "Margin wat", margin_top: 17)
-    assert_select "[class^='govuk-\!-margin-top-']", false
-  end
-
   it "applies context language if supplied to a context link" do
     render_component(title: "Bonjour", context: "Format", context_locale: "en")
     assert_select ".govuk-caption-xl[lang='en']"


### PR DESCRIPTION
## What
- our spacing model is to apply margin bottom, so this is an anomaly
- replace margin_top with default padding on the component, so no visual changes
- margin_top option isn't widely used and can be replaced with alternatives, separate PRs will be raised

Applications that use this component, and their use of the `margin_top` option are:

- `collections` (changes covered in https://github.com/alphagov/collections/pull/3918) (done)
- `datagovuk_find` (no use of `margin_top` so no change required)
- `email-alert-frontend` (no use of `margin_top` so no change required)
- `feedback` (changes covered in https://github.com/alphagov/feedback/pull/2042) (done)
- `finder-frontend` (no use of `margin_top` so no change required)
- `frontend` (changes covered in https://github.com/alphagov/frontend/pull/4550) (done)
- `government-frontend` need to deploy this so we can switch from the title to heading component: https://github.com/alphagov/govuk_publishing_components/pull/4510) (done) and now need to switch titles with zero margin top to headings (https://github.com/alphagov/government-frontend/pull/3539)
- `manuals-publisher` (changes covered in https://github.com/alphagov/manuals-publisher/pull/2595) (done)
- `release` (no use of `margin_top` so no change required)
- `search-admin` (no use of `margin_top` so no change required)
- `smart-answers` (no use of `margin_top` so no change required)
- `whitehall` (changes covered in https://github.com/alphagov/whitehall/pull/9835) (done)
- `govuk_publishing_components` (changes covered inhttps://github.com/alphagov/govuk_publishing_components/pull/4591) (done)

**Note that this PR will have to wait for the ones mentioned above and further work to check it is okay before merging**

## Why
This is part of a wider piece of work to move the margin options from the shared helper into the component wrapper helper and standardise our component spacing model. This is a step towards being able to remove the `margin_top` option from the shared helper.

This is a bit of a stop gap because we intend to replace all instances of the title component with the heading component eventually, but that's a larger piece of work.

## Visual Changes
Percy is showing a visual diff on the inverse header, which is expected. But this change has been accounted for by a [corresponding change in the inverse header](https://github.com/alphagov/govuk_publishing_components/pull/4590) to allow custom padding top and bottom. That PR is linked to several PRs in applications where those changes are accounted for to produce no visual difference. Once this code is and that code is in a new gem release we'll merge those other application PRs and everything (should) be fine.

Trello card: https://trello.com/c/Y0pDWbHw/390-move-some-shared-helper-options-into-component-wrapper