### PR TITLE
Add option for organisation logos to hide the link underline until it's hovered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Use govuk-spacing for highlight answer govspeak component ([PR #4515](https://github.com/alphagov/govuk_publishing_components/pull/4515))
 * Add context option to heading component ([PR #4510](https://github.com/alphagov/govuk_publishing_components/pull/4510))
+* Add option for organisation logos to hide the link underline until it's hovered ([PR #4509](https://github.com/alphagov/govuk_publishing_components/pull/4509))
 
 ## 46.4.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_organisation-logo.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_organisation-logo.scss
@@ -82,6 +82,10 @@
   }
 }
 
+.gem-c-organisation-logo__link-hide-underline:link:not(:hover) {
+  text-decoration: none;
+}
+
 .gem-c-organisation-logo--inverse {
   .gem-c-organisation-logo__container {
     border-color: govuk-colour("white");

--- a/app/views/govuk_publishing_components/components/docs/organisation_logo.yml
+++ b/app/views/govuk_publishing_components/components/docs/organisation_logo.yml
@@ -183,6 +183,15 @@ examples:
         brand: cabinet-office
         crest: 'single-identity'
       inline: true
+  no_underline_until_hover:
+    description: Remove the underline text-decoration unless hovered. Useful when combined with the `inverse` option.
+    data:
+      organisation:
+        name: Cabinet Office
+        url: '/government/organisations/cabinet-office'
+        brand: cabinet-office
+        crest: 'single-identity'
+      hide_underline: true
   on_a_dark_background:
     data:
       organisation:

--- a/lib/govuk_publishing_components/presenters/organisation_logo_helper.rb
+++ b/lib/govuk_publishing_components/presenters/organisation_logo_helper.rb
@@ -4,7 +4,7 @@ module GovukPublishingComponents
       include ActionView::Helpers
       include ActionView::Context
 
-      attr_reader :name, :url, :crest, :image, :logo_image_src, :logo_image_alt
+      attr_reader :name, :url, :crest, :image, :logo_image_src, :logo_image_alt, :hide_underline
 
       def initialize(local_assigns)
         @name = local_assigns[:organisation][:name]
@@ -15,6 +15,7 @@ module GovukPublishingComponents
           @logo_image_src = local_assigns[:organisation][:image][:url] || false
           @logo_image_alt = local_assigns[:organisation][:image][:alt_text] || false
         end
+        @hide_underline = local_assigns[:hide_underline] || false
       end
 
       def logo_content
@@ -28,6 +29,7 @@ module GovukPublishingComponents
       def logo_container_class
         logo_class = "gem-c-organisation-logo__container"
         logo_class = "#{logo_class} gem-c-organisation-logo__link" if url
+        logo_class = "#{logo_class} gem-c-organisation-logo__link-hide-underline" if hide_underline
         logo_class = "#{logo_class} gem-c-organisation-logo__crest gem-c-organisation-logo__crest--#{crest}" if crest
         logo_class
       end

--- a/spec/components/organisation_logo_spec.rb
+++ b/spec/components/organisation_logo_spec.rb
@@ -72,6 +72,11 @@ describe "Organisation logo", type: :view do
     assert_select "a.gem-c-organisation-logo__container--inline"
   end
 
+  it "renders without a text underline when set" do
+    render_component(organisation: { name: "Name", url: "/some-link" }, hide_underline: true)
+    assert_select "a.gem-c-organisation-logo__link-hide-underline"
+  end
+
   it "renders on a dark background" do
     render_component(organisation: { name: "Name", url: "/some-link" }, inverse: true)
     assert_select ".gem-c-organisation-logo.gem-c-organisation-logo--inverse"


### PR DESCRIPTION
## What
An option for organisation logos to hide the link underline until it's hovered. [Trello](https://trello.com/c/TT6qZYWG/216-org-logo-component-has-app-level-styling)

## Why
On the new [Missions](https://www.gov.uk/missions) landing page served by the frontend app, the organisation logo in the header has the underline removed. This was achieved using some localised override CSS, which is against our principle of component isolation.

## Visuals

| Unhovered | Hovered |
| -------- | ------- |
| <img width="332" alt="image" src="https://github.com/user-attachments/assets/9d64d860-2ded-4dee-86d8-50158ffd4e3c" /> | <img width="332" alt="image" src="https://github.com/user-attachments/assets/b8769fd2-71ec-403d-8ae9-cc2b6a8ca94b" />|
