### PR TITLE
Use govuk-spacing for highlight answer govspeak component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Use govuk-spacing for highlight answer govspeak component ([PR #4515](https://github.com/alphagov/govuk_publishing_components/pull/4515))
+
 ## 46.4.0
 
 * Add canonical_url value to GA4 page view tracking ([PR #4500](https://github.com/alphagov/govuk_publishing_components/pull/4500))

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_highlight-answer.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_highlight-answer.scss
@@ -9,8 +9,8 @@ $highlight-answer-color: govuk-colour("white");
     background-color: $highlight-answer-bg-color;
     color: $highlight-answer-color;
     text-align: center;
-    padding: 1.75em .75em 1.25em;
-    margin: 0 0 1em;
+    padding: govuk-spacing(5) govuk-spacing(2) govuk-spacing(4);
+    margin: 0 0 govuk-spacing(2);
 
     p {
       color: $highlight-answer-color;
@@ -18,7 +18,7 @@ $highlight-answer-color: govuk-colour("white");
 
       em {
         display: block;
-        padding-top: .1em;
+        padding-top: govuk-spacing(2);
         color: $highlight-answer-color;
         @include govuk-font($size: 80, $weight: bold);
       }
@@ -29,7 +29,7 @@ $highlight-answer-color: govuk-colour("white");
     }
 
     @include govuk-media-query($until: tablet) {
-      margin: 0 0 1em;
+      margin: 0 0 govuk-spacing(2);
       @include govuk-font($size: 48);
 
       p {


### PR DESCRIPTION
## What
Change the spacing in the highlight-answer styling to use govuk-spacing. 

## Why
This change is to increase reliance on the design system and decrease the amount of custom styling we have in the publishing components. 

## Visual Changes
There will be some slight changes to the spacing in the answer component. Since only 5 pages use this component I will include all of the changes below:

### Before & After
| Before | After |
|--------|--------|
| <img width="1005" alt="image" src="https://github.com/user-attachments/assets/5bddb67e-bd34-4974-b1c9-b936a08a78aa" /> | <img width="1007" alt="image" src="https://github.com/user-attachments/assets/db1aadcc-d9ba-421b-b6bc-78b87d9900d3" />|
| <img width="1005" alt="image" src="https://github.com/user-attachments/assets/47fec071-87f3-4f5a-a1a6-825616eeb54e" /> | <img width="1008" alt="image" src="https://github.com/user-attachments/assets/7f03a147-de83-4833-9018-cab075348082" /> |
| <img width="1005" alt="image" src="https://github.com/user-attachments/assets/422734fd-8b8c-4ec7-aa86-7ac3434288cb" /> | <img width="1007" alt="image" src="https://github.com/user-attachments/assets/07c28ffa-bf03-4f8e-956c-598ad0623fd6" />  |
| <img width="1009" alt="image" src="https://github.com/user-attachments/assets/b1d56b1a-7fa3-482a-9d94-e7c22d4ca0a2" /> | <img width="1007" alt="image" src="https://github.com/user-attachments/assets/7460110c-888f-48d7-82a7-2c5970b83082" /> | 
| <img width="1009" alt="image" src="https://github.com/user-attachments/assets/8cc11a47-bdb7-4360-bd6c-f3c63b979797" /> | <img width="1008" alt="image" src="https://github.com/user-attachments/assets/384fe1d0-1ca1-4977-8788-ef323c7d72ce" /> |

Trello card: https://trello.com/c/XjfIgy2X/3019-update-spacing-on-highlight-answer-component