### PR TITLE
Use component wrapper on skip link component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Add context option to heading component ([PR #4510](https://github.com/alphagov/govuk_publishing_components/pull/4510))
 * Add option for organisation logos to hide the link underline until it's hovered ([PR #4509](https://github.com/alphagov/govuk_publishing_components/pull/4509))
 * Remove chat entry component ([PR #4512](https://github.com/alphagov/govuk_publishing_components/pull/4512))
+* Use component wrapper on skip link component ([PR #4520](https://github.com/alphagov/govuk_publishing_components/pull/4520))
 
 ## 46.4.0
 

--- a/app/views/govuk_publishing_components/components/_skip_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_skip_link.html.erb
@@ -3,5 +3,10 @@
 
   href ||= '#main-content'
   text ||= t('components.skip_link.text')
+
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("gem-c-skip-link govuk-skip-link govuk-!-display-none-print")
+  component_helper.add_data_attribute({ module: "govuk-skip-link" })
+
 %>
-<%= link_to(text, href, class: "gem-c-skip-link govuk-skip-link govuk-!-display-none-print", data: { module: "govuk-skip-link" }) %>
+<%= link_to(text, href, **component_helper.all_attributes) %>

--- a/app/views/govuk_publishing_components/components/docs/skip_link.yml
+++ b/app/views/govuk_publishing_components/components/docs/skip_link.yml
@@ -11,6 +11,7 @@ accessibility_criteria: |
   - is the first items that screen readers hear and that keyboard users tab to
 accessibility_excluded_rules:
   - skip-link # This component is creating a reference to #content which is part of the layout
+uses_component_wrapper_helper: true
 examples:
   default:
     data:


### PR DESCRIPTION
## What
- Adds the component wrapper helper to the `skip link` component.

## Why
As the [trello card](https://trello.com/c/qH4NyWJw/364-add-component-wrapper-to-more-components) states:

> Standardising our components to use the component wrapper helper will reduce code, increase standardisation, and improve future feature implementation speed.

## Visual changes

None.