### PR TITLE
Use component wrapper on step nav related component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Remove chat entry component ([PR #4512](https://github.com/alphagov/govuk_publishing_components/pull/4512))
 * Use component wrapper on skip link component ([PR #4520](https://github.com/alphagov/govuk_publishing_components/pull/4520))
 * Use component wrapper on step nav header component ([PR #4521](https://github.com/alphagov/govuk_publishing_components/pull/4521))
+* Use component wrapper on step nav related component ([PR #4522](https://github.com/alphagov/govuk_publishing_components/pull/4522))
 
 ## 46.4.0
 

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav_related.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav_related.html.erb
@@ -4,13 +4,14 @@
   links ||= []
   pretitle ||= t("components.step_by_step_nav_related.part_of")
   always_display_as_list ||= false
-  classes = %w(gem-c-step-nav-related)
-  classes << "gem-c-step-nav-related--singular" if links.length == 1
-  data = {}
-  data[:module] = "ga4-link-tracker" unless disable_ga4
+
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("gem-c-step-nav-related")
+  component_helper.add_class("gem-c-step-nav-related--singular") if links.length == 1
+  component_helper.add_data_attribute({ module: "ga4-link-tracker" }) unless disable_ga4
 %>
 <% if links.any? %>
-  <%= tag.div(class: classes, data: data) do %>
+  <%= tag.div(**component_helper.all_attributes) do %>
     <h2 class="gem-c-step-nav-related__heading">
       <span class="gem-c-step-nav-related__pretitle"><%= pretitle %></span>
       <% if links.length == 1 && !always_display_as_list %>

--- a/app/views/govuk_publishing_components/components/docs/step_by_step_nav_related.yml
+++ b/app/views/govuk_publishing_components/components/docs/step_by_step_nav_related.yml
@@ -16,6 +16,7 @@ accessibility_criteria: |
   - display multiple links outside of a heading in a separate list
 shared_accessibility_criteria:
   - link
+uses_component_wrapper_helper: true
 examples:
   default:
     data:


### PR DESCRIPTION
## What
- Adds the component wrapper helper to the `step nav related` component.

## Why
As the [trello card](https://trello.com/c/qH4NyWJw/364-add-component-wrapper-to-more-components) states:

> Standardising our components to use the component wrapper helper will reduce code, increase standardisation, and improve future feature implementation speed.

## Visual changes

None.