### PR TITLE
Version 47.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 47.0.0
 
 * **BREAKING** Remove chart component ([PR #4518](https://github.com/alphagov/govuk_publishing_components/pull/4518))
 * Use govuk-spacing for highlight answer govspeak component ([PR #4515](https://github.com/alphagov/govuk_publishing_components/pull/4515))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (46.4.0)
+    govuk_publishing_components (47.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "46.4.0".freeze
+  VERSION = "47.0.0".freeze
 end


### PR DESCRIPTION
## 47.0.0

* **BREAKING** Remove chart component ([PR #4518](https://github.com/alphagov/govuk_publishing_components/pull/4518))
* Use govuk-spacing for highlight answer govspeak component ([PR #4515](https://github.com/alphagov/govuk_publishing_components/pull/4515))
* Add context option to heading component ([PR #4510](https://github.com/alphagov/govuk_publishing_components/pull/4510))
* Add option for organisation logos to hide the link underline until it's hovered ([PR #4509](https://github.com/alphagov/govuk_publishing_components/pull/4509))
* Remove chat entry component ([PR #4512](https://github.com/alphagov/govuk_publishing_components/pull/4512))
* Use component wrapper on skip link component ([PR #4520](https://github.com/alphagov/govuk_publishing_components/pull/4520))
* Use component wrapper on step nav header component ([PR #4521](https://github.com/alphagov/govuk_publishing_components/pull/4521))
* Use component wrapper on step nav related component ([PR #4522](https://github.com/alphagov/govuk_publishing_components/pull/4522))
