### PR TITLE
Use component wrapper on subscription links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Use component wrapper on subscription links ([PR #4525](https://github.com/alphagov/govuk_publishing_components/pull/4525))
+
 ## 47.0.0
 
 * **BREAKING** Remove chart component ([PR #4518](https://github.com/alphagov/govuk_publishing_components/pull/4518))

--- a/app/views/govuk_publishing_components/components/_subscription_links.html.erb
+++ b/app/views/govuk_publishing_components/components/_subscription_links.html.erb
@@ -5,17 +5,11 @@
   brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)
 
   sl_helper = GovukPublishingComponents::Presenters::SubscriptionLinksHelper.new(local_assigns)
-  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
 
-  local_assigns[:margin_bottom] ||= 0
-  local_assigns[:margin_bottom] = 0 if local_assigns[:margin_bottom] > 9
-
-  css_classes = %w( gem-c-subscription-links govuk-!-display-none-print )
-  css_classes << shared_helper.get_margin_bottom unless local_assigns[:margin_bottom] == 0
-  css_classes << brand_helper.brand_class
-  css_classes << "gem-c-subscription-links--with-feed-box" if sl_helper.feed_link_box_value
-
-  data = {"module": "gem-toggle"} if sl_helper.feed_link_box_value
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("gem-c-subscription-links govuk-!-display-none-print #{brand_helper.brand_class}")
+  component_helper.add_class("gem-c-subscription-links--with-feed-box") if sl_helper.feed_link_box_value
+  component_helper.add_data_attribute({ module: "gem-toggle" }) if sl_helper.feed_link_box_value
 
   hide_heading ||= false
 
@@ -23,7 +17,7 @@
   feed_link_text_locale = local_assigns[:feed_link_text_locale].presence
 %>
 <% if sl_helper.component_data_is_valid? %>
-  <%= tag.section class: css_classes, data: data do %>
+  <%= tag.section(**component_helper.all_attributes) do %>
     <% unless hide_heading %>
       <h2 class="gem-c-subscription-links__hidden-header visuallyhidden"><%= t("components.subscription_links.subscriptions") %></h2>
     <% end %>

--- a/app/views/govuk_publishing_components/components/docs/subscription_links.yml
+++ b/app/views/govuk_publishing_components/components/docs/subscription_links.yml
@@ -14,6 +14,7 @@ accessibility_criteria: |
   - show hidden elements by default when JavaScript is disabled
 shared_accessibility_criteria:
   - link
+uses_component_wrapper_helper: true
 examples:
   default:
     data:

--- a/spec/components/subscription_links_spec.rb
+++ b/spec/components/subscription_links_spec.rb
@@ -32,11 +32,6 @@ describe "subscription links", type: :view do
     assert_select '.gem-c-subscription-links.govuk-\!-margin-bottom-7'
   end
 
-  it "defaults to the initial bottom margin if an incorrect value is passed" do
-    render_component(email_signup_link: "email-signup", feed_link: "singapore.atom", margin_bottom: 20)
-    assert_select "[class^='govuk-\!-margin-bottom-']", false
-  end
-
   it "has no margin class added by default" do
     render_component(email_signup_link: "email-signup", feed_link: "singapore.atom")
     assert_select "[class^='govuk-\!-margin-bottom-']", false


### PR DESCRIPTION
## What
- Adds the component wrapper helper to the `subscription links` component.

## Why
As the [trello card](https://trello.com/c/qH4NyWJw/364-add-component-wrapper-to-more-components) states:

> Standardising our components to use the component wrapper helper will reduce code, increase standardisation, and improve future feature implementation speed.

## Visual changes

None.