### PR TITLE
Use component wrapper on success alert component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Use component wrapper on subscription links ([PR #4525](https://github.com/alphagov/govuk_publishing_components/pull/4525))
+* Use component wrapper on success alert component ([PR #4527](https://github.com/alphagov/govuk_publishing_components/pull/4527))
 
 ## 47.0.0
 

--- a/app/views/govuk_publishing_components/components/_success_alert.html.erb
+++ b/app/views/govuk_publishing_components/components/_success_alert.html.erb
@@ -3,20 +3,16 @@
 
   description ||= nil
   title_id ||= "govuk-notification-banner-title-#{SecureRandom.hex(4)}"
-  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
-  classes = %w(gem-c-success-alert govuk-notification-banner govuk-notification-banner--success)
-  classes << shared_helper.get_margin_bottom if local_assigns[:margin_bottom]
+
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("gem-c-success-alert govuk-notification-banner govuk-notification-banner--success")
+  component_helper.add_role("alert")
+  component_helper.set_tabindex(-1)
+  component_helper.add_aria_attribute({ labelledby: title_id })
+  component_helper.add_data_attribute({ module: "initial-focus" })
 %>
 
-<%= tag.div class: classes,
-  role: "alert",
-  tabindex: "-1",
-  aria: {
-    labelledby: title_id,
-  },
-  data: {
-    module: "initial-focus",
-  } do %>
+<%= tag.div(**component_helper.all_attributes) do %>
   <div class="govuk-notification-banner__header">
     <%= tag.h2 t("components.success_alert.success"), class: "govuk-notification-banner__title", id: title_id %>
   </div>

--- a/app/views/govuk_publishing_components/components/docs/success_alert.yml
+++ b/app/views/govuk_publishing_components/components/docs/success_alert.yml
@@ -7,6 +7,7 @@ accessibility_criteria: |
     assistive tech
   - Should have a role of ‘alert’ to communicate that is a important and
     time sensitive message
+uses_component_wrapper_helper: true
 examples:
   default:
     data:


### PR DESCRIPTION
## What
- Adds the component wrapper helper to the `success alert` component.

## Why
As the [trello card](https://trello.com/c/qH4NyWJw/364-add-component-wrapper-to-more-components) states:

> Standardising our components to use the component wrapper helper will reduce code, increase standardisation, and improve future feature implementation speed.

## Visual changes

None.