### PR TITLE
Use component wrapper on summary card component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Use component wrapper on subscription links ([PR #4525](https://github.com/alphagov/govuk_publishing_components/pull/4525))
 * Use component wrapper on success alert component ([PR #4527](https://github.com/alphagov/govuk_publishing_components/pull/4527))
+* Use component wrapper on summary card component ([PR #4528](https://github.com/alphagov/govuk_publishing_components/pull/4528))
 
 ## 47.0.0
 

--- a/app/views/govuk_publishing_components/components/_summary_card.html.erb
+++ b/app/views/govuk_publishing_components/components/_summary_card.html.erb
@@ -3,12 +3,14 @@
 
   id ||= nil
   title ||= nil
-  data_attributes ||= {}
   summary_card_actions ||= []
   rows ||=[]
+
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("gem-c-summary-card")
 %>
 <% if title || rows.any? %>
-  <%= tag.div class: "gem-c-summary-card", id: id, data: data_attributes do %>
+  <%= tag.div(**component_helper.all_attributes) do %>
     <%= tag.div class: "govuk-summary-card" do %>
       <%= tag.div class: "govuk-summary-card__title-wrapper" do %>
         <%= tag.h2 class: "govuk-summary-card__title" do %>

--- a/app/views/govuk_publishing_components/components/docs/summary_card.yml
+++ b/app/views/govuk_publishing_components/components/docs/summary_card.yml
@@ -5,6 +5,7 @@ accessibility_criteria: |
   - be focusable with a keyboard
   - be usable with a keyboard
   - indicate when it has focus
+uses_component_wrapper_helper: true
 examples:
   default:
     data:


### PR DESCRIPTION
## What
- Adds the component wrapper helper to the `summary card` component.

## Why
As the [trello card](https://trello.com/c/qH4NyWJw/364-add-component-wrapper-to-more-components) states:

> Standardising our components to use the component wrapper helper will reduce code, increase standardisation, and improve future feature implementation speed.

## Visual changes

None.