### PR TITLE
Use component wrapper on summary list component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Use component wrapper on subscription links ([PR #4525](https://github.com/alphagov/govuk_publishing_components/pull/4525))
 * Use component wrapper on success alert component ([PR #4527](https://github.com/alphagov/govuk_publishing_components/pull/4527))
 * Use component wrapper on summary card component ([PR #4528](https://github.com/alphagov/govuk_publishing_components/pull/4528))
+* Use component wrapper on summary list component ([PR #4529](https://github.com/alphagov/govuk_publishing_components/pull/4529))
 
 ## 47.0.0
 

--- a/app/views/govuk_publishing_components/components/_summary_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_summary_list.html.erb
@@ -5,7 +5,6 @@
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
   heading_size = "m" unless shared_helper.valid_heading_size?(heading_size)
 
-  id ||= nil
   title ||= nil
   borderless ||= false
   edit ||= {}
@@ -13,9 +12,14 @@
   items ||= []
   block ||= yield
   wide_title ||= false
+
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("gem-c-summary-list")
+  component_helper.add_class("govuk-summary-list--no-border") if borderless
+  component_helper.add_class("gem-c-summary-list--wide-title") if wide_title
 %>
 <% if title || items.any? %>
-  <%= tag.div class: "gem-c-summary-list #{"govuk-summary-list--no-border" if borderless} #{"gem-c-summary-list--wide-title" if wide_title}", id: id do %>
+  <%= tag.div(**component_helper.all_attributes) do %>
     <% if title %>
       <%= content_tag(shared_helper.get_heading_level, title, class: "govuk-heading-#{heading_size} gem-c-summary-list__group-title") %>
 

--- a/app/views/govuk_publishing_components/components/docs/summary_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/summary_list.yml
@@ -9,6 +9,7 @@ shared_accessibility_criteria:
   - link
 govuk_frontend_components:
   - summary-list
+uses_component_wrapper_helper: true
 examples:
   default:
     data: &default-example-data


### PR DESCRIPTION
## What
- Adds the component wrapper helper to the `summary list` component.

## Why
As the [trello card](https://trello.com/c/qH4NyWJw/364-add-component-wrapper-to-more-components) states:

> Standardising our components to use the component wrapper helper will reduce code, increase standardisation, and improve future feature implementation speed.

## Visual changes

None.