### PR TITLE
Remove `GOVUK_DISABLE_SEARCH_AUTOCOMPLETE` feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Use component wrapper on warning text component ([PR #4351](https://github.com/alphagov/govuk_publishing_components/pull/4531))
 * Remove govspeak advisory component ([PR #4349](https://github.com/alphagov/govuk_publishing_components/pull/4349))
 * Use component wrapper on super navigation header ([PR #4534](https://github.com/alphagov/govuk_publishing_components/pull/4534))
+* Remove `GOVUK_DISABLE_SEARCH_AUTOCOMPLETE` feature flag ([PR #4533](https://github.com/alphagov/govuk_publishing_components/pull/4533))
 
 ## 47.0.0
 

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -312,7 +312,7 @@
                   label: "Site-wide",
                 }
               ) do %>
-                <% search_options = {
+                <%= render "govuk_publishing_components/components/search_with_autocomplete", {
                   name: "keywords",
                   inline_label: false,
                   label_size: "m",
@@ -321,15 +321,9 @@
                   size: "large",
                   margin_bottom: 0,
                   disable_corrections: true,
+                  source_url: [Plek.new.website_root, "/api/search/autocomplete.json"].join,
+                  source_key: "suggestions",
                 } %>
-                <% if ENV["GOVUK_DISABLE_SEARCH_AUTOCOMPLETE"] %>
-                  <%= render "govuk_publishing_components/components/search", search_options %>
-                <% else %>
-                  <%= render "govuk_publishing_components/components/search_with_autocomplete", search_options.merge({
-                    source_url: [Plek.new.website_root, "/api/search/autocomplete.json"].join,
-                    source_key: "suggestions",
-                  }) %>
-                <% end %>
               <% end %>
             </div>
           </div>

--- a/spec/components/layout_super_navigation_header_spec.rb
+++ b/spec/components/layout_super_navigation_header_spec.rb
@@ -181,13 +181,5 @@ describe "Super navigation header", type: :view do
       render_component({})
       assert_select ".gem-c-search-with-autocomplete[data-source-url='http://www.dev.gov.uk/api/search/autocomplete.json']"
     end
-
-    it "allows the GOVUK_DISABLE_SEARCH_AUTOCOMPLETE env var presence to fallback to search without autocomplete" do
-      ClimateControl.modify GOVUK_DISABLE_SEARCH_AUTOCOMPLETE: "1" do
-        render_component({})
-        assert_select ".gem-c-search-autocomplete", false
-        assert_select ".gem-c-search"
-      end
-    end
   end
 end


### PR DESCRIPTION
## What
We are centralising the enabling/disabling of autocomplete in Search API v2 so we don't need individual feature flags across several apps and in the component itself.

## Why
The rationale for being able to disable autocomplete centres on a scenario in which the underlying search engine returns unsuitable results. The `search_with_autocomplete` component degrades gracefully anyway when no suggestions are returned, so we are moving to a simpler setup where there is a feature flag on Search API v2 to force returning empty responses instead.

**Depends on https://github.com/alphagov/search-api-v2/pull/375**