### PR TITLE
Use component wrapper on super navigation header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Use component wrapper on warning text component ([PR #4351](https://github.com/alphagov/govuk_publishing_components/pull/4531))
 * Remove govspeak advisory component ([PR #4349](https://github.com/alphagov/govuk_publishing_components/pull/4349))
 * **BREAKING**: Add component wrapper helper to intervention component ([PR #4378](https://github.com/alphagov/govuk_publishing_components/pull/4378))
+* Use component wrapper on super navigation header ([PR #4534](https://github.com/alphagov/govuk_publishing_components/pull/4534))
 
 ## 47.0.0
 

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -35,9 +35,6 @@
   search_toggle_button_classes << "gem-c-layout-super-navigation-header__search-toggle-button--blue-background" if blue_background
   search_toggle_button_classes << "gem-c-layout-super-navigation-header__search-toggle-button--large-navbar" if large_navbar
 
-  layout_super_navigation_header_classes = %w(gem-c-layout-super-navigation-header)
-  layout_super_navigation_header_classes << "gem-c-layout-super-navigation-header--blue-background" if blue_background
-
   item_link_classes = %w(gem-c-layout-super-navigation-header__navigation-item-link)
   item_link_classes << "gem-c-layout-super-navigation-header__navigation-item-link--blue-background" if blue_background
   item_link_classes << "gem-c-layout-super-navigation-header__navigation-item-link--large-navbar" if large_navbar
@@ -64,16 +61,14 @@
   dropdown_menu_classes << "gem-c-layout-super-navigation-header__navigation-dropdown-menu--large-navbar" if large_navbar
 
   absolute_links_helper = GovukPublishingComponents::Presenters::AbsoluteLinksHelper.new()
+
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("gem-c-layout-super-navigation-header")
+  component_helper.add_class("gem-c-layout-super-navigation-header--blue-background") if blue_background
+  component_helper.add_role("banner")
+  component_helper.add_data_attribute({ module: "ga4-event-tracker ga4-link-tracker", ga4_expandable: "" })
 %>
-<%= content_tag("header",
-  {
-    role: "banner",
-    class: layout_super_navigation_header_classes,
-    data: {
-      module: "ga4-event-tracker ga4-link-tracker",
-      "ga4-expandable": '',
-    }
-}) do %>
+<%= tag.header(**component_helper.all_attributes) do %>
   <div class="gem-c-layout-super-navigation-header__container govuk-clearfix">
     <div class="govuk-width-container">
       <%= content_tag(:div, {

--- a/app/views/govuk_publishing_components/components/docs/layout_super_navigation_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_super_navigation_header.yml
@@ -26,6 +26,7 @@ accessibility_excluded_rules:
   - duplicate-id-aria
   - landmark-no-duplicate-banner
   - landmark-unique
+uses_component_wrapper_helper: true
 examples:
   default:
   with_custom_logo_link:


### PR DESCRIPTION
## What
- Adds the component wrapper helper to the `super navigation header` component.
- This was tagged as breaking, but it doesn't look it is so it was probably labelled by mistake when I started adding the wrapper to components.

## Why
As the [trello card](https://trello.com/c/OJ0nOkQr/420-add-component-wrapper-helper-to-layout-super-navigation-component) states:

> Standardising our components to use the component wrapper helper will reduce code, increase standardisation, and improve future feature implementation speed.

## Visual changes

None.