### PR TITLE
[BREAKING] Change devolved nations component type option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* **BREAKING** Change devolved nations component type option ([PR #4535](https://github.com/alphagov/govuk_publishing_components/pull/4535))
 * Use component wrapper on subscription links ([PR #4525](https://github.com/alphagov/govuk_publishing_components/pull/4525))
 * Use component wrapper on success alert component ([PR #4527](https://github.com/alphagov/govuk_publishing_components/pull/4527))
 * Use component wrapper on summary card component ([PR #4528](https://github.com/alphagov/govuk_publishing_components/pull/4528))

--- a/app/views/govuk_publishing_components/components/docs/devolved_nations.yml
+++ b/app/views/govuk_publishing_components/components/docs/devolved_nations.yml
@@ -72,7 +72,7 @@ examples:
         northern_ireland:
           applicable: false
           alternative_url: /
-      type: consultation
+      content_type: consultation
   applies_to_one_nation_individual_guidance_available:
     description: Specify alternative type for the content e.g. Guidance
     data:
@@ -82,7 +82,7 @@ examples:
         northern_ireland:
           applicable: false
           alternative_url: /
-      type: detailed_guide
+      content_type: detailed_guide
   specific_heading level:
     description: Use a different heading level for the main link title. Defaults to `h2` if not passed.
     data:
@@ -104,5 +104,5 @@ examples:
         northern_ireland:
           applicable: false
           alternative_url: /
-      type: detailed_guide
+      content_type: detailed_guide
       disable_ga4: true

--- a/lib/govuk_publishing_components/presenters/devolved_nations_helper.rb
+++ b/lib/govuk_publishing_components/presenters/devolved_nations_helper.rb
@@ -1,11 +1,11 @@
 module GovukPublishingComponents
   module Presenters
     class DevolvedNationsHelper
-      attr_reader :national_applicability, :type
+      attr_reader :national_applicability, :content_type
 
       def initialize(local_assigns)
         @national_applicability = local_assigns[:national_applicability]
-        @type = local_assigns[:type] || "publication"
+        @content_type = local_assigns[:content_type] || "publication"
       end
 
       def applicable_nations_title_text(use_english_translation = nil)
@@ -42,8 +42,8 @@ module GovukPublishingComponents
       def alternative_content_text(name)
         nation = I18n.t("components.devolved_nations.#{name}")
 
-        if I18n.exists?("components.devolved_nations.type.#{@type}")
-          I18n.t("components.devolved_nations.type.#{@type}", nation:)
+        if I18n.exists?("components.devolved_nations.type.#{@content_type}")
+          I18n.t("components.devolved_nations.type.#{@content_type}", nation:)
         else
           I18n.t("components.devolved_nations.type.publication", nation:)
         end

--- a/spec/components/devolved_nations_spec.rb
+++ b/spec/components/devolved_nations_spec.rb
@@ -106,7 +106,7 @@ describe "Devolved Nations", type: :view do
           alternative_url: "/consultation-northern-ireland",
         },
       },
-      type: "consultation",
+      content_type: "consultation",
     )
     assert_select ".gem-c-devolved-nations > h2", text: "Applies to England"
     assert_select ".gem-c-devolved-nations > ul > li:nth-child(1) > [href='/consultation-northern-ireland']", text: "Consultation for Northern Ireland"
@@ -123,7 +123,7 @@ describe "Devolved Nations", type: :view do
           alternative_url: "/guidance-northern-ireland",
         },
       },
-      type: "detailed_guide",
+      content_type: "detailed_guide",
     )
     assert_select ".gem-c-devolved-nations > h2", text: "Applies to England"
     assert_select ".gem-c-devolved-nations > ul > li:nth-child(1) > [href='/guidance-northern-ireland']", text: "Guidance for Northern Ireland"
@@ -140,7 +140,7 @@ describe "Devolved Nations", type: :view do
           alternative_url: "/publication-northern-ireland",
         },
       },
-      type: "invalid_type",
+      content_type: "invalid_type",
     )
     assert_select ".gem-c-devolved-nations > h2", text: "Applies to England"
     assert_select ".gem-c-devolved-nations > ul > li:nth-child(1) > [href='/publication-northern-ireland']", text: "Publication for Northern Ireland"

--- a/spec/lib/govuk_publishing_components/components/devolved_nations_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/components/devolved_nations_helper_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe GovukPublishingComponents::Presenters::DevolvedNationsHelper do
             alternative_url: "/consultation-northern-ireland",
           },
         },
-        type: "consultation",
+        content_type: "consultation",
       )
       expect(devolved_nations_helper.applicable_nations_title_text).to eql("England")
       expect(devolved_nations_helper.alternative_content_text("northern_ireland")).to eql("Consultation for Northern Ireland")
@@ -108,7 +108,7 @@ RSpec.describe GovukPublishingComponents::Presenters::DevolvedNationsHelper do
             alternative_url: "/guidance-northern-ireland",
           },
         },
-        type: "detailed_guide",
+        content_type: "detailed_guide",
       )
       expect(devolved_nations_helper.applicable_nations_title_text).to eql("England")
       expect(devolved_nations_helper.alternative_content_text("northern_ireland")).to eql("Guidance for Northern Ireland")
@@ -125,7 +125,7 @@ RSpec.describe GovukPublishingComponents::Presenters::DevolvedNationsHelper do
             alternative_url: "/publication-northern-ireland",
           },
         },
-        type: "invalid_type",
+        content_type: "invalid_type",
       )
       expect(devolved_nations_helper.applicable_nations_title_text).to eql("England")
       expect(devolved_nations_helper.alternative_content_text("northern_ireland")).to eql("Publication for Northern Ireland")


### PR DESCRIPTION
## What / why
Change an option on the devolved nations component.

- rename from 'type' to 'content_type'
- doing this work ahead of adding a 'type' option to the component wrapper helper, which would conflict with this component
- will be a **breaking change** as this option is used in `government-frontend` - see related fix in https://github.com/alphagov/government-frontend/pull/3508

## Visual Changes
None.

Trello card: https://trello.com/c/hUDC8lzz/418-add-component-wrapper-helper-to-button-component