### PR TITLE
Version 48.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 48.0.0
 
 * Report cache status to RUM ([PR #4537](https://github.com/alphagov/govuk_publishing_components/pull/4537))
 * Add type option to component wrapper helper ([PR #4536](https://github.com/alphagov/govuk_publishing_components/pull/4536))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (47.0.0)
+    govuk_publishing_components (48.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "47.0.0".freeze
+  VERSION = "48.0.0".freeze
 end


### PR DESCRIPTION
## 48.0.0

* Report cache status to RUM ([PR #4537](https://github.com/alphagov/govuk_publishing_components/pull/4537))
* Add type option to component wrapper helper ([PR #4536](https://github.com/alphagov/govuk_publishing_components/pull/4536))
* **BREAKING** Change devolved nations component type option ([PR #4535](https://github.com/alphagov/govuk_publishing_components/pull/4535))
* **BREAKING** Add component wrapper helper to intervention component ([PR #4378](https://github.com/alphagov/govuk_publishing_components/pull/4378))
* **BREAKING** Add component wrapper helper to the list component ([PR #4441](https://github.com/alphagov/govuk_publishing_components/pull/4441))
* **BREAKING** Add component wrapper helper to the search component ([PR #4540](https://github.com/alphagov/govuk_publishing_components/pull/4540))
* Use component wrapper on subscription links ([PR #4525](https://github.com/alphagov/govuk_publishing_components/pull/4525))
* Use component wrapper on success alert component ([PR #4527](https://github.com/alphagov/govuk_publishing_components/pull/4527))
* Use component wrapper on summary card component ([PR #4528](https://github.com/alphagov/govuk_publishing_components/pull/4528))
* Use component wrapper on summary list component ([PR #4529](https://github.com/alphagov/govuk_publishing_components/pull/4529))
* Use component wrapper on translation nav component ([PR #4530](https://github.com/alphagov/govuk_publishing_components/pull/4530))
* Use component wrapper on warning text component ([PR #4351](https://github.com/alphagov/govuk_publishing_components/pull/4531))
* Remove govspeak advisory component ([PR #4349](https://github.com/alphagov/govuk_publishing_components/pull/4349))
* Use component wrapper on super navigation header ([PR #4534](https://github.com/alphagov/govuk_publishing_components/pull/4534))
* Remove `GOVUK_DISABLE_SEARCH_AUTOCOMPLETE` feature flag ([PR #4533](https://github.com/alphagov/govuk_publishing_components/pull/4533))