### PR TITLE
Update the document list equal item spacing docs to reflect usage

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/document_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/document_list.yml
@@ -246,8 +246,7 @@ examples:
           document_type: 'Statistical data set'
   with_equal_item_spacing:
     description: |
-      The new search UI has consistently equal spacing between items in the document list, instead
-      of the original larger bottom padding.
+      Use this option to add equal spacing between items in the document list.
     data:
       equal_item_spacing: true
       items:


### PR DESCRIPTION
## What
Update the documentation for the equal item spacing in the document list component to reflect usage

## Why
This option for the document-list component was originally added for the new search UI, but is now used in other contexts together with the full size description text.

[Trello](https://trello.com/c/F3iYypdh/3053-settle-on-an-approach-for-rendering-a-list-of-links-with-paragraph-tags-as-well-as-the-correct-spacing-m)