### PR TITLE
[DO NOT MERGE] Add component wrapper helper to button component

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_button.scss
@@ -2,18 +2,10 @@
 @import "govuk/components/button/button";
 
 // Because govuk-frontend adds a responsive bottom margin by default for each component
-// we reset it to zero so we can set it separately using `gem-c-button--bottom-margin`
+// we reset it to zero so we can set it separately using margin classes
 // If we decide to use responsive margins consistently across components we can remove this
 .gem-c-button {
   margin-bottom: 0;
-}
-
-// this will be moved and extended into a model for general component spacing
-// once this has been decided upon and other work completed, see:
-// https://trello.com/c/KEkNsxG3/142-3-implement-customisable-spacing-for-components
-.gem-c-button--bottom-margin,
-.gem-c-button__info-text--bottom-margin {
-  @include responsive-bottom-margin;
 }
 
 .gem-c-button--inline {

--- a/app/views/govuk_publishing_components/components/_button.html.erb
+++ b/app/views/govuk_publishing_components/components/_button.html.erb
@@ -9,13 +9,7 @@
   # local_assigns[:classes] = shared_helper.classes
   button = GovukPublishingComponents::Presenters::ButtonHelper.new(local_assigns)
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
-  component_helper.add_class("gem-c-button govuk-button")
-  component_helper.add_class("govuk-button--start") if local_assigns[:start]
-  component_helper.add_class("gem-c-button--secondary") if local_assigns[:secondary]
-  component_helper.add_class("gem-c-button--secondary-quiet") if local_assigns[:secondary_quiet]
-  component_helper.add_class("govuk-button--secondary") if local_assigns[:secondary_solid]
-  component_helper.add_class("govuk-button--warning") if local_assigns[:destructive]
-  component_helper.add_class("gem-c-button--inline") if local_assigns[:inline_layout]
+  component_helper.add_class(button.classes)
   component_helper.set_margin_bottom(0) if local_assigns[:info_text]
   component_helper.add_data_attribute({ module: "govuk-button" }) if local_assigns[:href]
 

--- a/app/views/govuk_publishing_components/components/_button.html.erb
+++ b/app/views/govuk_publishing_components/components/_button.html.erb
@@ -1,26 +1,19 @@
 <%
   add_gem_component_stylesheet("button")
 
-  disable_ga4 ||= false
-  local_assigns[:type] ||= "submit" unless local_assigns[:href].present?
-  text ||= ""
-
-  # shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
-  # local_assigns[:classes] = shared_helper.classes
   button = GovukPublishingComponents::Presenters::ButtonHelper.new(local_assigns)
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class(button.classes)
   component_helper.set_margin_bottom(0) if local_assigns[:info_text]
   component_helper.add_data_attribute({ module: "govuk-button" }) if local_assigns[:href]
-
-  # if margin_bottom && !info_text
-  #   margin_class = get_margin_bottom(margin_bottom, false)
-  #   css_classes << margin_class
-  # end
+  component_helper.add_data_attribute({ ga4_attributes: button.ga4_attributes })
+  component_helper.set_type(button.type)
+  component_helper.add_aria_attribute({ labelledby: button.aria_labelledby })
+  component_helper.set_draggable("false") if local_assigns[:href]
 %>
 <% start_button_text = capture do %>
   <span>
-    <%= text %>
+    <%= button.text %>
   </span>
   <svg class="govuk-button__start-icon govuk-!-display-none-print" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" focusable="false" aria-hidden="true">
     <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
@@ -31,7 +24,7 @@
   if button.start
     button_text = start_button_text
   else
-    button_text = text
+    button_text = button.text
   end
 %>
 

--- a/app/views/govuk_publishing_components/components/_button.html.erb
+++ b/app/views/govuk_publishing_components/components/_button.html.erb
@@ -1,16 +1,32 @@
 <%
   add_gem_component_stylesheet("button")
+
   disable_ga4 ||= false
+  local_assigns[:type] ||= "submit" unless local_assigns[:href].present?
+  text ||= ""
 
-  # button_helper.css_classes generates "gem-c-button"
-  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
-  local_assigns[:classes] = shared_helper.classes
+  # shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+  # local_assigns[:classes] = shared_helper.classes
   button = GovukPublishingComponents::Presenters::ButtonHelper.new(local_assigns)
-%>
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("gem-c-button govuk-button")
+  component_helper.add_class("govuk-button--start") if local_assigns[:start]
+  component_helper.add_class("gem-c-button--secondary") if local_assigns[:secondary]
+  component_helper.add_class("gem-c-button--secondary-quiet") if local_assigns[:secondary_quiet]
+  component_helper.add_class("govuk-button--secondary") if local_assigns[:secondary_solid]
+  component_helper.add_class("govuk-button--warning") if local_assigns[:destructive]
+  component_helper.add_class("gem-c-button--inline") if local_assigns[:inline_layout]
+  component_helper.set_margin_bottom(0) if local_assigns[:info_text]
+  component_helper.add_data_attribute({ module: "govuk-button" }) if local_assigns[:href]
 
+  # if margin_bottom && !info_text
+  #   margin_class = get_margin_bottom(margin_bottom, false)
+  #   css_classes << margin_class
+  # end
+%>
 <% start_button_text = capture do %>
   <span>
-    <%= button.text %>
+    <%= text %>
   </span>
   <svg class="govuk-button__start-icon govuk-!-display-none-print" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" focusable="false" aria-hidden="true">
     <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
@@ -21,14 +37,14 @@
   if button.start
     button_text = start_button_text
   else
-    button_text = button.text
+    button_text = text
   end
 %>
 
 <% if button.link? %>
-  <%= link_to button_text, button.href, **button.html_options %>
+  <%= link_to button_text, button.href, **component_helper.all_attributes %>
 <% else %>
-  <%= content_tag :button, button_text, **button.html_options %>
+  <%= content_tag :button, button_text, **component_helper.all_attributes %>
 <% end %>
 
 <% if button.info_text %>

--- a/app/views/govuk_publishing_components/components/docs/button.yml
+++ b/app/views/govuk_publishing_components/components/docs/button.yml
@@ -100,7 +100,6 @@ examples:
     description: Data attributes can be applied as required. Note that the component does not include built in tracking. If this is required consider using the [GA4 link tracker](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/trackers/ga4-link-tracker.md).
     data:
       text: Track this!
-      margin_bottom: true
       data_attributes: {
         module: cross-domain-tracking,
         tracking-code: GA-123ABC,
@@ -109,7 +108,6 @@ examples:
   with_title_attribute:
     data:
       text: Click me
-      margin_bottom: true
       title: A button to click
   inline_layout:
     description: Buttons will display adjacent to each other until mobile view, when they will appear on top of each other.

--- a/lib/govuk_publishing_components/presenters/button_helper.rb
+++ b/lib/govuk_publishing_components/presenters/button_helper.rb
@@ -14,7 +14,7 @@ module GovukPublishingComponents
                   :id,
                   :inline_layout,
                   :target,
-                  # :type,
+                  :type,
                   :start,
                   :secondary,
                   :secondary_quiet,
@@ -44,7 +44,7 @@ module GovukPublishingComponents
         @margin_bottom = local_assigns[:margin_bottom]
         @inline_layout = local_assigns[:inline_layout]
         @target = local_assigns[:target]
-        # @type = local_assigns[:type]
+        @type = button_type(local_assigns[:type])
         @start = local_assigns[:start]
         @data_attributes[:ga4_attributes] = ga4_attribute if start
         @secondary = local_assigns[:secondary]
@@ -53,7 +53,8 @@ module GovukPublishingComponents
         @destructive = local_assigns[:destructive]
         @name = local_assigns[:name]
         @value = local_assigns[:value]
-        @classes = local_assigns[:classes]
+        # @classes = local_assigns[:classes]
+        @classes = css_classes
         @aria_label = local_assigns[:aria_label]
         @info_text_id = "info-text-id-#{SecureRandom.hex(4)}"
         @button_id = "button-id-#{SecureRandom.hex(4)}"
@@ -85,7 +86,7 @@ module GovukPublishingComponents
       end
 
       def html_options
-        options = { class: css_classes }
+        # options = { class: css_classes }
         options[:role] = "button" if link?
         # options[:type] = button_type
         options[:id] = @button_id if info_text?
@@ -103,9 +104,9 @@ module GovukPublishingComponents
         options
       end
 
-      # def button_type
-      #   type || "submit" unless link?
-      # end
+      def button_type(type)
+        type || "submit" unless link?
+      end
 
     private
 
@@ -116,10 +117,10 @@ module GovukPublishingComponents
         css_classes << "gem-c-button--secondary-quiet" if secondary_quiet
         css_classes << "govuk-button--secondary" if secondary_solid
         css_classes << "govuk-button--warning" if destructive
-        if margin_bottom && !info_text
-          margin_class = get_margin_bottom(margin_bottom, false)
-          css_classes << margin_class
-        end
+        # if margin_bottom && !info_text
+        #   margin_class = get_margin_bottom(margin_bottom, false)
+        #   css_classes << margin_class
+        # end
         css_classes << "gem-c-button--inline" if inline_layout
         css_classes << classes if classes
         css_classes.join(" ")

--- a/lib/govuk_publishing_components/presenters/button_helper.rb
+++ b/lib/govuk_publishing_components/presenters/button_helper.rb
@@ -9,7 +9,7 @@ module GovukPublishingComponents
                   :info_text,
                   :info_text_classes,
                   :rel,
-                  :data_attributes,
+                  # :data_attributes,
                   :ga4_attributes,
                   :margin_bottom,
                   :id,
@@ -41,7 +41,7 @@ module GovukPublishingComponents
           @info_text_classes << margin_class
         end
         @rel = local_assigns[:rel]
-        @data_attributes = local_assigns[:data_attributes]&.symbolize_keys || {}
+        # @data_attributes = local_assigns[:data_attributes]&.symbolize_keys || {}
         # @data_attributes[:module] = "govuk-button #{data_attributes[:module]}".strip if link?
         @margin_bottom = local_assigns[:margin_bottom]
         @inline_layout = local_assigns[:inline_layout]
@@ -96,7 +96,7 @@ module GovukPublishingComponents
         options[:id] = @button_id if info_text?
         # options[:aria] = { labelledby: aria_labelledby }
         # options[:rel] = rel if rel
-        options[:data] = data_attributes if data_attributes
+        # options[:data] = data_attributes if data_attributes
         options[:title] = title if title
         # options[:target] = target if target
         options[:name] = name if name.present? && value.present?

--- a/lib/govuk_publishing_components/presenters/button_helper.rb
+++ b/lib/govuk_publishing_components/presenters/button_helper.rb
@@ -98,7 +98,7 @@ module GovukPublishingComponents
         # options[:rel] = rel if rel
         options[:data] = data_attributes if data_attributes
         options[:title] = title if title
-        options[:target] = target if target
+        # options[:target] = target if target
         options[:name] = name if name.present? && value.present?
         options[:value] = value if name.present? && value.present?
         options[:aria] = { label: aria_label } if aria_label

--- a/lib/govuk_publishing_components/presenters/button_helper.rb
+++ b/lib/govuk_publishing_components/presenters/button_helper.rb
@@ -4,7 +4,7 @@ module GovukPublishingComponents
   module Presenters
     class ButtonHelper
       attr_reader :href,
-                  :text,
+                  # :text,
                   :title,
                   :info_text,
                   :info_text_classes,
@@ -30,7 +30,7 @@ module GovukPublishingComponents
       def initialize(local_assigns)
         @disable_ga4 = local_assigns[:disable_ga4]
         @href = local_assigns[:href]
-        @text = local_assigns[:text]
+        # @text = local_assigns[:text]
         @title = local_assigns[:title]
         @info_text = local_assigns[:info_text]
         @info_text_classes = %w[gem-c-button__info-text]
@@ -40,7 +40,7 @@ module GovukPublishingComponents
         end
         @rel = local_assigns[:rel]
         @data_attributes = local_assigns[:data_attributes]&.symbolize_keys || {}
-        @data_attributes[:module] = "govuk-button #{data_attributes[:module]}".strip if link?
+        # @data_attributes[:module] = "govuk-button #{data_attributes[:module]}".strip if link?
         @margin_bottom = local_assigns[:margin_bottom]
         @inline_layout = local_assigns[:inline_layout]
         @target = local_assigns[:target]

--- a/lib/govuk_publishing_components/presenters/button_helper.rb
+++ b/lib/govuk_publishing_components/presenters/button_helper.rb
@@ -14,7 +14,7 @@ module GovukPublishingComponents
                   :id,
                   :inline_layout,
                   :target,
-                  :type,
+                  # :type,
                   :start,
                   :secondary,
                   :secondary_quiet,
@@ -44,7 +44,7 @@ module GovukPublishingComponents
         @margin_bottom = local_assigns[:margin_bottom]
         @inline_layout = local_assigns[:inline_layout]
         @target = local_assigns[:target]
-        @type = local_assigns[:type]
+        # @type = local_assigns[:type]
         @start = local_assigns[:start]
         @data_attributes[:ga4_attributes] = ga4_attribute if start
         @secondary = local_assigns[:secondary]
@@ -87,7 +87,7 @@ module GovukPublishingComponents
       def html_options
         options = { class: css_classes }
         options[:role] = "button" if link?
-        options[:type] = button_type
+        # options[:type] = button_type
         options[:id] = @button_id if info_text?
         options[:aria] = { labelledby: aria_labelledby }
         options[:rel] = rel if rel
@@ -99,13 +99,13 @@ module GovukPublishingComponents
         options[:aria] = { label: aria_label } if aria_label
         options[:aria][:controls] =  aria_controls if aria_controls
         options[:aria][:describedby] = aria_describedby if aria_describedby
-        options[:draggable] = false if link?
+        # options[:draggable] = false if link?
         options
       end
 
-      def button_type
-        type || "submit" unless link?
-      end
+      # def button_type
+      #   type || "submit" unless link?
+      # end
 
     private
 

--- a/lib/govuk_publishing_components/presenters/button_helper.rb
+++ b/lib/govuk_publishing_components/presenters/button_helper.rb
@@ -4,12 +4,13 @@ module GovukPublishingComponents
   module Presenters
     class ButtonHelper
       attr_reader :href,
-                  # :text,
+                  :text,
                   :title,
                   :info_text,
                   :info_text_classes,
                   :rel,
                   :data_attributes,
+                  :ga4_attributes,
                   :margin_bottom,
                   :id,
                   :inline_layout,
@@ -24,13 +25,14 @@ module GovukPublishingComponents
                   :value,
                   :classes,
                   :aria_label,
+                  :aria_labelledby,
                   :aria_controls,
                   :aria_describedby
 
       def initialize(local_assigns)
         @disable_ga4 = local_assigns[:disable_ga4]
         @href = local_assigns[:href]
-        # @text = local_assigns[:text]
+        @text = local_assigns[:text]
         @title = local_assigns[:title]
         @info_text = local_assigns[:info_text]
         @info_text_classes = %w[gem-c-button__info-text]
@@ -46,7 +48,8 @@ module GovukPublishingComponents
         @target = local_assigns[:target]
         @type = button_type(local_assigns[:type])
         @start = local_assigns[:start]
-        @data_attributes[:ga4_attributes] = ga4_attribute if start
+        # @data_attributes[:ga4_attributes] = ga4_attribute if start
+        @ga4_attributes = ga4_attribute if start
         @secondary = local_assigns[:secondary]
         @secondary_quiet = local_assigns[:secondary_quiet]
         @secondary_solid = local_assigns[:secondary_solid]
@@ -59,6 +62,7 @@ module GovukPublishingComponents
         @info_text_id = "info-text-id-#{SecureRandom.hex(4)}"
         @button_id = "button-id-#{SecureRandom.hex(4)}"
         @aria_controls = local_assigns[:aria_controls]
+        @aria_labelledby = aria_labelledby
         @aria_describedby = local_assigns[:aria_describedby]
       end
 
@@ -90,8 +94,8 @@ module GovukPublishingComponents
         options[:role] = "button" if link?
         # options[:type] = button_type
         options[:id] = @button_id if info_text?
-        options[:aria] = { labelledby: aria_labelledby }
-        options[:rel] = rel if rel
+        # options[:aria] = { labelledby: aria_labelledby }
+        # options[:rel] = rel if rel
         options[:data] = data_attributes if data_attributes
         options[:title] = title if title
         options[:target] = target if target

--- a/spec/components/button_spec.rb
+++ b/spec/components/button_spec.rb
@@ -107,21 +107,10 @@ describe "Button", type: :view do
   end
 
   it "renders info text with margin bottom" do
-    render_component(text: "Start now", info_text: "Information text", margin_bottom: true)
-
-    assert_select ".gem-c-button--bottom-margin", count: 0
-
-    assert_select ".govuk-button", text: "Start now"
-    assert_select ".gem-c-button__info-text.gem-c-button__info-text--bottom-margin", text: "Information text"
-  end
-
-  it "renders info text with variable margin bottom" do
-    render_component(text: "Start now", info_text: "Information text", margin_bottom: 6)
-
-    assert_select ".gem-c-button--bottom-margin", count: 0
-
-    assert_select ".govuk-button", text: "Start now"
-    assert_select '.gem-c-button__info-text.govuk-\!-margin-bottom-6', text: "Information text"
+    render_component(text: "Start now", info_text: "Information text", margin_bottom: 2)
+    assert_select '.gem-c-button.govuk-\!-margin-bottom-2', count: 0
+    assert_select ".gem-c-button", text: "Start now"
+    assert_select '.gem-c-button__info-text.govuk-\!-margin-bottom-2', text: "Information text"
   end
 
   it "renders rel attribute correctly" do

--- a/spec/components/button_spec.rb
+++ b/spec/components/button_spec.rb
@@ -127,15 +127,6 @@ describe "Button", type: :view do
     assert_select "button.govuk-button", false
   end
 
-  it "renders margin bottom class correctly" do
-    render_component(text: "Submit")
-    assert_select ".govuk-button", text: "Submit"
-    assert_select ".gem-c-button--bottom-margin", count: 0
-
-    render_component(text: "Submit", margin_bottom: true)
-    assert_select ".govuk-button.gem-c-button--bottom-margin", text: "Submit"
-  end
-
   it "renders a variable margin bottom correctly" do
     render_component(text: "Submit", margin_bottom: 6)
     assert_select '.govuk-button.govuk-\!-margin-bottom-6', text: "Submit"
@@ -167,7 +158,7 @@ describe "Button", type: :view do
       },
     )
 
-    assert_select "a.govuk-button[data-module='govuk-button cross-domain-tracking']"
+    assert_select "a.govuk-button[data-module='cross-domain-tracking govuk-button']"
     assert_select "a.govuk-button[data-tracking-code='GA-123ABC']"
     assert_select "a.govuk-button[data-tracking-name='transactionTracker']"
   end


### PR DESCRIPTION
## What
Adds the [component wrapper helper](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/component-wrapper-helper.md) to the [button component](https://components.publishing.service.gov.uk/component-guide/button).

## Why
The button component is the last component in the gem using the bottom margin option from the shared helper, which has been moved to the component wrapper helper. Once we've done this change we can remove the duplicate margin bottom option from the shared helper.

Also, the component wrapper helper de-duplicates code and improves future maintainability of components, so double win. Although this will likely be a breaking change.

## Visual Changes
None, hopefully.

Trello card: https://trello.com/c/hUDC8lzz/418-add-component-wrapper-helper-to-button-component