### PR TITLE
BREAKING Use component wrapper on attachment link component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * **BREAKING**  Use component wrapper on big number component ([PR #4550](https://github.com/alphagov/govuk_publishing_components/pull/4550))
 * **BREAKING** Use component wrapper on attachment component ([PR #4545](https://github.com/alphagov/govuk_publishing_components/pull/4545))
+* **BREAKING** Use component wrapper on attachment link component ([PR #4549](https://github.com/alphagov/govuk_publishing_components/pull/4549))
 * Add 'draggable' attribute to component wrapper helper ([PR #4544](https://github.com/alphagov/govuk_publishing_components/pull/4544))
 
 ## 48.0.0

--- a/app/views/govuk_publishing_components/components/_attachment_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_attachment_link.html.erb
@@ -3,7 +3,7 @@
 
   attachment = GovukPublishingComponents::Presenters::AttachmentHelper.new(attachment)
   target ||= nil
-  data_attributes ||= {}
+  url_data_attributes ||= {}
   attributes = []
   if attachment.content_type_name
     content = if attachment.content_type_abbr
@@ -30,11 +30,14 @@
       class: "gem-c-attachment-link__attribute",
     )
   end
+
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("gem-c-attachment-link")
 %>
-<%= tag.span(class: "gem-c-attachment-link") do %>
+<%= tag.span(**component_helper.all_attributes) do %>
   <%= link_to(attachment.title, attachment.url,
               class: "govuk-link",
               target: target,
-              data: data_attributes) -%>
+              data: url_data_attributes) -%>
   <%= raw("(#{attributes.join(', ')})") if attributes.any? -%>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/attachment_link.yml
+++ b/app/views/govuk_publishing_components/components/docs/attachment_link.yml
@@ -14,6 +14,7 @@ accessibility_criteria: |
     Attachment links within paragraphs of text do not need to meet the 24 by 24 CSS pixels requirements.    
 shared_accessibility_criteria:
 - link
+uses_component_wrapper_helper: true
 examples:
   default:
     data:
@@ -58,10 +59,10 @@ examples:
         title: "Temporary snow ploughs: guidance note"
         url: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/259634/temporary-snow-ploughs.pdf
       target: _blank
-  with_data_attributes:
+  with_data_attributes_on_url:
     data:
       attachment:
         title: "Temporary snow ploughs: guidance note"
         url: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/259634/temporary-snow-ploughs.pdf
-      data_attributes:
+      url_data_attributes:
         gtm: "attachment-preview"

--- a/spec/components/attachment_link_spec.rb
+++ b/spec/components/attachment_link_spec.rb
@@ -58,7 +58,7 @@ describe "Attachment Link", type: :view do
         title: "Attachment",
         url: "attachment",
       },
-      data_attributes: { gtm: "attachment-preview" },
+      url_data_attributes: { gtm: "attachment-preview" },
     )
     assert_select "a.govuk-link[data-gtm='attachment-preview']"
   end


### PR DESCRIPTION
## What
- Adds the component wrapper to the attachment component
- This is a breaking change, as it renames `data_attributes` to `url_data_attributes`, as those data attributes were being used on a child component - `data_attributes` is now for data attributes applied to the parent HTML element.
- This should only affect one template which I verified using [this search criteria](https://github.com/search?q=org%3Aalphagov+govuk_publishing_components%2Fcomponents%2Fattachment_link&type=Code).

## Why
As the [trello card](https://trello.com/c/oSMnbqXu/427-add-component-wrapper-helper-to-attachment-link-component) states:

> Standardising our components to use the component wrapper helper will reduce code, increase standardisation, and improve future feature implementation speed.

## Visual changes

1 example has had its titled changed.