### PR TITLE
Fix component wrapper rel option

### DIFF
--- a/lib/govuk_publishing_components/presenters/component_wrapper_helper.rb
+++ b/lib/govuk_publishing_components/presenters/component_wrapper_helper.rb
@@ -240,7 +240,8 @@ module GovukPublishingComponents
         return if rel_attribute.blank?
 
         options = %w[alternate author bookmark canonical dns-prefetch external expect help icon license manifest me modulepreload next nofollow noopener noreferrer opener pingback preconnect prefetch preload prerender prev privacy-policy search stylesheet tag terms-of-service]
-        unless options.include? rel_attribute
+        rel_array = rel_attribute.split(" ")
+        unless rel_array.all? { |r| options.include? r }
           raise(ArgumentError, "rel attribute (#{rel_attribute}) is not recognised")
         end
       end

--- a/spec/lib/govuk_publishing_components/components/component_wrapper_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/components/component_wrapper_helper_spec.rb
@@ -396,9 +396,21 @@ RSpec.describe GovukPublishingComponents::Presenters::ComponentWrapperHelper do
         }.to raise_error(ArgumentError, error)
       end
 
-      it "accepts valid rel value" do
+      it "accepts a valid rel value" do
         component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(rel: "nofollow")
         expect(component_helper.all_attributes[:rel]).to eql("nofollow")
+      end
+
+      it "accepts multiple valid rel values" do
+        component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(rel: "nofollow noreferrer")
+        expect(component_helper.all_attributes[:rel]).to eql("nofollow noreferrer")
+      end
+
+      it "does not accept multiple rel values if one of them is invalid" do
+        error = "rel attribute (nofollow noreferrer potato) is not recognised"
+        expect {
+          GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(rel: "nofollow noreferrer potato")
+        }.to raise_error(ArgumentError, error)
       end
 
       it "can set a rel, overriding a passed value" do
@@ -411,6 +423,12 @@ RSpec.describe GovukPublishingComponents::Presenters::ComponentWrapperHelper do
         helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(rel: "nofollow")
         helper.add_rel("noreferrer")
         expect(helper.all_attributes[:rel]).to eql("nofollow noreferrer")
+      end
+
+      it "can add multiple rels to an existing rel" do
+        helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(rel: "nofollow")
+        helper.add_rel("noreferrer external")
+        expect(helper.all_attributes[:rel]).to eql("nofollow noreferrer external")
       end
     end
 


### PR DESCRIPTION
## What
Fixes a bug in how the component wrapper handles the `rel` option.

- code previously assumed that only one rel option would be passed, but you can have more than one in the attribute
- passing more than one previously caused an error even if all of the rels were valid, this change corrects that

## Why
Because I didn't think of this when I was writing it yesterday 🤦 

## Visual Changes
None.

Trello card: https://trello.com/c/hUDC8lzz/418-add-component-wrapper-helper-to-button-component