### PR TITLE
Add more options to the component wrapper helper

### DIFF
--- a/app/models/govuk_publishing_components/component_wrapper_helper_options.rb
+++ b/app/models/govuk_publishing_components/component_wrapper_helper_options.rb
@@ -13,11 +13,12 @@ This component uses the component wrapper helper. It accepts the following optio
 - `lang` - accepts a language attribute value
 - `open` - accepts an open attribute value (true or false)
 - `hidden` - accepts an empty string, 'hidden', or 'until-found'
-- `tabindex` - accepts an integer. The integer can also be passed as a string.
-- `dir` - accepts 'rtl', 'ltr', or 'auto'.
-- `type` - accepts any valid type attribute e.g. 'button', 'submit', 'text'.
-- `rel` - accepts any valid rel attribute e.g. 'nofollow'.
-- `target` - accepts a valid target attribute e.g. '_blank'.
+- `tabindex` - accepts an integer. The integer can also be passed as a string
+- `dir` - accepts 'rtl', 'ltr', or 'auto'
+- `type` - accepts any valid type attribute e.g. 'button', 'submit', 'text'
+- `rel` - accepts any valid rel attribute e.g. 'nofollow'
+- `target` - accepts a valid target attribute e.g. '_blank'
+- `title` - accepts any string
 - `draggable` - accepts a draggable attribute value (\"true\" or \"false\")
       "
     end

--- a/app/models/govuk_publishing_components/component_wrapper_helper_options.rb
+++ b/app/models/govuk_publishing_components/component_wrapper_helper_options.rb
@@ -17,6 +17,7 @@ This component uses the component wrapper helper. It accepts the following optio
 - `dir` - accepts 'rtl', 'ltr', or 'auto'.
 - `type` - accepts any valid type attribute e.g. 'button', 'submit', 'text'.
 - `rel` - accepts any valid rel attribute e.g. 'nofollow'.
+- `target` - accepts a valid target attribute e.g. '_blank'.
 - `draggable` - accepts a draggable attribute value (\"true\" or \"false\")
       "
     end

--- a/docs/component-wrapper-helper.md
+++ b/docs/component-wrapper-helper.md
@@ -38,6 +38,7 @@ These options can be passed to any component that uses the component wrapper.
 - `dir` - accepts 'rtl', 'ltr', or 'auto'.
 - `type` - accepts any valid type attribute e.g. 'button', 'submit', 'text'
 - `rel` - accepts any valid rel attribute e.g. 'nofollow'
+- `target` - accepts a valid target attribute e.g. '_blank'
 - `draggable` - accepts a draggable attribute value ("true" or "false")
 
 To prevent breaking [component isolation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/component_principles.md#a-component-is-isolated-when), passed classes should only be used for JavaScript hooks and not styling. All component styling should be included only in the component itself. Any passed classes should be prefixed with `js-`. To allow for extending this option, classes prefixed with `gem-c-`, `govuk-`, `app-c-`, `brand--`, or `brand__` are also permitted, as well as an exact match of `direction-rtl`, but these classes should only be used within the component and not passed to it.
@@ -87,6 +88,7 @@ The component wrapper includes several methods to make managing options easier, 
   component_helper.set_draggable("true")
   component_helper.set_rel("nofollow") # overrides any existing rel
   component_helper.add_rel("noopener") # adds to existing rel
+  component_helper.set_target("_blank")
   component_helper.set_margin_bottom(3) # can pass any number from 1 to 9
 %>
 <%= tag.div(**component_helper.all_attributes) do %>

--- a/docs/component-wrapper-helper.md
+++ b/docs/component-wrapper-helper.md
@@ -39,6 +39,7 @@ These options can be passed to any component that uses the component wrapper.
 - `type` - accepts any valid type attribute e.g. 'button', 'submit', 'text'
 - `rel` - accepts any valid rel attribute e.g. 'nofollow'
 - `target` - accepts a valid target attribute e.g. '_blank'
+- `title` - accepts any string
 - `draggable` - accepts a draggable attribute value ("true" or "false")
 
 To prevent breaking [component isolation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/component_principles.md#a-component-is-isolated-when), passed classes should only be used for JavaScript hooks and not styling. All component styling should be included only in the component itself. Any passed classes should be prefixed with `js-`. To allow for extending this option, classes prefixed with `gem-c-`, `govuk-`, `app-c-`, `brand--`, or `brand__` are also permitted, as well as an exact match of `direction-rtl`, but these classes should only be used within the component and not passed to it.
@@ -89,6 +90,7 @@ The component wrapper includes several methods to make managing options easier, 
   component_helper.set_rel("nofollow") # overrides any existing rel
   component_helper.add_rel("noopener") # adds to existing rel
   component_helper.set_target("_blank")
+  component_helper.set_title("this is a title")
   component_helper.set_margin_bottom(3) # can pass any number from 1 to 9
 %>
 <%= tag.div(**component_helper.all_attributes) do %>

--- a/lib/govuk_publishing_components/presenters/component_wrapper_helper.rb
+++ b/lib/govuk_publishing_components/presenters/component_wrapper_helper.rb
@@ -17,6 +17,7 @@ module GovukPublishingComponents
         check_type_is_valid(@options[:type]) if @options.include?(:type)
         check_draggable_is_valid(@options[:draggable]) if @options.include?(:draggable)
         check_rel_is_valid(@options[:rel]) if @options.include?(:rel)
+        check_target_is_valid(@options[:target]) if @options.include?(:target)
         check_margin_bottom_is_valid(@options[:margin_bottom]) if @options.include?(:margin_bottom)
       end
 
@@ -39,6 +40,7 @@ module GovukPublishingComponents
         attributes[:type] = @options[:type] unless @options[:type].blank?
         attributes[:draggable] = @options[:draggable] unless @options[:draggable].blank?
         attributes[:rel] = @options[:rel] unless @options[:rel].blank?
+        attributes[:target] = @options[:target] unless @options[:target].blank?
 
         attributes
       end
@@ -111,6 +113,11 @@ module GovukPublishingComponents
       def set_rel(rel_attribute)
         check_rel_is_valid(rel_attribute)
         @options[:rel] = rel_attribute
+      end
+
+      def set_target(target_attribute)
+        check_target_is_valid(target_attribute)
+        @options[:target] = target_attribute
       end
 
       def set_margin_bottom(margin_bottom)
@@ -243,6 +250,15 @@ module GovukPublishingComponents
         rel_array = rel_attribute.split(" ")
         unless rel_array.all? { |r| options.include? r }
           raise(ArgumentError, "rel attribute (#{rel_attribute}) is not recognised")
+        end
+      end
+
+      def check_target_is_valid(target_attribute)
+        return if target_attribute.blank?
+
+        options = %w[_self _blank _parent _top _unfencedTop]
+        unless options.include? target_attribute
+          raise(ArgumentError, "target attribute (#{target_attribute}) is not recognised")
         end
       end
 

--- a/lib/govuk_publishing_components/presenters/component_wrapper_helper.rb
+++ b/lib/govuk_publishing_components/presenters/component_wrapper_helper.rb
@@ -41,6 +41,7 @@ module GovukPublishingComponents
         attributes[:draggable] = @options[:draggable] unless @options[:draggable].blank?
         attributes[:rel] = @options[:rel] unless @options[:rel].blank?
         attributes[:target] = @options[:target] unless @options[:target].blank?
+        attributes[:title] = @options[:title] unless @options[:title].blank?
 
         attributes
       end
@@ -118,6 +119,10 @@ module GovukPublishingComponents
       def set_target(target_attribute)
         check_target_is_valid(target_attribute)
         @options[:target] = target_attribute
+      end
+
+      def set_title(title_attribute)
+        @options[:title] = title_attribute
       end
 
       def set_margin_bottom(margin_bottom)

--- a/spec/lib/govuk_publishing_components/components/component_wrapper_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/components/component_wrapper_helper_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe GovukPublishingComponents::Presenters::ComponentWrapperHelper do
         dir: "rtl",
         type: "submit",
         draggable: "true",
+        title: "Hello",
       }
       component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(args)
       expected = {
@@ -35,6 +36,7 @@ RSpec.describe GovukPublishingComponents::Presenters::ComponentWrapperHelper do
         dir: "rtl",
         type: "submit",
         draggable: "true",
+        title: "Hello",
       }
       expect(component_helper.all_attributes).to eql(expected)
     end
@@ -53,6 +55,7 @@ RSpec.describe GovukPublishingComponents::Presenters::ComponentWrapperHelper do
         dir: nil,
         type: nil,
         draggable: nil,
+        title: nil,
       )
       expect(component_helper.all_attributes).to eql({})
     end
@@ -70,6 +73,7 @@ RSpec.describe GovukPublishingComponents::Presenters::ComponentWrapperHelper do
         dir: "",
         type: "",
         draggable: "",
+        title: "",
       )
       expect(component_helper.all_attributes).to eql({})
     end
@@ -449,6 +453,19 @@ RSpec.describe GovukPublishingComponents::Presenters::ComponentWrapperHelper do
         helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(target: "_blank")
         helper.set_target("_self")
         expect(helper.all_attributes[:target]).to eql("_self")
+      end
+    end
+
+    describe "target" do
+      it "accepts a valid title value" do
+        component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(title: "this is a title")
+        expect(component_helper.all_attributes[:title]).to eql("this is a title")
+      end
+
+      it "can set a title, overriding a passed value" do
+        helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(title: "this is a title")
+        helper.set_title("this is a different title")
+        expect(helper.all_attributes[:title]).to eql("this is a different title")
       end
     end
 

--- a/spec/lib/govuk_publishing_components/components/component_wrapper_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/components/component_wrapper_helper_spec.rb
@@ -432,6 +432,26 @@ RSpec.describe GovukPublishingComponents::Presenters::ComponentWrapperHelper do
       end
     end
 
+    describe "target" do
+      it "does not accept an invalid target value" do
+        error = "target attribute (zelda) is not recognised"
+        expect {
+          GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(target: "zelda")
+        }.to raise_error(ArgumentError, error)
+      end
+
+      it "accepts a valid target value" do
+        component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(target: "_blank")
+        expect(component_helper.all_attributes[:target]).to eql("_blank")
+      end
+
+      it "can set a target, overriding a passed value" do
+        helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(target: "_blank")
+        helper.set_target("_self")
+        expect(helper.all_attributes[:target]).to eql("_self")
+      end
+    end
+
     describe "margins" do
       it "complains about an invalid margin" do
         error = "margin_bottom option (15) is not recognised"


### PR DESCRIPTION
## What
Adds options to include `target` and `title` attributes on elements with the component wrapper helper.

## Why
Needed for migrating the button component onto the helper.

Slightly conflicted on the the `title` attribute as there are accessibility concerns around it and I'm not even sure we're using it, but I don't have time right now to do a deep dive so decided to preserve the original functionality for now.

## Visual Changes
None.

Trello card: https://trello.com/c/hUDC8lzz/418-add-component-wrapper-helper-to-button-component