### PR TITLE
BREAKING Use component wrapper on modal dialogue component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add more options to the component wrapper helper ([PR #4554](https://github.com/alphagov/govuk_publishing_components/pull/4554))
+* **BREAKING** Use component wrapper on modal dialogue component ([PR #4555](https://github.com/alphagov/govuk_publishing_components/pull/4555))
 * **BREAKING**  Use component wrapper on big number component ([PR #4550](https://github.com/alphagov/govuk_publishing_components/pull/4550))
 * **BREAKING** Use component wrapper on attachment component ([PR #4545](https://github.com/alphagov/govuk_publishing_components/pull/4545))
 * **BREAKING** Use component wrapper on attachment link component ([PR #4549](https://github.com/alphagov/govuk_publishing_components/pull/4549))

--- a/app/views/govuk_publishing_components/components/_modal_dialogue.html.erb
+++ b/app/views/govuk_publishing_components/components/_modal_dialogue.html.erb
@@ -3,15 +3,19 @@
 
   id ||= "modal-dialogue-#{SecureRandom.hex(4)}"
   wide ||= false
-  data_attributes = {}
   aria_label ||= nil
   dialog_classes = ["gem-c-modal-dialogue__box"]
   dialog_classes << "gem-c-modal-dialogue__box--wide" if wide
+
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("gem-c-modal-dialogue")
+  component_helper.add_data_attribute({ module: "modal-dialogue" })
+  component_helper.set_id(id)
 %>
 
-<%= tag.div class: "gem-c-modal-dialogue", data: { module: "modal-dialogue" }, id: id do %>
+<%= tag.div(**component_helper.all_attributes) do %>
   <%= tag.div class: "gem-c-modal-dialogue__overlay" %>
-  <%= tag.dialog class: dialog_classes, data: data_attributes, aria: { modal: true, label: aria_label }, role: "dialog", tabindex: 0 do %>
+  <%= tag.dialog class: dialog_classes, aria: { modal: true, label: aria_label }, role: "dialog", tabindex: 0 do %>
     <%= tag.div class: "gem-c-modal-dialogue__header" do %>
       <%= render "govuk_publishing_components/components/govuk_logo/govuk_logo_crown_only", {
         classes: %w[gem-c-modal-dialogue__logotype-crown],

--- a/app/views/govuk_publishing_components/components/docs/modal_dialogue.yml
+++ b/app/views/govuk_publishing_components/components/docs/modal_dialogue.yml
@@ -24,6 +24,7 @@ accessibility_criteria: |
   - return focus to last focused element on close
 
 display_preview: false
+uses_component_wrapper_helper: true
 examples:
   default:
     embed: |
@@ -100,20 +101,3 @@ examples:
           <p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet fringilla dictum. Morbi at vehicula augue. Pellentesque varius orci et augue pellentesque, sed elementum massa posuere. Curabitur egestas consectetur arcu, in porta lorem sagittis eu. Nulla facilisi. Sed scelerisque ligula lectus. Nulla et ligula a eros laoreet lacinia nec et ipsum. Ut sagittis sapien est, ut blandit risus laoreet at. Vestibulum vitae erat sed dolor ultricies efficitur.</p>
           <p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet fringilla dictum. Morbi at vehicula augue. Pellentesque varius orci et augue pellentesque, sed elementum massa posuere. Curabitur egestas consectetur arcu, in porta lorem sagittis eu. Nulla facilisi. Sed scelerisque ligula lectus. Nulla et ligula a eros laoreet lacinia nec et ipsum. Ut sagittis sapien est, ut blandit risus laoreet at. Vestibulum vitae erat sed dolor ultricies efficitur.</p>
           <p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet fringilla dictum. Morbi at vehicula augue. Pellentesque varius orci et augue pellentesque, sed elementum massa posuere. Curabitur egestas consectetur arcu, in porta lorem sagittis eu. Nulla facilisi. Sed scelerisque ligula lectus. Nulla et ligula a eros laoreet lacinia nec et ipsum. Ut sagittis sapien est, ut blandit risus laoreet at. Vestibulum vitae erat sed dolor ultricies efficitur.</p>
-  with_data_attributes:
-    embed: |
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Open modal with data attributes",
-        data_attributes: {
-          toggle: "modal",
-          target: "modal-with-data-attributes"
-        }
-      } %>
-      <%= component %>
-    data:
-      id: modal-with-data-attributes
-      data_attributes:
-        gtm: modal
-      block: |
-        <h1 class="govuk-heading-l">Modal title</h1>
-        <p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet fringilla dictum. Morbi at vehicula augue. Pellentesque varius orci et augue pellentesque, sed elementum massa posuere. Curabitur egestas consectetur arcu, in porta lorem sagittis eu. Nulla facilisi. Sed scelerisque ligula lectus. Nulla et ligula a eros laoreet lacinia nec et ipsum. Ut sagittis sapien est, ut blandit risus laoreet at. Vestibulum vitae erat sed dolor ultricies efficitur.</p>


### PR DESCRIPTION
## What
- Adds the component wrapper to the modal dialogue component
- This is a breaking change, as it removes the `data_attributes` hash which was placed on a child element. `data_attributes` is not actually used across any templates currently, so it can be safely removed. https://github.com/search?q=org%3Aalphagov+govuk_publishing_components%2Fcomponents%2Fmodal_dialogue&type=Code 
- Although this is a breaking change, it shouldn't affect any existing code on GOVUK.

## Why
As the [trello card](https://trello.com/c/NigFMJSC/431-add-component-wrapper-helper-to-modal-dialog-component) states:

> Standardising our components to use the component wrapper helper will reduce code, increase standardisation, and improve future feature implementation speed.

## Visual changes

Removed an example.
