### PR TITLE
Release Version 49.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 49.0.0
 
 * Add more options to the component wrapper helper ([PR #4554](https://github.com/alphagov/govuk_publishing_components/pull/4554))
 * **BREAKING** Use component wrapper on modal dialogue component ([PR #4555](https://github.com/alphagov/govuk_publishing_components/pull/4555))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (48.0.0)
+    govuk_publishing_components (49.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "48.0.0".freeze
+  VERSION = "49.0.0".freeze
 end


### PR DESCRIPTION
## 49.0.0

* Add more options to the component wrapper helper ([PR #4554](https://github.com/alphagov/govuk_publishing_components/pull/4554))
* **BREAKING** Use component wrapper on modal dialogue component ([PR #4555](https://github.com/alphagov/govuk_publishing_components/pull/4555))
* **BREAKING**  Use component wrapper on big number component ([PR #4550](https://github.com/alphagov/govuk_publishing_components/pull/4550))
* **BREAKING** Use component wrapper on attachment component ([PR #4545](https://github.com/alphagov/govuk_publishing_components/pull/4545))
* **BREAKING** Use component wrapper on attachment link component ([PR #4549](https://github.com/alphagov/govuk_publishing_components/pull/4549))
* Add rel attribute to component wrapper ([PR #4551](https://github.com/alphagov/govuk_publishing_components/pull/4551))
* Add 'draggable' attribute to component wrapper helper ([PR #4544](https://github.com/alphagov/govuk_publishing_components/pull/4544))
* Remove redundant `role` attributes from elements ([PR #4556](https://github.com/alphagov/govuk_publishing_components/pull/4556))