### PR TITLE
Style breadcrumbs in RTL (right-to-left) writing mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Use component wrapper on contextual breadcrumbs ([PR #4560](https://github.com/alphagov/govuk_publishing_components/pull/4560))
 * Use component wrapper on contextual sidebar ([PR #4561](https://github.com/alphagov/govuk_publishing_components/pull/4561))
 * Correctly translate 'Published' word to Arabic ([PR #4563](https://github.com/alphagov/govuk_publishing_components/pull/4563))
+* Style breadcrumbs in RTL (right-to-left) writing mode ([PR #4559](https://github.com/alphagov/govuk_publishing_components/pull/4559))
 
 ## 49.0.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_breadcrumbs.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_breadcrumbs.scss
@@ -55,6 +55,22 @@
   }
 }
 
+.gem-c-breadcrumbs[dir="rtl"] {
+  text-align: start;
+
+  .govuk-breadcrumbs__list-item {
+    float: inline-start;
+    margin-inline-end: .625em;
+    padding-inline-end: .978em;
+
+    &::before {
+      transform: rotate(-135deg);
+      left: 0;
+      right: -1.2069em;
+    }
+  }
+}
+
 @include govuk-media-query($media-type: print) {
   .gem-c-breadcrumbs {
     font-size: 12pt;

--- a/app/views/govuk_publishing_components/components/docs/breadcrumbs.yml
+++ b/app/views/govuk_publishing_components/components/docs/breadcrumbs.yml
@@ -121,3 +121,14 @@ examples:
         url: "/section/sub-section"
       - title: "Sub-sub-section"
         url: "/section/sub-section/sub-section"
+  right_to_left:
+    data:
+      collapse_on_mobile: true
+      dir: rtl
+      breadcrumbs:
+      - title: "Section"
+        url: "/section"
+      - title: "Sub-section"
+        url: "/section/sub-section"
+      - title: "Sub-sub-section"
+        url: "/section/sub-section/sub-section"


### PR DESCRIPTION
## What
Style breadcrumbs in RTL (right-to-left) writing mode. [Trello](https://trello.com/c/6E5UoTiK/335-rtl-print-styles-have-been-considered-and-implemented-where-required)

Note that this CSS uses some "magic numbers" derived from the computed values for the `govuk-breadcrumbs` component.

This is part of the work to improve print styles more generally. 

## Why
The breadcrumb component had no support for RTL writing mode. The component was therefore incorrectly left aligned on pages in RTL languages.

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

### Before
<img width="1108" alt="image" src="https://github.com/user-attachments/assets/d00e8a20-0b25-4a1c-836c-f344ec7e175f" />

### After
<img width="1108" alt="image" src="https://github.com/user-attachments/assets/38d97f87-e7f8-4eac-a639-be918f47755b" />
