### PR TITLE
Use component wrapper on contextual breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Use component wrapper on contextual breadcrumbs ([PR #4560](https://github.com/alphagov/govuk_publishing_components/pull/4560))
+
 ## 49.0.0
 
 * Add more options to the component wrapper helper ([PR #4554](https://github.com/alphagov/govuk_publishing_components/pull/4554))

--- a/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
@@ -4,9 +4,12 @@
   breadcrumb_selector = GovukPublishingComponents::Presenters::BreadcrumbSelector.new(content_item, request, prioritise_taxon_breadcrumbs, disable_ga4)
   inverse ||= false
   collapse_on_mobile ||= true unless local_assigns[:collapse_on_mobile].eql?(false)
+
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("gem-c-contextual-breadcrumbs")
 %>
 
-<div class="gem-c-contextual-breadcrumbs">
+<%= tag.div(**component_helper.all_attributes) do %>
   <% if breadcrumb_selector.step_by_step %>
     <%= render 'govuk_publishing_components/components/step_by_step_nav_header', breadcrumb_selector.breadcrumbs %>
   <% elsif breadcrumb_selector.breadcrumbs %>
@@ -17,4 +20,4 @@
                  collapse_on_mobile: collapse_on_mobile %>
     </div>
   <% end %>
-</div>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/contextual_breadcrumbs.yml
+++ b/app/views/govuk_publishing_components/components/docs/contextual_breadcrumbs.yml
@@ -20,6 +20,7 @@ body: |
   [breadcrumbs]: https://components.publishing.service.gov.uk/component-guide/breadcrumbs
 accessibility_criteria: |
   Components called by this component must be accessible
+uses_component_wrapper_helper: true
 examples:
   default:
     data:


### PR DESCRIPTION
## What
- Adds the component wrapper helper to the `contextual breadcrumbs` component.

## Why
As the [trello card](https://trello.com/c/7sAlXpYy/434-add-component-wrapper-helper-to-contextual-breadcrumbs-footer-and-sidebar-component) states:

> Standardising our components to use the component wrapper helper will reduce code, increase standardisation, and improve future feature implementation speed.

## Visual changes

None.