### PR TITLE
Use component wrapper on contextual sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Use component wrapper on contextual breadcrumbs ([PR #4560](https://github.com/alphagov/govuk_publishing_components/pull/4560))
+* Use component wrapper on contextual sidebar ([PR #4561](https://github.com/alphagov/govuk_publishing_components/pull/4561))
 
 ## 49.0.0
 

--- a/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
@@ -7,9 +7,12 @@
   show_ukraine_cta = navigation.show_ukraine_cta?
   ga4_tracking_counts = OpenStruct.new(index_section_count: 0)
   ga4_tracking_counts.index_section_count = 1 if show_ukraine_cta
+
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("gem-c-contextual-sidebar govuk-!-display-none-print")
 %>
 
-<div class="gem-c-contextual-sidebar govuk-!-display-none-print">
+<%= tag.div(**component_helper.all_attributes) do %>
   <% if navigation.content_tagged_to_a_reasonable_number_of_step_by_steps? %>
     <%# Rendering step by step related items because there are a few but not too many of them %>
     <%= render 'govuk_publishing_components/components/step_by_step_nav_related', links: navigation.step_nav_helper.related_links, disable_ga4: disable_ga4 %>
@@ -36,4 +39,4 @@
   <% if show_ukraine_cta %>
     <%= render 'govuk_publishing_components/components/contextual_sidebar/ukraine_cta', content_item: content_item, disable_ga4: disable_ga4, ga4_tracking_counts: ga4_tracking_counts %>
   <% end %>
-</div>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/contextual_sidebar.yml
+++ b/app/views/govuk_publishing_components/components/docs/contextual_sidebar.yml
@@ -17,6 +17,7 @@ body: |
   [contextual_breadcrumbs]: /component-guide/contextual_breadcrumbs
 accessibility_criteria: |
   Components called by this component must be accessible
+uses_component_wrapper_helper: true
 examples:
   default:
     description: Display collections, guides, quick links, ordered related items and related mainstream content.


### PR DESCRIPTION
## What
- Adds the component wrapper helper to the `contextual sidebar` component.

## Why
As the [trello card](https://trello.com/c/7sAlXpYy/434-add-component-wrapper-helper-to-contextual-breadcrumbs-footer-and-sidebar-component) states:

> Standardising our components to use the component wrapper helper will reduce code, increase standardisation, and improve future feature implementation speed.

## Visual changes

None.