### PR TITLE
Use component wrapper on contextual footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Use component wrapper on contextual footer ([PR #4562](https://github.com/alphagov/govuk_publishing_components/pull/4562))
+
 ## 49.1.0
 
 * Use component wrapper on contextual breadcrumbs ([PR #4560](https://github.com/alphagov/govuk_publishing_components/pull/4560))

--- a/app/views/govuk_publishing_components/components/_contextual_footer.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_footer.html.erb
@@ -1,12 +1,17 @@
-<% navigation = GovukPublishingComponents::Presenters::ContextualNavigation.new(content_item, request) %>
-<% disable_ga4 ||= false %>
+<%
+  navigation = GovukPublishingComponents::Presenters::ContextualNavigation.new(content_item, request)
+  disable_ga4 ||= false
+
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("gem-c-contextual-footer govuk-!-display-none-print")
+%>
 
 <% unless navigation.content_tagged_to_current_step_by_step? %>
-  <div class="gem-c-contextual-footer govuk-!-display-none-print">
+  <%= tag.div(**component_helper.all_attributes) do %>
     <%# Rendering related navigation because no step by step list %>
     <%= render 'govuk_publishing_components/components/related_navigation',
                content_item: content_item,
                disable_ga4: disable_ga4,
                context: :footer %>
-  </div>
+  <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/contextual_footer.yml
+++ b/app/views/govuk_publishing_components/components/docs/contextual_footer.yml
@@ -15,6 +15,7 @@ body: |
   [contextual_breadcrumbs]: /component-guide/contextual_breadcrumbs
 accessibility_criteria: |
   Components called by this component must be accessible
+uses_component_wrapper_helper: true
 examples:
   default:
     description: Displays contacts, external links, statistical datasets, topical events, topics and world locations.


### PR DESCRIPTION
## What
- Adds the component wrapper helper to the `contextual footer` component.

## Why
As the [trello card](https://trello.com/c/7sAlXpYy/434-add-component-wrapper-helper-to-contextual-breadcrumbs-footer-and-sidebar-component) states:

> Standardising our components to use the component wrapper helper will reduce code, increase standardisation, and improve future feature implementation speed.

## Visual changes

None.