### PR TITLE
Fix Arabic translation for 'Published'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Use component wrapper on contextual breadcrumbs ([PR #4560](https://github.com/alphagov/govuk_publishing_components/pull/4560))
 * Use component wrapper on contextual sidebar ([PR #4561](https://github.com/alphagov/govuk_publishing_components/pull/4561))
+* Correctly translate 'Published' word to Arabic ([PR #4563](https://github.com/alphagov/govuk_publishing_components/pull/4563))
 
 ## 49.0.0
 

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -134,7 +134,7 @@ ar:
       history: المحفوظات
       last_updated: التحديث الأخير
       part_of: جزء من
-      published: منشورة
+      published: تاريخ النشر
       see_all_updates: اطلع على كل التحديثات
     modal_dialogue:
       close_modal: إغلاق مربع الحوار المشروط


### PR DESCRIPTION
Correctly translate "Published" word to Arabic.

Before:
<img width="550" alt="Screenshot 2025-01-17 at 11 07 14" src="https://github.com/user-attachments/assets/1f2b0d74-5275-4fcd-88b4-af9db92730df" />


After:
<img width="554" alt="Screenshot 2025-01-17 at 11 07 20" src="https://github.com/user-attachments/assets/a1bb23af-f247-497d-ad6f-f1b05578553d" />


Trello card: https://trello.com/c/NkLPasOt/3166-fix-arabic-translation-in-government-frontend 
