### PR TITLE
Version 49.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 49.1.0
 
 * Use component wrapper on contextual breadcrumbs ([PR #4560](https://github.com/alphagov/govuk_publishing_components/pull/4560))
 * Use component wrapper on contextual sidebar ([PR #4561](https://github.com/alphagov/govuk_publishing_components/pull/4561))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (49.0.0)
+    govuk_publishing_components (49.1.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "49.0.0".freeze
+  VERSION = "49.1.0".freeze
 end


### PR DESCRIPTION
## 49.1.0

* Use component wrapper on contextual breadcrumbs ([PR #4560](https://github.com/alphagov/govuk_publishing_components/pull/4560))
* Use component wrapper on contextual sidebar ([PR #4561](https://github.com/alphagov/govuk_publishing_components/pull/4561))
* Correctly translate 'Published' word to Arabic ([PR #4563](https://github.com/alphagov/govuk_publishing_components/pull/4563))
* Style breadcrumbs in RTL (right-to-left) writing mode ([PR #4559](https://github.com/alphagov/govuk_publishing_components/pull/4559))
* Improve metadata component to support RTL print styles ([PR #4365](https://github.com/alphagov/govuk_publishing_components/pull/4365))
* Update organisation stylesheet ([PR #4565](https://github.com/alphagov/govuk_publishing_components/pull/4565))