### PR TITLE
Remove shared helper from button component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Remove shared helper from button component ([PR #4569](https://github.com/alphagov/govuk_publishing_components/pull/4569))
 * Remove shared helper from inset text component ([PR #4571](https://github.com/alphagov/govuk_publishing_components/pull/4571))
 * Use component wrapper on contextual footer ([PR #4562](https://github.com/alphagov/govuk_publishing_components/pull/4562))
 

--- a/app/views/govuk_publishing_components/components/_button.html.erb
+++ b/app/views/govuk_publishing_components/components/_button.html.erb
@@ -3,11 +3,8 @@
   disable_ga4 ||= false
 
   # button_helper.css_classes generates "gem-c-button"
-  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
-  local_assigns[:classes] = shared_helper.classes
   button = GovukPublishingComponents::Presenters::ButtonHelper.new(local_assigns)
 %>
-
 <% start_button_text = capture do %>
   <span>
     <%= button.text %>

--- a/lib/govuk_publishing_components/presenters/button_helper.rb
+++ b/lib/govuk_publishing_components/presenters/button_helper.rb
@@ -53,12 +53,18 @@ module GovukPublishingComponents
         @destructive = local_assigns[:destructive]
         @name = local_assigns[:name]
         @value = local_assigns[:value]
-        @classes = local_assigns[:classes]
         @aria_label = local_assigns[:aria_label]
         @info_text_id = "info-text-id-#{SecureRandom.hex(4)}"
         @button_id = "button-id-#{SecureRandom.hex(4)}"
         @aria_controls = local_assigns[:aria_controls]
         @aria_describedby = local_assigns[:aria_describedby]
+
+        if local_assigns.include?(:classes)
+          @classes = local_assigns[:classes].split(" ")
+          unless @classes.all? { |c| c.start_with?("js-") }
+            raise(ArgumentError, "Passed classes must be prefixed with `js-`")
+          end
+        end
       end
 
       def link?


### PR DESCRIPTION
## What
Remove the shared helper from the button component, and copy a little bit of the shared helper code (for adding additional classes) into the button helper, so no resulting change in functionality.

## Why
We want to remove some options from the shared helper (specifically `classes` and `margin_bottom`) and put them in the component wrapper helper. Button was still reliant on the shared helper for `classes` but it proved impractical to add the component wrapper helper to it to replace this functionality (see https://github.com/alphagov/govuk_publishing_components/pull/4543). Instead, copy a little bit of the shared helper code for `classes` into the button helper, and remove the shared helper from the component.

## Visual Changes
None.

Trello card: https://trello.com/c/Y0pDWbHw/390-move-some-shared-helper-options-into-component-wrapper