### PR TITLE
GA4 search tracker: Normalise initial value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Use component wrapper on contextual footer ([PR #4562](https://github.com/alphagov/govuk_publishing_components/pull/4562))
+* GA4 search tracker: normalise initial value ([PR #4570](https://github.com/alphagov/govuk_publishing_components/pull/4570))
 
 ## 49.1.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-search-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-search-tracker.js
@@ -22,7 +22,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         return
       }
 
-      this.initialKeywords = this.$searchInput.value
+      this.initialKeywords = this.searchTerm()
 
       if (window.GOVUK.getConsentCookie() && window.GOVUK.getConsentCookie().usage) {
         this.startModule()

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-search-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-search-tracker.spec.js
@@ -15,7 +15,7 @@ describe('Google Analytics search tracking', () => {
       data-ga4-search-index-section="19"
       data-ga4-search-index-section-count="89"
     >
-      <input type="search" name="keyword" value="initial value">
+      <input type="search" name="keyword" value=" iNiTiAl VaLuE ">
       <button type="submit">Search</button>
     </form>
   `


### PR DESCRIPTION
## What
In the search tracker, we do not want to fire the search event if the keyword(s) are unchanged.

The way we do this is by comparing the current value of the search field to its initial value, but there was a subtle bug: we normalised the current value on every check, but not the initial value when it was being set.

This changes the setting of the initial value from using the input's raw value to using the (existing) `searchTerm()` method which includes normalisation.

## Why
Making sure our analytics are more accurate 🙇 