### PR TITLE
Remove shared helper from inset text component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Remove shared helper from inset text component ([PR #4571](https://github.com/alphagov/govuk_publishing_components/pull/4571))
 * Use component wrapper on contextual footer ([PR #4562](https://github.com/alphagov/govuk_publishing_components/pull/4562))
 
 ## 49.1.0

--- a/app/views/govuk_publishing_components/components/_inset_text.html.erb
+++ b/app/views/govuk_publishing_components/components/_inset_text.html.erb
@@ -2,16 +2,10 @@
   add_gem_component_stylesheet("inset-text")
 
   id ||= "inset-text-#{SecureRandom.hex(4)}"
-  margin_top ||= 6
   local_assigns[:margin_bottom] ||= 6
-
-  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new({
-    margin_top: margin_top,
-  })
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-inset-text govuk-inset-text gem-c-force-print-link-styles-within")
-  component_helper.add_class(shared_helper.get_margin_top)
   component_helper.set_id(id)
 %>
 <%= tag.div(**component_helper.all_attributes) do %>

--- a/app/views/govuk_publishing_components/components/docs/inset_text.yml
+++ b/app/views/govuk_publishing_components/components/docs/inset_text.yml
@@ -19,9 +19,3 @@ examples:
           <h2 class="govuk-heading-m" id='heading'>To publish this step by step you need to</h2>
           <a class="govuk-link" href='/foo'>Check for broken links</a>
         </div>
-  with_custom_margins:
-    description: The component accepts a number for margin bottom from `0` to `9` (`0px` to `60px`) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to having margin of `6` (`30px`) top and bottom.
-    data:
-      text: "When a failure occurs, you must submit logbook, landing and transhipment data manually to the UK Fisheries Call Centre each day and by no later than 23.59 UTC"
-      margin_top: 0
-      margin_bottom: 9

--- a/spec/components/inset_text_spec.rb
+++ b/spec/components/inset_text_spec.rb
@@ -8,7 +8,7 @@ describe "Inset text", type: :view do
   it "renders inset text" do
     render_component(text: "It can take up to 8 weeks to register a lasting power of attorney if there are no mistakes in the application.")
 
-    assert_select(".govuk-inset-text.govuk-\\!-margin-top-6.govuk-\\!-margin-bottom-6", text: "It can take up to 8 weeks to register a lasting power of attorney if there are no mistakes in the application.")
+    assert_select(".govuk-inset-text.govuk-\\!-margin-bottom-6", text: "It can take up to 8 weeks to register a lasting power of attorney if there are no mistakes in the application.")
   end
 
   it "renders a block" do
@@ -30,13 +30,12 @@ describe "Inset text", type: :view do
     assert_select(".govuk-inset-text p#foo", false, "Block should not have rendered")
   end
 
-  it "applies custom margin bottom and top" do
+  it "applies custom margin bottom" do
     render_component(
       text: "margin!",
-      margin_top: 0,
       margin_bottom: 9,
     )
 
-    assert_select(".govuk-inset-text.govuk-\\!-margin-top-0.govuk-\\!-margin-bottom-9", text: "margin!")
+    assert_select(".govuk-inset-text.govuk-\\!-margin-bottom-9", text: "margin!")
   end
 end


### PR DESCRIPTION
## What
Remove the shared helper from the inset text component. Specifically, this removes the `margin_top` option from the component.

I've checked the 14 applications this component is used in and as far as I can tell none of them were using the `margin_top` option, so this seems safe to remove.

## Why
We're trying to move some options out of the shared helper and into the component wrapper helper, as well as doing some cleanup, specifically to standardise our components to only use margin bottom. Removing this option from this component gets us one step closer to that goal.

## Visual Changes
Inset text had a default top margin of Design System spacing 6 applied through the shared helper but also has the same top margin from the Design System component styles, so removing this makes no visual difference.

Trello card: https://trello.com/c/Y0pDWbHw/390-move-some-shared-helper-options-into-component-wrapper