### PR TITLE
Add component wrapper helper to textarea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* **BREAKING** Add component wrapper helper to textarea ([PR #4574](https://github.com/alphagov/govuk_publishing_components/pull/4574))
 * Remove margin top from print link ([PR #4577](https://github.com/alphagov/govuk_publishing_components/pull/4577))
 * **BREAKING** Use component wrapper on print link component  ([PR #4576](https://github.com/alphagov/govuk_publishing_components/pull/4576))
 * Refactor single page notification component ([PR #4501](https://github.com/alphagov/govuk_publishing_components/pull/4501))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_textarea.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_textarea.scss
@@ -5,7 +5,11 @@
   .govuk-textarea {
     margin-bottom: 0;
 
-    + .govuk-hint {
+    ~ .govuk-hint {
+      margin-top: govuk-spacing(1);
+    }
+
+    ~ .govuk-error-message {
       margin-top: govuk-spacing(1);
     }
   }

--- a/app/views/govuk_publishing_components/components/_character_count.html.erb
+++ b/app/views/govuk_publishing_components/components/_character_count.html.erb
@@ -1,9 +1,14 @@
 <%
+  add_gem_component_stylesheet("error-message")
+  add_gem_component_stylesheet("character-count")
+
   id ||= "character-count-#{SecureRandom.hex(4)}"
   maxlength ||= nil
   maxwords ||= nil
   threshold ||= nil
   textarea ||= {}
+
+  textarea[:textarea_id] = id
 %>
 <% if maxlength || maxwords %>
   <%= content_tag :div,
@@ -15,14 +20,10 @@
       threshold: threshold
     } do %>
 
-    <%= render "govuk_publishing_components/components/textarea", { id: id, character_count: true }.merge(textarea.symbolize_keys) %>
+    <%= render "govuk_publishing_components/components/textarea", { textarea_id: id, character_count: true, margin_bottom: 1 }.merge(textarea.symbolize_keys) %>
 
     <div id="<%= id %>-info" class="govuk-hint govuk-character-count__message">
       <%= t("components.character_count.body", number: maxlength || maxwords, type: maxwords ? t("components.character_count.type.words") : t("components.character_count.type.characters")) %>
     </div>
   <% end %>
 <% end %>
-<%
-  add_gem_component_stylesheet("error-message")
-  add_gem_component_stylesheet("character-count")
-%>

--- a/app/views/govuk_publishing_components/components/_textarea.html.erb
+++ b/app/views/govuk_publishing_components/components/_textarea.html.erb
@@ -1,7 +1,7 @@
 <%
   add_gem_component_stylesheet("textarea")
 
-  id ||= "textarea-#{SecureRandom.hex(4)}"
+  textarea_id ||= "textarea-#{SecureRandom.hex(4)}"
   value ||= nil
   rows ||= 5
   describedby ||= nil
@@ -11,7 +11,6 @@
   label ||= nil
   hint ||= nil
   local_assigns[:margin_bottom] ||= 6
-  local_assigns[:margin_bottom] = 6 if local_assigns[:margin_bottom] > 9
   error_message ||= nil
   error_items ||= []
   character_count ||= nil
@@ -22,14 +21,13 @@
   right_to_left ||= false
   right_to_left_help = right_to_left_help.nil? ? right_to_left : right_to_left_help
 
-  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("gem-c-textarea govuk-form-group")
+  component_helper.add_class("govuk-form-group--error") if has_error
 
-  css_classes = %w(govuk-textarea)
-  css_classes << "govuk-js-character-count" if character_count
-  css_classes << "govuk-textarea--error" if has_error
-  form_group_css_classes = %w(gem-c-textarea govuk-form-group)
-  form_group_css_classes << "govuk-form-group--error" if has_error
-  form_group_css_classes << shared_helper.get_margin_bottom
+  textarea_classes = %w(govuk-textarea)
+  textarea_classes << "govuk-js-character-count" if character_count
+  textarea_classes << "govuk-textarea--error" if has_error
 
   aria_described_by ||= nil
   if hint || has_error || describedby
@@ -40,11 +38,10 @@
     aria_described_by = aria_described_by.join(" ")
   end
 %>
-
-<%= content_tag :div, class: form_group_css_classes do %>
+<%= tag.div(**component_helper.all_attributes) do %>
   <% if label %>
     <%= render "govuk_publishing_components/components/label", {
-      html_for: id,
+      html_for: textarea_id,
       right_to_left: right_to_left_help
     }.merge(label.symbolize_keys) %>
   <% end %>
@@ -67,9 +64,9 @@
   <% end %>
 
   <%= tag.textarea name: name,
-    class: css_classes,
+    class: textarea_classes,
     dir: right_to_left ? "rtl" : nil,
-    id: id,
+    id: textarea_id,
     rows: rows,
     maxlength: maxlength,
     data: data,

--- a/app/views/govuk_publishing_components/components/docs/textarea.yml
+++ b/app/views/govuk_publishing_components/components/docs/textarea.yml
@@ -14,6 +14,7 @@ accessibility_criteria: |
   - have correctly associated labels
 
   Labels use the [label component](/component-guide/label).
+uses_component_wrapper_helper: true
 examples:
   default:
     data:
@@ -26,7 +27,7 @@ examples:
       label:
         text: "What is the nature of your medical emergency?"
       name: "emergency-name"
-      id: "emergency-id"
+      textarea_id: "emergency-id"
   with_margin_bottom:
     description: The component accepts a number for margin bottom from `0` to `9` (`0px` to `60px`) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to a margin bottom of 6 (30px).
     data:
@@ -102,7 +103,7 @@ examples:
         <%= component %>
       <% end %>
     data:
-      id: "contextual-guidance-id"
+      textarea_id: "contextual-guidance-id"
       label:
         text: "Title"
         bold: true

--- a/spec/components/character_count_spec.rb
+++ b/spec/components/character_count_spec.rb
@@ -9,38 +9,46 @@ describe "Character count", type: :view do
     assert_empty render_component({})
   end
 
-  it "renders character count with textarea" do
+  it "renders character count with minimal data passed" do
     render_component(
-      name: "character-count",
+      textarea: {
+        name: "more-details",
+      },
+      maxlength: "100",
+    )
+    assert_select ".govuk-character-count .govuk-textarea[name='more-details']"
+  end
+
+  it "renders character count with more options" do
+    render_component(
       textarea: {
         label: { text: "Can you provide more detail?" },
         name: "more-details",
       },
-      data: {
-        module: "character-count",
-      },
       maxlength: "100",
+      maxwords: "3",
+      threshold: "11",
     )
-
-    assert_select ".govuk-character-count .govuk-textarea"
-
+    assert_select ".gem-c-character-count[data-maxlength='100']"
+    assert_select ".gem-c-character-count[data-maxwords='3']"
+    assert_select ".gem-c-character-count[data-threshold='11']"
+    assert_select ".govuk-character-count .govuk-textarea[name='more-details']"
     assert_select ".govuk-character-count .govuk-label", text: "Can you provide more detail?"
   end
 
-  it "renders character count with data attributes" do
+  it "renders character count with the correct id for the textarea" do
     render_component(
-      name: "character-count",
       textarea: {
         label: { text: "Can you provide more detail?" },
         name: "more-details",
-      },
-      data: {
-        module: "character-count",
+        textarea_id: "textarea-element-id",
+        id: "textarea-component-id",
       },
       maxlength: "100",
+      id: "character-count-id",
     )
-
-    assert_select ".govuk-character-count[data-module='govuk-character-count']"
-    assert_select ".govuk-character-count[data-maxlength='100']"
+    assert_select "#textarea-component-id.gem-c-textarea"
+    assert_select "textarea#character-count-id"
+    assert_select "#textarea-element-id", false
   end
 end

--- a/spec/components/textarea_spec.rb
+++ b/spec/components/textarea_spec.rb
@@ -27,10 +27,12 @@ describe "Textarea", type: :view do
     render_component(
       label: { text: "Can you provide more detail?" },
       name: "more-details",
-      id: "this-id",
+      textarea_id: "this-id",
+      id: "component-id",
     )
 
-    assert_select "#this-id.govuk-textarea"
+    assert_select "#component-id.gem-c-textarea"
+    assert_select "textarea#this-id"
   end
 
   it "renders textarea with a custom number of rows" do
@@ -100,16 +102,6 @@ describe "Textarea", type: :view do
     )
 
     assert_select '.gem-c-textarea.govuk-\!-margin-bottom-4'
-  end
-
-  it "defaults to the initial bottom margin if an incorrect value is passed" do
-    render_component(
-      label: { text: "Can you provide more detail?" },
-      name: "with-fallback-margin-bottom",
-      margin_bottom: 12,
-    )
-
-    assert_select '.gem-c-textarea.govuk-\!-margin-bottom-6'
   end
 
   it "defaults to the initial bottom margin if no value is passed" do


### PR DESCRIPTION
## What
Apply the component wrapper helper to the textarea component.

- breaking change, renames `id` option to `textarea_id` as this is applied to a child element and `id` is applied to the parent by the component wrapper
- removes the shared helper, instead relying on the component wrapper helper to provide the same functionality for `margin_bottom`
- removes a bit of code that sets the margin back to normal if an invalid value is passed, but this outcome is now handled by the component wrapper

To deal with this breaking change, other PRs will need to be raised in applications as follows ahead of deployment.

- collections-publisher https://github.com/alphagov/collections-publisher/pull/2373
- content-publisher https://github.com/alphagov/content-publisher/pull/3295
- govspeak-preview https://github.com/alphagov/govspeak-preview/pull/604
- manuals-publisher https://github.com/alphagov/manuals-publisher/pull/2609
- places-manager uses textarea but doesn't pass `id`
- publisher https://github.com/alphagov/publisher/pull/2504
- release uses textarea but doesn't pass `id`
- search-admin https://github.com/alphagov/search-admin/pull/1342
- transition https://github.com/alphagov/transition/pull/1821
- travel-advice-publisher https://github.com/alphagov/travel-advice-publisher/pull/2121
- whitehall https://github.com/alphagov/whitehall/pull/9833

This change also impacts the character count component, which wraps the textarea component. The character count component accepts an `id` option, which is then passed to the textarea to be the id of the textarea element (not the component id). I've updated the component to explicitly pass this when it exists, because there was a corner case where passing an id as part of the textarea object overwrote the value of id passed directly to character count. Hopefully the tests clarify this behaviour (without causing a breaking change to the character count component).

## Why
The code for `margin_bottom` is moving from the shared helper to the component wrapper helper, so we need to remove any instance of this before the work can be completed. Additionally, having the component wrapper on a component helps reduce code and maintenance effort.

## Visual Changes
None.

Trello card: https://trello.com/c/GQ1p2oSC/438-not-doing-add-component-wrapper-helper-to-form-textarea-component
