### PR TITLE
Add configuration to "Add another"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * **BREAKING** Add global bar component from static ([PR #4538](https://github.com/alphagov/govuk_publishing_components/pull/4538))
 * Add custom padding to inverse header ([PR #4590](https://github.com/alphagov/govuk_publishing_components/pull/4590))
 * Add another: fix problem in createRemoveButtons method ([PR #11719](https://github.com/alphagov/govuk_publishing_components/pull/4586))
+* Add configuration to "Add another" ([PR #4575](https://github.com/alphagov/govuk_publishing_components/pull/4575))
 
 ## 50.0.1
 

--- a/app/assets/javascripts/govuk_publishing_components/components/add-another.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/add-another.js
@@ -67,10 +67,12 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         legend.textContent = this.module.dataset.fieldsetLegend + ' ' + (index + 1)
       }.bind(this))
 
-    this.module.querySelector('.js-add-another__remove-button').classList.toggle(
-      'js-add-another__remove-button--hidden',
-      this.module.querySelectorAll('.js-add-another__fieldset:not([hidden])').length === 1
-    )
+    if (this.module.dataset.emptyFields === 'false') {
+      this.module.querySelector('.js-add-another__remove-button').classList.toggle(
+        'js-add-another__remove-button--hidden',
+        this.module.querySelectorAll('.js-add-another__fieldset:not([hidden])').length === 1
+      )
+    }
   }
 
   AddAnother.prototype.addNewFieldset = function (event) {

--- a/app/views/govuk_publishing_components/components/_add_another.html.erb
+++ b/app/views/govuk_publishing_components/components/_add_another.html.erb
@@ -4,19 +4,27 @@
   empty ||= ""
   fieldset_legend ||= ""
   add_button_text ||= "Add another"
+  empty_fields ||= false
 %>
 
-<div data-module="add-another" class="gem-c-add-another" data-add-button-text="<%= add_button_text %>" data-fieldset-legend="<%= fieldset_legend %>">
-  <% items.each_with_index do |item, index| %>
-    <%= render "govuk_publishing_components/components/fieldset", {
-      classes: "js-add-another__fieldset",
-      legend_text: "#{fieldset_legend} #{index + 1}",
-      heading_size: "m"
-    } do %>
-      <div class="js-add-another__destroy-checkbox">
-        <%= item[:destroy_checkbox] %>
-      </div>
-      <%= item[:fields] %>
+<%= tag.div class: "gem-c-add-another", data: {
+  module: "add-another",
+  "add-button-text": add_button_text,
+  "fieldset-legend": fieldset_legend,
+  "empty-fields": empty_fields
+} do %>
+  <% unless empty_fields && items.count == 0 %>
+    <% items.each_with_index do |item, index| %>
+      <%= render "govuk_publishing_components/components/fieldset", {
+        classes: "js-add-another__fieldset",
+        legend_text: "#{fieldset_legend} #{index + 1}",
+        heading_size: "m"
+      } do %>
+        <div class="js-add-another__destroy-checkbox">
+          <%= item[:destroy_checkbox] %>
+        </div>
+        <%= item[:fields] %>
+      <% end %>
     <% end %>
   <% end %>
   <%= render "govuk_publishing_components/components/fieldset", {
@@ -26,4 +34,4 @@
   } do %>
     <%= empty %>
   <% end %>
-</div>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/add_another.yml
+++ b/app/views/govuk_publishing_components/components/docs/add_another.yml
@@ -46,3 +46,15 @@ examples:
           <label for="person_1_name" class="gem-c-label govuk-label">Full name</label>
           <input class="gem-c-input govuk-input" id="person_1_name" name="person[1]name">
         </div>
+  start_empty:
+    description: By default no form fields are displayed when the component loads if no content is specified
+    data:
+      fieldset_legend: "Employee"
+      add_button_text: "Add an employee"
+      empty_fields: true
+      items: null
+      empty:
+        <div class="govuk-form-group">
+          <label for="employee_1_name" class="gem-c-label govuk-label">Full name</label>
+          <input class="gem-c-input govuk-input" id="employee_1_name" name="employee[1]name">
+        </div>

--- a/spec/components/add_another_spec.rb
+++ b/spec/components/add_another_spec.rb
@@ -5,44 +5,74 @@ describe "Add another", type: :view do
     "add_another"
   end
 
-  def default_items
-    [
-      {
-        fields: sanitize("<div class=\"item1\">item1</div>"),
-        destroy_checkbox: sanitize("<input type=\"checkbox\" />"),
-      },
-      {
-        fields: sanitize("<div class=\"item2\">item2</div>"),
-        destroy_checkbox: sanitize("<input type=\"checkbox\" />"),
-      },
-    ]
+  describe "Default" do
+    def default_items
+      [
+        {
+          fields: sanitize("<div class=\"item1\">item1</div>"),
+          destroy_checkbox: sanitize("<input type=\"checkbox\" />"),
+        },
+        {
+          fields: sanitize("<div class=\"item2\">item2</div>"),
+          destroy_checkbox: sanitize("<input type=\"checkbox\" />"),
+        },
+      ]
+    end
+
+    it "renders a wrapper element" do
+      render_component(items: default_items)
+
+      assert_select "div.gem-c-add-another[data-module='add-another'][data-empty-fields='false']"
+    end
+
+    it "renders the items provided" do
+      empty = ""
+      render_component({ items: default_items, empty: })
+
+      assert_select "div.js-add-another__fieldset .item1"
+      assert_select "div.js-add-another__fieldset .item2"
+    end
+
+    it "renders a destroy checkbox for each item" do
+      empty = ""
+      render_component({ items: default_items, empty: })
+
+      assert_select "div.js-add-another__fieldset .js-add-another__destroy-checkbox", count: 2
+    end
+
+    it "renders the empty item" do
+      empty = sanitize("<div class=\"empty\">empty</div>")
+      render_component({ items: default_items, empty: })
+
+      assert_select ".js-add-another__empty div.empty"
+    end
   end
 
-  it "renders a wrapper element" do
-    render_component(items: default_items)
+  describe "Start empty" do
+    def empty_items
+      []
+    end
 
-    assert_select "div.gem-c-add-another[data-module='add-another']"
-  end
+    it "renders a wrapper element" do
+      render_component({ items: empty_items, empty_fields: true })
 
-  it "renders the items provided" do
-    empty = ""
-    render_component({ items: default_items, empty: })
+      assert_select "div.gem-c-add-another[data-module='add-another'][data-empty-fields='true']"
+    end
 
-    assert_select "div.js-add-another__fieldset .item1"
-    assert_select "div.js-add-another__fieldset .item2"
-  end
+    it "renders only the empty item provided" do
+      empty = sanitize("<div class=\"empty\">empty</div>")
+      render_component({ items: empty_items, empty:, empty_fields: true })
 
-  it "renders a destroy checkbox for each item" do
-    empty = ""
-    render_component({ items: default_items, empty: })
+      assert_select ".js-add-another__empty div.empty"
+      assert_select "div.js-add-another__fieldset .item1", false
+      assert_select "div.js-add-another__fieldset .item2", false
+    end
 
-    assert_select "div.js-add-another__fieldset .js-add-another__destroy-checkbox", count: 2
-  end
+    it "does not render a destroy checkbox" do
+      empty = sanitize("<div class=\"empty\">empty</div>")
+      render_component({ items: empty_items, empty: })
 
-  it "renders the empty item" do
-    empty = sanitize("<div class=\"empty\">empty</div>")
-    render_component({ items: default_items, empty: })
-
-    assert_select ".js-add-another__empty div.empty"
+      assert_select ".js-add-another__destroy-checkbox", count: 0
+    end
   end
 end

--- a/spec/javascripts/components/add-another-spec.js
+++ b/spec/javascripts/components/add-another-spec.js
@@ -3,228 +3,300 @@
 describe('GOVUK.Modules.AddAnother', function () {
   var fixture, addAnother, addButton, fieldset, fieldset0, fieldset1, fieldset2, fieldset3
 
-  beforeEach(function () {
-    fixture = document.createElement('form')
-    fixture.setAttribute('data-module', 'AddAnother')
-    fixture.setAttribute('data-fieldset-legend', 'Thing')
-    fixture.setAttribute('data-add-button-text', 'Add another thing')
-    fixture.innerHTML = `
-      <div>
-        <div class="js-add-another__fieldset">
-          <fieldset>
-            <legend>Thing 1</legend>
-            <input type="hidden" name="test[0][id]" value="test_id" />
-            <label for="test_0_foo">Foo</label>
-            <input type="text" id="test_0_foo" name="test[0][foo]" value="test foo" />
-            <label for="test_0_bar"></label>
-            <textarea id="test_0_bar" name="test[0][bar]">test bar</textarea>
-            <label for="test_0__destroy">Delete</label>
-            <div class="js-add-another__destroy-checkbox">
-              <input type="checkbox" id="test_0_destroy" name="test[0][_destroy]" />
-            </div>
-          </fieldset>
+  describe('One fieldset is rendered', function () {
+    beforeEach(function () {
+      fixture = document.createElement('form')
+      fixture.setAttribute('data-module', 'AddAnother')
+      fixture.setAttribute('data-fieldset-legend', 'Thing')
+      fixture.setAttribute('data-add-button-text', 'Add another thing')
+      fixture.innerHTML = `
+        <div>
+          <div class="js-add-another__fieldset">
+            <fieldset>
+              <legend>Thing 1</legend>
+              <input type="hidden" name="test[0][id]" value="test_id" />
+              <label for="test_0_foo">Foo</label>
+              <input type="text" id="test_0_foo" name="test[0][foo]" value="test foo" />
+              <label for="test_0_bar"></label>
+              <textarea id="test_0_bar" name="test[0][bar]">test bar</textarea>
+              <label for="test_0__destroy">Delete</label>
+              <div class="js-add-another__destroy-checkbox">
+                <input type="checkbox" id="test_0_destroy" name="test[0][_destroy]" />
+              </div>
+            </fieldset>
+          </div>
+          <div class="js-add-another__empty">
+            <fieldset>
+              <legend>Thing 2</legend>
+              <input type="hidden" name="test[1][id]" value="test_id" />
+              <label for="test_1_foo">Foo</label>
+              <input type="text" id="test_1_foo" name="test[1][foo]" value="" />
+              <label for="test_1_bar"></label>
+              <textarea id="test_1_bar" name="test[1][bar]"></textarea>
+              <label for="test_1__destroy">Delete</label>
+            </fieldset>
+          </div>
         </div>
-        <div class="js-add-another__fieldset">
-          <fieldset>
-            <legend>Thing 2</legend>
-            <input type="hidden" name="test[1][id]" value="test_id" />
-            <label for="test_1_foo">Foo</label>
-            <input type="text" id="test_1_foo" name="test[1][foo]" value="test foo" />
-            <label for="test_1_bar"></label>
-            <textarea id="test_1_bar" name="test[1][bar]">test bar</textarea>
-            <label for="test_1__destroy">Delete</label>
-            <div class="js-add-another__destroy-checkbox">
-              <input type="checkbox" id="test_1_destroy" name="test[1][_destroy]" />
-            </div>
-          </fieldset>
-        </div>
-        <div class="js-add-another__empty">
-          <fieldset>
-            <legend>Thing 3</legend>
-            <input type="hidden" name="test[2][id]" value="test_id" />
-            <label for="test_2_foo">Foo</label>
-            <input type="text" id="test_2_foo" name="test[2][foo]" value="" />
-            <label for="test_2_bar"></label>
-            <textarea id="test_2_bar" name="test[2][bar]"></textarea>
-            <label for="test_2__destroy">Delete</label>
-          </fieldset>
-        </div>
-      </div>
-    `
-    document.body.append(fixture)
+      `
+      document.body.append(fixture)
 
-    addAnother = new GOVUK.Modules.AddAnother(fixture)
-    addAnother.init()
+      addAnother = new GOVUK.Modules.AddAnother(fixture)
+      addButton = document.querySelector('.js-add-another__add-button')
+    })
 
-    addButton = document.querySelector('.js-add-another__add-button')
-  })
+    afterEach(function () {
+      document.body.removeChild(fixture)
+    })
 
-  afterEach(function () {
-    document.body.removeChild(fixture)
-  })
+    it('should add a hidden "Remove" button to the fieldset when the component is initialised with `empty_fields` set to false', function () {
+      fixture.setAttribute('data-empty-fields', 'false')
+      addAnother.init()
 
-  it('should add an "Add" button to the container when the component is initialised', function () {
-    expect(addButton).toBeTruthy()
-    expect(addButton.textContent).toBe('Add another thing')
-  })
+      var removeButtons = document.querySelectorAll('.js-add-another__remove-button')
 
-  it('should add a "Remove" button to each repeated fieldset when the component is initialised', function () {
-    var removeButtons = document.querySelectorAll('.js-add-another__remove-button')
-    expect(removeButtons).toHaveSize(2)
-    expect(removeButtons[0].textContent).toBe('Delete')
-  })
+      expect(removeButtons).toHaveSize(1)
+      expect(removeButtons[0].textContent).toBe('Delete')
+      expect(removeButtons[0].classList.contains('js-add-another__remove-button--hidden')).toBe(true)
+    })
 
-  it('should hide the destroy checkbox for each repeated fieldset when the component is initialised', function () {
-    var destroyCheckboxes = document.querySelectorAll('.js-add-another__destroy-checkbox')
-    destroyCheckboxes.forEach(function (checkbox) {
-      expect(checkbox).toBeHidden()
+    it('should add a visible "Remove" button to the fieldset when the component is initialised with `empty_fields` set to true', function () {
+      fixture.setAttribute('data-empty-fields', 'true')
+      addAnother.init()
+
+      var removeButtons = document.querySelectorAll('.js-add-another__remove-button')
+
+      expect(removeButtons).toHaveSize(1)
+      expect(removeButtons[0].textContent).toBe('Delete')
+      expect(removeButtons[0].classList.contains('js-add-another__remove-button--hidden')).toBe(false)
     })
   })
 
-  it('should remove the empty fieldset when the component is initialised', function () {
-    expect(document.querySelectorAll('.js-add-another__empty')).toHaveSize(0)
-  })
+  describe('Two fieldsets are rendered', function () {
+    beforeEach(function () {
+      fixture = document.createElement('form')
+      fixture.setAttribute('data-module', 'AddAnother')
+      fixture.setAttribute('data-fieldset-legend', 'Thing')
+      fixture.setAttribute('data-add-button-text', 'Add another thing')
+      fixture.innerHTML = `
+        <div>
+          <div class="js-add-another__fieldset">
+            <fieldset>
+              <legend>Thing 1</legend>
+              <input type="hidden" name="test[0][id]" value="test_id" />
+              <label for="test_0_foo">Foo</label>
+              <input type="text" id="test_0_foo" name="test[0][foo]" value="test foo" />
+              <label for="test_0_bar"></label>
+              <textarea id="test_0_bar" name="test[0][bar]">test bar</textarea>
+              <label for="test_0__destroy">Delete</label>
+              <div class="js-add-another__destroy-checkbox">
+                <input type="checkbox" id="test_0_destroy" name="test[0][_destroy]" />
+              </div>
+            </fieldset>
+          </div>
+          <div class="js-add-another__fieldset">
+            <fieldset>
+              <legend>Thing 2</legend>
+              <input type="hidden" name="test[1][id]" value="test_id" />
+              <label for="test_1_foo">Foo</label>
+              <input type="text" id="test_1_foo" name="test[1][foo]" value="test foo" />
+              <label for="test_1_bar"></label>
+              <textarea id="test_1_bar" name="test[1][bar]">test bar</textarea>
+              <label for="test_1__destroy">Delete</label>
+              <div class="js-add-another__destroy-checkbox">
+                <input type="checkbox" id="test_1_destroy" name="test[1][_destroy]" />
+              </div>
+            </fieldset>
+          </div>
+          <div class="js-add-another__empty">
+            <fieldset>
+              <legend>Thing 3</legend>
+              <input type="hidden" name="test[2][id]" value="test_id" />
+              <label for="test_2_foo">Foo</label>
+              <input type="text" id="test_2_foo" name="test[2][foo]" value="" />
+              <label for="test_2_bar"></label>
+              <textarea id="test_2_bar" name="test[2][bar]"></textarea>
+              <label for="test_2__destroy">Delete</label>
+            </fieldset>
+          </div>
+        </div>
+      `
+      document.body.append(fixture)
 
-  it('should add new fields with the correct values when the "Add" button is clicked', function () {
-    window.GOVUK.triggerEvent(addButton, 'click')
+      addAnother = new GOVUK.Modules.AddAnother(fixture)
+      addAnother.init()
 
-    fieldset0 = document.querySelectorAll('.js-add-another__fieldset')[0]
-    fieldset2 = document.querySelectorAll('.js-add-another__fieldset')[2]
+      addButton = document.querySelector('.js-add-another__add-button')
+    })
 
-    expect(document.querySelectorAll('.js-add-another__fieldset').length).toBe(3)
-    expect(fieldset0.querySelector('input[type="hidden"]').value).toBe('test_id')
-    expect(fieldset0.querySelector('input[type="text"]').value).toBe('test foo')
-    expect(fieldset2.querySelector('input[type="text"]').value).toBe('')
-    expect(fieldset0.querySelector('textarea').value).toBe('test bar')
-    expect(fieldset2.querySelector('textarea').value).toBe('')
-    expect(fieldset0.querySelector('legend').textContent).toBe('Thing 1')
-    expect(fieldset2.querySelector('legend').textContent).toBe('Thing 3')
-  })
+    afterEach(function () {
+      document.body.removeChild(fixture)
+    })
 
-  it('should move focus to the first relevant field in the new set when the "Add" button is clicked', function () {
-    window.GOVUK.triggerEvent(addButton, 'click')
+    it('should add an "Add" button to the container when the component is initialised', function () {
+      expect(addButton).toBeTruthy()
+      expect(addButton.textContent).toBe('Add another thing')
+    })
 
-    expect(document.activeElement).toBe(
-      document.querySelector('input[name="test[2][foo]"]')
-    )
-  })
+    it('should add hidden "Remove" buttons to each repeated fieldset when the component is initialised', function () {
+      var removeButtons = document.querySelectorAll('.js-add-another__remove-button')
+      expect(removeButtons).toHaveSize(2)
+      expect(removeButtons[0].textContent).toBe('Delete')
+      expect(removeButtons[0].classList.contains('js-add-another__remove-button--hidden')).toBe(false)
+      expect(removeButtons[1].classList.contains('js-add-another__remove-button--hidden')).toBe(false)
+    })
 
-  it('should increment the id/name/for values of the added fields', function () {
-    window.GOVUK.triggerEvent(addButton, 'click')
-    window.GOVUK.triggerEvent(addButton, 'click')
+    it('should hide the destroy checkbox for each repeated fieldset when the component is initialised', function () {
+      var destroyCheckboxes = document.querySelectorAll('.js-add-another__destroy-checkbox')
+      destroyCheckboxes.forEach(function (checkbox) {
+        expect(checkbox).toBeHidden()
+      })
+    })
 
-    fieldset1 = document.querySelectorAll('.js-add-another__fieldset')[1]
-    fieldset2 = document.querySelectorAll('.js-add-another__fieldset')[2]
-    fieldset3 = document.querySelectorAll('.js-add-another__fieldset')[3]
+    it('should remove the empty fieldset when the component is initialised', function () {
+      expect(document.querySelectorAll('.js-add-another__empty')).toHaveSize(0)
+    })
 
-    expect(
-      fieldset1.querySelector('input[type="hidden"]').getAttribute('name')
-    ).toBe('test[1][id]')
-    expect(
-      fieldset2.querySelector('input[type="hidden"]').getAttribute('name')
-    ).toBe('test[2][id]')
-    expect(
-      fieldset3.querySelector('input[type="hidden"]').getAttribute('name')
-    ).toBe('test[3][id]')
-    expect(fieldset1.querySelectorAll('label')[0].getAttribute('for')).toBe(
-      'test_1_foo'
-    )
-    expect(fieldset2.querySelectorAll('label')[0].getAttribute('for')).toBe(
-      'test_2_foo'
-    )
-    expect(fieldset3.querySelectorAll('label')[0].getAttribute('for')).toBe(
-      'test_3_foo'
-    )
-    expect(fieldset1.querySelector('input[type="text"]').getAttribute('id')).toBe(
-      'test_1_foo'
-    )
-    expect(fieldset2.querySelector('input[type="text"]').getAttribute('id')).toBe(
-      'test_2_foo'
-    )
-    expect(fieldset3.querySelector('input[type="text"]').getAttribute('id')).toBe(
-      'test_3_foo'
-    )
-    expect(
-      fieldset1.querySelector('input[type="text"]').getAttribute('name')
-    ).toBe('test[1][foo]')
-    expect(
-      fieldset2.querySelector('input[type="text"]').getAttribute('name')
-    ).toBe('test[2][foo]')
-    expect(
-      fieldset3.querySelector('input[type="text"]').getAttribute('name')
-    ).toBe('test[3][foo]')
-    expect(fieldset1.querySelectorAll('label')[1].getAttribute('for')).toBe(
-      'test_1_bar'
-    )
-    expect(fieldset2.querySelectorAll('label')[1].getAttribute('for')).toBe(
-      'test_2_bar'
-    )
-    expect(fieldset3.querySelectorAll('label')[1].getAttribute('for')).toBe(
-      'test_3_bar'
-    )
-    expect(fieldset1.querySelector('textarea').getAttribute('id')).toBe('test_1_bar')
-    expect(fieldset2.querySelector('textarea').getAttribute('id')).toBe('test_2_bar')
-    expect(fieldset3.querySelector('textarea').getAttribute('id')).toBe('test_3_bar')
-    expect(fieldset1.querySelector('textarea').getAttribute('name')).toBe(
-      'test[1][bar]'
-    )
-    expect(fieldset2.querySelector('textarea').getAttribute('name')).toBe(
-      'test[2][bar]'
-    )
-    expect(fieldset3.querySelector('textarea').getAttribute('name')).toBe(
-      'test[3][bar]'
-    )
-  })
+    it('should add new fields with the correct values when the "Add" button is clicked', function () {
+      window.GOVUK.triggerEvent(addButton, 'click')
 
-  it('should hide and check the destroy checkbox for an existing field when its "Remove" button is clicked', function () {
-    fieldset = document.querySelector('.js-add-another__fieldset')
+      fieldset0 = document.querySelectorAll('.js-add-another__fieldset')[0]
+      fieldset2 = document.querySelectorAll('.js-add-another__fieldset')[2]
 
-    var removeButton = fieldset.querySelector('.js-add-another__remove-button')
-    window.GOVUK.triggerEvent(removeButton, 'click')
+      expect(document.querySelectorAll('.js-add-another__fieldset').length).toBe(3)
+      expect(fieldset0.querySelector('input[type="hidden"]').value).toBe('test_id')
+      expect(fieldset0.querySelector('input[type="text"]').value).toBe('test foo')
+      expect(fieldset2.querySelector('input[type="text"]').value).toBe('')
+      expect(fieldset0.querySelector('textarea').value).toBe('test bar')
+      expect(fieldset2.querySelector('textarea').value).toBe('')
+      expect(fieldset0.querySelector('legend').textContent).toBe('Thing 1')
+      expect(fieldset2.querySelector('legend').textContent).toBe('Thing 3')
+    })
 
-    var destroyCheckbox = fieldset.querySelector('.js-add-another__destroy-checkbox input')
-    expect(destroyCheckbox).toBeTruthy()
-    expect(fieldset).toBeHidden()
-  })
+    it('should move focus to the first relevant field in the new set when the "Add" button is clicked', function () {
+      window.GOVUK.triggerEvent(addButton, 'click')
 
-  it('should remove a new fieldset when its "Remove" button is clicked', function () {
-    window.GOVUK.triggerEvent(addButton, 'click')
+      expect(document.activeElement).toBe(
+        document.querySelector('input[name="test[2][foo]"]')
+      )
+    })
 
-    fieldset = document.querySelectorAll('.js-add-another__fieldset')[2]
+    it('should increment the id/name/for values of the added fields', function () {
+      window.GOVUK.triggerEvent(addButton, 'click')
+      window.GOVUK.triggerEvent(addButton, 'click')
 
-    var removeButton = fieldset.querySelector('.js-add-another__remove-button')
-    window.GOVUK.triggerEvent(removeButton, 'click')
+      fieldset1 = document.querySelectorAll('.js-add-another__fieldset')[1]
+      fieldset2 = document.querySelectorAll('.js-add-another__fieldset')[2]
+      fieldset3 = document.querySelectorAll('.js-add-another__fieldset')[3]
 
-    expect(document.querySelectorAll('.js-add-another__fieldset').length).toBe(2)
-  })
+      expect(
+        fieldset1.querySelector('input[type="hidden"]').getAttribute('name')
+      ).toBe('test[1][id]')
+      expect(
+        fieldset2.querySelector('input[type="hidden"]').getAttribute('name')
+      ).toBe('test[2][id]')
+      expect(
+        fieldset3.querySelector('input[type="hidden"]').getAttribute('name')
+      ).toBe('test[3][id]')
+      expect(fieldset1.querySelectorAll('label')[0].getAttribute('for')).toBe(
+        'test_1_foo'
+      )
+      expect(fieldset2.querySelectorAll('label')[0].getAttribute('for')).toBe(
+        'test_2_foo'
+      )
+      expect(fieldset3.querySelectorAll('label')[0].getAttribute('for')).toBe(
+        'test_3_foo'
+      )
+      expect(fieldset1.querySelector('input[type="text"]').getAttribute('id')).toBe(
+        'test_1_foo'
+      )
+      expect(fieldset2.querySelector('input[type="text"]').getAttribute('id')).toBe(
+        'test_2_foo'
+      )
+      expect(fieldset3.querySelector('input[type="text"]').getAttribute('id')).toBe(
+        'test_3_foo'
+      )
+      expect(
+        fieldset1.querySelector('input[type="text"]').getAttribute('name')
+      ).toBe('test[1][foo]')
+      expect(
+        fieldset2.querySelector('input[type="text"]').getAttribute('name')
+      ).toBe('test[2][foo]')
+      expect(
+        fieldset3.querySelector('input[type="text"]').getAttribute('name')
+      ).toBe('test[3][foo]')
+      expect(fieldset1.querySelectorAll('label')[1].getAttribute('for')).toBe(
+        'test_1_bar'
+      )
+      expect(fieldset2.querySelectorAll('label')[1].getAttribute('for')).toBe(
+        'test_2_bar'
+      )
+      expect(fieldset3.querySelectorAll('label')[1].getAttribute('for')).toBe(
+        'test_3_bar'
+      )
+      expect(fieldset1.querySelector('textarea').getAttribute('id')).toBe('test_1_bar')
+      expect(fieldset2.querySelector('textarea').getAttribute('id')).toBe('test_2_bar')
+      expect(fieldset3.querySelector('textarea').getAttribute('id')).toBe('test_3_bar')
+      expect(fieldset1.querySelector('textarea').getAttribute('name')).toBe(
+        'test[1][bar]'
+      )
+      expect(fieldset2.querySelector('textarea').getAttribute('name')).toBe(
+        'test[2][bar]'
+      )
+      expect(fieldset3.querySelector('textarea').getAttribute('name')).toBe(
+        'test[3][bar]'
+      )
+    })
 
-  it('should update the fieldset legends when an entry is removed', function () {
-    window.GOVUK.triggerEvent(addButton, 'click')
+    it('should hide and check the destroy checkbox for an existing field when its "Remove" button is clicked', function () {
+      fieldset = document.querySelector('.js-add-another__fieldset')
 
-    fieldset0 = document.querySelector('.js-add-another__fieldset')
-    fieldset1 = document.querySelectorAll('.js-add-another__fieldset')[1]
-    fieldset2 = document.querySelectorAll('.js-add-another__fieldset')[2]
+      var removeButton = fieldset.querySelector('.js-add-another__remove-button')
+      window.GOVUK.triggerEvent(removeButton, 'click')
 
-    expect(fieldset0.querySelector('legend').textContent).toBe('Thing 1')
-    expect(fieldset1.querySelector('legend').textContent).toBe('Thing 2')
-    expect(fieldset2.querySelector('legend').textContent).toBe('Thing 3')
+      var destroyCheckbox = fieldset.querySelector('.js-add-another__destroy-checkbox input')
+      expect(destroyCheckbox).toBeTruthy()
+      expect(fieldset).toBeHidden()
+    })
 
-    var removeButton = fieldset0.querySelector('.js-add-another__remove-button')
-    window.GOVUK.triggerEvent(removeButton, 'click')
+    it('should remove a new fieldset when its "Remove" button is clicked', function () {
+      window.GOVUK.triggerEvent(addButton, 'click')
 
-    expect(fieldset1.querySelector('legend').textContent).toBe('Thing 1')
-    expect(fieldset2.querySelector('legend').textContent).toBe('Thing 2')
-  })
+      fieldset = document.querySelectorAll('.js-add-another__fieldset')[2]
 
-  it('should move focus to the add another button when any "Remove" button is clicked', function () {
-    window.GOVUK.triggerEvent(addButton, 'click')
-    window.GOVUK.triggerEvent(addButton, 'click')
+      var removeButton = fieldset.querySelector('.js-add-another__remove-button')
+      window.GOVUK.triggerEvent(removeButton, 'click')
 
-    var removeButton = document.querySelectorAll('.js-add-another__remove-button')[0]
-    window.GOVUK.triggerEvent(removeButton, 'click')
+      expect(document.querySelectorAll('.js-add-another__fieldset').length).toBe(2)
+    })
 
-    expect(document.activeElement).toBe(
-      document.querySelector('.js-add-another__add-button')
-    )
+    it('should update the fieldset legends when an entry is removed', function () {
+      window.GOVUK.triggerEvent(addButton, 'click')
+
+      fieldset0 = document.querySelector('.js-add-another__fieldset')
+      fieldset1 = document.querySelectorAll('.js-add-another__fieldset')[1]
+      fieldset2 = document.querySelectorAll('.js-add-another__fieldset')[2]
+
+      expect(fieldset0.querySelector('legend').textContent).toBe('Thing 1')
+      expect(fieldset1.querySelector('legend').textContent).toBe('Thing 2')
+      expect(fieldset2.querySelector('legend').textContent).toBe('Thing 3')
+
+      var removeButton = fieldset0.querySelector('.js-add-another__remove-button')
+      window.GOVUK.triggerEvent(removeButton, 'click')
+
+      expect(fieldset1.querySelector('legend').textContent).toBe('Thing 1')
+      expect(fieldset2.querySelector('legend').textContent).toBe('Thing 2')
+    })
+
+    it('should move focus to the add another button when any "Remove" button is clicked', function () {
+      window.GOVUK.triggerEvent(addButton, 'click')
+      window.GOVUK.triggerEvent(addButton, 'click')
+
+      var removeButton = document.querySelectorAll('.js-add-another__remove-button')[0]
+      window.GOVUK.triggerEvent(removeButton, 'click')
+
+      expect(document.activeElement).toBe(
+        document.querySelector('.js-add-another__add-button')
+      )
+    })
   })
 })


### PR DESCRIPTION
## What
[Publishing Components Issue #4564](https://github.com/alphagov/govuk_publishing_components/issues/4564)

This adds some configuration to the ["Add another" component](https://components.publishing.service.gov.uk/component-guide/add_another) so that authors can choose how the component displays by default when it is rendered on a page and no content is provided to it.

<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
The current default behaviour of the "Add another" component when it loads is to:
- display empty form fields where no content is provided
- not display a “Delete” button where a single instance of content is provided

There is a need to customise this behaviour for these scenarios when it is implemented on the Mainstream publisher app so that:
- no empty fields are displayed where no content is provided
- a "Delete" button is displayed where a single instance of content is provided

## Visual Changes
The screenshots below show the component implemented on Mainstream Publisher as it currently displays and how it is displayed with these changes. 

||Before|After|
|-|-|-|
|On load|![Screenshot 2025-01-24 at 09 59 50](https://github.com/user-attachments/assets/b9e2b5b6-7691-4592-9f20-8e608123e1ef)|![Screenshot 2025-01-24 at 09 51 18](https://github.com/user-attachments/assets/1c10524c-a1d3-48a2-9d45-c0f1d6561031)|
|"Add another link" clicked||![Screenshot 2025-01-24 at 09 51 09](https://github.com/user-attachments/assets/bd66cee6-b01b-4f31-b6cb-041a8b56a7de)|

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

<!-- ### Before


### After -->
