### PR TITLE
BREAKING Use component wrapper on print link component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* **BREAKING** Use component wrapper on print link component  ([PR #4576](https://github.com/alphagov/govuk_publishing_components/pull/4576))
 * Refactor single page notification component ([PR #4501](https://github.com/alphagov/govuk_publishing_components/pull/4501))
 * Remove shared helper from button component ([PR #4569](https://github.com/alphagov/govuk_publishing_components/pull/4569))
 * Remove shared helper from inset text component ([PR #4571](https://github.com/alphagov/govuk_publishing_components/pull/4571))

--- a/app/views/govuk_publishing_components/components/_print_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_print_link.html.erb
@@ -3,41 +3,40 @@
 
   text ||= t('components.print_link.text')
   href ||= nil
-  data_attributes ||= {}
+  child_data_attributes ||= {}
   require_js ||= href.nil?
   margin_top ||= 3
-  margin_bottom ||= 3
+  local_assigns[:margin_bottom] ||= 3
 
-  ((data_attributes[:module] ||= "") << " " << (require_js ? "print-link" : "button")).strip!
+  ((child_data_attributes[:module] ||= "") << " " << (require_js ? "print-link" : "button")).strip!
 
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new({
     margin_top: margin_top,
-    margin_bottom: margin_bottom
   })
 
-  wrapper_classes = %w(gem-c-print-link govuk-!-display-none-print)
-  wrapper_classes << "gem-c-print-link--show-without-js" unless require_js
-  wrapper_classes << shared_helper.get_margin_top
-  wrapper_classes << shared_helper.get_margin_bottom
+  child_classes = %w[govuk-link]
+  child_classes << "govuk-body-s gem-c-print-link__button" if href.nil?
+  child_classes << "gem-c-print-link__link govuk-link--no-visited-state" if href.present?
 
-  classes = %w[govuk-link]
-  classes << "govuk-body-s gem-c-print-link__button" if href.nil?
-  classes << "gem-c-print-link__link govuk-link--no-visited-state" if href.present?
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("gem-c-print-link govuk-!-display-none-print")
+  component_helper.add_class("gem-c-print-link--show-without-js") unless require_js
+  component_helper.add_class(shared_helper.get_margin_top)
 %>
 
-<%= tag.div class: wrapper_classes do %>
+<%= tag.div(**component_helper.all_attributes) do %>
   <% if require_js %>
     <%= content_tag(:button, text, {
-        class: classes,
-        data: data_attributes
+        class: child_classes,
+        data: child_data_attributes
     }) %>
   <% else %>
     <%= link_to(
       text,
       href,
-      class: classes,
+      class: child_classes,
       rel: "alternate",
-      data: data_attributes,
+      data: child_data_attributes,
       role: "button"
     ) %>
   <% end %>

--- a/app/views/govuk_publishing_components/components/docs/print_link.yml
+++ b/app/views/govuk_publishing_components/components/docs/print_link.yml
@@ -6,6 +6,7 @@ accessibility_criteria: |
   - The print icon must be presentational and ignored by screen readers.
 shared_accessibility_criteria:
   - link
+uses_component_wrapper_helper: true
 examples:
   default:
     description: This component calls `print()` via the browser's DOM API. By default it relies on JavaScript and is not shown in environments where JavaScript is disabled. The \"link\" here is actually a button tag because this is not a navigation event.
@@ -16,13 +17,13 @@ examples:
     description: You can specify a alternative `href` URL that will override the default behaviour. When a `href` is specified the print link will render as an anchor tag and be displayed even when JavaScript is disabled.
     data:
       href: "/print"
-  with_data_attributes:
+  with_child_data_attributes:
     description: |
-      Data attributes can be passed to the component as shown.
+      Data attributes can be passed to the link/button as shown.
 
       Note that the component does not include built in tracking. If this is required consider using the [GA4 link tracker](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/trackers/ga4-link-tracker.md).
     data:
-      data_attributes:
+      child_data_attributes:
         an_attribute: some_value
   with_custom_margins:
     description: The component accepts a number for margin bottom from `0` to `9` (`0px` to `60px`) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to having margin level `3` on top and bottom.

--- a/spec/components/print_link_spec.rb
+++ b/spec/components/print_link_spec.rb
@@ -56,9 +56,9 @@ describe "Print link", type: :view do
     )
   end
 
-  it "displays data attributes" do
+  it "displays child data attributes" do
     render_component({
-      data_attributes: {
+      child_data_attributes: {
         snow: "patrol",
       },
     })
@@ -68,7 +68,7 @@ describe "Print link", type: :view do
 
   it "accepts an additional passed data module when rendering as a button" do
     render_component({
-      data_attributes: {
+      child_data_attributes: {
         module: "ga4-link-tracker",
       },
     })
@@ -79,7 +79,7 @@ describe "Print link", type: :view do
   it "accepts an additional passed data module when rendering as a link" do
     render_component({
       href: "/print",
-      data_attributes: {
+      child_data_attributes: {
         module: "ga4-link-tracker",
       },
     })


### PR DESCRIPTION
## What
- Adds the component wrapper to the print link component
- This is a breaking change, as it renames the `data_attributes` object that was used on child elements. This is not actually used across any templates currently, so it can be safely removed.
- Although this is a breaking change, it shouldn't affect any existing code on GOVUK.

## Why
As the [trello card](https://trello.com/c/T0F8HJwj/442-add-component-wrapper-helper-to-print-link-component) states:

> Standardising our components to use the component wrapper helper will reduce code, increase standardisation, and improve future feature implementation speed.

## Visual changes

Edited example titles/descriptions.
