### PR TITLE
Remove margin top from print link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Remove margin top from print link ([PR #4577](https://github.com/alphagov/govuk_publishing_components/pull/4577))
 * **BREAKING** Use component wrapper on print link component  ([PR #4576](https://github.com/alphagov/govuk_publishing_components/pull/4576))
 * Refactor single page notification component ([PR #4501](https://github.com/alphagov/govuk_publishing_components/pull/4501))
 * Remove shared helper from button component ([PR #4569](https://github.com/alphagov/govuk_publishing_components/pull/4569))

--- a/app/models/govuk_publishing_components/component_wrapper_helper_options.rb
+++ b/app/models/govuk_publishing_components/component_wrapper_helper_options.rb
@@ -8,7 +8,7 @@ This component uses the component wrapper helper. It accepts the following optio
 - `data_attributes` - accepts a hash of data attributes
 - `aria` - accepts a hash of aria attributes
 - `classes` - accepts a space separated string of classes, these should not be used for styling and must be prefixed with `js-`
-- `margin_bottom` - accepts a number from `0` to `9` (`0px` to `60px`) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale) (defaults to no margin)
+- `margin_bottom` - accepts a number from `0` to `9` (`0px` to `60px`) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale)
 - `role` - accepts a space separated string of roles
 - `lang` - accepts a language attribute value
 - `open` - accepts an open attribute value (true or false)

--- a/app/views/govuk_publishing_components/components/_print_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_print_link.html.erb
@@ -5,14 +5,9 @@
   href ||= nil
   child_data_attributes ||= {}
   require_js ||= href.nil?
-  margin_top ||= 3
   local_assigns[:margin_bottom] ||= 3
 
   ((child_data_attributes[:module] ||= "") << " " << (require_js ? "print-link" : "button")).strip!
-
-  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new({
-    margin_top: margin_top,
-  })
 
   child_classes = %w[govuk-link]
   child_classes << "govuk-body-s gem-c-print-link__button" if href.nil?
@@ -21,9 +16,7 @@
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-print-link govuk-!-display-none-print")
   component_helper.add_class("gem-c-print-link--show-without-js") unless require_js
-  component_helper.add_class(shared_helper.get_margin_top)
 %>
-
 <%= tag.div(**component_helper.all_attributes) do %>
   <% if require_js %>
     <%= content_tag(:button, text, {

--- a/app/views/govuk_publishing_components/components/docs/print_link.yml
+++ b/app/views/govuk_publishing_components/components/docs/print_link.yml
@@ -25,8 +25,3 @@ examples:
     data:
       child_data_attributes:
         an_attribute: some_value
-  with_custom_margins:
-    description: The component accepts a number for margin bottom from `0` to `9` (`0px` to `60px`) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to having margin level `3` on top and bottom.
-    data:
-      margin_top: 0
-      margin_bottom: 4

--- a/spec/components/print_link_spec.rb
+++ b/spec/components/print_link_spec.rb
@@ -9,7 +9,6 @@ describe "Print link", type: :view do
     render_component({})
 
     assert_select ".gem-c-print-link"
-    assert_select ".gem-c-print-link.govuk-\\!-margin-top-3"
     assert_select ".gem-c-print-link.govuk-\\!-margin-bottom-3"
     assert_select(
       "button.gem-c-print-link__button[data-module='print-link']",
@@ -37,21 +36,6 @@ describe "Print link", type: :view do
     assert_select ".gem-c-print-link"
     assert_select(
       'a.gem-c-print-link__link[href="/print"][data-module="button"]',
-      text: "Print this page",
-    )
-  end
-
-  it "renders with custom margin" do
-    render_component({
-      margin_top: 0,
-      margin_bottom: 4,
-    })
-
-    assert_select ".gem-c-print-link"
-    assert_select ".gem-c-print-link.govuk-\\!-margin-top-0"
-    assert_select ".gem-c-print-link.govuk-\\!-margin-bottom-4"
-    assert_select(
-      "button.gem-c-print-link__button",
       text: "Print this page",
     )
   end


### PR DESCRIPTION
## What
- removes the default margin top and the option to change the margin top from the print link component
- also removes the shared helper from the component, as this was the only thing it was used for

This seemed like it would be a big change but it turns out not so much, I don't think any changes to applications are needed to support this. Most print link components are already set to have a margin top of 0 or have an element above them with bottom margin, which overlaps with the top margin (and produces no or only a small visual difference with this change).

Exhaustive list of where we use the print link:

government-frontend
- [detailed guides](https://www.gov.uk/guidance/apply-for-an-electronic-travel-authorisation-eta) already set to margin top 0 so fine to change
- [printable versions of guide](https://www.gov.uk/log-in-register-hmrc-online-services/print) has margin top but overlaps with bottom margin on element above, fine to change
- [html publications](https://www.gov.uk/government/publications/car-show-me-tell-me-vehicle-safety-questions/car-show-me-tell-me-vehicle-safety-questions) already has margin top 0, fine to change
- [manuals](https://www.gov.uk/guidance/mot-inspection-manual-for-private-passenger-and-light-commercial-vehicles) setting margin top to 0 makes no visual difference
- [manual section](https://www.gov.uk/guidance/mot-inspection-manual-for-private-passenger-and-light-commercial-vehicles/5-axles-wheels-tyres-and-suspension) would make a tiny difference on desktop only but still an acceptable gap
- [manual updates](https://www.gov.uk/guidance/mot-inspection-manual-for-private-passenger-and-light-commercial-vehicles/updates) would make a tiny difference on desktop but still acceptable
- published dates with notification button (not a page type), not sure where this but already set to margin top 0 so would make no difference

frontend
- [printable travel advice pages](https://www.gov.uk/foreign-travel-advice/usa/print) would make no difference

smart answers
- [custom result page](https://www.gov.uk/next-steps-for-your-business/results?activities%5B%5D=export_goods_or_services&activities%5B%5D=import_goods&annual_turnover_over_90k=not_sure&business_premises%5B%5D=home&business_premises%5B%5D=owned&employ_someone=no&financial_support=yes) would make no difference

## Why
We're moving to a component layout model where we only set margin bottom. We're also moving the margin options out of the shared helper and into the component wrapper helper.

## Visual Changes
Before | After
----- | ------
![Screenshot 2025-01-21 at 13 13 08](https://github.com/user-attachments/assets/a90b3f58-2f3b-4e15-bec7-9eec34561f26) | ![Screenshot 2025-01-21 at 13 13 32](https://github.com/user-attachments/assets/286bc53c-b20d-4cd3-b531-97d17cc42539)
