### PR TITLE
Make "Add another" component styles more specific

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Remove shared helper from inset text component ([PR #4571](https://github.com/alphagov/govuk_publishing_components/pull/4571))
 * Use component wrapper on contextual footer ([PR #4562](https://github.com/alphagov/govuk_publishing_components/pull/4562))
 * Update Govspeak "Warning Text" component styles ([PR #4487](https://github.com/alphagov/govuk_publishing_components/pull/4487))
+* Make "Add another" component styles more specific ([PR #4579](https://github.com/alphagov/govuk_publishing_components/pull/4579))
 
 ## 49.1.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_add-another.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_add-another.scss
@@ -2,11 +2,13 @@
 @import "govuk/components/button/button";
 @import "govuk/components/fieldset/fieldset";
 
-.gem-c-add-another__remove-button {
-  margin-top: govuk-spacing(6);
-  margin-bottom: 0;
-}
+.gem-c-add-another {
+  .gem-c-add-another__remove-button {
+    margin-top: govuk-spacing(6);
+    margin-bottom: 0;
+  }
 
-.js-add-another__remove-button--hidden {
-  display: none;
+  .js-add-another__remove-button--hidden {
+    display: none;
+  }
 }


### PR DESCRIPTION
## What
This change wraps the styles for the "Add another" component in their parent class.

## Why
The change here raises the specificity of the component-specific styles so that they are not over-written by more generic styles on the page on which the component is rendered. This is demonstrated below on an implementation of the component on Mainstream Publisher:
- before this change the `margin-top` value of the "Delete" button is over-written by the value in the "Button" component
- after the change the value for `margin-top` is applied as expected.

## Visual Changes
|Before|After|
|-|-|
|![External-links-actual](https://github.com/user-attachments/assets/b7eee921-5313-422f-acec-9ffa13c4f409)|![External-links-expected](https://github.com/user-attachments/assets/6551d505-5136-48c3-bbed-0beaa0ca2a30)|