### PR TITLE
Translate "and" connective in metadata component to Chinese, Russian and Arabic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Use component wrapper on contextual footer ([PR #4562](https://github.com/alphagov/govuk_publishing_components/pull/4562))
 * Update Govspeak "Warning Text" component styles ([PR #4487](https://github.com/alphagov/govuk_publishing_components/pull/4487))
 * Make "Add another" component styles more specific ([PR #4579](https://github.com/alphagov/govuk_publishing_components/pull/4579))
+* Translate "and" connective in metadata component to Chinese, Russian and Arabic ([PR #4580](https://github.com/alphagov/govuk_publishing_components/pull/4580))
 
 ## 49.1.0
 

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -129,7 +129,7 @@ ar:
       navigation_search_subheading:
       search_text:
     metadata:
-      and:
+      and: و
       from: من
       history: المحفوظات
       last_updated: التحديث الأخير

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -130,7 +130,7 @@ ru:
       navigation_search_subheading:
       search_text:
     metadata:
-      and:
+      and: и
       from: Из
       history: История
       last_updated: Последнее обновление

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -124,8 +124,8 @@ zh:
       navigation_search_subheading:
       search_text:
     metadata:
-      and:
-      from: 从
+      and: 和
+      from: 发自
       history: 历史
       last_updated: 上次更新
       part_of: 一部分

--- a/spec/components/metadata_spec.rb
+++ b/spec/components/metadata_spec.rb
@@ -94,6 +94,22 @@ describe "Metadata", type: :view do
     end
   end
 
+  it "renders multiples as a single sentence (except history) in a right to left foreign language" do
+    I18n.with_locale("ar") do
+      render_component(
+        from: %w[واحد اثنان],
+        part_of: %w[ثلاثة أربعة],
+        other: {
+          "المواضيع": %w[خمسة ستة سبعة],
+        },
+      )
+
+      assert_definition("من:", "واحد و اثنان")
+      assert_definition("جزء من:", "ثلاثة و أربعة")
+      assert_definition("المواضيع:", "خمسة, ستة و سبعة")
+    end
+  end
+
   it "long lists of metadata are truncated and the remainder hidden behind a toggle for from" do
     links = [
       "<a href=\"/government/organisations/ministry-of-defence\">Ministry of Defence</a>",


### PR DESCRIPTION
## What

The [previous PR](https://github.com/alphagov/govuk_publishing_components/pull/4477) only provided translations for French, Spanish, German and Polish. This is about adding Chinese, Russian and Arabic translations.

For Arabic, which is a right to left language, this PR only adds the translations, but it doesn't change the order (if that's necessary). There is a separate ticket dealing with the ordering issues.

## Why

So the the metadata component works correctly for languages other than English.

[Trello card](https://trello.com/c/MHOShO2A/3162-add-translations-of-the-word-and-for-chinese-russian-and-arabic-to-the-metadata-component-m)

## Testing

[Testing branch](https://government-frontend-pr-3530.herokuapp.com/government/publications/uk-candidate-for-the-international-court-of-justice-election-2026-professor-dapo-akande-election-brochure.zh)

## Visual Changes

### Before

![Screenshot 2025-01-22](https://github.com/user-attachments/assets/aa6f7f86-9720-4809-9433-f8f7e780b290)


![screenshot - russian](https://github.com/user-attachments/assets/c7cc21cc-51d2-4b1d-a032-4b8cefafcb84)


![Screenshot 2025-01-22 at 09-40-43 مرشح المملكة المتحدة لانتخابات محكمة العدل الدولية لعام 2026 بروفيسور دابو أكانديه، كتيب الانتخابات - GOV UK](https://github.com/user-attachments/assets/c38f920d-755b-439e-9f80-58ead2209fc3)


### After

![Screenshot 2025-01-22 at 10-58-12 2026年国际法院法官英国候选人达波·阿坎德教授 竞选手册 - GOV UK](https://github.com/user-attachments/assets/8e534162-8572-4de2-a752-26007fcee210)
![Screenshot 2025-01-22 at 10-58-27 russian](https://github.com/user-attachments/assets/cbe77ad5-186b-40bd-b697-d6d91eb07d09)
![Screenshot 2025-01-22 at 10-59-12 مرشح المملكة المتحدة لانتخابات محكمة العدل الدولية لعام 2026 بروفيسور دابو أكانديه، كتيب الانتخابات - GOV UK](https://github.com/user-attachments/assets/c35157f8-def5-4426-b128-63053f82dc0b)

