### PR TITLE
Add another: fix problem in `createRemoveButtons` method:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add custom padding to inverse header ([PR #4590](https://github.com/alphagov/govuk_publishing_components/pull/4590))
+* Add another: fix problem in createRemoveButtons method ([PR #11719](https://github.com/alphagov/govuk_publishing_components/pull/4586))
 
 ## 50.0.1
 

--- a/app/assets/javascripts/govuk_publishing_components/components/add-another.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/add-another.js
@@ -49,7 +49,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   AddAnother.prototype.createRemoveButtons = function () {
     var fieldsets =
-      document.querySelectorAll('.js-add-another__fieldset')
+      this.module.querySelectorAll('.js-add-another__fieldset')
     fieldsets.forEach(function (fieldset) {
       this.createRemoveButton(fieldset, this.removeExistingFieldset.bind(this))
       fieldset.querySelector('.js-add-another__destroy-checkbox').hidden = true


### PR DESCRIPTION
## What
This change updates a `querySelectorAll` call to be made on the module rather than the document. 

<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
As it is this creates multiple "Delete" buttons if there are more than one instance of the component on the page (i.e. one per instance). 
