### PR TITLE
Add custom padding to inverse header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add custom padding to inverse header ([PR #4590](https://github.com/alphagov/govuk_publishing_components/pull/4590))
+
 ## 50.0.1
 
 * Change id validation on component wrapper ([PR #4584](https://github.com/alphagov/govuk_publishing_components/pull/4584))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_inverse-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_inverse-header.scss
@@ -5,7 +5,7 @@
   background-color: govuk-colour("blue");
   color: govuk-colour("white");
   margin-bottom: govuk-spacing(6);
-  padding: 0 govuk-spacing(6) govuk-spacing(6);
+  padding: govuk-spacing(3) govuk-spacing(6) govuk-spacing(6) govuk-spacing(6);
   box-sizing: border-box;
 }
 
@@ -22,10 +22,6 @@
   padding-left: 0;
   padding-right: 0;
   padding-bottom: govuk-spacing(3);
-}
-
-.gem-c-inverse-header--padding-top {
-  padding-top: govuk-spacing(3);
 }
 
 @include govuk-media-query($media-type: print) {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_inverse-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_inverse-header.scss
@@ -9,12 +9,9 @@
   box-sizing: border-box;
 }
 
-.gem-c-inverse-header .gem-c-inverse-header__supplement,
-.gem-c-inverse-header .publication-header__last-changed {
+.gem-c-inverse-header__subtext {
   color: govuk-colour("white");
   margin: 0;
-  // This publication-header class is injected on publication pages, really
-  // it should be a component class or be a component in it's own right.
   @include govuk-font($size: 16, $line-height: 1.5);
 }
 

--- a/app/views/govuk_publishing_components/components/_inverse_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_inverse_header.html.erb
@@ -3,6 +3,7 @@
 
   padding_top ||= nil
   padding_bottom ||= nil
+  subtext ||= nil
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-inverse-header")
@@ -14,5 +15,6 @@
 <% unless block.empty? %>
   <%= tag.header(**component_helper.all_attributes) do %>
     <%= block %>
+    <%= content_tag(:p, subtext, class: "gem-c-inverse-header__subtext") if subtext %>
   <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/_inverse_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_inverse_header.html.erb
@@ -1,10 +1,14 @@
 <%
   add_gem_component_stylesheet("inverse-header")
 
+  padding_top ||= nil
+  padding_bottom ||= nil
+
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-inverse-header")
   component_helper.add_class("gem-c-inverse-header--full-width") if local_assigns[:full_width]
-  component_helper.add_class("gem-c-inverse-header--padding-top") unless local_assigns[:padding_top].eql?(false)
+  component_helper.add_class("govuk-!-padding-top-#{padding_top}") if [*0..9].include?(padding_top)
+  component_helper.add_class("govuk-!-padding-bottom-#{padding_bottom}") if [*0..9].include?(padding_bottom)
 %>
 <% block = yield %>
 <% unless block.empty? %>

--- a/app/views/govuk_publishing_components/components/docs/inverse_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/inverse_header.yml
@@ -43,6 +43,17 @@ examples:
               inverse: true
             } %>
             <!-- end of example content -->
+  with_subtext:
+    data:
+      subtext: This is some text
+      block: |
+        <!-- example content -->
+          <%= render "govuk_publishing_components/components/heading", {
+            text: "Education, Training and Skills",
+            inverse: true,
+            margin_bottom: 0
+          } %>
+          <!-- end of example content -->
   html_publication_header:
     description: "The inverse header component is used on HTML publications. [See example on GOV.UK here](https://www.gov.uk/government/publications/ln5-0at-jackson-homes-scopwick-ltd-environmental-permit-application-advertisement/ln5-0at-jackson-homes-scopwick-ltd-environmental-permit-application)"
     data:

--- a/app/views/govuk_publishing_components/components/docs/inverse_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/inverse_header.yml
@@ -1,7 +1,7 @@
 name: Inverse header
 description: A wrapper to contain header content in white text
 body: |
-  This component can be passed a block of template code and will wrap it in a blue header. This is as light-touch as possible and doesn't attempt to deal with the margins and paddings of its content. White text is enforced on content and would need to be overridden where unwanted. Implemented to accommodate topic and list page headings but unopinionated about its contents.
+  This component can be passed a block of template code and will wrap it in a blue header. White text is enforced on content and would need to be overridden where unwanted. Implemented to accommodate topic and list page headings but unopinionated about its contents.
 
   If passing links to the block make sure to add [the inverse modifier](https://design-system.service.gov.uk/styles/links/#links-on-dark-backgrounds).
 uses_component_wrapper_helper: true
@@ -17,6 +17,19 @@ examples:
           <%= render "govuk_publishing_components/components/title", {
             title: "Education, Training and Skills",
             inverse: true
+          } %>
+          <!-- end of example content -->
+  with_custom_padding:
+    description: Custom padding can be applied as shown, using the [Design System spacing scale](https://design-system.service.gov.uk/styles/spacing/).
+    data:
+      padding_top: 6
+      padding_bottom: 1
+      block: |
+        <!-- example content -->
+          <%= render "govuk_publishing_components/components/heading", {
+            text: "Education, Training and Skills",
+            inverse: true,
+            margin_bottom: 0
           } %>
           <!-- end of example content -->
   for_full_page_width:

--- a/spec/components/inverse_header_spec.rb
+++ b/spec/components/inverse_header_spec.rb
@@ -38,4 +38,10 @@ describe "Inverse header", type: :view do
 
     assert_select '.gem-c-inverse-header.govuk-\!-padding-top-5.govuk-\!-padding-bottom-3'
   end
+
+  it "renders with subtext" do
+    render_component(subtext: "this is some text") { block }
+
+    assert_select ".gem-c-inverse-header__subtext", text: "this is some text"
+  end
 end

--- a/spec/components/inverse_header_spec.rb
+++ b/spec/components/inverse_header_spec.rb
@@ -33,9 +33,9 @@ describe "Inverse header", type: :view do
     assert_select ".gem-c-inverse-header--full-width"
   end
 
-  it "renders correct css class when padding_top flag is set to false" do
-    render_component(padding_top: false) { block }
+  it "renders with custom padding top and bottom" do
+    render_component(padding_top: 5, padding_bottom: 3) { block }
 
-    assert_select ".gem-c-inverse-header--padding-top", false
+    assert_select '.gem-c-inverse-header.govuk-\!-padding-top-5.govuk-\!-padding-bottom-3'
   end
 end


### PR DESCRIPTION
## What
Adds a `padding_top` and `padding_bottom` option to the inverse header component, as well as a `subtext` option.

- adds options to set the padding top/bottom on the component using the Design System spacing scale (from 0 to 9)
- removes the (undocumented) padding_top false option, which is used in a few places, but can be replaced with the new options

Component with custom padding:

![Screenshot 2025-01-24 at 11 39 10](https://github.com/user-attachments/assets/0c7d13e5-d34d-4a5c-b66e-df82e90cd7fe)

Component with subtext. This is to support functionality on [HTML publications](https://www.gov.uk/government/publications/benefit-and-pension-rates-2025-to-2026/benefit-and-pension-rates-2025-to-2026). See commit message for details.

![Screenshot 2025-01-24 at 14 10 52](https://github.com/user-attachments/assets/756dc9b4-768f-434c-8093-81d88e4a2b6a)


## Why
There was previously a `padding_top` option, but it was used only to remove the default padding top from the component. This was employed where the inverse header contained the page title component, which already had top margin. We're removing top margin from that component, so these changes are needed to preserve the visual appearance of some pages.

Two examples of usage:
- this [Taxon page for entering the UK](https://www.gov.uk/entering-staying-uk). The blue bar at the top is achieved by a combination of two blue elements (a custom breadcrumb and the inverse header) and the spacing is achieved by disabling the top padding in the inverse header and relying on the custom breadcrumb to push it down.
- this [HTML publication for car safety](https://www.gov.uk/government/publications/car-show-me-tell-me-vehicle-safety-questions/car-show-me-tell-me-vehicle-safety-questions). The spacing at the top of the blue block is achieved by a combination of padding top on the inverse header and margin top on the title inside it.
- additionally in the previous example the spacing at the bottom of the inverse header is achieved by some custom styling on the paragraph inside it

Apart from removing top margin it seems like we could make the frontend in the examples above a bit cleaner and clearer through these changes.

## Visual Changes
No visual appearance in the default state of the component, although Percy will complain as the component guide page for this component has been updated.

Trello card: https://trello.com/c/hRL2Nmyp/450-improve-inverse-header-component-padding