### PR TITLE
Replace title component with heading

### DIFF
--- a/app/views/govuk_publishing_components/audit/show.html.erb
+++ b/app/views/govuk_publishing_components/audit/show.html.erb
@@ -5,7 +5,13 @@
 %>
 
 <% content_for :title, "Component audit" %>
-<%= render 'govuk_publishing_components/components/title', title: "Components audit", margin_top: 0; %>
+<%= render 'govuk_publishing_components/components/heading', {
+    text: "Components audit",
+    heading_level: 1,
+    font_size: "xl",
+    margin_bottom: 8
+  }
+%>
 
 <% applications = capture do %>
   <%= render "applications" %>

--- a/app/views/govuk_publishing_components/component_guide/example.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/example.html.erb
@@ -5,7 +5,14 @@
   <% end %>
 <% end %>
 
-<%= render 'govuk_publishing_components/components/title', title: @component_example.name, context: "#{@component_doc.name} example", margin_top: 0 %>
+<%= render 'govuk_publishing_components/components/heading', {
+    text: @component_example.name,
+    context: "#{@component_doc.name} example",
+    heading_level: 1,
+    font_size: "xl",
+    margin_bottom: 8
+  }
+%>
 
 <% code_example = capture do %>
   <%= render partial: "govuk_publishing_components/component_guide/component_doc/call", locals: { component_doc: @component_doc, example: @component_example } %>

--- a/app/views/govuk_publishing_components/component_guide/index.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/index.html.erb
@@ -1,4 +1,10 @@
-<%= render 'govuk_publishing_components/components/title', title: GovukPublishingComponents::Config.component_guide_title, margin_top: 0 %>
+<%= render 'govuk_publishing_components/components/heading', {
+    text: GovukPublishingComponents::Config.component_guide_title,
+    heading_level: 1,
+    font_size: "xl",
+    margin_bottom: 8
+  }
+%>
 
 <div class="component-markdown">
   <p>Components are packages of template, style, behaviour and documentation that live in your application.</p>

--- a/app/views/govuk_publishing_components/component_guide/show.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/show.html.erb
@@ -5,7 +5,14 @@
   <% end %>
 <% end %>
 
-<%= render 'govuk_publishing_components/components/title', title: @component_doc.name, context: "Component", margin_top: 0; %>
+<%= render 'govuk_publishing_components/components/heading', {
+    text: @component_doc.name,
+    context: "Component",
+    heading_level: 1,
+    font_size: "xl",
+    margin_bottom: 8
+  }
+%>
 
 <div class="component-show">
   <div class="govuk-grid-row">


### PR DESCRIPTION
## What
Replaces the H1s rendered in the component guide by the title component with H1s rendered using the heading component.

Probably no need for a changelog entry as this is an internal change to the component guide.

## Why
These title components used the margin top option, which we're trying to remove (moving towards a world where components only have bottom margin).

Additionally we're trying to retire the title component, as the same functionality is provided by the heading component.

## Visual Changes
None.

Trello card: https://trello.com/c/Y0pDWbHw/390-remove-margintop-option-from-shared-helper
