### PR TITLE
Remove margin_top option from shared helper

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/title.yml
+++ b/app/views/govuk_publishing_components/components/docs/title.yml
@@ -62,13 +62,3 @@ examples:
       margin_bottom: 0
     context:
       dark_background: true
-  using_design_system_template:
-    description: |
-      This option allows the removal of top margin from the component so that it works within a [Design System page template](https://design-system.service.gov.uk/styles/page-template/default/index.html), where spacing above the title is already provided by padding on the wrapping div.
-    embed: |
-      <main class="govuk-main-wrapper">
-        <%= component %>
-      </main>
-    data:
-      title: My page title
-      margin_top: 0

--- a/lib/govuk_publishing_components/presenters/shared_helper.rb
+++ b/lib/govuk_publishing_components/presenters/shared_helper.rb
@@ -1,11 +1,10 @@
 module GovukPublishingComponents
   module Presenters
     class SharedHelper
-      attr_reader :options, :margin_top, :margin_bottom, :heading_level, :classes
+      attr_reader :options, :margin_bottom, :heading_level, :classes
 
       def initialize(local_assigns)
         @options = local_assigns
-        @margin_top = @options[:margin_top] || nil
         @margin_bottom = @options[:margin_bottom] || 3
         @heading_level = @options[:heading_level] || 2
 
@@ -15,10 +14,6 @@ module GovukPublishingComponents
             raise(ArgumentError, "Passed classes must be prefixed with `js-`")
           end
         end
-      end
-
-      def get_margin_top
-        [*0..9].include?(@margin_top) ? "govuk-!-margin-top-#{margin_top}" : ""
       end
 
       def get_margin_bottom


### PR DESCRIPTION
## What
Removes the `margin_top` option from the shared helper.

- should no longer be in use by any components
- moves us towards a world where components only have bottom margin
- also remove an example from the title component guide page that uses margin_top and is out of date

## Why
We want to have a standard model of only margin bottom on components.

## Visual Changes
None.

Trello card: https://trello.com/c/Y0pDWbHw/390-remove-margintop-option-from-shared-helper
