### PR TITLE
Version 51.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 51.1.0
 
 * Update to LUX 4.0.29 ([PR #4597](https://github.com/alphagov/govuk_publishing_components/pull/4597))
 * Add a `form` attribute to the button component ([PR #4588](https://github.com/alphagov/govuk_publishing_components/pull/4588))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (51.0.0)
+    govuk_publishing_components (51.1.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "51.0.0".freeze
+  VERSION = "51.1.0".freeze
 end


### PR DESCRIPTION
* Update to LUX 4.0.29 ([PR #4597](https://github.com/alphagov/govuk_publishing_components/pull/4597))
* Add a `form` attribute to the button component ([PR #4588](https://github.com/alphagov/govuk_publishing_components/pull/4588))