### PR TITLE
Update big number documentation

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/big_number.yml
+++ b/app/views/govuk_publishing_components/components/docs/big_number.yml
@@ -9,6 +9,7 @@ accessibility_criteria: |
   - convey the meaning of the number shown
 shared_accessibility_criteria:
 - link
+uses_component_wrapper_helper: true
 examples:
   default:
     data:


### PR DESCRIPTION
## What / why
Big number uses the component wrapper helper, but was missing this line in the documentation that shows information about the wrapper in the component guide page for this component.

## Visual Changes
Details of the component wrapper options will now appear in the component guide page for big number.