### PR TITLE
[DO NOT MERGE] Pass attachment name to GA4 details component tracking

### DIFF
--- a/app/views/govuk_publishing_components/components/_attachment.html.erb
+++ b/app/views/govuk_publishing_components/components/_attachment.html.erb
@@ -8,6 +8,7 @@
   attributes = []
   url_data_attributes ||= {}
   details_ga4_attributes ||= {}
+  details_ga4_attributes[:section] = attachment.title unless details_ga4_attributes[:section]
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)

--- a/app/views/govuk_publishing_components/components/_details.html.erb
+++ b/app/views/govuk_publishing_components/components/_details.html.erb
@@ -13,7 +13,6 @@
       event_name: "select_content",
       type: "detail",
       text: title,
-      section: title,
       index_section: @ga4[:index_section],
     }
     ga4_event.merge!(ga4_attributes)

--- a/spec/components/attachment_spec.rb
+++ b/spec/components/attachment_spec.rb
@@ -107,11 +107,35 @@ describe "Attachment", type: :view do
       event_name: "select_content",
       type: "detail",
       text: "Request an accessible format.",
-      section: "Request an accessible format.",
       index_section: 1,
       index_section_count: 4,
       another_attribute: "here",
+      section: "Attachment",
     }.to_json
+    assert_select ".govuk-details[data-ga4-event='#{attributes}']"
+  end
+
+  it "allows the default GA4 section on the details component to be overwritten" do
+    render_component(
+      attachment: {
+        title: "Attachment",
+        url: "attachment",
+        content_type: "application/vnd.oasis.opendocument.spreadsheet",
+        alternative_format_contact_email: "defra.helpline@defra.gsi.gov.uk",
+      },
+      details_ga4_attributes: {
+        section: "Hello",
+      },
+    )
+    assert_select "a[href='mailto:defra.helpline@defra.gsi.gov.uk']"
+    attributes = {
+      event_name: "select_content",
+      type: "detail",
+      text: "Request an accessible format.",
+      index_section: 1,
+      section: "Hello",
+    }.to_json
+    puts rendered
     assert_select ".govuk-details[data-ga4-event='#{attributes}']"
   end
 

--- a/spec/components/details_spec.rb
+++ b/spec/components/details_spec.rb
@@ -58,10 +58,10 @@ describe "Details", type: :view do
 
   it "increments the GA4 index_section parameter when more than one component instance" do
     render_component(title: "first details")
-    assert_select '.govuk-details[data-ga4-event=\'{"event_name":"select_content","type":"detail","text":"first details","section":"first details","index_section":1}\']'
+    assert_select '.govuk-details[data-ga4-event=\'{"event_name":"select_content","type":"detail","text":"first details","index_section":1}\']'
 
     render_component(title: "second details")
-    assert_select '.govuk-details[data-ga4-event=\'{"event_name":"select_content","type":"detail","text":"second details","section":"second details","index_section":2}\']'
+    assert_select '.govuk-details[data-ga4-event=\'{"event_name":"select_content","type":"detail","text":"second details","index_section":2}\']'
   end
 
   it "accepts GA4 event data parameters" do
@@ -69,7 +69,7 @@ describe "Details", type: :view do
       title: "some title",
       ga4_attributes: { index_section_count: 12 },
     )
-    assert_select '.govuk-details[data-ga4-event=\'{"event_name":"select_content","type":"detail","text":"some title","section":"some title","index_section":1,"index_section_count":12}\']'
+    assert_select '.govuk-details[data-ga4-event=\'{"event_name":"select_content","type":"detail","text":"some title","index_section":1,"index_section_count":12}\']'
   end
 
   it "can override GA4 event data parameters" do
@@ -77,7 +77,7 @@ describe "Details", type: :view do
       title: "some title",
       ga4_attributes: { type: "a mouse!", index_section_count: 12 },
     )
-    assert_select '.govuk-details[data-ga4-event=\'{"event_name":"select_content","type":"a mouse!","text":"some title","section":"some title","index_section":1,"index_section_count":12}\']'
+    assert_select '.govuk-details[data-ga4-event=\'{"event_name":"select_content","type":"a mouse!","text":"some title","index_section":1,"index_section_count":12}\']'
   end
 
   it "can disable GA4" do


### PR DESCRIPTION
## What/Why
<!-- What are the reasons behind this change being made? -->
- On pages with attachments, all of the `Request an accessible format` details elements have the same GA4 `title`/`section` - they all pass  `Request an accessible format` as their `title`/`section` when clicked. 
- This means PAs can't tell which details component have been clicked, as they're all passing the same data.
- For example, see the attachments on https://www.gov.uk/guidance/prove-your-english-language-abilities-with-a-secure-english-language-test-selt 
- Therefore this PR makes the `section` values the name of the attachment they are sitting under.


<img width="696" alt="image" src="https://github.com/user-attachments/assets/b063cb4c-72e1-481a-aaf7-a668fc41d8bd" />


## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
