### PR TITLE
Add `govuk-text-break-word` style to markdown links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Remove classes functionality from shared helper ([PR #4605](https://github.com/alphagov/govuk_publishing_components/pull/4605))
+* Add govuk-text-break-word style to markdown links ([PR #4603](https://github.com/alphagov/govuk_publishing_components/pull/4603))
 
 ## 51.1.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_markdown-typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_markdown-typography.scss
@@ -77,6 +77,7 @@
   a {
     @include govuk-link-common;
     @include govuk-link-style-default;
+    @include govuk-text-break-word;
 
     &:focus {
       @include govuk-focused-text;


### PR DESCRIPTION
## What

Add `govuk-text-break-word` style to markdown links.

https://components-gem-pr-4603.herokuapp.com/component-guide/govspeak#how-it-looks

## Why

Enable long words or URLs to break and wrap onto a new line in Govspeak components.

## Visual Changes

https://www.gov.uk/guidance/local-authority-collected-waste-definition-of-terms

### Before

<img src="https://github.com/user-attachments/assets/4fc17ce1-ac51-4cae-996e-48872fab1992" width=330>

### After

<img src="https://github.com/user-attachments/assets/eb640ac3-231e-4d49-9708-19e6cbb5f6e9" width=330>