### PR TITLE
Add global banner sass to all components sass

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -38,6 +38,7 @@
 @import "components/fieldset";
 @import "components/file-upload";
 @import "components/glance-metric";
+@import "components/global-banner";
 @import "components/govspeak-html-publication";
 @import "components/govspeak";
 @import "components/heading";


### PR DESCRIPTION
## What
Add the Sass for the global banner component into all components sass.

## Why
Missed in https://github.com/alphagov/govuk_publishing_components/pull/4538

## Visual Changes
None.
