### PR TITLE
Remove classes functionality from shared helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Remove classes functionality from shared helper ([PR #4605](https://github.com/alphagov/govuk_publishing_components/pull/4605))
+
 ## 51.1.1
 
 * Fix RTL support in metadata component ([PR #4596](https://github.com/alphagov/govuk_publishing_components/pull/4596))

--- a/lib/govuk_publishing_components/presenters/shared_helper.rb
+++ b/lib/govuk_publishing_components/presenters/shared_helper.rb
@@ -7,13 +7,6 @@ module GovukPublishingComponents
         @options = local_assigns
         @margin_bottom = @options[:margin_bottom] || 3
         @heading_level = @options[:heading_level] || 2
-
-        if local_assigns.include?(:classes)
-          @classes = local_assigns[:classes].split(" ")
-          unless @classes.all? { |c| c.start_with?("js-") }
-            raise(ArgumentError, "Passed classes must be prefixed with `js-`")
-          end
-        end
       end
 
       def get_margin_bottom

--- a/spec/lib/govuk_publishing_components/components/shared_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/components/shared_helper_spec.rb
@@ -46,17 +46,6 @@ RSpec.describe GovukPublishingComponents::Presenters::SharedHelper do
       expect(result).to eql("span")
     end
 
-    it "accepts passed class names if prefixed with 'js-'" do
-      shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(classes: "js-okay js-fine")
-      expect(shared_helper.classes).to eql(%w[js-okay js-fine])
-    end
-
-    it "rejects passed class names if not prefixed with 'js-'" do
-      expect {
-        GovukPublishingComponents::Presenters::SharedHelper.new(classes: "js-okay not-cool-man")
-      }.to raise_error(ArgumentError, "Passed classes must be prefixed with `js-`")
-    end
-
     it "returns nil if given locale is same as page locale" do
       default_locale = I18n.locale
       shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new({})


### PR DESCRIPTION
## What / Why
<!-- What are the reasons behind this change being made? -->
- Removes `shared_helper.classes` from the gem
- Correct me if I'm wrong but it doesn't seem to be used anywhere, so should be a simple removal
- Trello: https://trello.com/c/iMAtJbup/469-move-classes-option-into-component-wrapper

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None