### PR TITLE
Remove margin bottom functionality from the shared helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Remove classes functionality from shared helper ([PR #4605](https://github.com/alphagov/govuk_publishing_components/pull/4605))
 * Add govuk-text-break-word style to markdown links ([PR #4603](https://github.com/alphagov/govuk_publishing_components/pull/4603))
+* Remove margin bottom functionality from shared helper ([PR #4608](https://github.com/alphagov/govuk_publishing_components/pull/4608))
 
 ## 51.1.1
 

--- a/app/views/govuk_publishing_components/components/_title.html.erb
+++ b/app/views/govuk_publishing_components/components/_title.html.erb
@@ -9,12 +9,11 @@
 
   inverse ||= false
   local_assigns[:margin_bottom] ||= 8
-
-  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+  margin_bottom = [*0..9].include?(local_assigns[:margin_bottom]) ? "govuk-!-margin-bottom-#{local_assigns[:margin_bottom]}" : "govuk-!-margin-bottom-3"
 
   classes = %w[gem-c-title]
   classes << "gem-c-title--inverse" if inverse
-  classes << shared_helper.get_margin_bottom
+  classes << margin_bottom
 
   heading_classes = %w[gem-c-title__text]
   heading_classes << (average_title_length.present? ? 'govuk-heading-l' : 'govuk-heading-xl')

--- a/docs/component_conventions.md
+++ b/docs/component_conventions.md
@@ -357,9 +357,7 @@ Code can be called and referred to in the template as follows:
 
 There is a [shared helper](https://github.com/alphagov/govuk_publishing_components/blob/main/lib/govuk_publishing_components/presenters/shared_helper.rb) that can provide common functionality to all components. This includes:
 
-- set margin bottom and top
 - set heading level and heading font size
-- allow JavaScript classes to be added that begin with `js-` but reject any others
 - translation helpers
 
 The following is an example of how to use the shared helper to set margin bottom on a component.
@@ -369,23 +367,6 @@ Add the shared helper to the component template:
 ```erb
 shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
 ```
-
-Call the shared helper to provide a margin bottom class:
-
-```erb
-classes << shared_helper.get_margin_bottom
-```
-
-The component will accept a number for `margin_bottom` from `0` to `9` (`0px` to `60px`) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to a margin bottom of 15px (3). If you require a different default value, change the code as shown.
-
-```erb
-local_assigns[:margin_bottom] ||= 0 # this will be the default
-shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
-```
-
-Tests should be added to the component to check that the default margin bottom is correct and that the expected given margin bottom is set. The shared helper has its own tests to check that it returns the correct values.
-
-See components that use the shared helper for further examples of usage, including the accordion, attachment, button, heading, radio, and others.
 
 ## Passing HTML to a component
 

--- a/lib/govuk_publishing_components/presenters/shared_helper.rb
+++ b/lib/govuk_publishing_components/presenters/shared_helper.rb
@@ -9,10 +9,6 @@ module GovukPublishingComponents
         @heading_level = @options[:heading_level] || 2
       end
 
-      def get_margin_bottom
-        [*0..9].include?(@margin_bottom) ? "govuk-!-margin-bottom-#{margin_bottom}" : "govuk-!-margin-bottom-3"
-      end
-
       def get_heading_level
         return [*1..6].include?(@heading_level) ? "h#{@heading_level}" : "h2" unless @heading_level.zero?
 

--- a/spec/components/title_spec.rb
+++ b/spec/components/title_spec.rb
@@ -66,9 +66,9 @@ describe "Title", type: :view do
     assert_select '.gem-c-title.govuk-\!-margin-bottom-4'
   end
 
-  it "ignores an invalid margin bottom" do
+  it "sets margin bottom to 3 if an invalid number is passed" do
     render_component(title: "Margin wat", margin_bottom: 17)
-    assert_select "[class^='govuk-\!-margin-bottom-']", false
+    assert_select '.gem-c-title.govuk-\!-margin-bottom-3'
   end
 
   it "applies context language if supplied to a context link" do

--- a/spec/lib/govuk_publishing_components/components/shared_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/components/shared_helper_spec.rb
@@ -4,24 +4,6 @@ RSpec.describe GovukPublishingComponents::Presenters::SharedHelper do
       I18n.locale = :en
     end
 
-    it "returns a default margin class" do
-      shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new({})
-      margin_class = shared_helper.get_margin_bottom
-      expect(margin_class).to eql("govuk-!-margin-bottom-3")
-    end
-
-    it "returns a given margin class" do
-      shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(margin_bottom: 6)
-      margin_class = shared_helper.get_margin_bottom
-      expect(margin_class).to eql("govuk-!-margin-bottom-6")
-    end
-
-    it "returns the default margin class if passed value is wrong" do
-      shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(margin_bottom: "a")
-      margin_class = shared_helper.get_margin_bottom
-      expect(margin_class).to eql("govuk-!-margin-bottom-3")
-    end
-
     it "returns a default heading level" do
       shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new({})
       heading = shared_helper.get_heading_level


### PR DESCRIPTION
## What / Why
- Removes `shared_helper.get_margin_bottom` from the gem
- As the `title` component still used`shared_helper.get_margin_bottom`, I added some specific code for `title` so that the change isn't breaking - the `title` component is being retired soon too.
- Updates the shared helper docs too. I was going to mark the shared helper as deprecated in the docs, but wasn't sure if that was true.
- Trello card https://trello.com/c/hnfXA4lu/471-move-marginbottom-option-into-component-wrapper
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

Should be none.
