### PR TITLE
Remove full stop from default hint text in "Checkboxes" component

### DIFF
--- a/lib/govuk_publishing_components/presenters/checkboxes_helper.rb
+++ b/lib/govuk_publishing_components/presenters/checkboxes_helper.rb
@@ -34,7 +34,7 @@ module GovukPublishingComponents
         @is_page_heading = options[:is_page_heading]
         @description = options[:description] || nil
         @no_hint_text = options[:no_hint_text]
-        @hint_text = options[:hint_text] || "Select all that apply." unless @no_hint_text
+        @hint_text = options[:hint_text] || "Select all that apply" unless @no_hint_text
         @visually_hide_heading = options[:visually_hide_heading]
       end
 

--- a/spec/components/checkboxes_spec.rb
+++ b/spec/components/checkboxes_spec.rb
@@ -30,7 +30,7 @@ describe "Checkboxes", type: :view do
     assert_select "fieldset.govuk-fieldset"
     assert_select "legend", text: "What is your favourite colour?"
     assert_select "legend h1", false
-    assert_select ".govuk-hint", text: "Select all that apply."
+    assert_select ".govuk-hint", text: "Select all that apply"
     assert_select ".govuk-checkboxes"
     assert_select ".govuk-label", text: "Red"
     assert_select ".govuk-label", text: "Green"


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
This removes the full stop from the default hint text for the component. 

## Why
<!-- What are the reasons behind this change being made? -->
This was raised in [this issue](https://github.com/alphagov/govuk_publishing_components/issues/4589) and makes this component consistent with the way hint text is presented in the Design System. 

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->
<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

|Before|After|
|-|-|
|![Screenshot 2025-02-04 at 15 58 19](https://github.com/user-attachments/assets/79c6a764-5737-4569-8c16-79c70e33e69d)|![Screenshot 2025-02-04 at 15 59 07](https://github.com/user-attachments/assets/9921c619-48fc-473e-962e-78fe70ea66e9)|

