### PR TITLE
Make padding around component previews consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Remove classes functionality from shared helper ([PR #4605](https://github.com/alphagov/govuk_publishing_components/pull/4605))
 * Add govuk-text-break-word style to markdown links ([PR #4603](https://github.com/alphagov/govuk_publishing_components/pull/4603))
 * Remove margin bottom functionality from shared helper ([PR #4608](https://github.com/alphagov/govuk_publishing_components/pull/4608))
+* Make padding around component previews consistent ([PR #4610](https://github.com/alphagov/govuk_publishing_components/pull/4610))
 
 ## 51.1.1
 

--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -116,7 +116,7 @@ $gem-guide-border-width: 1px;
 }
 
 .component-guide-preview {
-  padding: ($govuk-gutter * 1.5) $govuk-gutter $govuk-gutter;
+  padding: $govuk-gutter;
   border: $gem-guide-border-width solid $govuk-border-colour;
   position: relative;
 


### PR DESCRIPTION
## What / Why
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Make the padding around component previews `30px`
- Previously the padding was `30px` for the sides/bottom, and `45px` for the top
- This made testing spacing of components more confusing as the top always had more spacing around it.
- It looks like the previous padding was added 7.5 years ago to make it the same as GOVUK Elements, but we want the padding to be the same around the whole component to make the spacing of components easier to test. See trello card for sources: https://trello.com/c/pvbZKJJX/473-investigate-component-guide-example-vertical-spacing
- See https://components-gem-pr-4610.herokuapp.com/ for visual testing


## Visual Changes
None, surprisingly - I thought Percy would complain!