### PR TITLE
Version 51.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 51.2.0
 
 * Remove classes functionality from shared helper ([PR #4605](https://github.com/alphagov/govuk_publishing_components/pull/4605))
 * Add govuk-text-break-word style to markdown links ([PR #4603](https://github.com/alphagov/govuk_publishing_components/pull/4603))
 * Remove margin bottom functionality from shared helper ([PR #4608](https://github.com/alphagov/govuk_publishing_components/pull/4608))
 * Make padding around component previews consistent ([PR #4610](https://github.com/alphagov/govuk_publishing_components/pull/4610))
+* Bump govuk-frontend from 5.7.1 to 5.8.0 ([PR #4539](https://github.com/alphagov/govuk_publishing_components/pull/4539))
 
 ## 51.1.1
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (51.1.1)
+    govuk_publishing_components (51.2.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "51.1.1".freeze
+  VERSION = "51.2.0".freeze
 end


### PR DESCRIPTION
## 51.2.0

* Remove classes functionality from shared helper ([PR #4605](https://github.com/alphagov/govuk_publishing_components/pull/4605))
* Add govuk-text-break-word style to markdown links ([PR #4603](https://github.com/alphagov/govuk_publishing_components/pull/4603))
* Remove margin bottom functionality from shared helper ([PR #4608](https://github.com/alphagov/govuk_publishing_components/pull/4608))
* Make padding around component previews consistent ([PR #4610](https://github.com/alphagov/govuk_publishing_components/pull/4610))
* Bump govuk-frontend from 5.7.1 to 5.8.0 ([PR #4539](https://github.com/alphagov/govuk_publishing_components/pull/4539))