### PR TITLE
[DO NOT MERGE] Remove blue bar

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
@@ -4,6 +4,12 @@
 @import "govuk/components/header/header";
 @import "govuk/components/tag/tag";
 
+// Anticipated change that will impact the blue bar
+.govuk-header__container {
+  border-bottom: none;
+  margin-bottom: 0;
+}
+
 .gem-c-layout-header--production .govuk-header__container {
   border-bottom-color: govuk-colour("red");
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
@@ -5,6 +5,10 @@
 @import "govuk/components/tag/tag";
 
 // Anticipated change that will impact the blue bar
+.govuk-header {
+  border-bottom: none;
+}
+
 .govuk-header__container {
   border-bottom: none;
   margin-bottom: 0;

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -4,12 +4,10 @@
   for_static ||= false
   emergency_banner ||= nil
   full_width ||= false
-  blue_bar ||= local_assigns.include?(:blue_bar) ? local_assigns[:blue_bar] : !full_width
   global_banner ||= nil
   html_lang ||= "en"
   homepage ||= false
   layout_helper = GovukPublishingComponents::Presenters::PublicLayoutHelper.new(local_assigns)
-  blue_bar_background_colour = layout_helper.blue_bar_background_colours.include?(blue_bar_background_colour) ? blue_bar_background_colour : nil
   logo_link ||= "/"
   navigation_items ||= []
   one_login_navigation_items ||= {}
@@ -31,31 +29,9 @@
   omit_account_navigation ||= false
   omit_account_phase_banner ||= false
 
-# This is a hack - but it's the only way I can find to not have two blue bars on
-# constrained width layouts.
-#
-# The full width layout hides the blue bar underneath the black header bar - so
-# full width pages won't see the blue bar unless it's added by another component
-# - and for most pages that component is the global banner.
-#
-# The constrained width layout doesn't hide the blue bar - so having the global
-# banner on a constrained width layout means there are two blue bars.
-#
-# The global banner is shown with JavaScript, so users without JavaScript won't
-# see it. So the constrained width blue bar can't be turned off as then it'll be
-# off for everyone.
-#
-# This booleon adds a CSS class that shifts the banners up by the blue bar's
-# height, making the two blue bars overlap and appear as one. The class is added
-# when a) there's content for the emergency or global banner *and* b) when using
-# the contrained width layout.
-  blue_bar_dedupe = !full_width && global_banner.present?
   body_css_classes = %w(gem-c-layout-for-public govuk-template__body)
   body_css_classes << "draft" if draft_watermark
   body_css_classes << "global-banner-present" if global_banner.present?
-
-  blue_bar_wrapper_classes = %w()
-  blue_bar_wrapper_classes << "gem-c-layout-for-public__blue-bar-wrapper--#{blue_bar_background_colour}" if blue_bar_background_colour
 -%>
 <!DOCTYPE html>
   <!--[if lt IE 9]><html class="lte-ie8 govuk-template" lang="<%= html_lang %>"><![endif]-->
@@ -133,16 +109,8 @@
 
     <%= raw(emergency_banner) %>
 
-    <% if (blue_bar && !global_banner.present? && !homepage) || (blue_bar_dedupe) %>
-      <%= content_tag(:div, class: blue_bar_wrapper_classes) do %>
-        <div class="gem-c-layout-for-public__blue-bar govuk-width-container"></div>
-      <% end %>
-    <% end %>
-
     <% if global_banner.present? %>
-      <%= content_tag("div", {
-        class: blue_bar_dedupe ? "gem-c-layout-for-public__global-banner-wrapper" : nil,
-      }) do %>
+      <%= content_tag("div") do %>
         <%= raw(global_banner) %>
       <% end %>
     <% end %>

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -127,10 +127,6 @@
           logo_link: logo_link,
           navigation_items: navigation_items,
           product_name: product_name,
-
-          # The (blue) bottom border needs to be underneath the emergency banner -
-          # so it has been turned off and added in manually.
-          remove_bottom_border: true,
         } %>
       <% end %>
     <% end %>

--- a/app/views/govuk_publishing_components/components/_layout_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_header.html.erb
@@ -6,7 +6,6 @@
   navigation_aria_label ||= t("components.layout_header.top_level")
   navigation_items ||= []
   product_name ||= nil
-  remove_bottom_border ||= false
   search ||= false
   width_class = full_width ? "govuk-header__container--full-width" : "govuk-width-container"
   logo_link ||= "/"
@@ -14,7 +13,6 @@
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-layout-header govuk-header")
   component_helper.add_class("gem-c-layout-header--#{environment}") if environment
-  component_helper.add_class("gem-c-layout-header--no-bottom-border") if remove_bottom_border
   component_helper.add_data_attribute({ module: "govuk-header" })
 
 %>

--- a/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
@@ -37,13 +37,6 @@ examples:
     description: This allows the header to be omitted which is currently used when rendering CSV previews from Whitehall
     data:
       omit_header: true
-  blue_bar_background:
-    description: For use when a page has a heading component with a background colour.
-    data:
-      for_static: true
-      full_width: true
-      blue_bar: true
-      blue_bar_background_colour: "no"
   omit_feedback:
     description: This allows the feedback form to be omitted
     data:

--- a/app/views/govuk_publishing_components/components/docs/layout_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_header.yml
@@ -59,10 +59,6 @@ examples:
     data:
       environment: production
       full_width: true
-  no_bottom_border:
-    description: This is useful for pages where a large full-width banner is the first thing to appear on the page, for example, the [GOV.UK homepage](https://www.gov.uk)
-    data:
-      remove_bottom_border: true
   with_search_bar:
     data:
       search: true

--- a/lib/govuk_publishing_components/presenters/public_layout_helper.rb
+++ b/lib/govuk_publishing_components/presenters/public_layout_helper.rb
@@ -1,7 +1,6 @@
 module GovukPublishingComponents
   module Presenters
     class PublicLayoutHelper
-      BLUE_BAR_BACKGROUND_COLOURS = %w[browse].freeze
       FOOTER_NAVIGATION_COLUMNS = [2, 1].freeze
       FOOTER_META = {
         items: [
@@ -63,10 +62,6 @@ module GovukPublishingComponents
 
       def footer_navigation_columns
         FOOTER_NAVIGATION_COLUMNS
-      end
-
-      def blue_bar_background_colours
-        BLUE_BAR_BACKGROUND_COLOURS
       end
     end
   end

--- a/spec/components/layout_for_public_spec.rb
+++ b/spec/components/layout_for_public_spec.rb
@@ -117,24 +117,6 @@ describe "Layout for public", :capybara, type: :view do
     assert_select "#test-global-banner", text: "This is a global banner test"
   end
 
-  it "has a blue bar by default" do
-    render_component({})
-
-    assert_select ".gem-c-layout-for-public__blue-bar"
-  end
-
-  it "has no blue bar when using the full width layout" do
-    render_component(full_width: true)
-
-    assert_select ".gem-c-layout-for-public__blue-bar", false
-  end
-
-  it "renders the blue bar if `blue_bar` is `true`" do
-    render_component(blue_bar: true)
-
-    assert_select ".gem-c-layout-for-public__blue-bar"
-  end
-
   it "renders homepage variant of layout super navigation header if `homepage` is true" do
     render_component(show_explore_header: true, homepage: true)
 
@@ -142,24 +124,6 @@ describe "Layout for public", :capybara, type: :view do
     assert_select ".govuk-header__logotype[height='30']"
     assert_select ".gem-c-layout-super-navigation-header--blue-background"
     assert_select ".gem-c-layout-super-navigation-header__header-logo--large-navbar"
-  end
-
-  it "renders the blue bar if `full_width` is true and `blue_bar` is true" do
-    render_component(full_width: true, blue_bar: true)
-
-    assert_select ".gem-c-layout-for-public__blue-bar"
-  end
-
-  it "renders the blue bar with a background if valid background specified" do
-    render_component(blue_bar: true, full_width: true, blue_bar_background_colour: "browse")
-
-    assert_select ".gem-c-layout-for-public__blue-bar-wrapper--browse .gem-c-layout-for-public__blue-bar"
-  end
-
-  it "does not render the blue bar with a background if an invalid background specified" do
-    render_component(blue_bar: true, full_width: true, blue_bar_background_colour: "invalid")
-
-    assert page.has_no_selector? ".gem-c-layout-for-public__blue-bar-wrapper--invalid"
   end
 
   it "has the default logo link when no logo_link is specified" do

--- a/spec/components/layout_header_spec.rb
+++ b/spec/components/layout_header_spec.rb
@@ -102,12 +102,6 @@ describe "Layout header", type: :view do
     assert_select ".gem-c-header__nav .govuk-header__link[data-more-than-one-word='test']", text: "Bar"
   end
 
-  it "renders the header without the bottom border" do
-    render_component(remove_bottom_border: true, environment: "public")
-
-    assert_select ".gem-c-layout-header--no-bottom-border"
-  end
-
   it "renders without a search bar by default" do
     render_component({ environment: "" })
 


### PR DESCRIPTION
## What
Remove various 'blue bar' configurations

https://trello.com/c/3EkNY2Bs/3254-prepare-a-pr-to-turn-off-the-blue-border-at-the-bottom-of-the-header?filter=label:Frontend%20devs

https://trello.com/c/9kohZAvu/3347-remove-support-for-the-blue-bar-below-the-header

## Why
The blue bar beneath the current black header on [GOV.UK](http://gov.uk/) pages is applied by https://github.com/alphagov/govuk_publishing_components. We want to remove the blue bar and we will need to update the gem accordingly. However the blue bar code is very old and complicated and we’re not sure how best to do it.

## Visual Changes

### Before

### After

## Anything else
https://github.com/alphagov/collections/pull/3976
https://github.com/alphagov/frontend/pull/4627
https://github.com/alphagov/static/pull/3578