### PR TITLE
Fix spacing between govspeak headings and attachment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix spacing between govspeak headings and attachment ([PR #4618](https://github.com/alphagov/govuk_publishing_components/pull/4618))
+
 ## 51.2.0
 
 * Remove classes functionality from shared helper ([PR #4605](https://github.com/alphagov/govuk_publishing_components/pull/4605))

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_markdown-typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_markdown-typography.scss
@@ -31,12 +31,11 @@
 
   h2 {
     margin-top: $govuk-gutter;
-    margin-bottom: 0;
+    margin-bottom: govuk-spacing(4);
     @include govuk-font($size: 27, $weight: bold);
 
     @include govuk-media-query($from: desktop) {
       margin-top: $govuk-gutter * 1.5;
-      margin-bottom: 0;
     }
   }
 


### PR DESCRIPTION
## What / why
Add a margin bottom to govspeak `H2` elements.

- headings don't have margin bottom in govspeak, so rely on elements following them to have top margin for spacing
- when followed by an attachment, this is a problem because an attachment is a gem component and therefore doesn't have top margin
- solution is to add bottom margin to headings that does not exceed the top margin of other elements, so if both are present they will overlap without a visual difference
- but for attachments the space will be provided by this new bottom margin
- only doing this for H2 for now as this is the only example of this problem in the wild and I'm hesitant to make sweeping changes to govspeak

## Visual Changes
Before | After
------ | ------
![Screenshot 2025-02-06 at 13 13 29](https://github.com/user-attachments/assets/880a9a11-0013-443f-a6cb-694f8d3a1693) | ![Screenshot 2025-02-06 at 13 13 45](https://github.com/user-attachments/assets/7952f1e7-8202-4395-8c71-8248e27f51e9)


Fixes https://github.com/alphagov/govuk_publishing_components/issues/4072
