### PR TITLE
Make heading component default size match govuk-frontend

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_heading.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_heading.scss
@@ -5,11 +5,6 @@
   margin: 0;
 }
 
-.gem-c-heading--font-size-27 {
-  @include govuk-text-colour;
-  @include govuk-font(27, $weight: bold);
-}
-
 .gem-c-heading--padding {
   padding: govuk-spacing(3) 0;
 }

--- a/lib/govuk_publishing_components/presenters/heading_helper.rb
+++ b/lib/govuk_publishing_components/presenters/heading_helper.rb
@@ -17,7 +17,6 @@ module GovukPublishingComponents
     private
 
       def heading_size(option)
-        gem_class = "gem-c-heading--font-size-"
         govuk_class = "govuk-heading-"
 
         case option
@@ -30,7 +29,7 @@ module GovukPublishingComponents
         when 19, "s"
           "#{govuk_class}s"
         else
-          "#{gem_class}27"
+          "#{govuk_class}m"
         end
       end
     end

--- a/spec/components/heading_spec.rb
+++ b/spec/components/heading_spec.rb
@@ -53,10 +53,10 @@ describe "Heading", type: :view do
 
   it "adds default font size if given no or an invalid value" do
     render_component(text: "font size not specified")
-    assert_select ".gem-c-heading h2.gem-c-heading--font-size-27"
+    assert_select ".gem-c-heading h2.govuk-heading-m"
 
     render_component(text: "font size 199", font_size: 199)
-    assert_select ".gem-c-heading h2.gem-c-heading--font-size-27"
+    assert_select ".gem-c-heading h2.govuk-heading-m"
   end
 
   it "has a specified id attribute" do


### PR DESCRIPTION
## What
Change the default font size of the heading component.

- the heading component has options to control the font size (independently of the heading level) and all the options directly match the govuk-frontend heading sizes: xl, l, m and s
- however if no size option is passed to the component it defaults to a font size of 27px, which is between l (36px) and m (24px)
- this could lead to a confusion in the visual hierarchy of headings on a page
- removing this custom code and allowing the component to default to 24px (to match govuk-heading-m)

## Why
Fixes https://github.com/alphagov/govuk_publishing_components/issues/1995 

This issue is marked as a breaking change, but I don't think it will actually cause any errors in our code, only that a fair amount of headings will suddenly appear slightly smaller.

## Visual Changes
Before | After
----- | -----
![Screenshot 2025-02-06 at 17 44 42](https://github.com/user-attachments/assets/79933b1c-bc61-4597-ac38-a1c69cd87f8a) | ![Screenshot 2025-02-06 at 17 44 58](https://github.com/user-attachments/assets/118946c8-0891-4fcf-9f00-3adaac94ac20)

