### PR TITLE
Change govspeak spacing model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Change govspeak spacing model ([PR #4623](https://github.com/alphagov/govuk_publishing_components/pull/4623))
 * Move govspeak attachment sass includes into view ([PR #4659](https://github.com/alphagov/govuk_publishing_components/pull/4659))
 * **BREAKING:** Remove layout_header component from layout_for_public ([PR #4643](https://github.com/alphagov/govuk_publishing_components/pull/4643))
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_govspeak-html-publication.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_govspeak-html-publication.scss
@@ -25,29 +25,20 @@
       @include govuk-font($size: 27, $weight: bold);
     }
 
+    * + h2,
+    * + h3 {
+      padding-top: govuk-spacing(3);
+
+      @include govuk-media-query($from: tablet) {
+        padding-top: govuk-spacing(9);
+      }
+    }
+
     .stat-headline:first-child {
       margin-top: govuk-spacing(6);
 
       @include govuk-media-query($from: tablet) {
         margin-top: govuk-spacing(9) + govuk-spacing(4);
-      }
-    }
-
-    h2,
-    h3 {
-      margin-top: govuk-spacing(6);
-
-      @include govuk-media-query($from: tablet) {
-        margin-top: govuk-spacing(9) + govuk-spacing(4);
-      }
-    }
-
-    h2:first-child,
-    h3:first-child {
-      margin-top: govuk-spacing(4);
-
-      @include govuk-media-query($from: tablet) {
-        margin-top: 0;
       }
     }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
@@ -9,22 +9,13 @@
 
 .govspeak, // Legacy class name that's still used in some content items - needs to be kept until `.govspeak` is removed from the content items.
 .gem-c-govspeak {
-  // This block is duplicated from Whitehall as a transitional step, see the
-  // commit message for 2d893c10ee3f2cab27162b9aba38b12379a71d07 before making
-  // changes, original version:
-  // https://github.com/alphagov/whitehall/blob/main/app/assets/stylesheets/frontend/helpers/_attachment.scss
   $thumbnail-width: 99px;
 
   .attachment {
     position: relative;
-    margin: govuk-spacing(6) 0;
-    padding: govuk-spacing(3) 0 0 ($thumbnail-width + govuk-spacing(6));
+    margin: 0 0 govuk-spacing(6) 0;
+    padding: 0 0 0 ($thumbnail-width + govuk-spacing(6));
     @include govuk-clearfix;
-
-    &:first-child {
-      margin-top: 0;
-      padding-top: 0;
-    }
 
     @include govuk-media-query($media-type: print) {
       padding-left: 0;
@@ -59,12 +50,12 @@
 
     .attachment-details {
       h2 {
-        margin: 0;
+        margin: 0 0 govuk-spacing(2) 0;
         @include govuk-font($size: 27);
       }
 
       p {
-        margin: govuk-spacing(2) 0;
+        margin: 0 0 govuk-spacing(2) 0;
       }
 
       .metadata {

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_call-to-action.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_call-to-action.scss
@@ -9,18 +9,9 @@
 .govspeak, // Legacy class name that's still used in some content items - needs to be kept until `.govspeak` is removed from the content items.
 .gem-c-govspeak {
   .call-to-action {
-    margin: 2em 0;
+    margin: 0 0 govuk-spacing(4) 0;
     background-color: govuk-colour("light-grey");
-    padding: 2em;
-
-    &:first-child {
-      margin-top: 0;
-    }
-
-    p:last-child,
-    ul:last-child,
-    ol:last-child {
-      margin-bottom: 0;
-    }
+    padding: govuk-spacing(6);
+    padding-bottom: govuk-spacing(2);
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_contact.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_contact.scss
@@ -14,8 +14,7 @@
   .contact {
     border-left: 1px solid govuk-colour("mid-grey");
     padding-left: govuk-spacing(3);
-    margin-bottom: govuk-spacing(6);
-    margin-top: govuk-spacing(6);
+    margin: 0 0 govuk-spacing(6) 0;
   }
 
   .contact {

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_example.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_example.scss
@@ -9,15 +9,8 @@
 .gem-c-govspeak {
   .example {
     border-left: 10px solid govuk-colour("mid-grey");
-    padding: 1em 0 1em 1em;
-    margin: 2em 0;
-
-    // Remove margin from the last element
-    p:last-child,
-    ul:last-child,
-    ol:last-child {
-      margin-bottom: 0;
-    }
+    padding: govuk-spacing(4) 0 0.1234px govuk-spacing(4); // non-zero padding on bottom keeps margin of last element inside parent, simulating padding
+    margin: 0 0 govuk-spacing(4) 0;
 
     strong {
       display: block;

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_footnotes.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_footnotes.scss
@@ -15,20 +15,11 @@
 .gem-c-govspeak {
   .footnotes {
     border-top: 1px solid govuk-colour("mid-grey");
-    margin-top: govuk-spacing(6);
-    padding-top: govuk-spacing(2);
+    margin: 0 0 govuk-spacing(4) 0;
+    padding-top: govuk-spacing(4);
 
     a {
       overflow-wrap: break-word;
-    }
-
-    ol {
-      margin-top: 0;
-      padding-top: 0;
-
-      li p {
-        margin: 10px 0;
-      }
     }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_form-download.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_form-download.scss
@@ -1,11 +1,7 @@
 .govspeak, // Legacy class name that's still used in some content items - needs to be kept until `.govspeak` is removed from the content items.
 .gem-c-govspeak {
   .form-download {
-    padding: .25em 0;
-
-    @include govuk-media-query($until: tablet) {
-      margin: 1em 0 1.5em;
-    }
+    margin: 0 0 govuk-spacing(4) 0;
 
     p {
       padding-right: 3em;

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_highlight-answer.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_highlight-answer.scss
@@ -10,7 +10,7 @@ $highlight-answer-color: govuk-colour("white");
     color: $highlight-answer-color;
     text-align: center;
     padding: govuk-spacing(5) govuk-spacing(2) govuk-spacing(4);
-    margin: 0 0 govuk-spacing(2);
+    margin: 0 0 govuk-spacing(4);
 
     p {
       color: $highlight-answer-color;
@@ -29,7 +29,6 @@ $highlight-answer-color: govuk-colour("white");
     }
 
     @include govuk-media-query($until: tablet) {
-      margin: 0 0 govuk-spacing(2);
       @include govuk-font($size: 48);
 
       p {

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_images.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_images.scss
@@ -16,8 +16,7 @@
     width: 100%;
     clear: both;
     overflow: hidden;
-    padding: govuk-spacing(2) 0 0;
-    margin: 0;
+    margin: 0 0 govuk-spacing(4) 0;
 
     img {
       display: inline;

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_information-callout.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_information-callout.scss
@@ -10,14 +10,7 @@
 .gem-c-govspeak {
   .info-notice {
     border-left: 10px solid govuk-colour("mid-grey");
-    padding: 1em 0 1em 1em;
-    margin: 2em 0;
-
-    // Remove margin from the last element
-    p:last-child,
-    ul:last-child,
-    ol:last-child {
-      margin-bottom: 0;
-    }
+    padding: govuk-spacing(4) 0 0.1234px govuk-spacing(4); // non-zero padding on bottom keeps margin of last element inside parent, simulating padding
+    margin: 0 0 govuk-spacing(4) 0;
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_legislative-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_legislative-list.scss
@@ -9,19 +9,6 @@
 .gem-c-govspeak {
   .legislative-list {
     list-style: none;
-    margin: 5px 0;
-
-    li {
-      margin: 5px 0;
-    }
-
-    p {
-      margin: 20px 0;
-    }
-
-    ol {
-      margin: govuk-spacing(2) 0 govuk-spacing(2) govuk-spacing(6);
-      list-style: none;
-    }
+    margin: 0 0 govuk-spacing(4) 0;
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_media-player.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_media-player.scss
@@ -9,8 +9,7 @@
   position: relative;
   height: 0;
   overflow: hidden;
-  margin-top: govuk-spacing(2);
-  margin-bottom: govuk-spacing(2);
+  margin: 0 0 govuk-spacing(4) 0;
   padding-top: 0;
   padding-left: 0;
   padding-right: 0;

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_place.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_place.scss
@@ -2,7 +2,7 @@
 .govspeak, // Legacy class name that's still used in some content items - needs to be kept until `.govspeak` is removed from the content items.
 .gem-c-govspeak {
   .place {
-    margin: 1.5em 0;
+    margin: 0 0 govuk-spacing(4) 0;
     border-bottom: solid 1px govuk-colour("mid-grey");
     padding-bottom: 1.5em;
 
@@ -24,10 +24,6 @@
       p {
         margin: .25em 0;
       }
-    }
-
-    @include govuk-media-query($until: tablet) {
-      margin: .75em 0;
     }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_stat-headline.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_stat-headline.scss
@@ -8,13 +8,7 @@
 .govspeak, // Legacy class name that's still used in some content items - needs to be kept until `.govspeak` is removed from the content items.
 .gem-c-govspeak {
   .stat-headline {
-    margin-bottom: govuk-spacing(3);
-    margin-top: govuk-spacing(3);
-
-    @include govuk-media-query($from: tablet) {
-      margin-bottom: govuk-spacing(4);
-      margin-top: govuk-spacing(4);
-    }
+    margin: 0 0 govuk-spacing(4) 0;
 
     p {
       margin: 0;
@@ -23,7 +17,6 @@
 
     em {
       display: block;
-      margin: 3px 0 -5px;
       @include govuk-font($size: 80, $weight: bold);
     }
   }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_steps.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_steps.scss
@@ -6,7 +6,7 @@
 
     > li {
       list-style-type: none;
-      margin-left: 0;
+      margin: 0;
       padding: .75em 0 .75em 2.5em;
       position: relative;
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_tables.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_tables.scss
@@ -11,7 +11,7 @@
     border-collapse: collapse;
     border-spacing: 0;
     display: block;
-    margin: govuk-spacing(6) 0;
+    margin: 0 0 govuk-spacing(6) 0;
     overflow-x: auto;
     width: 100%;
     @include govuk-font($size: 19);

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
@@ -26,7 +26,6 @@
 
     ul,
     ol {
-      margin-top: 0;
       margin-bottom: 0;
     }
   }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_warning-callout.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_warning-callout.scss
@@ -14,8 +14,8 @@
     $icon-size: 35px;
     $icon-spacing: 10px;
 
-    margin: 2em 0;
-    padding-left: calc($icon-size + $icon-spacing);
+    padding: govuk-spacing(3) 0 0 calc($icon-size + $icon-spacing);
+    margin: 0 0 govuk-spacing(6) 0;
     position: relative;
 
     &::before {
@@ -26,13 +26,6 @@
 
     p {
       @include govuk-font($size: 19, $weight: bold);
-    }
-  }
-
-  // Prevent excessive spacing when placed in a call-to-action block
-  .call-to-action {
-    .help-notice:first-child {
-      margin-top: 0;
     }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_markdown-typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_markdown-typography.scss
@@ -1,22 +1,23 @@
 @mixin markdown-typography {
   @include govuk-text-colour;
-
   @include govuk-font($size: 16);
 
   ol,
   ul,
   p {
-    margin-top: govuk-spacing(3);
-    margin-bottom: govuk-spacing(3);
+    margin: 0 0 govuk-spacing(4) 0;
     @include govuk-font($size: 19);
-
-    @include govuk-media-query($from: tablet) {
-      margin-top: govuk-spacing(4);
-      margin-bottom: govuk-spacing(4);
-    }
   }
 
   // Headings
+
+  // put some spacing between any element followed by a heading
+  // has to be padding on the heading otherwise margins would overlap
+
+  * + h2,
+  * + h3 {
+    padding-top: govuk-spacing(4);
+  }
 
   // Markdown is expected to be styled within a document with a H1 title
   // thus H1's are not expected and are discouraged by bare styling
@@ -28,18 +29,12 @@
   }
 
   h2 {
-    margin-top: govuk-spacing(6);
-    margin-bottom: govuk-spacing(4);
+    margin: 0 0 govuk-spacing(4) 0;
     @include govuk-font($size: 27, $weight: bold);
-
-    @include govuk-media-query($from: desktop) {
-      margin-top: govuk-spacing(6) * 1.5;
-    }
   }
 
   h3 {
-    margin-top: govuk-spacing(6) + 5px;
-    margin-bottom: 0;
+    margin: 0 0 govuk-spacing(4) 0;
     @include govuk-font($size: 19, $weight: bold);
   }
 
@@ -48,25 +43,8 @@
   h4,
   h5,
   h6 {
-    margin-top: govuk-spacing(6) + 5px;
-    margin-bottom: 0;
-    @include govuk-font($size: 19, $weight: bold);
-
-    + p {
-      margin-top: 5px;
-    }
-  }
-
-  h5,
-  h6 {
     margin: 0;
-  }
-
-  h2:first-child,
-  h3:first-child,
-  h4:first-child,
-  p:first-child {
-    margin-top: 0;
+    @include govuk-font($size: 19, $weight: bold);
   }
 
   // Links
@@ -89,15 +67,8 @@
     // utilise the type attribute for the formatting. Browsers default to a
     // style of decimal.
     list-style-position: outside;
-    margin-left: govuk-spacing(4);
+    margin: 0 0 govuk-spacing(4) govuk-spacing(4);
     padding: 0;
-
-    ul,
-    ol {
-      margin-top: 0;
-      margin-bottom: 0;
-      padding: 0;
-    }
   }
 
   ul {
@@ -105,22 +76,11 @@
   }
 
   li {
-    margin: 0 0 5px;
+    margin: 0 0 govuk-spacing(2);
     padding: 0;
 
     p {
-      margin: 0;
-      padding: 0;
-    }
-
-    p + p,
-    p + ul,
-    p + ol,
-    ul + p,
-    ul + ol,
-    ol + p,
-    ol + ul {
-      margin-top: 5px;
+      margin: 0 0 govuk-spacing(2);
     }
   }
 


### PR DESCRIPTION
## What
Change the govspeak CSS model from a margin top and bottom approach to a margin bottom only approach.

Trying to keep visual changes to a minimum but some small changes are likely, particularly as this change will include switching to `govuk-spacing()` for many margins instead of using `em` values.

To do:

- check appearance of many page types with changes
- check contents of main component govspeak sass, and govspeak html publication sass
- check with govspeak preview, and see how dependency works
- is govspeak previewed in any publishing interfaces?

For reference, I've checked these changes in the following page types. While there are minor differences I don't think there are any problems.

- news article (e.g. https://www.gov.uk/government/news/10-things-to-love-about-us)
- publication (e.g. https://www.gov.uk/government/publications/hm-land-registry-disclosure-log-april-to-june-2018)
- specialist document (e.g. https://www.gov.uk/residential-property-tribunal-decisions/fearn-island-mills-leeds-ls9-8ee-man-slash-00da-slash-ldc-slash-2021-slash-0064)
- detailed guide (e.g. https://www.gov.uk/guidance/remote-gaming-duty-appointing-a-representative-in-the-uk)
- hmrc manuals section (e.g. https://www.gov.uk/hmrc-internal-manuals/appeals-reviews-and-tribunals-guidance/artg6380)
- case study (e.g. https://www.gov.uk/government/case-studies/driving-economic-growth-and-recovery-in-the-legal-sector)
- about (e.g. https://www.gov.uk/government/organisations/disclosure-and-barring-service/about)
- access and opening (e.g. https://www.gov.uk/government/organisations/companies-house/about/access-and-opening)
- answer (e.g. https://www.gov.uk/personal-tax-account)
- call for evidence (e.g. https://www.gov.uk/government/calls-for-evidence/non-road-mobile-machinery-decarbonisation-options)
- html publications (e.g. https://www.gov.uk/government/publications/car-show-me-tell-me-vehicle-safety-questions/car-show-me-tell-me-vehicle-safety-questions)

## Why
Margin top and bottom relies upon overlapping margins to provide spacing. This is wasteful (why declare two things when you can declare one?), involves lots of overrides for first/last children, and does not follow the Design System approach, or the approach we try to use throughout the components gem.

## Visual Changes
Detailed below. Haven't included screenshots for everything as the preview app is better in many cases.

**Address** - margin top is removed, but otherwise largely the same.

Before | After
------ | ------
![Screenshot 2025-02-14 at 15 16 59](https://github.com/user-attachments/assets/3ef879bf-41b1-405b-9391-d23558744a22) | ![Screenshot 2025-02-14 at 15 17 20](https://github.com/user-attachments/assets/1221ea30-c8e0-4ee8-89ec-301dd22a1a22)

**Attachment link** - no visual changes.

**Attachment** - no visual change, but due to the change in spacing around paragraphs, the gap between attachments and following paragraphs is reduced. Was going to change this but the attachment is using styles from the attachment component (gem-c-attachment) so the change would need to be made there.

Before | After
------ | ------
![Screenshot 2025-02-14 at 15 20 41](https://github.com/user-attachments/assets/1560a778-4829-4509-890d-966ff40bc8e0) | ![Screenshot 2025-02-14 at 15 20 59](https://github.com/user-attachments/assets/300155d7-5533-40be-9a9e-948dc9321a1d)

**Attachment inline** - no visual changes.

**Whitehall block attachments** - removed padding top, so the spacing between these elements is smaller. I thought about increasing the margin bottom to compensate, but decided to stick with 30px as that seems to be the standard.

Before | After
------ | ------
![Screenshot 2025-02-14 at 15 26 03](https://github.com/user-attachments/assets/88a34c76-5feb-480c-ac47-62e93b6c4da6) | ![Screenshot 2025-02-14 at 15 26 22](https://github.com/user-attachments/assets/9704dfa5-513e-4213-ac38-436fdbbb7b35)

**Blockquote** - no visual changes, although I'm not entirely comfortable over how the margin bottom is handled by child elements rather than the blockquote itself. Although it does save having extra CSS for last child, and blockquotes seem like they'd always contain a `p`.

**Buttons** - no visual changes.

**Call to action** - slight visual change as we switch from using `em` to `govuk-spacing()` for the element padding. The other change is using a smaller padding on the bottom, assuming that child paragraphs will provide part of the spacing. Again, a bit of an assumption, but I think a reasonable one.

Before | After
------ | ------
![Screenshot 2025-02-14 at 15 37 13](https://github.com/user-attachments/assets/700f631e-6e23-4115-beae-9f9ff11c1b59) | ![Screenshot 2025-02-14 at 15 37 26](https://github.com/user-attachments/assets/d6ee473b-5b18-417c-b46f-39bf441484c2)

This change also improves the spacing in some call to action boxes, as seen on https://www.gov.uk/government/news/transport-minister-visits-brighton-to-see-uks-most-accessible-buses-for-international-day-of-people-with-disabilities

Before | After
------ | ------
![Screenshot 2025-02-25 at 09 42 35](https://github.com/user-attachments/assets/8639db59-9bc3-492e-ba06-6ac0f1a75a1f) | ![Screenshot 2025-02-25 at 09 42 46](https://github.com/user-attachments/assets/e1cdb7d1-2f11-436c-a46b-7be423692df8)

**Information callout** - margin top has been removed, plus switching from `em` to `govuk-spacing()` results in a slight visual change.

Before | After
------ | ------
![Screenshot 2025-02-14 at 15 58 47](https://github.com/user-attachments/assets/95cf1938-c463-4a63-8e50-051985f1299b) | ![Screenshot 2025-02-14 at 15 59 16](https://github.com/user-attachments/assets/de44d6ee-f827-46cb-931a-319221ceb8ea)

**Warning callout** - this one was a bit tricky, because it's an element that requires a bit of padding top and also contains elements that themselves could have margins. Since so many possible elements can be inside it I'm letting them keep their own margin, which is actually overlapped by a larger margin on the bottom of the warning callout itself (screenshots don't adequately convey this).

**Contact** - broadly the same, but loses margin top.

**Charts** - no visual changes.

**Example** - no margin top now, plus slight left/right spacing changes due to switching away from `em`.

Before | After
------ | ------
![Screenshot 2025-02-14 at 16 05 45](https://github.com/user-attachments/assets/6b7f4ff7-1ee4-411a-8454-c85495eaa2d2) | ![Screenshot 2025-02-14 at 16 05 59](https://github.com/user-attachments/assets/2dc60348-fa14-482e-ba9a-2d6dd8e0b4f7)

**Footnotes** - some reduction in spacing, because this is partly made up of paragraphs and the spacing around paragraphs has changed. Again, could have added some more spacing to reduce the visual difference but it's good to have a consistent spacing approach.

Before | After
------ | ------
![Screenshot 2025-02-14 at 16 08 09](https://github.com/user-attachments/assets/354e1adb-ab19-431c-a792-f7fe3ab656ce) | ![Screenshot 2025-02-14 at 16 08 25](https://github.com/user-attachments/assets/dc816656-caf6-46f4-a160-0358bd787f35)

**Form download** - moves up slightly as padding top is removed. Padding bottom is also reduced, but margin bottom is added to compensate.

**Highlight answer** - increased margin bottom to be more consistent with other elements (was a bit small).

**Headings** - broadly the same, despite all the changes. Removed margin top but also added a rule so that whenever a heading follows anything else, padding top is added to increase the space. Otherwise the gap between paragraphs and headings is the same as the gap between paragraphs, which I think would make the headings harder to spot (see the common example for clarity). H4s downwards are deliberately unstyled (to discourage their use).

**Image** - padding top is replaced with margin bottom, otherwise unchanged.

**Lists** - removes margin top. The rest is a bit tricky, because it turns out some lists can contain paragraphs, so there needs to be spacing between them, but less than between normal paragraphs. As a compromise the spacing between list items is increased to match the reduced spacing between paragraphs in lists, so although overall list spacing is increased, normal lists and lists containing paragraphs have consistent spacing.

Before | After
------ | ------
![Screenshot 2025-02-14 at 16 26 42](https://github.com/user-attachments/assets/92f2ff58-e23f-4a4d-9417-4e28fd5ad9ac) | ![Screenshot 2025-02-14 at 16 26 59](https://github.com/user-attachments/assets/e1d26993-4323-4bbc-ba6c-d987767b38f1)

**Govspeak HTML publication**

Changes are minimal and there should be no visual difference.


Trello card: https://trello.com/c/IGbGxOO6/481-standardise-govspeak-element-spacing