### PR TITLE
Version 51.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 51.2.1
 
 * Fix spacing between govspeak headings and attachment ([PR #4618](https://github.com/alphagov/govuk_publishing_components/pull/4618))
 * Update LUX to v4.0.30 ([PR #4621](https://github.com/alphagov/govuk_publishing_components/pull/4621))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (51.2.0)
+    govuk_publishing_components (51.2.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "51.2.0".freeze
+  VERSION = "51.2.1".freeze
 end


### PR DESCRIPTION
## 51.2.1

* Fix spacing between govspeak headings and attachment ([PR #4618](https://github.com/alphagov/govuk_publishing_components/pull/4618))
* Update LUX to v4.0.30 ([PR #4621](https://github.com/alphagov/govuk_publishing_components/pull/4621))
* Remove IE11 specific code from feedback.js ([PR #4622](https://github.com/alphagov/govuk_publishing_components/pull/4622))
