### PR TITLE
Make account layout respect for static

### DIFF
--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -156,6 +156,7 @@
         omit_account_phase_banner: omit_account_phase_banner,
         omit_account_navigation: omit_account_navigation,
         account_nav_location: account_nav_location,
+        for_static: for_static,
       } do %>
         <%= yield :before_content %>
         <%= yield %>

--- a/app/views/govuk_publishing_components/components/layout_for_public/_account-layout.html.erb
+++ b/app/views/govuk_publishing_components/components/layout_for_public/_account-layout.html.erb
@@ -12,9 +12,13 @@
     <div class="govuk-grid-column-two-thirds">
       <div id="wrapper">
         <%= yield :before_content %>
-        <main id="content">
+        <% if for_static %>
+          <main id="content">
+            <%= yield %>
+          </main>
+        <% else %>
           <%= yield %>
-        </main>
+        <% end %>
       </div>
     </div>
   </div>

--- a/spec/components/layout_for_public_spec.rb
+++ b/spec/components/layout_for_public_spec.rb
@@ -333,14 +333,14 @@ describe "Layout for public", :capybara, type: :view do
     end
 
     assert_select "main#custom-layout"
-    assert page.has_no_selector?("div#wrapper")
-    assert page.has_no_selector?("main.govuk-main-wrapper")
+    assert_select "div#wrapper", false
+    assert_select "main.govuk-main-wrapper", false
   end
 
   it "renders without the wrapper if for_static is not explictly set to true" do
     render_component({})
 
-    assert page.has_no_selector?("div#wrapper")
-    assert page.has_no_selector?("main.govuk-main-wrapper")
+    assert_select "div#wrapper", false
+    assert_select "main.govuk-main-wrapper", false
   end
 end

--- a/spec/components/layout_for_public_spec.rb
+++ b/spec/components/layout_for_public_spec.rb
@@ -236,6 +236,12 @@ describe "Layout for public", :capybara, type: :view do
     assert page.has_no_selector?("html > head > script[src*='lux/lux-reporter']", visible: :hidden)
   end
 
+  it "account layout renders with a main element if for_static is explicitly set to true" do
+    render_component({ show_account_layout: true, for_static: true })
+
+    assert_select ".gem-c-layout-for-public main#content"
+  end
+
   it "account layout renders with a phase banner by default" do
     render_component({ show_account_layout: true })
 
@@ -342,5 +348,11 @@ describe "Layout for public", :capybara, type: :view do
 
     assert_select "div#wrapper", false
     assert_select "main.govuk-main-wrapper", false
+  end
+
+  it "account layout renders without the main element if for_static is not explicitly set to true" do
+    render_component({ show_account_layout: true })
+
+    assert_select ".gem-c-layout-for-public main#content", false
   end
 end


### PR DESCRIPTION
## What
- Add tests to ensure that for_static: true results in a main element, false results in an absence.
- Additionally, fix some tests that would always pass

## Why

Currently the for_static: false value if called for the account layout won't skip the main element in the same way the non-account layouts do. This leads to double main element in no-slimmer apps that use the account layout.

## Visual Changes

No visual changes expected.