### PR TITLE
Remove left border from the super nav menu button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Make account layout respect `for_static` ([PR #4630](https://github.com/alphagov/govuk_publishing_components/pull/4630))
+* Remove left border from the super nav menu button ([PR #4631](https://github.com/alphagov/govuk_publishing_components/pull/4631))
 
 ## 51.2.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -311,12 +311,10 @@ $after-button-padding-left: govuk-spacing(4);
 }
 
 .gem-c-layout-super-navigation-header__navigation-item-link-inner {
-  border-left: 1px solid $button-pipe-colour;
   padding: govuk-spacing(1) $after-link-padding;
 }
 
 .gem-c-layout-super-navigation-header__navigation-item-link-inner--blue-background {
-  border-left: 0;
   border-right: 1px solid $pale-blue-colour;
 }
 
@@ -589,7 +587,6 @@ $after-button-padding-left: govuk-spacing(4);
 
 .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
   display: inline-block;
-  border-left: 1px solid govuk-colour("white");
   border-right: 1px solid govuk-colour("white");
   margin: 0;
   padding: govuk-spacing(1) govuk-spacing(4);
@@ -599,10 +596,6 @@ $after-button-padding-left: govuk-spacing(4);
       @include chevron(govuk-colour("white"));
     }
   }
-}
-
-.gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner--no-left-border {
-  border-left: 0;
 }
 
 // Styles for search toggle button.

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -7,7 +7,6 @@
   logo_text = t("components.layout_super_navigation_header.logo_text")
 
   hide_logo_text ||= false
-  hide_button_left_border ||= false
   blue_background ||= false
   large_navbar ||= false
 
@@ -28,7 +27,6 @@
   top_toggle_button_classes << "gem-c-layout-super-navigation-header__navigation-top-toggle-button--large-navbar" if large_navbar
 
   top_toggle_button_inner_classes = %w(gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner)
-  top_toggle_button_inner_classes << "gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner--no-left-border" if hide_button_left_border
   top_toggle_button_inner_classes << "gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner--blue-background" if blue_background
 
   search_toggle_button_classes = %w(gem-c-layout-super-navigation-header__search-toggle-button)

--- a/app/views/govuk_publishing_components/components/docs/layout_super_navigation_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_super_navigation_header.yml
@@ -39,10 +39,9 @@ examples:
       logo_link_title: "Go to example"
   homepage:
     description: |
-      This variant is used for the homepage. It toggles the following attributes: hide_button_left_border, hide_logo_text and blue_background
+      This variant is used for the homepage. It toggles the following attributes: hide_logo_text and blue_background
     data:
       hide_logo_text: true
-      hide_button_left_border: true
       blue_background: true
       large_navbar: true      
   hide_logo_text:
@@ -50,11 +49,6 @@ examples:
       Logo text is shown by default. This option allows us to hide the text for the homepage.
     data:
       hide_logo_text: true
-  remove_left_button_border:
-    description: |
-      The left border for the toggle button is shown by default. This option allows us to hide the text for the homepage.
-    data:
-      hide_button_left_border: true
   blue_blackground_colour:
     description: |
       The black background is shown by default. This option allows us to change the background colour for the homepage.

--- a/app/views/govuk_publishing_components/components/layout_for_public/_layout_super_navigation_header_homepage.html.erb
+++ b/app/views/govuk_publishing_components/components/layout_for_public/_layout_super_navigation_header_homepage.html.erb
@@ -5,7 +5,6 @@
     hide_logo_text: true,
     logo_link: logo_link,
     blue_background: true,
-    hide_button_left_border: true,
     large_navbar: true,
   }
 %>

--- a/spec/components/layout_super_navigation_header_spec.rb
+++ b/spec/components/layout_super_navigation_header_spec.rb
@@ -112,14 +112,6 @@ describe "Super navigation header", type: :view do
     assert_select "a.govuk-header__link--homepage .govuk-visually-hidden"
   end
 
-  it "hides left border of button" do
-    render_component({
-      hide_button_left_border: true,
-    })
-
-    assert_select ".gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner--no-left-border"
-  end
-
   it "allows a custom crown logo link and custom title" do
     render_component({
       logo_link: "https://www.example.com/",


### PR DESCRIPTION
## What

Removed the 1px left border style, and the `hide_button_left_border` option from the super navigation menu component.

## Why

- To align the menu button styling on gov.uk with the styling used on the gov.uk homepage
- The `hide_button_left_border` option is no longer as it is now removed by default

[Trello card](https://trello.com/c/2xMlOLhe/3289-remove-hidebuttonleftborder-from-the-menu-in-the-super-navigation-header)

## Visual Changes

- Live preview before - https://components.publishing.service.gov.uk/component-guide/layout_super_navigation_header/default/preview
- Live preview after - https://components-gem-pr-4631.herokuapp.com/component-guide/layout_super_navigation_header/default/preview

The failing visual regression tests in Percy are expected, screenshots of how the changes will appear on GOV.UK are included below.

### Mobile

| Before | After |
| --- | --- |
| ![menu-mobile-before](https://github.com/user-attachments/assets/527ad7a2-343f-400e-9683-c319c88e39ec) | ![menu-mobile-after](https://github.com/user-attachments/assets/8e5e8aaa-8e50-426f-875f-caed1137e880) |

### Desktop

| Before | After |
| --- | --- |
| ![menu-desktop-before](https://github.com/user-attachments/assets/12ad443c-28b0-464f-bcf1-a12d59a43828) | ![menu-desktop-after](https://github.com/user-attachments/assets/1af7ed5d-b4ce-4c5c-9033-3266afd002f8) |
