### PR TITLE
Use component wrapper on 'add another' component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Make account layout respect `for_static` ([PR #4630](https://github.com/alphagov/govuk_publishing_components/pull/4630))
 * Remove left border from the super nav menu button ([PR #4631](https://github.com/alphagov/govuk_publishing_components/pull/4631))
+* Use component wrapper on 'add another' component ([PR #4632](https://github.com/alphagov/govuk_publishing_components/pull/4632))
 
 ## 51.2.1
 

--- a/app/views/govuk_publishing_components/components/_add_another.html.erb
+++ b/app/views/govuk_publishing_components/components/_add_another.html.erb
@@ -5,14 +5,18 @@
   fieldset_legend ||= ""
   add_button_text ||= "Add another"
   empty_fields ||= false
+
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("gem-c-add-another")
+  component_helper.add_data_attribute({
+    module: "add-another",
+    add_button_text:,
+    fieldset_legend:,
+    empty_fields:,
+  })
 %>
 
-<%= tag.div class: "gem-c-add-another", data: {
-  module: "add-another",
-  "add-button-text": add_button_text,
-  "fieldset-legend": fieldset_legend,
-  "empty-fields": empty_fields
-} do %>
+<%= tag.div(**component_helper.all_attributes) do %>
   <% unless empty_fields && items.count == 0 %>
     <% items.each_with_index do |item, index| %>
       <%= render "govuk_publishing_components/components/fieldset", {

--- a/app/views/govuk_publishing_components/components/docs/add_another.yml
+++ b/app/views/govuk_publishing_components/components/docs/add_another.yml
@@ -20,7 +20,7 @@ body: |
 accessibility_criteria: |
   The form controls within the fieldsets must be fully accessible as per the
   design system guidance for each of the form control components.
-uses_component_wrapper_helper: false
+uses_component_wrapper_helper: true
 govuk_frontend_components:
   - button
 examples:


### PR DESCRIPTION
## What
- Adds the component wrapper helper to the `add another` component.
- Trello card: https://trello.com/c/QSiP4Bw6/495-add-component-wrapper-to-add-another-component

## Why

> Standardising our components to use the component wrapper helper will reduce code, increase standardisation, and improve future feature implementation speed.

## Visual changes

None.