### PR TITLE
Swap inset text top margin with padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Swap inset text top margin with padding ([PR #4634](https://github.com/alphagov/govuk_publishing_components/pull/4634))
+
 ## 52.0.0
 
 * Make account layout respect `for_static` ([PR #4630](https://github.com/alphagov/govuk_publishing_components/pull/4630))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_inset-text.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_inset-text.scss
@@ -6,3 +6,15 @@
     break-inside: avoid;
   }
 }
+
+.gem-c-inset-text {
+  padding-top: govuk-spacing(4);
+
+  .govuk-inset-text {
+    margin-top: 0;
+  }
+
+  @include govuk-media-query($from: tablet) {
+    padding-top: govuk-spacing(6);
+  }
+}

--- a/app/views/govuk_publishing_components/components/_inset_text.html.erb
+++ b/app/views/govuk_publishing_components/components/_inset_text.html.erb
@@ -5,13 +5,15 @@
   local_assigns[:margin_bottom] ||= 6
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
-  component_helper.add_class("gem-c-inset-text govuk-inset-text gem-c-force-print-link-styles-within")
+  component_helper.add_class("gem-c-inset-text gem-c-force-print-link-styles-within")
   component_helper.set_id(id)
 %>
 <%= tag.div(**component_helper.all_attributes) do %>
-  <% if defined? text %>
-    <%= text %>
-  <% elsif block_given? %>
-    <%= yield %>
-  <% end %>
+  <div class="govuk-inset-text">
+    <% if defined? text %>
+      <%= text %>
+    <% elsif block_given? %>
+      <%= yield %>
+    <% end %>
+  </div>
 <% end %>

--- a/spec/components/inset_text_spec.rb
+++ b/spec/components/inset_text_spec.rb
@@ -8,7 +8,7 @@ describe "Inset text", type: :view do
   it "renders inset text" do
     render_component(text: "It can take up to 8 weeks to register a lasting power of attorney if there are no mistakes in the application.")
 
-    assert_select(".govuk-inset-text.govuk-\\!-margin-bottom-6", text: "It can take up to 8 weeks to register a lasting power of attorney if there are no mistakes in the application.")
+    assert_select(".gem-c-inset-text.govuk-\\!-margin-bottom-6", text: "It can take up to 8 weeks to register a lasting power of attorney if there are no mistakes in the application.")
   end
 
   it "renders a block" do
@@ -36,6 +36,6 @@ describe "Inset text", type: :view do
       margin_bottom: 9,
     )
 
-    assert_select(".govuk-inset-text.govuk-\\!-margin-bottom-9", text: "margin!")
+    assert_select(".gem-c-inset-text.govuk-\\!-margin-bottom-9", text: "margin!")
   end
 end


### PR DESCRIPTION
## What / Why
<!-- What are the reasons behind this change being made? -->
- Swap the margin top on this component for padding as we're trying to standardise the top/bottom spacing on components. 
- Trello card: https://trello.com/c/tpFgf7uM/498-investigate-margin-top-on-inset-text-component
- This required nesting the component in a `<div>`, as we can't change the padding directly on the existing component, as the current `padding` here is used for the `border-left` effect where the border is taller than the text content. Therefore, padding had to be added to a new parent component so that the new padding doesn't affect how the component itself looks and ensures it's just used for spacing.
 - You can compare the spacing with the live component: https://components.publishing.service.gov.uk/component-guide/inset_text/preview vs https://components-gem-pr-4634.herokuapp.com/component-guide/inset_text/preview

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None, hopefully
