### PR TITLE
Remove `custom_header` and `custom_layout` options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Remove left border from the super nav menu button ([PR #4631](https://github.com/alphagov/govuk_publishing_components/pull/4631))
 * Use component wrapper on 'add another' component ([PR #4632](https://github.com/alphagov/govuk_publishing_components/pull/4632))
 * Use component wrapper on 'copy to clipboard' component ([PR #4633](https://github.com/alphagov/govuk_publishing_components/pull/4633))
+* **BREAKING** Remove custom_header and custom_layout options ([PR #4635](https://github.com/alphagov/govuk_publishing_components/pull/4635))
 
 ## 51.2.1
 

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -18,7 +18,6 @@
   omit_footer_navigation ||= false
   omit_footer_border ||= false
   omit_header ||= false
-  custom_layout ||= false
   product_name ||= nil
   show_explore_header ||= false
   show_cross_service_header ||= false
@@ -119,8 +118,6 @@
           service_navigation_items: service_navigation_items,
           product_name: product_name,
         } %>
-      <% elsif content_for?(:custom_header) %>
-        <%= yield :custom_header %>
       <% else %>
         <%= render "govuk_publishing_components/components/layout_header", {
           search: show_search,
@@ -161,8 +158,6 @@
         <%= yield :before_content %>
         <%= yield %>
       <% end %>
-    <% elsif custom_layout %>
-      <%= yield %>
     <% elsif for_static %>
       <div id="wrapper" class="<%= "govuk-width-container" unless full_width %>">
         <%= yield :before_content %>

--- a/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
@@ -134,19 +134,3 @@ examples:
           cookie_preferences:
             text: How GOV.UK accounts use cookies
             href: https://www.gov.uk/government/publications/govuk-accounts-trial-full-privacy-notice-and-accessibility-statement
-  with_custom_layout:
-    description: Yields a custom layout for the content.
-    data:
-      custom_layout: true
-      block: |
-        <main id="custom-layout">
-          <h1>This is a custom layout</h1>
-        </main>
-  with_custom_header:
-    description: Allows the header to be replaced with HTML injected by the calling application in a `content_for` tag named `:custom_header`.
-    embed: |
-      <% content_for(:custom_header) do %>
-        <header id="custom-header">I'm a custom header</header>
-      <% end %>
-      <%= render "govuk_publishing_components/components/layout_for_public", {
-      } %>

--- a/spec/components/layout_for_public_spec.rb
+++ b/spec/components/layout_for_public_spec.rb
@@ -325,24 +325,6 @@ describe "Layout for public", :capybara, type: :view do
     assert_select ".gem-c-cookie-banner + .gem-c-skip-link"
   end
 
-  it "can render a custom header instead of the default one" do
-    view.content_for(:custom_header) { content_tag(:header, "GOV.UK with a custom header", id: "custom-header") }
-    render_component({})
-
-    assert_select "header#custom-header"
-    assert page.has_no_selector?(".gem-c-layout-header")
-  end
-
-  it "can render a custom layout instead of the default one" do
-    render_component({ custom_layout: true }) do
-      content_tag(:main, "GOV.UK with a custom layout", id: "custom-layout")
-    end
-
-    assert_select "main#custom-layout"
-    assert_select "div#wrapper", false
-    assert_select "main.govuk-main-wrapper", false
-  end
-
   it "renders without the wrapper if for_static is not explictly set to true" do
     render_component({})
 


### PR DESCRIPTION
## What

**Breaking**: Removes support for the `custom_header` and `custom_layout` options from layout_for_public view template, these options were originally created for and only used by GOV.UK Chat.

These options only appeared to be used by GOV.UK Chat, searching GitHub for `custom_layout` and `custom_header` only returns results for the govuk_publishing_components repo:
- https://github.com/search?q=org%3Aalphagov+%3Acustom_header&type=code
- https://github.com/search?q=org%3Aalphagov+custom_layout&type=code

This PR essentially reverts the changes made in https://github.com/alphagov/govuk_publishing_components/pull/4004

[Trello card](https://trello.com/c/aKklGLh5/3302-remove-customheader-option-from-govuk-publishing-components)

## Why

These options are no longer required, GOV.UK Chat now uses a custom layout instead of layout_for_public - https://github.com/alphagov/govuk-chat/commit/ff58ec0049ec6a14d10c7cc7ff0543125622f3e2

## Visual Changes

The visual changes shown in Percy are expected following the removal of the `custom_header` and `custom_layout` examples