### PR TITLE
Ensure 'search with autocomplete' component uses its own margin bottom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Fix bottom border colour issue in the super nav search button ([PR #4642](https://github.com/alphagov/govuk_publishing_components/pull/4642))
 * Use govuk-spacing instead of govuk-gutter ([PR #4650](https://github.com/alphagov/govuk_publishing_components/pull/4650))
+* Ensure 'search with autocomplete' component uses its own margin bottom ([PR #4637](https://github.com/alphagov/govuk_publishing_components/pull/4637))
 
 ## 52.1.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -24,7 +24,6 @@ $large-input-size: 50px;
 
 .gem-c-search {
   position: relative;
-  margin-bottom: 30px;
 }
 
 .gem-c-search__label {

--- a/app/views/govuk_publishing_components/components/_search.html.erb
+++ b/app/views/govuk_publishing_components/components/_search.html.erb
@@ -18,6 +18,7 @@
   no_border ||= false
   size ||= ""
   value ||= ""
+  local_assigns[:margin_bottom] ||= 6
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_data_attribute({ module: "gem-toggle-input-class-on-focus" })

--- a/app/views/govuk_publishing_components/components/_search_with_autocomplete.html.erb
+++ b/app/views/govuk_publishing_components/components/_search_with_autocomplete.html.erb
@@ -8,16 +8,20 @@
     raise ArgumentError, "The search_with_autocomplete component requires source_url and source_key"
   end
 
-  search_component_options = local_assigns.except(:autocomplete, :source_url, :source_key).merge(
+  search_component_options = local_assigns.except(:autocomplete, :source_url, :source_key, :margin_bottom).merge(
     # The `search` component has an inline label by default, but this conflicts with the accessible-
     # autocomplete component's markup and styling. Every potential use of this component is in
     # situations where we want the label not to be inline anyway, so we override the default here.
-    inline_label: false
+    inline_label: false,
+    margin_bottom: 0
   )
 
   classes = %w[gem-c-search-with-autocomplete]
   classes << "gem-c-search-with-autocomplete--large" if local_assigns[:size] == "large"
   classes << "gem-c-search-with-autocomplete--on-govuk-blue" if local_assigns[:on_govuk_blue]
+
+  margin_bottom = [*0..9].include?(local_assigns[:margin_bottom]) ? local_assigns[:margin_bottom] : 6
+  classes << "govuk-!-margin-bottom-#{margin_bottom}" if margin_bottom
 %>
 <%= tag.div(
   class: classes.join(" "),

--- a/app/views/govuk_publishing_components/components/docs/search_with_autocomplete.yml
+++ b/app/views/govuk_publishing_components/components/docs/search_with_autocomplete.yml
@@ -60,3 +60,10 @@ examples:
       source_url: 'https://www.gov.uk/api/search.json?suggest=autocomplete'
       source_key: suggested_autocomplete
       label_text: <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Search GOV.UK</h2>
+  with_margin_bottom:
+    description: |
+      The component accepts a number for margin bottom from `0` to `9` (`0px` to `60px`) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to having a margin bottom value of 6.
+    data:
+      source_url: 'https://www.gov.uk/api/search.json?suggest=autocomplete'
+      source_key: suggested_autocomplete
+      margin_bottom: 9

--- a/spec/components/search_with_autocomplete_spec.rb
+++ b/spec/components/search_with_autocomplete_spec.rb
@@ -49,4 +49,47 @@ describe "Search with autocomplete", type: :view do
 
     assert_select ".gem-c-search.gem-c-search--on-govuk-blue.gem-c-search--large"
   end
+
+  it "applies a margin bottom of 0" do
+    render_component({
+      source_url: "http://example.org/api/autocomplete",
+      source_key: "suggestions",
+      margin_bottom: 0,
+    })
+    assert_select '.gem-c-search-with-autocomplete.govuk-\!-margin-bottom-0'
+  end
+
+  it "applies a valid margin bottom" do
+    render_component({
+      source_url: "http://example.org/api/autocomplete",
+      source_key: "suggestions",
+      margin_bottom: 4,
+    })
+    assert_select '.gem-c-search-with-autocomplete.govuk-\!-margin-bottom-4'
+  end
+
+  it "defaults to a margin bottom of 6" do
+    render_component({
+      source_url: "http://example.org/api/autocomplete",
+      source_key: "suggestions",
+    })
+    assert_select '.gem-c-search-with-autocomplete.govuk-\!-margin-bottom-6'
+  end
+
+  it "sets margin bottom to 6 if an invalid number is passed" do
+    render_component({
+      source_url: "http://example.org/api/autocomplete",
+      source_key: "suggestions",
+      margin_bottom: -1,
+    })
+    assert_select '.gem-c-search-with-autocomplete.govuk-\!-margin-bottom-6'
+  end
+
+  it "disables margin bottom on the child search component" do
+    render_component({
+      source_url: "http://example.org/api/autocomplete",
+      source_key: "suggestions",
+    })
+    assert_select '.gem-c-search.govuk-\!-margin-bottom-0'
+  end
 end


### PR DESCRIPTION
## What / Why
- The `search with autocomplete` component is a simple component that renders the `search` component inside of it.
- The `search` component had a hardcoded 30px margin bottom in its SASS, but weirdly can be overridden as the `search` component has the component wrapper helper on it. This is what is happening on production with 2 out of 3 of the `search with autocomplete` renders currently, as they are passing a 0 margin_bottom on the homepage in `frontend`, and on the `finder-frontend` search results page.
- However having this hardcoded default margin bottom is probably not ideal, as ideally the parent component (`search with autocomplete`) should always be in control of the margin bottom that it is rendering on the page.
- The `search with autocomplete` component is also a bit unique though, as it passes all it's `local_assigns` down to the child `search` component, apart from a few options that are explicitly left out.
- Therefore I couldn't add the component helper wrapper here as the local assigns would've ended up duplicated across the components.
- Therefore, I've modified the `search` component to not have any hardcoded static margin bottom defined in it's SASS 
 and instead have it defined by the component wrapper, so the margin is set in a more standardised way.
- I've then added some logic to set `margin_bottom` within the `search with autocomplete` component.
- [Trello card](https://trello.com/c/RJoaAO4J/499-fix-search-with-autocomplete-margin-layout)

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

As the search component now uses the component helper wrapper's responsive margin bottom instead of a static margin bottom, there's a visual change on mobile, as 30px of responsive margin bottom will drop to 20px on mobile.
