### PR TITLE
Allow margin bottom to be configured on the table component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Swap inset text top margin with padding ([PR #4634](https://github.com/alphagov/govuk_publishing_components/pull/4634))
+* Allow margin bottom to be configured on the table component ([PR #4638](https://github.com/alphagov/govuk_publishing_components/pull/4638))
 
 ## 52.0.0
 

--- a/app/views/govuk_publishing_components/components/_table.html.erb
+++ b/app/views/govuk_publishing_components/components/_table.html.erb
@@ -9,6 +9,7 @@
   sortable ||= false
   filterable ||= false
   label ||= t("components.table.filter_label")
+  margin_bottom ||= nil
 
   table_id = "table-id-#{SecureRandom.hex(4)}"
   filter_count_id = "filter-count-id-#{SecureRandom.hex(4)}"
@@ -16,10 +17,11 @@
 
 <% @table = capture do %>
   <%= GovukPublishingComponents::AppHelpers::TableHelper.helper(self, caption, {
-      sortable: sortable,
-      filterable: filterable,
-      caption_classes: caption_classes,
-      table_id: table_id
+      sortable:,
+      filterable:,
+      caption_classes:,
+      table_id:,
+      margin_bottom:,
     }) do |t| %>
 
     <% if head.any? %>

--- a/app/views/govuk_publishing_components/components/docs/table.yml
+++ b/app/views/govuk_publishing_components/components/docs/table.yml
@@ -140,7 +140,7 @@ examples:
         - text: £80
           format: numeric
   with_filter:
-    description: This option allows table rows to be filtered by user input. Since this filtering is implemented client-side the filter section is not displayed by default but displays only when JavaScript is enabled. The label for the input field can be set when the coponent is rendered via the `label` key. if this is not set a fallback value will display.
+    description: This option allows table rows to be filtered by user input. Since this filtering is implemented client-side the filter section is not displayed by default but displays only when JavaScript is enabled. The label for the input field can be set when the component is rendered via the `label` key. If this is not set a fallback value will display.
     data:
       filterable: true
       label: Filter months

--- a/app/views/govuk_publishing_components/components/docs/table.yml
+++ b/app/views/govuk_publishing_components/components/docs/table.yml
@@ -169,3 +169,34 @@ examples:
           format: numeric
         - text: £125
           format: numeric
+  with_custom_margin_bottom:
+    description: The component accepts a number for margin bottom from `0` to `9` (`0px` to `60px`) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). By default, this component has a margin bottom of `30px`, as determined by the design system styles.
+    data:
+      margin_bottom: 0
+      filterable: true
+      label: Filter months
+      head:
+        - text: Month you apply
+        - text: Rate for bicycles
+          format: numeric
+        - text: Rate for vehicles
+          format: numeric
+      rows:
+      -
+        - text: January
+        - text: £85
+          format: numeric
+        - text: £95
+          format: numeric
+      -
+        - text: February
+        - text: £75
+          format: numeric
+        - text: £55
+          format: numeric
+      -
+        - text: March
+        - text: £165
+          format: numeric
+        - text: £125
+          format: numeric

--- a/lib/govuk_publishing_components/app_helpers/table_helper.rb
+++ b/lib/govuk_publishing_components/app_helpers/table_helper.rb
@@ -8,6 +8,7 @@ module GovukPublishingComponents
 
         classes = %w[gem-c-table govuk-table]
         classes << "govuk-table--sortable" if opt[:sortable]
+        classes << "govuk-!-margin-bottom-#{opt[:margin_bottom]}" if [*0..9].include?(opt[:margin_bottom])
 
         caption_classes = %w[govuk-table__caption]
         caption_classes << opt[:caption_classes] if opt[:caption_classes]

--- a/spec/lib/govuk_publishing_components/app_helpers/table_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/app_helpers/table_helper_spec.rb
@@ -38,5 +38,20 @@ RSpec.describe GovukPublishingComponents::AppHelpers::TableHelper do
 
       expect(table).to match(/<table(?:.*)id="table-id">/)
     end
+
+    it "can be configured to set margin_bottom on the table" do
+      # valid margin is added
+      (0..9).each do |margin|
+        table = described_class.helper(view_context, nil, margin_bottom: margin) { |_builder| }
+        expect(table).to match("<table class=\"gem-c-table govuk-table govuk-!-margin-bottom-#{margin}\">")
+      end
+
+      # invalid margin is ignored
+      invalid_margin = [-1, 10, "hello", nil, true]
+      invalid_margin.each do |margin|
+        table = described_class.helper(view_context, nil, margin_bottom: margin) { |_builder| }
+        expect(table).to match("<table class=\"gem-c-table govuk-table\">")
+      end
+    end
   end
 end


### PR DESCRIPTION
## What / Why
<!-- What are the reasons behind this change being made? -->
- Adds a `margin_bottom` option to the `table` component
- This is needed so that we can set the `margin_bottom` to 0 where this component is nested within another component (as parent components should control all of the `margin_bottom`, not child components that render inside them)
- Usually we would add the component wrapper helper to achieve this, as that helper includes `margin_bottom` functionality, but here that isn't easy due to how the component is architected. Therefore, I've added setting margin bottom as it's own option to the component.
- This is a pre requisite to completing this trello card: https://trello.com/c/Q4quM0zo/500-fix-calendar-component-margin
- Test link: https://components-gem-pr-4638.herokuapp.com/component-guide/table/with_custom_margin_bottom

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->
None - though I've added a new example in the docs, so there is a visual change in Percy.
