### PR TITLE
 Fix bottom border colour issue in the super nav search button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix bottom border colour issue in the super nav search button ([PR #4642](https://github.com/alphagov/govuk_publishing_components/pull/4642))
+
 ## 52.1.0
 
 * Swap inset text top margin with padding ([PR #4634](https://github.com/alphagov/govuk_publishing_components/pull/4634))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -641,7 +641,7 @@ $after-button-padding-left: govuk-spacing(4);
     right: 0;
 
     @include focus-not-focus-visible {
-      border-bottom: 1px solid govuk-colour("dark-blue");
+      border-bottom: 1px solid transparent;
       border-left: none;
       position: relative;
     }


### PR DESCRIPTION
## What
The search button had in its default unopened state an unintended 1px dark navy bottom border. The colour change to navy was made in https://github.com/alphagov/govuk_publishing_components/pull/2413 and the colour wasn't updated when the header design subsequently changed.

This changes the bottom border to a transparent colour, instead of removing it, so that when user changes the default colours of their browser such as in Firefox, or uses Windows High Contrast mode, the button still has a visual bottom border.

The change doesn't impact the current homepage header which continues to set its own brighter blue bottom border.

## Why
The bottom dark navy border isn't part of the intended design for the search button.

## Preview link 
https://components-gem-pr-4642.herokuapp.com/public

## Visual Changes

### Before
![359843018-4d0b1aa0-943b-4a8c-9ad5-d09cadaa24be](https://github.com/user-attachments/assets/b01b0f91-3669-4abf-b289-6b79b60aabcf)


### After
<img width="500" alt="Screenshot 2025-02-18 at 15 05 47" src="https://github.com/user-attachments/assets/5d80dc36-b141-431c-a1c3-0e1c0b06b3a3" />

### Before
<img width="500" alt="Screenshot 2025-02-18 at 14 54 19" src="https://github.com/user-attachments/assets/7328406d-6ba5-4c14-ab49-2c3c87457aed" />


### After (no change)
<img width="500" alt="Screenshot 2025-02-18 at 14 54 11" src="https://github.com/user-attachments/assets/21f8648d-931d-474e-99f7-78c688e4fe3c" />

### Firefox with user defined colours

#### Before
<img width="500" alt="Screenshot 2025-02-18 at 15 01 26" src="https://github.com/user-attachments/assets/d6d08606-be46-4d68-b31d-60e0d75673b3" />

#### After (no change)
<img width="500" alt="Screenshot 2025-02-18 at 15 01 20" src="https://github.com/user-attachments/assets/7cd8aa83-d4f3-41c4-ab2c-d38783c4e106" />

### Windows High Contrast mode 

#### Before
<img width="500" alt="Screenshot 2025-02-18 at 15 02 25" src="https://github.com/user-attachments/assets/c3b771e6-6d10-4fc1-b8f6-064a49764f64" />

#### After (no change)
<img width="500" alt="Screenshot 2025-02-18 at 15 00 44" src="https://github.com/user-attachments/assets/3b4a5354-5bf2-4a08-92b2-89fa6d58458c" />

Fixes https://github.com/alphagov/govuk_publishing_components/issues/4166

Trello https://trello.com/c/kw9acHlY/3312-fix-search-toggle-button-styling-in-super-navigation-menu


