### PR TITLE
BREAKING: Remove layout_header component from layout_for_public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Move govspeak attachment sass includes into view ([PR #4659](https://github.com/alphagov/govuk_publishing_components/pull/4659))
+* **BREAKING:** Remove layout_header component from layout_for_public ([PR #4643](https://github.com/alphagov/govuk_publishing_components/pull/4643))
 
 ## 53.0.0
 

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -19,7 +19,6 @@
   omit_footer_border ||= false
   omit_header ||= false
   product_name ||= nil
-  show_explore_header ||= false
   show_cross_service_header ||= false
   draft_watermark ||= false
   show_search = local_assigns.include?(:show_search) ? local_assigns[:show_search] : true
@@ -102,32 +101,19 @@
       href: "#content"
     } %>
     <% unless omit_header %>
-      <% if show_explore_header %>
-        <% if homepage %>
-          <%= render "govuk_publishing_components/components/layout_for_public/layout_super_navigation_header_homepage", {
-            logo_link: logo_link,
-          } %>
-        <% else %>
-          <%= render "govuk_publishing_components/components/layout_super_navigation_header", {
-            logo_link: logo_link,
-          } %>
-        <% end %>
-      <% elsif show_cross_service_header %>
+      <% if show_cross_service_header %>
         <%= render "govuk_publishing_components/components/cross_service_header", {
           one_login_navigation_items: one_login_navigation_items,
           service_navigation_items: service_navigation_items,
           product_name: product_name,
         } %>
-      <% else %>
-        <%= render "govuk_publishing_components/components/layout_header", {
-          search: show_search,
+      <% elsif homepage %>
+        <%= render "govuk_publishing_components/components/layout_for_public/layout_super_navigation_header_homepage", {
           logo_link: logo_link,
-          navigation_items: navigation_items,
-          product_name: product_name,
-
-          # The (blue) bottom border needs to be underneath the emergency banner -
-          # so it has been turned off and added in manually.
-          remove_bottom_border: true,
+        } %>
+      <% else %>
+        <%= render "govuk_publishing_components/components/layout_super_navigation_header", {
+          logo_link: logo_link,
         } %>
       <% end %>
     <% end %>

--- a/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
@@ -52,7 +52,6 @@ examples:
     description: This allows for rendering the layout super navigation header in a different way for only the homepage.
     data:
       homepage: true
-      show_explore_header: true
   omit_footer_navigation:
     description: This allows the footer navigation to be omitted
     data:

--- a/spec/components/layout_for_public_spec.rb
+++ b/spec/components/layout_for_public_spec.rb
@@ -47,12 +47,6 @@ describe "Layout for public", :capybara, type: :view do
     assert_select ".gem-c-layout-for-public .gem-c-search"
   end
 
-  it "can display without search bar" do
-    render_component(show_search: false)
-
-    assert_select ".gem-c-layout-for-public .gem-c-search", false
-  end
-
   it "can omit the header" do
     render_component(omit_header: true)
 
@@ -83,12 +77,6 @@ describe "Layout for public", :capybara, type: :view do
 
     assert_select ".gem-c-layout-for-public .govuk-footer__navigation", true
     assert_select ".gem-c-layout-for-public .govuk-footer__section-break", true
-  end
-
-  it "can add a product name in the header" do
-    render_component(product_name: "Account")
-
-    assert_select ".gem-c-layout-for-public .gem-c-header__product-name", text: "Account"
   end
 
   it "can add a emergency banner" do
@@ -136,7 +124,7 @@ describe "Layout for public", :capybara, type: :view do
   end
 
   it "renders homepage variant of layout super navigation header if `homepage` is true" do
-    render_component(show_explore_header: true, homepage: true)
+    render_component(homepage: true)
 
     assert_select ".govuk-header__logotype[width='32']"
     assert_select ".govuk-header__logotype[height='30']"

--- a/spec/dummy/app/views/layouts/dummy_public_layout.html.erb
+++ b/spec/dummy/app/views/layouts/dummy_public_layout.html.erb
@@ -3,7 +3,6 @@
     global_banner: '<div class="govuk-width-container govuk-!-margin-top-2"><p class="govuk-body">This is the global banner slot.</p></div>',
     title: "Example public page",
     for_static: true,
-    show_explore_header: true,
 } do %>
   <%= yield %>
 <% end %>


### PR DESCRIPTION
## What

- Remove the layout_header component from the layout_for_public view template
- Update layout_for_public tests:
  - Removed test for `show_explore_header` as this option is no longer available in layout_for_public
  - Removed tests for `show_search` and `product_name` options, these were only required when `layout_header` was included in layout_for_public. The same tests are included in [layout_header.spec.rb](https://github.com/alphagov/govuk_publishing_components/blob/main/spec/components/layout_header_spec.rb)

[Trello card](https://trello.com/c/qE79TFYj/3303-remove-legacy-header-variants-from-layoutforpublic)

## Why

To help keep provide a consistent experience when navigating GOV.UK.

### Service Manual/Toolkit

The layout_header component is only used by [/service-manual](https://www.gov.uk/service-manual) and [/service-toolkit](https://www.gov.uk/service-toolkit) pages on GOV.UK, these pages will now use the layout_super_navigation_header to help provide a more consistent navigation experience when on GOV.UK, for example, the super navigation menu is shown when navigating to /guidance/government-design-principles from the /service-toolkit page.

### Email Alert Frontend

The `show_explore_header` option is set to `false` in the [gem_layout_account_manager.html.erb](https://github.com/alphagov/static/blob/fbc921281d7161efc2adbfe8005c4069271021c7/app/views/root/gem_layout_account_manager.html.erb#L14) template in static, this template is [used by email-alert-frontend](https://github.com/alphagov/email-alert-frontend/blob/bc3ffdcd72f09708635558350493d5ef9549a018/app/controllers/subscriptions_management_controller.rb#L101) when a user is logged in.

This option is not required here as email-alert-frontend sets [show_cross_service_header](https://github.com/alphagov/static/blob/fbc921281d7161efc2adbfe8005c4069271021c7/app/views/root/gem_layout_account_manager.html.erb#L13 ) to true to use the [One Login header](https://components.publishing.service.gov.uk/component-guide/cross_service_header) instead.

### Help simplify the logic in the code

The default value for `show_explore_header` is false in the layout_for_public view template, however on most of GOV.UK the super navigation menu is used, as the [value for show_explore_header is set to true in static](https://github.com/alphagov/static/blob/ffa7fba8bed9156f36b29e20657fa773dff907e5/app/views/root/_gem_base.html.erb#L12C3-L12C22).

This means that you have to set the `show_explore_header` value back to false in static if you do not want the super navigation menu, this is currently [only used by the service manual/toolkit](https://github.com/alphagov/static/blob/ffa7fba8bed9156f36b29e20657fa773dff907e5/app/views/root/gem_layout_no_footer_navigation.html.erb#L4).

## Visual Changes

The visual changes in Percy are expected following the updates to the docs.

### Service Manual - Desktop

| Before | After |
| --- | --- |
| <img width="845" alt="sm-desktop-before" src="https://github.com/user-attachments/assets/ffa1e902-24fd-4d0b-832d-b8bd2a1521fc" /> | <img width="855" alt="sm-desktop-after" src="https://github.com/user-attachments/assets/a374ceda-8d3e-41a2-9e2b-bdc112a8c46c" /> |

| Before | After |
| --- | --- |
| ![sm1-desktop-before](https://github.com/user-attachments/assets/09c8c712-8890-4e0e-aea4-3a207da06dc9) | ![sm1-desktop-after](https://github.com/user-attachments/assets/c2ba0bc4-3c04-416b-a936-cdf8332c376e) |

### Service Manual - Mobile

| Before | After |
| --- | --- |
| ![smh-mobile-before](https://github.com/user-attachments/assets/053c38cf-395e-41c8-969b-187517bbc993) | ![smh-mobile-after](https://github.com/user-attachments/assets/7648e92c-2ba7-4905-bef9-338e0d5d1f45) |

| Before | After |
| --- | --- |
| ![sm-mobile-before](https://github.com/user-attachments/assets/525be6f7-b22e-4c1a-b95d-58fff38fae44) | ![sm-mobile-after](https://github.com/user-attachments/assets/d8bec057-ad81-4544-81b2-a357b46ec707) |
