### PR TITLE
Turn off the blue bar below the header

### DIFF
--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -4,7 +4,7 @@
   for_static ||= false
   emergency_banner ||= nil
   full_width ||= false
-  blue_bar ||= local_assigns.include?(:blue_bar) ? local_assigns[:blue_bar] : !full_width
+  blue_bar = false
   global_banner ||= nil
   html_lang ||= "en"
   homepage ||= false
@@ -47,7 +47,7 @@
 # height, making the two blue bars overlap and appear as one. The class is added
 # when a) there's content for the emergency or global banner *and* b) when using
 # the contrained width layout.
-  blue_bar_dedupe = !full_width && global_banner.present?
+  blue_bar_dedupe = false
   body_css_classes = %w(gem-c-layout-for-public govuk-template__body)
   body_css_classes << "draft" if draft_watermark
   body_css_classes << "global-banner-present" if global_banner.present?

--- a/spec/components/layout_for_public_spec.rb
+++ b/spec/components/layout_for_public_spec.rb
@@ -105,10 +105,10 @@ describe "Layout for public", :capybara, type: :view do
     assert_select "#test-global-banner", text: "This is a global banner test"
   end
 
-  it "has a blue bar by default" do
+  it "has no blue bar by default" do
     render_component({})
 
-    assert_select ".gem-c-layout-for-public__blue-bar"
+    assert_select ".gem-c-layout-for-public__blue-bar", false
   end
 
   it "has no blue bar when using the full width layout" do
@@ -117,10 +117,10 @@ describe "Layout for public", :capybara, type: :view do
     assert_select ".gem-c-layout-for-public__blue-bar", false
   end
 
-  it "renders the blue bar if `blue_bar` is `true`" do
+  it "will not render the blue bar even if `blue_bar` is `true`" do
     render_component(blue_bar: true)
 
-    assert_select ".gem-c-layout-for-public__blue-bar"
+    assert_select ".gem-c-layout-for-public__blue-bar", false
   end
 
   it "renders homepage variant of layout super navigation header if `homepage` is true" do
@@ -132,16 +132,16 @@ describe "Layout for public", :capybara, type: :view do
     assert_select ".gem-c-layout-super-navigation-header__header-logo--large-navbar"
   end
 
-  it "renders the blue bar if `full_width` is true and `blue_bar` is true" do
+  it "will not render the blue bar even if `full_width` is true and `blue_bar` is true" do
     render_component(full_width: true, blue_bar: true)
 
-    assert_select ".gem-c-layout-for-public__blue-bar"
+    assert_select ".gem-c-layout-for-public__blue-bar", false
   end
 
-  it "renders the blue bar with a background if valid background specified" do
+  it "will not render the blue bar with a background even if valid background specified" do
     render_component(blue_bar: true, full_width: true, blue_bar_background_colour: "browse")
 
-    assert_select ".gem-c-layout-for-public__blue-bar-wrapper--browse .gem-c-layout-for-public__blue-bar"
+    assert_select ".gem-c-layout-for-public__blue-bar-wrapper--browse .gem-c-layout-for-public__blue-bar", false
   end
 
   it "does not render the blue bar with a background if an invalid background specified" do


### PR DESCRIPTION
## What
Turn off blue bar under the header

## Why
Temporary change to be fully implemented at a later date.

## Visual Changes
See [trello](https://trello.com/c/3EkNY2Bs/3254-prepare-a-pr-to-turn-off-the-blue-border-at-the-bottom-of-the-header) card
