### PR TITLE
Version 52.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 52.0.0
 
 * Make account layout respect `for_static` ([PR #4630](https://github.com/alphagov/govuk_publishing_components/pull/4630))
 * Remove left border from the super nav menu button ([PR #4631](https://github.com/alphagov/govuk_publishing_components/pull/4631))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (51.2.1)
+    govuk_publishing_components (52.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "51.2.1".freeze
+  VERSION = "52.0.0".freeze
 end


### PR DESCRIPTION
## 52.0.0

* Make account layout respect `for_static` ([PR #4630](https://github.com/alphagov/govuk_publishing_components/pull/4630))
* Remove left border from the super nav menu button ([PR #4631](https://github.com/alphagov/govuk_publishing_components/pull/4631))
* Use component wrapper on 'add another' component ([PR #4632](https://github.com/alphagov/govuk_publishing_components/pull/4632))
* Use component wrapper on 'copy to clipboard' component ([PR #4633](https://github.com/alphagov/govuk_publishing_components/pull/4633))
* **BREAKING** Remove custom_header and custom_layout options ([PR #4635](https://github.com/alphagov/govuk_publishing_components/pull/4635))