### PR TITLE
Use govuk-spacing instead of govuk-gutter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Fix bottom border colour issue in the super nav search button ([PR #4642](https://github.com/alphagov/govuk_publishing_components/pull/4642))
+* Use govuk-spacing instead of govuk-gutter ([PR #4650](https://github.com/alphagov/govuk_publishing_components/pull/4650))
 
 ## 52.1.0
 

--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -13,7 +13,7 @@ $gem-guide-border-width: 1px;
   @extend %govuk-list--bullet;
 
   li {
-    margin-bottom: $govuk-gutter-half;
+    margin-bottom: govuk-spacing(3);
     @include govuk-font($size: 19);
   }
 
@@ -27,7 +27,7 @@ $gem-guide-border-width: 1px;
 
   .js-enabled & {
     display: block;
-    margin-top: $govuk-gutter * 2;
+    margin-top: govuk-spacing(9);
   }
 }
 
@@ -45,8 +45,8 @@ $gem-guide-border-width: 1px;
 
 .component-violation {
   border: 3px solid $govuk-error-colour;
-  margin: 0 0 $govuk-gutter;
-  padding: $govuk-gutter $govuk-gutter;
+  margin: 0 0 govuk-spacing(6);
+  padding: govuk-spacing(6);
   @include govuk-text-colour;
 
   .component-violation__title {
@@ -57,13 +57,13 @@ $gem-guide-border-width: 1px;
   .component-violation__link {
     display: block;
     color: $govuk-error-colour;
-    margin: $govuk-gutter-half 0;
+    margin: govuk-spacing(3) 0;
     @include govuk-font($size: 19, $weight: bold);
   }
 }
 
 .component-doc-h2 {
-  margin: ($govuk-gutter * 1.5) 0 $govuk-gutter;
+  margin: (govuk-spacing(6) * 1.5) 0 govuk-spacing(6);
   @include govuk-text-colour;
   @include govuk-font($size: 27, $weight: bold);
 
@@ -72,15 +72,9 @@ $gem-guide-border-width: 1px;
   }
 }
 
-.component-doc-h3 {
-  margin: $govuk-gutter 0 $govuk-gutter-half;
-  @include govuk-text-colour;
-  @include govuk-font($size: 19, $weight: bold);
-}
-
 .component-call {
   margin-top: -$gem-guide-border-width;
-  margin-bottom: $govuk-gutter-half;
+  margin-bottom: govuk-spacing(3);
 
   font-family: Consolas, Monaco, "Andale Mono", monospace;
   font-size: 16px;
@@ -97,7 +91,7 @@ $gem-guide-border-width: 1px;
 
   > pre {
     margin: 0;
-    padding: $govuk-gutter;
+    padding: govuk-spacing(6);
     max-height: 300px;
     overflow: auto;
     font-family: inherit;
@@ -116,7 +110,7 @@ $gem-guide-border-width: 1px;
 }
 
 .component-guide-preview {
-  padding: $govuk-gutter;
+  padding: govuk-spacing(6);
   border: $gem-guide-border-width solid $govuk-border-colour;
   position: relative;
 
@@ -168,7 +162,7 @@ $gem-guide-border-width: 1px;
   h3,
   h4 {
     margin-top: 0;
-    margin-bottom: calc($govuk-gutter / 2);
+    margin-bottom: govuk-spacing(3);
   }
 
   h3 a {
@@ -176,7 +170,7 @@ $gem-guide-border-width: 1px;
   }
 
   h3:not(:first-child) {
-    margin-top: $govuk-gutter;
+    margin-top: govuk-spacing(6);
   }
 
   ul {
@@ -219,10 +213,10 @@ $gem-guide-border-width: 1px;
 
 .examples {
   .component-example {
-    margin: 0 0 $govuk-gutter * 1.5;
+    margin: 0 0 govuk-spacing(6) * 1.5;
 
     .example-title {
-      margin: $govuk-gutter-half 0;
+      margin: govuk-spacing(3) 0;
       @include govuk-text-colour;
       @include govuk-font($size: 24, $weight: bold);
     }
@@ -255,7 +249,7 @@ html {
 }
 
 .component-guide-preview-page {
-  padding: ($govuk-gutter * 1.5) 0;
+  padding: (govuk-spacing(6) * 1.5) 0;
   position: relative;
 
   .preview-title {

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_markdown-typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_markdown-typography.scss
@@ -3,18 +3,16 @@
 
   @include govuk-font($size: 16);
 
-  $gutter-two-thirds: $govuk-gutter - calc($govuk-gutter / 3);
-
   ol,
   ul,
   p {
-    margin-top: $govuk-gutter-half;
-    margin-bottom: $govuk-gutter-half;
+    margin-top: govuk-spacing(3);
+    margin-bottom: govuk-spacing(3);
     @include govuk-font($size: 19);
 
     @include govuk-media-query($from: tablet) {
-      margin-top: $gutter-two-thirds;
-      margin-bottom: $gutter-two-thirds;
+      margin-top: govuk-spacing(4);
+      margin-bottom: govuk-spacing(4);
     }
   }
 
@@ -30,17 +28,17 @@
   }
 
   h2 {
-    margin-top: $govuk-gutter;
+    margin-top: govuk-spacing(6);
     margin-bottom: govuk-spacing(4);
     @include govuk-font($size: 27, $weight: bold);
 
     @include govuk-media-query($from: desktop) {
-      margin-top: $govuk-gutter * 1.5;
+      margin-top: govuk-spacing(6) * 1.5;
     }
   }
 
   h3 {
-    margin-top: $govuk-gutter + 5px;
+    margin-top: govuk-spacing(6) + 5px;
     margin-bottom: 0;
     @include govuk-font($size: 19, $weight: bold);
   }
@@ -50,7 +48,7 @@
   h4,
   h5,
   h6 {
-    margin-top: $govuk-gutter + 5px;
+    margin-top: govuk-spacing(6) + 5px;
     margin-bottom: 0;
     @include govuk-font($size: 19, $weight: bold);
 
@@ -91,7 +89,7 @@
     // utilise the type attribute for the formatting. Browsers default to a
     // style of decimal.
     list-style-position: outside;
-    margin-left: $gutter-two-thirds;
+    margin-left: govuk-spacing(4);
     padding: 0;
 
     ul,
@@ -142,8 +140,8 @@
   // Horizontal Rule
 
   hr {
-    margin-top: $govuk-gutter - 1px;
-    margin-bottom: $govuk-gutter;
+    margin-top: govuk-spacing(6) - 1px;
+    margin-bottom: govuk-spacing(6);
     border-top: 1px solid $govuk-border-colour;
   }
 


### PR DESCRIPTION
## What / Why
<!-- What are the reasons behind this change being made? -->
- `govuk-gutter` seems to be an old variable that was used before spacing was moved to use `govuk-spacing`and `govuk-responsive-margin`.
- Therefore, this PR changes any reference to `govuk-gutter` to `govuk-spacing`.
- `govuk-gutter` equals a fixed `30px`. Therefore we can use `govuk-spacing(6)` instead, and have no visual changes. 
- `govuk-gutter-half` can be changed to `govuk-spacing(3)` which are both `15px`.
- This also replaces `$gutter-two-thirds: $govuk-gutter - calc($govuk-gutter / 3);` with `govuk-spacing(4)` as that mathematical equation equals `20px` i.e. `(30 - (30/3)) = 20`. `govuk-spacing(4)`  is `20px`.
- This also deletes a `.component-doc-h3` class that is not used anywhere.
- See https://github.com/alphagov/govuk-frontend/blob/4faad64a3af93ad5d96f2c9de78b5cc7140df70f/packages/govuk-frontend/src/govuk/settings/_measurements.scss#L45 and  https://design-system.service.gov.uk/styles/spacing/ for references for the spacing values.
- The `application.scss` changes are the component previews in the component guide. `markdown_typography.scss` is govspeak. 
- Closes https://github.com/alphagov/govuk_publishing_components/issues/4612
- [Trello](https://trello.com/c/JEziLO4S/501-remove-govuk-gutter-usage-from-govukpublishingcomponents)

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None, hopefully
