### PR TITLE
Version 52.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 52.1.0
 
 * Swap inset text top margin with padding ([PR #4634](https://github.com/alphagov/govuk_publishing_components/pull/4634))
 * Allow margin bottom to be configured on the table component ([PR #4638](https://github.com/alphagov/govuk_publishing_components/pull/4638))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (52.0.0)
+    govuk_publishing_components (52.1.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "52.0.0".freeze
+  VERSION = "52.1.0".freeze
 end


### PR DESCRIPTION
## 52.1.0

* Swap inset text top margin with padding ([PR #4634](https://github.com/alphagov/govuk_publishing_components/pull/4634))
* Allow margin bottom to be configured on the table component ([PR #4638](https://github.com/alphagov/govuk_publishing_components/pull/4638))