### PR TITLE
Add simplecov to test code coverage of test suite

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,7 @@ GEM
       sass-embedded (~> 1.63)
     date (3.4.1)
     diff-lcs (1.5.1)
+    docile (1.4.1)
     domain_name (0.6.20240107)
     drb (2.2.1)
     erubi (1.13.1)
@@ -590,6 +591,12 @@ GEM
     sentry-ruby (5.22.4)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.1)
+    simplecov_json_formatter (0.1.4)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -646,6 +653,7 @@ DEPENDENCIES
   rake
   rspec-rails
   rubocop-govuk
+  simplecov
   terser
   webmock
   yard

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec-rails"
   s.add_development_dependency "rubocop-govuk"
+  s.add_development_dependency "simplecov"
   s.add_development_dependency "terser"
   s.add_development_dependency "webmock"
   s.add_development_dependency "yard"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,8 @@
+require "simplecov"
+SimpleCov.start "rails" do
+  enable_coverage :branch
+end
+
 require "webmock/rspec"
 require "govuk_publishing_components"
 require "govuk_schemas"


### PR DESCRIPTION
## What
There's currently no code coverage (only locale coverage in the gem), so add simplecov. We'll turn on branch coverage reporting for better coverage, but won't specify a minimum coverage yet.

## Why
It's useful to have code coverage to ensure that rare paths in the code are being exercised. 

## Visual Changes
No visual changes (in fact, no external changes, this only affects CI and local testing).