### PR TITLE
Add custom css exclude list to Asset Helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add custom css exclude list to Asset Helper ([PR #4656](https://github.com/alphagov/govuk_publishing_components/pull/4656))
 * Rubocop is now configured for rails and rspec defaults ([PR #4660](https://github.com/alphagov/govuk_publishing_components/pull/4660))
 
 ## 54.0.0

--- a/docs/set-up-individual-component-css-loading.md
+++ b/docs/set-up-individual-component-css-loading.md
@@ -119,6 +119,17 @@ GovukPublishingComponents.configure do |c|
 end
 ```
 
+If you are not using static but you want to provide your own application css which bundles component css includes, and you do not want them to also be included as individual component stylesheets, you can provide a custom list of components to exclude. These component should be ones that you have explicitly
+included in your application stylesheet:
+
+```rb
+# config/initializers/govuk_publishing_components.rb
+GovukPublishingComponents.configure do |c|
+  c.custom_css_exclude_list = %w[button feedback label
+                                 layout-footer layout-super-navigation-header layout-header]
+end
+```
+
 #### Add the app components and views to the stylesheet array
 
 This bit will likely take the most time - and really benefits from a comprehensive list of what pages use which templates (and template variations).

--- a/lib/govuk_publishing_components/app_helpers/asset_helper.rb
+++ b/lib/govuk_publishing_components/app_helpers/asset_helper.rb
@@ -15,26 +15,25 @@ module GovukPublishingComponents
 
       # This is used to dedupe stylesheets.
       STATIC_STYLESHEET_LIST = %w[
-        govuk_publishing_components/components/_breadcrumbs.css
-        govuk_publishing_components/components/_button.css
-        govuk_publishing_components/components/_error-message.css
-        govuk_publishing_components/components/_heading.css
-        govuk_publishing_components/components/_hint.css
-        govuk_publishing_components/components/_input.css
-        govuk_publishing_components/components/_label.css
-        govuk_publishing_components/components/_search.css
-        govuk_publishing_components/components/_search-with-autocomplete.css
-        govuk_publishing_components/components/_skip-link.css
-        govuk_publishing_components/components/_textarea.css
-        govuk_publishing_components/components/_title.css
-
-        govuk_publishing_components/components/_cookie-banner.css
-        govuk_publishing_components/components/_cross-service-header.css
-        govuk_publishing_components/components/_feedback.css
-        govuk_publishing_components/components/_layout-footer.css
-        govuk_publishing_components/components/_layout-for-public.css
-        govuk_publishing_components/components/_layout-header.css
-        govuk_publishing_components/components/_layout-super-navigation-header.css
+        breadcrumbs
+        button
+        error-message
+        heading
+        hint
+        input
+        label
+        search
+        search-with-autocomplete
+        skip-link
+        textarea
+        title
+        cookie-banner
+        cross-service-header
+        feedback
+        layout-footer
+        layout-for-public
+        layout-header
+        layout-super-navigation-header
       ].freeze
 
       def add_stylesheet_path(component_path)
@@ -81,15 +80,22 @@ module GovukPublishingComponents
     private
 
       def is_already_used?(component)
-        if GovukPublishingComponents::Config.exclude_css_from_static && !viewing_component_guide?
-          all_component_stylesheets_being_used.include?(component) || STATIC_STYLESHEET_LIST.include?(component)
-        else
-          all_component_stylesheets_being_used.include?(component)
-        end
+        (all_component_stylesheets_being_used + component_paths(css_exclude_list)).include?(component)
+      end
+
+      def css_exclude_list
+        return [] if viewing_component_guide?
+        return STATIC_STYLESHEET_LIST if GovukPublishingComponents::Config.exclude_css_from_static
+
+        []
       end
 
       def viewing_component_guide?
         request&.path&.include?("/component-guide")
+      end
+
+      def component_paths(component_list)
+        component_list.map { |c| "govuk_publishing_components/components/_#{c}.css" }
       end
     end
   end

--- a/lib/govuk_publishing_components/app_helpers/asset_helper.rb
+++ b/lib/govuk_publishing_components/app_helpers/asset_helper.rb
@@ -85,6 +85,7 @@ module GovukPublishingComponents
 
       def css_exclude_list
         return [] if viewing_component_guide?
+        return GovukPublishingComponents::Config.custom_css_exclude_list if GovukPublishingComponents::Config.custom_css_exclude_list&.any?
         return STATIC_STYLESHEET_LIST if GovukPublishingComponents::Config.exclude_css_from_static
 
         []

--- a/lib/govuk_publishing_components/app_helpers/asset_helper.rb
+++ b/lib/govuk_publishing_components/app_helpers/asset_helper.rb
@@ -91,7 +91,9 @@ module GovukPublishingComponents
       end
 
       def viewing_component_guide?
-        request&.path&.include?("/component-guide")
+        return false unless request
+
+        request.path.include?("/component-guide")
       end
 
       def component_paths(component_list)

--- a/lib/govuk_publishing_components/config.rb
+++ b/lib/govuk_publishing_components/config.rb
@@ -18,6 +18,9 @@ module GovukPublishingComponents
     mattr_accessor :application_javascript
     self.application_javascript = "application"
 
+    mattr_accessor :custom_css_exclude_list
+    self.custom_css_exclude_list = []
+
     mattr_accessor :exclude_css_from_static
     self.exclude_css_from_static = true
 

--- a/spec/dummy/app/views/layouts/asset_helper_layout.html.erb
+++ b/spec/dummy/app/views/layouts/asset_helper_layout.html.erb
@@ -4,6 +4,7 @@
 
 <!DOCTYPE html>
 <html lang="en">
+  <head>
     <meta charset="utf-8">
     <title>Asset helper - GOV.UK</title>
     <%= stylesheet_link_tag "application", :media => "all" %>

--- a/spec/features/asset_helper_spec.rb
+++ b/spec/features/asset_helper_spec.rb
@@ -71,4 +71,36 @@ describe "When the asset helper is configured", :capybara do
       expect(page).to have_selector('link[href^="/assets/govuk_publishing_components/components/_heading-"][rel="stylesheet"]', visible: :hidden)
     end
   end
+
+  scenario "request only unexcluded stylesheets when custom_css_exclude_list is set" do
+    GovukPublishingComponents.configure do |config|
+      config.custom_css_exclude_list = %w[notice details]
+    end
+
+    visit "/asset_helper"
+
+    within(:xpath, "//head", visible: :hidden) do
+      expect(page).to have_xpath("//link", visible: :hidden, count: 2)
+
+      expect(page).to have_selector('link[href^="/assets/application-"][rel="stylesheet"]', visible: :hidden)
+      expect(page).not_to have_selector('link[href^="/assets/govuk_publishing_components/components/_notice-"][rel="stylesheet"]', visible: false)
+      expect(page).not_to have_selector('link[href^="/assets/govuk_publishing_components/components/_details-"][rel="stylesheet"]', visible: false)
+      expect(page).to have_selector('link[href^="/assets/govuk_publishing_components/components/_heading-"][rel="stylesheet"]', visible: false)
+    end
+  end
+
+  scenario "request all stylesheets when custom_css_exclude_list is set but visiting the component guide" do
+    GovukPublishingComponents.configure do |config|
+      config.custom_css_exclude_list = %w[notice details]
+    end
+
+    visit "/component-guide"
+
+    within(:xpath, "//head", visible: :hidden) do
+      expect(page).to have_xpath("//link[@rel=\"stylesheet\"]", visible: :hidden, count: 8)
+
+      expect(page).to have_selector('link[href^="/assets/component_guide/application-"][rel="stylesheet"]', visible: :hidden)
+      expect(page).to have_selector('link[href^="/assets/govuk_publishing_components/components/_details-"][rel="stylesheet"]', visible: false)
+    end
+  end
 end

--- a/spec/features/asset_helper_spec.rb
+++ b/spec/features/asset_helper_spec.rb
@@ -40,6 +40,21 @@ describe "When the asset helper is configured", :capybara do
     end
   end
 
+  scenario "request all stylesheets when exclude_css_from_static is set to true but visiting the component guide" do
+    GovukPublishingComponents.configure do |config|
+      config.exclude_css_from_static = true
+    end
+
+    visit "/component-guide"
+
+    within(:xpath, "//head", visible: :hidden) do
+      expect(page).to have_xpath("//link[@rel=\"stylesheet\"]", visible: :hidden, count: 8)
+
+      expect(page).to have_selector('link[href^="/assets/component_guide/application-"][rel="stylesheet"]', visible: :hidden)
+      expect(page).to have_selector('link[href^="/assets/govuk_publishing_components/components/_heading-"][rel="stylesheet"]', visible: false)
+    end
+  end
+
   scenario "request all stylesheets when exclude_css_from_static is set to false" do
     GovukPublishingComponents.configure do |config|
       config.exclude_css_from_static = false

--- a/spec/features/asset_helper_spec.rb
+++ b/spec/features/asset_helper_spec.rb
@@ -51,7 +51,7 @@ describe "When the asset helper is configured", :capybara do
       expect(page).to have_xpath("//link[@rel=\"stylesheet\"]", visible: :hidden, count: 8)
 
       expect(page).to have_selector('link[href^="/assets/component_guide/application-"][rel="stylesheet"]', visible: :hidden)
-      expect(page).to have_selector('link[href^="/assets/govuk_publishing_components/components/_heading-"][rel="stylesheet"]', visible: false)
+      expect(page).to have_selector('link[href^="/assets/govuk_publishing_components/components/_heading-"][rel="stylesheet"]', visible: :hidden)
     end
   end
 
@@ -83,9 +83,9 @@ describe "When the asset helper is configured", :capybara do
       expect(page).to have_xpath("//link", visible: :hidden, count: 2)
 
       expect(page).to have_selector('link[href^="/assets/application-"][rel="stylesheet"]', visible: :hidden)
-      expect(page).not_to have_selector('link[href^="/assets/govuk_publishing_components/components/_notice-"][rel="stylesheet"]', visible: false)
-      expect(page).not_to have_selector('link[href^="/assets/govuk_publishing_components/components/_details-"][rel="stylesheet"]', visible: false)
-      expect(page).to have_selector('link[href^="/assets/govuk_publishing_components/components/_heading-"][rel="stylesheet"]', visible: false)
+      expect(page).not_to have_selector('link[href^="/assets/govuk_publishing_components/components/_notice-"][rel="stylesheet"]', visible: :hidden)
+      expect(page).not_to have_selector('link[href^="/assets/govuk_publishing_components/components/_details-"][rel="stylesheet"]', visible: :hidden)
+      expect(page).to have_selector('link[href^="/assets/govuk_publishing_components/components/_heading-"][rel="stylesheet"]', visible: :hidden)
     end
   end
 
@@ -100,7 +100,7 @@ describe "When the asset helper is configured", :capybara do
       expect(page).to have_xpath("//link[@rel=\"stylesheet\"]", visible: :hidden, count: 8)
 
       expect(page).to have_selector('link[href^="/assets/component_guide/application-"][rel="stylesheet"]', visible: :hidden)
-      expect(page).to have_selector('link[href^="/assets/govuk_publishing_components/components/_details-"][rel="stylesheet"]', visible: false)
+      expect(page).to have_selector('link[href^="/assets/govuk_publishing_components/components/_details-"][rel="stylesheet"]', visible: :hidden)
     end
   end
 end

--- a/spec/lib/govuk_publishing_components/app_helpers/asset_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/app_helpers/asset_helper_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe GovukPublishingComponents::AppHelpers::AssetHelper do
     it "exclude stylesheets already in static when exclude_css_from_static is true and the request object is not available" do
       GovukPublishingComponents.configure do |config|
         config.exclude_css_from_static = true
+        config.custom_css_exclude_list = nil
       end
 
       add_gem_component_stylesheet("button")
@@ -35,6 +36,7 @@ RSpec.describe GovukPublishingComponents::AppHelpers::AssetHelper do
     it "initialize asset helper then add multiple stylesheets but exclude 'button' stylesheet since it's already in static" do
       GovukPublishingComponents.configure do |config|
         config.exclude_css_from_static = true
+        config.custom_css_exclude_list = nil
       end
 
       add_gem_component_stylesheet("accordion")


### PR DESCRIPTION
## What
Add an option to supply a custom css exclude list - this is like the current list that excludes anything always supplied by static from the individual component support, but for non-static based apps, where they might as a stopgap want to provide their own application.css with a hardcoded list of styles to include, but that might not be the same list as static's list.

Also mild refactoring of the asset helper to improve test coverage.

## Why
To support a bundled set of stylesheets for email-alert-frontend, as here: https://github.com/alphagov/email-alert-frontend/pull/1890.

https://trello.com/c/O6JhukLu/487-remove-slimmer-email-alert-frontend

## Visual Changes
None.