### PR TITLE
Version 53.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 53.0.0
 
 * **BREAKING:** Remove title component ([PR #4653](https://github.com/alphagov/govuk_publishing_components/pull/4653))
 * Fix bottom border colour issue in the super nav search button ([PR #4642](https://github.com/alphagov/govuk_publishing_components/pull/4642))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (52.1.0)
+    govuk_publishing_components (53.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -231,7 +231,7 @@ GEM
       racc (~> 1.4)
     null_logger (0.0.1)
     opentelemetry-api (1.4.0)
-    opentelemetry-common (0.21.0)
+    opentelemetry-common (0.22.0)
       opentelemetry-api (~> 1.0)
     opentelemetry-exporter-otlp (0.29.1)
       google-protobuf (>= 3.18)
@@ -428,14 +428,14 @@ GEM
       opentelemetry-helpers-sql-obfuscation
       opentelemetry-instrumentation-base (~> 0.23.0)
       opentelemetry-semantic_conventions (>= 1.8.0)
-    opentelemetry-registry (0.3.1)
+    opentelemetry-registry (0.4.0)
       opentelemetry-api (~> 1.1)
-    opentelemetry-sdk (1.7.0)
+    opentelemetry-sdk (1.8.0)
       opentelemetry-api (~> 1.1)
       opentelemetry-common (~> 0.20)
       opentelemetry-registry (~> 0.2)
       opentelemetry-semantic_conventions
-    opentelemetry-semantic_conventions (1.10.1)
+    opentelemetry-semantic_conventions (1.11.0)
       opentelemetry-api (~> 1.0)
     ostruct (0.6.1)
     parallel (1.26.3)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "52.1.0".freeze
+  VERSION = "53.0.0".freeze
 end


### PR DESCRIPTION
## 53.0.0

* **BREAKING:** Remove title component ([PR #4653](https://github.com/alphagov/govuk_publishing_components/pull/4653))
* Fix bottom border colour issue in the super nav search button ([PR #4642](https://github.com/alphagov/govuk_publishing_components/pull/4642))
* Use govuk-spacing instead of govuk-gutter ([PR #4650](https://github.com/alphagov/govuk_publishing_components/pull/4650))
* Ensure 'search with autocomplete' component uses its own margin bottom ([PR #4637](https://github.com/alphagov/govuk_publishing_components/pull/4637))

## Note 
We know that in static there's [a line that will need to be removed when we bump the gem](https://github.com/alphagov/static/blob/ffa7fba8bed9156f36b29e20657fa773dff907e5/app/assets/stylesheets/application.scss#L20). govuk-chat also needs a manual update, Ash has made the team there aware. Finally, DGU might need a manual update too but it's already very far behind on the gem.