### PR TITLE
Move govspeak attachment sass includes into view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Move govspeak attachment sass includes into view ([PR #4659](https://github.com/alphagov/govuk_publishing_components/pull/4659))
+
 ## 53.0.0
 
 * **BREAKING:** Remove title component ([PR #4653](https://github.com/alphagov/govuk_publishing_components/pull/4653))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
@@ -76,6 +76,18 @@ $thumbnail-icon-border-colour: govuk-colour("mid-grey");
   }
 }
 
+.govspeak,
+.gem-c-govspeak {
+  .gem-c-attachment__title {
+    @include govuk-font($size: 27, $weight: regular);
+    margin: 0 0 govuk-spacing(3) 0;
+  }
+
+  .gem-c-attachment__metadata {
+    margin: 0 0 govuk-spacing(3) 0;
+  }
+}
+
 .gem-c-attachment__metadata--compact {
   margin-bottom: 0;
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
@@ -9,11 +9,6 @@
 
 .govspeak, // Legacy class name that's still used in some content items - needs to be kept until `.govspeak` is removed from the content items.
 .gem-c-govspeak {
-  // Scope attachment and attachment-link component styles to gem-c-govspeak
-  @import "../attachment-link";
-  @import "../attachment";
-  @import "../details";
-
   // This block is duplicated from Whitehall as a transitional step, see the
   // commit message for 2d893c10ee3f2cab27162b9aba38b12379a71d07 before making
   // changes, original version:

--- a/app/views/govuk_publishing_components/components/_govspeak.html.erb
+++ b/app/views/govuk_publishing_components/components/_govspeak.html.erb
@@ -1,5 +1,8 @@
 <%
   add_gem_component_stylesheet("govspeak")
+  add_gem_component_stylesheet("attachment-link")
+  add_gem_component_stylesheet("attachment")
+  add_gem_component_stylesheet("details")
 
   inverse ||= false
   local_assigns[:margin_bottom] ||= 0


### PR DESCRIPTION
## What
- govspeak attachment sass included all necessary attachment component sass files in order to render any attachment components within govspeak
- this was done before our per-page asset model, which meant that these styles were always compiled into the govspeak sass regardless of whether they were already included on the page
- moving them out of the sass and into the view for the govspeak component means they are now included in the per-page asset handling and can be de-duplicated
- this only impacts pages where attachment components are present alongside govspeak containing attachments, which probably isn't that many, but it makes the sass handling more transparent and included in our general approach
- some extra sass is now required in the attachment component to prevent overrides, which admittedly isn't ideal
- however it will mean that if there is more than one govspeak section on a page, these assets will be de-duplicated

Worth noting that a similar thing is happening in govspeak with button styles, but they're included specifically there in order to give them higher precedence and override the govspeak link styles, which otherwise would break button styles.

## Why
We want to optimise our stylesheet loading and ensure that every part of our system is using a unified approach.

## Visual Changes
None.

Trello card: https://trello.com/c/IGbGxOO6/481-standardise-govspeak-element-spacing (not really related but discovered as part of this work)