### PR TITLE
Add govuk-chat to our component auditing tool

### DIFF
--- a/app/controllers/govuk_publishing_components/audit_controller.rb
+++ b/app/controllers/govuk_publishing_components/audit_controller.rb
@@ -17,6 +17,7 @@ module GovukPublishingComponents
         government-frontend
         govspeak
         govspeak-preview
+        govuk-chat
         govuk-developer-docs
         local-links-manager
         manuals-publisher


### PR DESCRIPTION
## What / Why
<!-- What are the reasons behind this change being made? -->
- Adds `govuk-chat` to our component auditing tool
- We missed some references to the `title` component while removing it, partly as `govuk-chat` wasn't in the auditing tool


## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
