### PR TITLE
Make /help/cookies link in cookie banner absolute instead of relative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Move govspeak attachment sass includes into view ([PR #4659](https://github.com/alphagov/govuk_publishing_components/pull/4659))
 * **BREAKING:** Remove layout_header component from layout_for_public ([PR #4643](https://github.com/alphagov/govuk_publishing_components/pull/4643))
+* Make /help/cookies link in cookie banner absolute instead of relative ([PR #4664](https://github.com/alphagov/govuk_publishing_components/pull/4664))
 
 ## 53.0.0
 

--- a/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
@@ -15,7 +15,8 @@
   end
   text = raw(text)
 
-  cookie_preferences_href ||= "/help/cookies"
+  absolute_links_helper = GovukPublishingComponents::Presenters::AbsoluteLinksHelper.new()
+  cookie_preferences_href ||= absolute_links_helper.make_url_absolute("/help/cookies")
   confirmation_message ||= raw(t("components.cookie_banner.confirmation_message.html",
                                 link: link_to(
                                   t("components.cookie_banner.confirmation_message.link"),

--- a/spec/components/cookie_banner_spec.rb
+++ b/spec/components/cookie_banner_spec.rb
@@ -100,4 +100,11 @@ describe "Cookie banner", type: :view do
     assert_select ".gem-c-cookie-banner__hide-button[data-module='ga4-event-tracker']", false
     assert_select ".gem-c-cookie-banner__hide-button[data-ga4-event]", false
   end
+
+  it "renders the default 'help/cookies' path as an absolute link" do
+    ENV["VIRTUAL_HOST"] = "https://www.random.gov.uk"
+    render_component({})
+    assert_select ".govuk-link[href='https://www.random.gov.uk/help/cookies']"
+    ENV["VIRTUAL_HOST"] = nil
+  end
 end


### PR DESCRIPTION
## What / Why
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- The cookie banner's `/help/cookies` link was a relative link
- Therefore on `assets.publishing.service.gov.uk` it would link to `assets.publishing.service.gov.uk/help/cookies` which is incorrect
- Therefore, use our existing `absolute links helper` workaround, which converts relative links to absolute ones
- This will make it link to `www.gov.uk/help/cookies`
- This fix already exists on the header and footer links on the assets domain, for example https://assets.publishing.service.gov.uk/media/6784f6eff029f40e508816d9/List_of_.gov.uk_domain_names_as_of_13_January_2025.csv/preview - you can see those links go to `www.gov.uk` so it will work similarly for the `help/cookies` link.

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.