### PR TITLE
Version 54.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 54.0.0
 
 * Change govspeak spacing model ([PR #4623](https://github.com/alphagov/govuk_publishing_components/pull/4623))
 * Move govspeak attachment sass includes into view ([PR #4659](https://github.com/alphagov/govuk_publishing_components/pull/4659))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (53.0.0)
+    govuk_publishing_components (54.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "53.0.0".freeze
+  VERSION = "54.0.0".freeze
 end


### PR DESCRIPTION
## 54.0.0

* Change govspeak spacing model ([PR #4623](https://github.com/alphagov/govuk_publishing_components/pull/4623))
* Move govspeak attachment sass includes into view ([PR #4659](https://github.com/alphagov/govuk_publishing_components/pull/4659))
* **BREAKING:** Remove layout_header component from layout_for_public ([PR #4643](https://github.com/alphagov/govuk_publishing_components/pull/4643))
* Make /help/cookies link in cookie banner absolute instead of relative ([PR #4664](https://github.com/alphagov/govuk_publishing_components/pull/4664))