### PR TITLE
Remove utf_encode method

### DIFF
--- a/app/views/govuk_publishing_components/components/_feedback.html.erb
+++ b/app/views/govuk_publishing_components/components/_feedback.html.erb
@@ -2,13 +2,9 @@
   add_gem_component_stylesheet("button")
   add_gem_component_stylesheet("feedback")
 
-  def utf_encode(element)
-    element.is_a?(String) ? element.encode : element
-  end
-
   email_regex = /[^\s=\/?&]+(?:@|%40)[^\s=\/?&]+/
-  url_without_pii = utf_encode(request.original_url.gsub(email_regex, '[email]'))
-  path_without_pii = utf_encode(request.fullpath.gsub(email_regex, '[email]'))
+  url_without_pii = request.original_url.gsub(email_regex, '[email]').encode
+  path_without_pii = request.fullpath.gsub(email_regex, '[email]').encode
 
   disable_ga4 ||= false
 


### PR DESCRIPTION
- defining a method inside a partial like this causes the method to be potentially defined multiple times, and causes `covered` to complain when running test suites in apps that use the gem.
- ...and in fact the method isn't really needed. It's checking if the thing to be encoded is a string, but it's being called only twice, with the output of a gsub (which by definition returns a string). So it'll always be a string, and always can just be passed to #encode.

