### PR TITLE
Adjust attachment component spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Adjust attachment component spacing ([PR #4669](https://github.com/alphagov/govuk_publishing_components/pull/4669))
 * Add custom css exclude list to Asset Helper ([PR #4656](https://github.com/alphagov/govuk_publishing_components/pull/4656))
 * Rubocop is now configured for rails and rspec defaults ([PR #4660](https://github.com/alphagov/govuk_publishing_components/pull/4660))
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
@@ -18,7 +18,6 @@ $thumbnail-icon-border-colour: govuk-colour("mid-grey");
 .gem-c-attachment__thumbnail {
   position: relative;
   width: auto;
-  margin-right: govuk-spacing(5);
   padding: $thumbnail-border-width;
   float: left;
 }
@@ -26,18 +25,27 @@ $thumbnail-icon-border-colour: govuk-colour("mid-grey");
 .gem-c-attachment__thumbnail-image {
   display: block;
   width: auto; // for IE8
-  max-width: $thumbnail-width;
-  height: $thumbnail-height;
+  max-width: calc($thumbnail-width / 1.5);
+  height: calc($thumbnail-height / 1.5);
   border: $thumbnail-border-colour; // for IE9 & IE10
   outline: $thumbnail-border-width solid $thumbnail-border-colour;
   background: $thumbnail-background;
   box-shadow: $thumbnail-shadow-width $thumbnail-shadow-colour;
   fill: $thumbnail-icon-border-colour;
   stroke: $thumbnail-icon-border-colour;
+
+  @include govuk-media-query($from: tablet) {
+    max-width: $thumbnail-width;
+    height: $thumbnail-height;
+  }
 }
 
 .gem-c-attachment__details {
-  padding-left: $thumbnail-width + $thumbnail-border-width * 2 + govuk-spacing(5);
+  padding-left: calc(($thumbnail-width + $thumbnail-border-width * 2 + govuk-spacing(5)) / 1.5);
+
+  @include govuk-media-query($from: tablet) {
+    padding-left: $thumbnail-width + $thumbnail-border-width * 2 + govuk-spacing(5);
+  }
 
   .gem-c-details {
     margin-top: govuk-spacing(3);

--- a/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
@@ -13,17 +13,12 @@ $thumbnail-icon-border-colour: govuk-colour("mid-grey");
   position: relative;
   @include govuk-font(19);
   @include govuk-clearfix;
-
-  .govuk-details {
-    margin: govuk-spacing(3) 0;
-  }
 }
 
 .gem-c-attachment__thumbnail {
   position: relative;
   width: auto;
   margin-right: govuk-spacing(5);
-  margin-bottom: govuk-spacing(3);
   padding: $thumbnail-border-width;
   float: left;
 }
@@ -45,6 +40,7 @@ $thumbnail-icon-border-colour: govuk-colour("mid-grey");
   padding-left: $thumbnail-width + $thumbnail-border-width * 2 + govuk-spacing(5);
 
   .gem-c-details {
+    margin-top: govuk-spacing(3);
     word-break: break-word;
     word-wrap: break-word;
   }

--- a/app/views/govuk_publishing_components/components/_attachment.html.erb
+++ b/app/views/govuk_publishing_components/components/_attachment.html.erb
@@ -8,6 +8,7 @@
   attributes = []
   url_data_attributes ||= {}
   details_ga4_attributes ||= {}
+  local_assigns[:margin_bottom] ||= 6
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
@@ -126,6 +127,7 @@
       <%= render "govuk_publishing_components/components/details", {
         title: t("components.attachment.request_format_cta"),
         ga4_attributes: details_ga4_attributes,
+        margin_bottom: 0,
       } do %>
         <%= t("components.attachment.request_format_details_html", alternative_format_contact_email: attachment.alternative_format_contact_email) %>
       <% end %>

--- a/spec/components/attachment_spec.rb
+++ b/spec/components/attachment_spec.rb
@@ -283,16 +283,16 @@ describe "Attachment", type: :view do
   end
 
   it "accepts margin_bottom" do
-    render_component(attachment: { title: "Attachment", url: "https://gov.uk/attachment" }, margin_bottom: 6)
-    assert_select '.gem-c-attachment[class~="govuk-!-margin-bottom-6"]'
+    render_component(attachment: { title: "Attachment", url: "https://gov.uk/attachment" }, margin_bottom: 1)
+    assert_select '.gem-c-attachment[class~="govuk-!-margin-bottom-1"]'
 
     render_component(attachment: { title: "Attachment", url: "https://gov.uk/attachment" }, margin_bottom: 3)
     assert_select '.gem-c-attachment[class~="govuk-!-margin-bottom-3"]'
   end
 
-  it "defaults to no margin_bottom" do
+  it "defaults to margin_bottom of 6" do
     render_component(attachment: { title: "Attachment", url: "https://gov.uk/attachment" })
-    assert_select '.gem-c-attachment:not([class*="govuk-!-margin-bottom-"])'
+    assert_select '.gem-c-attachment[class~="govuk-!-margin-bottom-6"]'
   end
 
   it "includes GA4 tracking on HTML attachment links by default" do


### PR DESCRIPTION
## What
Adjust the margins on the attachment component so that the component has a default margin bottom set on the outer element, rather than controlled by the bottom margins of inner elements sticking out.

Also make the attachment thumbnails a bit smaller on mobile.

## Why
Trying to make the component margin spacing more consistent and this relates to that work. This will also improve the spacing around attachments when included inside govspeak.

Also fixes https://github.com/alphagov/govuk_publishing_components/issues/4662

## Visual Changes
Margin bottom spacing changes (blue and red outlines have been added only to clarify boundaries of the component).

Before | After
------ | ------
![Screenshot 2025-03-05 at 09 28 53](https://github.com/user-attachments/assets/c445d5c5-20cd-4830-ae50-104ad0b8906e) | ![Screenshot 2025-03-05 at 09 27 27](https://github.com/user-attachments/assets/efbbbf96-9430-445e-a202-461e4aa183db)

Spacing when attachments contain a details element.

Before | After
------ | ------
![Screenshot 2025-03-05 at 09 29 00](https://github.com/user-attachments/assets/2f5dc367-6efa-4d00-b4d7-e2446441879e) | ![Screenshot 2025-03-05 at 09 27 41](https://github.com/user-attachments/assets/e3dd3f1a-e55f-427b-8b1d-d34cd059c1d6)

Improved spacing shown in govspeak:

![Screenshot 2025-03-05 at 09 27 53](https://github.com/user-attachments/assets/3480f451-bf97-40ec-b126-aa95683ebae0)


Size of attachment thumbnail on mobile (shown at 320px).

Before | After
------ | ------
![Screenshot 2025-03-05 at 10 17 17](https://github.com/user-attachments/assets/ccf5ef8b-06e1-4d2b-a91d-c30184b99a71) | ![Screenshot 2025-03-05 at 10 17 06](https://github.com/user-attachments/assets/95bec0eb-d3fa-4faf-991e-856528cd0be2)
