### PR TITLE
Update action link light icon style

### DIFF
--- a/app/assets/images/govuk_publishing_components/action-link-arrow--light.svg
+++ b/app/assets/images/govuk_publishing_components/action-link-arrow--light.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="27" height="27" viewBox="0 0 27 27" fill="none">
-  <circle cx="13.5" cy="13.5" r="13.5" fill="#EEEFEF"/>
+  <circle cx="13.5" cy="13.5" r="13.5" fill="#F3F3F3"/>
   <g transform="translate(5 3.5) scale(0.85)">
     <path fill-rule="evenodd" clip-rule="evenodd" d="M14.9429 11.7949L10.4402 7.29222L11.7327 5.99967L17.528 11.7949L11.7327 17.5902L10.4402 16.2976L14.9429 11.7949Z" fill="#000000"/>
     <path fill-rule="evenodd" clip-rule="evenodd" d="M3.95631 10.881L15.4414 10.881L15.4414 12.709L3.95631 12.709L3.95631 10.881Z" fill="#000000"/>


### PR DESCRIPTION
## What

Update Action link component light icon style from `#eeefef` to `#f3f3f3` (black tint 95%).

## Why

https://trello.com/c/NMwcObnm/3345-update-variant-of-action-link-component-to-align-with-branding

## Visual Changes

### Before

![components publishing service gov uk_component-guide_action_link_with_light_icon_preview(iPhone SE) (1)](https://github.com/user-attachments/assets/ba9e27f0-f48d-4c08-a2b3-74287a598261)

### After

![components-gem-pr-4671 herokuapp com_component-guide_action_link_with_light_icon_preview(iPhone SE)](https://github.com/user-attachments/assets/1d12dbdd-5e3d-45a6-a538-e0898d7a003a)