### PR TITLE
Update search homepage config background colour

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -199,11 +199,11 @@ $large-input-size: 50px;
 
 .gem-c-search--homepage {
   .gem-c-search__submit {
-    background-color: #d2e2f1;
+    background-color: govuk-tint(govuk-colour("blue"), 80%);
     color: govuk-colour("blue");
 
     &:hover {
-      background-color: lighten(#d2e2f1, 5%);
+      background-color: govuk-tint(govuk-colour("blue"), 95%);
     }
   }
 }


### PR DESCRIPTION
## What

Update search (homepage option) background colour

## Why

https://trello.com/c/9DdIRxZY/3287-draft-homepage-changes

## Visual Changes

### Before

#### Link

![components publishing service gov uk_component-guide_search_homepage_preview(Surface Pro 7)](https://github.com/user-attachments/assets/d9ff6ab5-7550-4f1b-a03a-a17ac505a22d)

#### Hover

![components publishing service gov uk_component-guide_search_homepage_preview(Surface Pro 7) (1)](https://github.com/user-attachments/assets/96760633-bf4e-4a29-b0df-795e3490a88d)

### After

#### Link (no change)

![components-gem-pr-4672 herokuapp com_component-guide_search_homepage_preview(Surface Pro 7)](https://github.com/user-attachments/assets/cddb2482-8a25-4f2e-b09f-d1765115e300)

#### Hover

![components-gem-pr-4672 herokuapp com_component-guide_search_homepage_preview(Surface Pro 7) (1)](https://github.com/user-attachments/assets/7d3482c8-1148-4d94-8182-be6192c6a897)