### PR TITLE
Fix govspeak legislative lists styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Fix govspeak legislative lists styles ([PR #4679](https://github.com/alphagov/govuk_publishing_components/pull/4679))
 * Adjust attachment component spacing ([PR #4669](https://github.com/alphagov/govuk_publishing_components/pull/4669))
 * Add custom css exclude list to Asset Helper ([PR #4656](https://github.com/alphagov/govuk_publishing_components/pull/4656))
 * Rubocop is now configured for rails and rspec defaults ([PR #4660](https://github.com/alphagov/govuk_publishing_components/pull/4660))

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_legislative-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_legislative-list.scss
@@ -10,5 +10,10 @@
   .legislative-list {
     list-style: none;
     margin: 0 0 govuk-spacing(4) 0;
+
+    ol {
+      margin: govuk-spacing(2) 0 govuk-spacing(2) govuk-spacing(6);
+      list-style: none;
+    }
   }
 }

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -775,13 +775,16 @@ examples:
           <li>three</li>
         </ul>
   legislative_lists:
+    description: Example taken from [GOV.UK Immigration rules](https://www.gov.uk/guidance/immigration-rules/immigration-rules-introduction)
     data:
       block: |
-        <h2>ordered list:</h2>
         <ol class="legislative-list">
-          <li>one</li>
-          <li>two</li>
-          <li>three</li>
+          <li>6.2. In these rules:
+            <ol>
+              <li>(a) references to primary and secondary legislation refers to that legislation as amended from time to time; and</li>
+              <li>(b) unless the contrary intention appears, the following definitions apply:</li>
+            </ol>
+          </li>
         </ol>
   nested_lists:
     data:


### PR DESCRIPTION
## What
Fix the appearance of legislative lists on pages like https://www.gov.uk/guidance/immigration-rules/immigration-rules-introduction (see the 'interpretation' section).

Have also updated the component guide to include a more detailed example of a legislative list, hopefully so any future changes will be caught by the visual diff.

## Why
This was accidentally broken in https://github.com/alphagov/govuk_publishing_components/pull/4623

## Visual Changes

Before | After
------ | ------
![Screenshot 2025-03-05 at 14 43 40](https://github.com/user-attachments/assets/2d723907-57f9-41ff-86aa-28af54ef227f) | ![Screenshot 2025-03-05 at 14 43 56](https://github.com/user-attachments/assets/53b501a5-8488-4936-b8dd-adac142254c8)
