### PR TITLE
Migrate banner component from government-frontend as 'Summary banner'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Remove IE8 support from action-link component ([PR #4690](https://github.com/alphagov/govuk_publishing_components/pull/4690))
 * **BREAKING** Remove search from the layout header component ([PR #4687](https://github.com/alphagov/govuk_publishing_components/pull/4687))
 * Remove the `no_border` option from the search component ([PR #4693](https://github.com/alphagov/govuk_publishing_components/pull/4693))
+* Migrate banner component from government-frontend as 'Summary banner' ([PR #4681](https://github.com/alphagov/govuk_publishing_components/pull/4681))
 
 ## 54.0.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -81,6 +81,7 @@
 @import "components/step-by-step-nav";
 @import "components/subscription-links";
 @import "components/success-alert";
+@import "components/summary-banner";
 @import "components/summary-card";
 @import "components/summary-list";
 @import "components/tabs";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_summary-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_summary-banner.scss
@@ -1,0 +1,33 @@
+@import "govuk_publishing_components/individual_component_support";
+
+.gem-c-summary-banner {
+  direction: ltr;
+  background: $govuk-brand-colour;
+  color: govuk-colour("white");
+  padding: govuk-spacing(6) govuk-spacing(3) govuk-spacing(3);
+  clear: both;
+  @include govuk-font(19);
+
+  @include govuk-media-query($from: tablet) {
+    padding: govuk-spacing(7) govuk-spacing(6) govuk-spacing(5);
+  }
+
+  a {
+    @include govuk-link-common;
+    @include govuk-link-style-inverse;
+  }
+}
+
+.gem-c-summary-banner__title {
+  margin-bottom: govuk-spacing(6);
+  color: govuk-colour("white");
+  @include govuk-font(27, $weight: bold);
+}
+
+.gem-c-summary-banner__text {
+  // Ensure the text has a line-length of around 60 characters
+  max-width: 30em;
+  padding: 0;
+  margin-bottom: govuk-spacing(4);
+  @include govuk-font(19);
+}

--- a/app/views/govuk_publishing_components/components/_summary_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_summary_banner.html.erb
@@ -1,0 +1,27 @@
+<%
+  add_gem_component_stylesheet("summary-banner")
+
+  title ||= false
+  text ||= false
+  secondary_text ||= false
+  local_assigns[:margin_bottom] ||= 7
+
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("gem-c-summary-banner")
+  component_helper.add_aria_attribute({ label: "Notice" })
+  component_helper.set_lang("en")
+  component_helper.add_data_attribute({ module: "ga4-link-tracker" })
+  component_helper.add_data_attribute({ ga4_track_links_only: "" })
+  component_helper.add_data_attribute({ ga4_link: { event_name: "navigation", type: "callout" } })
+%>
+<% if title.present? && text.present? %>
+  <%= tag.section(**component_helper.all_attributes) do %>
+    <h2 class="gem-c-summary-banner__title govuk-heading-m"><%= title %></h2>
+    <p class="gem-c-summary-banner__text">
+      <%= text %>
+    </p>
+    <% if secondary_text %>
+      <p class="gem-c-summary-banner__text"><%= secondary_text %></p>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/summary_banner.yml
+++ b/app/views/govuk_publishing_components/components/docs/summary_banner.yml
@@ -1,0 +1,28 @@
+name: Summary banner
+description: A page banner that is currently used on consultations and calls for evidence to display a summary or other important information.
+body: |
+  This component requires title and text attribute values passed to it, otherwise it will not render. This reflects how the component is currently used. If the component needed to become more flexible and work for other use cases, please raise an issue or a pull request in the gem.
+
+  Real world examples:
+
+  - [consultation](https://www.gov.uk/government/consultations/environmental-assessment-levels-for-the-amine-based-carbon-capture-process)
+  - [call for evidence](https://www.gov.uk/government/calls-for-evidence/financial-services-growth-and-competitiveness-strategy)
+accessibility_criteria: |
+  The banner must:
+
+  - be visually distinct from other content on the page
+  - have an accessible name that describes the banner as a notice
+  - have a text contrast ratio higher than 4.5:1 against the background colour to meet [WCAG AA](https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast)
+uses_component_wrapper_helper: true
+examples:
+  default:
+    data:
+      title: Summary
+      text: This call for evidence will inform the development of the financial services sector plan, a key part of the government’s modern industrial strategy.
+  with_secondary_text:
+    description: This example shows how the consultation and call for evidence templates use the secondary text to display dates.
+    data:
+      title: Summary
+      text: This call for evidence will inform the development of the financial services sector plan, a key part of the government’s modern industrial strategy.
+      secondary_text: This consultation ran from<br><strong class="consultation-date"><time datetime="2024-11-05T11:00:00.000+00:00">11am on 5 November 2024</time> to
+        <time datetime="2024-12-03T17:00:00.000+00:00">5pm on 3 December 2024</time></strong>

--- a/spec/components/summary_banner_spec.rb
+++ b/spec/components/summary_banner_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+describe "Summary banner", type: :view do
+  def component_name
+    "summary_banner"
+  end
+
+  it "fails to render a banner when nothing is passed to it" do
+    assert_empty render_component({})
+  end
+
+  it "fails to render a banner when no title or no text is passed to it" do
+    assert_empty render_component(title: "Summary")
+    assert_empty render_component(text: "This call for evidence will inform the development of the financial services sector plan, a key part of the government’s modern industrial strategy.")
+  end
+
+  it "renders a banner with title and text correctly" do
+    render_component(title: "Summary", text: "This call for evidence will inform the development of the financial services sector plan, a key part of the government’s modern industrial strategy.")
+
+    assert_select ".gem-c-summary-banner__title", text: "Summary"
+    assert_select ".gem-c-summary-banner__text", text: "This call for evidence will inform the development of the financial services sector plan, a key part of the government’s modern industrial strategy."
+  end
+
+  it "renders a banner with an aria label" do
+    render_component(title: "Summary", text: "Text")
+    assert_select "section[aria-label]"
+  end
+
+  it "renders a banner with title, text and secondary text correctly" do
+    render_component(
+      title: "Summary",
+      text: "This call for evidence will inform the development of the financial services sector plan, a key part of the government’s modern industrial strategy.",
+      secondary_text: "This consultation ran from<br><strong class='consultation-date'><time datetime='2024-11-05T11:00:00.000+00:00'>11am on 5 November 2024</time> to <time datetime='2024-12-03T17:00:00.000+00:00'>5pm on 3 December 2024</time></strong>",
+    )
+
+    assert_select ".gem-c-summary-banner__title", text: "Summary"
+    assert_select ".gem-c-summary-banner__text", text: "This call for evidence will inform the development of the financial services sector plan, a key part of the government’s modern industrial strategy."
+    assert_select ".gem-c-summary-banner__text", text: "This consultation ran from<br><strong class='consultation-date'><time datetime='2024-11-05T11:00:00.000+00:00'>11am on 5 November 2024</time> to <time datetime='2024-12-03T17:00:00.000+00:00'>5pm on 3 December 2024</time></strong>"
+  end
+
+  it "renders a banner with GA4 tracking" do
+    render_component(
+      title: "Summary",
+      text: "This call for evidence will inform the development of the financial services sector plan, a key part of the government’s modern industrial strategy.",
+    )
+
+    assert_select ".gem-c-summary-banner[data-module=ga4-link-tracker]"
+    assert_select ".gem-c-summary-banner[data-ga4-track-links-only]"
+    assert_select ".gem-c-summary-banner[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"callout\"}']"
+  end
+end

--- a/spec/lib/govuk_publishing_components/app_helpers/asset_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/app_helpers/asset_helper_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe GovukPublishingComponents::AppHelpers::AssetHelper do
     end
 
     it "detect the total number of stylesheet paths" do
-      expect(get_component_css_paths.count).to be(81)
+      expect(get_component_css_paths.count).to be(82)
     end
 
     it "initialize empty asset helper" do


### PR DESCRIPTION
## What / Why
<!-- What are the reasons behind this change being made? -->
- Migrates the [banner component from government-frontend](https://govuk-government-frontend.herokuapp.com/component-guide/banner) to this gem
- I've renamed it from `Banner` to `Summary banner`, as there are already multiple banners in this gem so it felt wrong for it to have a generic name.
- Trello card: https://trello.com/c/eF1B4BDf/513-migrate-government-frontend-components-to-the-gem

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

There should be none across `government-frontend` and this gem.

You can compare here: [government-frontend preview](https://govuk-government-frontend.herokuapp.com/component-guide/banner/preview) and [gem preview](https://components-gem-pr-4681.herokuapp.com/component-guide/summary_banner/preview)
