### PR TITLE
Remove search `large-mobile` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Remove search large-mobile option ([PR #4682](https://github.com/alphagov/govuk_publishing_components/pull/4682))
+
 ## 54.0.1
 
 * Fix govspeak legislative lists styles ([PR #4679](https://github.com/alphagov/govuk_publishing_components/pull/4679))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -257,12 +257,6 @@ $large-input-size: 50px;
   @include large-mode;
 }
 
-.gem-c-search--large-on-mobile {
-  @include govuk-media-query($until: "tablet") {
-    @include large-mode;
-  }
-}
-
 .gem-c-search--separate-label {
   .gem-c-search__label {
     position: relative;

--- a/app/views/govuk_publishing_components/components/_search.html.erb
+++ b/app/views/govuk_publishing_components/components/_search.html.erb
@@ -24,7 +24,6 @@
   component_helper.add_data_attribute({ module: "gem-toggle-input-class-on-focus" })
   component_helper.add_class("gem-c-search govuk-!-display-none-print")
   component_helper.add_class("gem-c-search--large") if size == "large"
-  component_helper.add_class("gem-c-search--large-on-mobile") if size == "large-mobile"
   component_helper.add_class("gem-c-search--homepage") if homepage
   component_helper.add_class("gem-c-search--no-border") if no_border
   component_helper.add_class("gem-c-search--on-govuk-blue") if local_assigns[:on_govuk_blue].eql?(true)

--- a/app/views/govuk_publishing_components/components/docs/search.yml
+++ b/app/views/govuk_publishing_components/components/docs/search.yml
@@ -54,9 +54,6 @@ examples:
   large_version:
     data:
       size: "large"
-  large_version_on_mobile_only:
-    data:
-      size: "large-mobile"
   change_field_name:
     description: To be used if you need to change the default name 'q'
     data:

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -54,11 +54,6 @@ describe "Search", type: :view do
     assert_select ".gem-c-search.gem-c-search--large"
   end
 
-  it "renders a large search box on mobile only" do
-    render_component(size: "large-mobile")
-    assert_select ".gem-c-search.gem-c-search--large-on-mobile"
-  end
-
   it "renders a search box with a default name" do
     render_component({})
     assert_select 'input[name="q"]'


### PR DESCRIPTION
## What

Remove search `large-mobile` option

## Why

https://trello.com/c/2WuCz8Wg/3350-remove-the-large-mobile-option-from-the-search-component