### PR TITLE
Migrate figure component from government-frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Remove the `no_border` option from the search component ([PR #4693](https://github.com/alphagov/govuk_publishing_components/pull/4693))
 * Migrate banner component from government-frontend as 'Summary banner' ([PR #4681](https://github.com/alphagov/govuk_publishing_components/pull/4681))
 * Add 'contents list with body' component from government-frontend ([PR #4686](https://github.com/alphagov/govuk_publishing_components/pull/4686))
+* Migrate figure component from government-frontend ([PR #4688](https://github.com/alphagov/govuk_publishing_components/pull/4688))
 
 ## 54.0.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -39,6 +39,7 @@
 @import "components/feedback";
 @import "components/fieldset";
 @import "components/file-upload";
+@import "components/figure";
 @import "components/glance-metric";
 @import "components/global-banner";
 @import "components/govspeak-html-publication";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_figure.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_figure.scss
@@ -1,0 +1,46 @@
+@import "govuk_publishing_components/individual_component_support";
+
+.gem-c-figure {
+  border-top: 1px solid $govuk-border-colour;
+  padding-top: govuk-spacing(3);
+  margin: 0;
+  margin-bottom: govuk-spacing(8);
+  @include govuk-clearfix;
+
+  @include govuk-media-query($until: tablet) {
+    margin-bottom: govuk-spacing(6);
+  }
+}
+
+.gem-c-figure__image {
+  display: block;
+  width: 100%;
+
+  @include govuk-media-query($from: tablet) {
+    float: inline-start;
+    width: 50%;
+  }
+}
+
+.gem-c-figure__figcaption {
+  @include govuk-font(16);
+
+  @include govuk-media-query($from: tablet) {
+    display: block;
+    vertical-align: top;
+    box-sizing: border-box;
+    float: inline-end;
+    padding-inline-start: govuk-spacing(3);
+    width: 50%;
+  }
+
+  @include govuk-media-query($until: tablet) {
+    margin-top: govuk-spacing(2);
+  }
+}
+
+.gem-c-figure__figcaption-text {
+  margin: 0;
+  margin-bottom: govuk-spacing(2);
+  @include govuk-font(16);
+}

--- a/app/views/govuk_publishing_components/components/_figure.html.erb
+++ b/app/views/govuk_publishing_components/components/_figure.html.erb
@@ -1,0 +1,28 @@
+<%
+  add_gem_component_stylesheet("figure")
+  alt ||= ""
+  caption ||= ""
+  credit ||= ""
+  local_assigns[:lang] ||= "en"
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("gem-c-figure")
+%>
+<%= tag.figure(**component_helper.all_attributes) do %>
+  <% if src.present? %>
+    <img class="gem-c-figure__image" src="<%= src %>" alt="<%= alt %>">
+  <% end %>
+  <% if caption.present? || credit.present? %>
+    <figcaption class="gem-c-figure__figcaption">
+      <% if caption.present? %>
+        <p class="gem-c-figure__figcaption-text">
+          <%= caption %>
+        </p>
+      <% end %>
+      <% if credit.present? %>
+        <p class="gem-c-figure__figcaption-text">
+          <%= I18n.t("components.figure.image_credit", credit: credit) %>
+        </p>
+      <% end %>
+    </figcaption>
+  <% end %>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/figure.yml
+++ b/app/views/govuk_publishing_components/components/docs/figure.yml
@@ -1,0 +1,43 @@
+name: Figure
+description: A figure containing an image that never exceeds the component’s width
+body: |
+  A figure should be used for images that are referenced within a page, but which can be moved around without affecting the flow of the page [(see guidance here)](https://developer.mozilla.org/en/docs/Web/HTML/Element/figure)
+
+  Examples:
+
+  - [Case Study containing an image](https://www.gov.uk/government/case-studies/2013-elections-in-swaziland)
+accessibility_criteria: |
+  The figure must:
+
+  - provide an informative text description, as alt text or caption
+
+uses_component_wrapper_helper: true
+examples:
+  default:
+    data:
+      src: 'https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/54374/s630_the_lords_chamber.jpg'
+  figure_with_alt_text:
+    data:
+      src: 'https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/54374/s630_the_lords_chamber.jpg'
+      alt: 'An image of the lords chamber'
+  figure_with_caption:
+    data:
+      src: 'https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/54374/s630_the_lords_chamber.jpg'
+      alt: 'An image of the lords chamber'
+      caption: 'The Lords Chamber'
+  right_to_left_with_caption:
+    data:
+      src: 'https://assets.publishing.service.gov.uk/government/uploads/system/uploads/image_data/file/31637/s300_Visas_-_Website.jpg'
+      alt: 'تأشيرات'
+      caption: 'تأشيرات'
+    context:
+      right_to_left: true
+  figure_with_credit:
+    data:
+      src: 'https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/54374/s630_the_lords_chamber.jpg'
+      credit: Wallis Crankled
+  figure_with_caption_and_credit:
+    data:
+      src: 'https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/54374/s630_the_lords_chamber.jpg'
+      caption: The Lords Chamber
+      credit: Wallis Crankled

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -92,6 +92,8 @@ ar:
       what_doing: ماذا كنت تفعل؟
       what_wrong: ما الخطأ الذي وقع؟
       'yes': نعم ‏  ‏
+    figure:
+      image_credit: 'حقوق ملكية الصورة: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -89,6 +89,8 @@ az:
       what_doing: Nə edirdiniz?
       what_wrong: Hansı yanlışlıq oldu?
       'yes': Bəli
+    figure:
+      image_credit: 'Təqdim edilmiş qrafik material: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -95,6 +95,8 @@ be:
       what_doing: Што вы рабiлi?
       what_wrong: Што пайшло не так?
       'yes': Так
+    figure:
+      image_credit: 'Крэдыт выявы: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -93,6 +93,8 @@ bg:
       what_doing: Какво правихте?
       what_wrong: Какво се обърка?
       'yes': Да
+    figure:
+      image_credit: 'Изображението е от: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -90,6 +90,8 @@ bn:
       what_doing: আপনি কী করছিলেন?
       what_wrong: কী ভুল হয়েছিল?
       'yes': হ্যাঁ
+    figure:
+      image_credit: 'ছবির কৃতিত্ব: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -94,6 +94,8 @@ cs:
       what_doing: Co jste dělal?
       what_wrong: Co se pokazilo?
       'yes': Ano
+    figure:
+      image_credit: zobrazení úvěru %{credit}
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -93,6 +93,8 @@ cy:
       what_doing: Beth oeddech chi'n wneud?
       what_wrong: Beth aeth o'i le?
       'yes': Ie
+    figure:
+      image_credit: 'Delwedd gan: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -90,6 +90,8 @@ da:
       what_doing: Hvad lavede du?
       what_wrong: Hvad gik galt?
       'yes': ja
+    figure:
+      image_credit: 'Billede kredit: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -93,6 +93,8 @@ de:
       what_doing: Was haben Sie gemacht?
       what_wrong: Was ist schief gelaufen?
       'yes': Ja
+    figure:
+      image_credit: 'Abbildung: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -91,6 +91,8 @@ dr:
       what_doing: مصروف چه کاری بودید؟
       what_wrong: چه اشتباهی رخ داد؟
       'yes': بلی
+    figure:
+      image_credit: "%{credit}:کریدت تصویر\n"
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -89,6 +89,8 @@ el:
       what_doing: Τι κάνατε;
       what_wrong: Τι πήγε στραβά;
       'yes': Ναι
+    figure:
+      image_credit: 'Εικόνα από: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -88,6 +88,8 @@ en:
       what_doing: What were you doing?
       what_wrong: What went wrong?
       'yes': 'Yes'
+    figure:
+      image_credit: 'Image credit: %{credit}'
     intervention:
       accessible_link_text_suffix: " (opens in a new tab)"
     layout_footer:

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -89,6 +89,8 @@ es-419:
       what_doing: "¿Qué estaba haciendo?"
       what_wrong: "¿Qué salió mal?"
       'yes': Sí
+    figure:
+      image_credit: 'Crédito de la imagen: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -89,6 +89,8 @@ es:
       what_doing: "¿Qué estaba haciendo?"
       what_wrong: "¿Qué ha fallado?"
       'yes': Sí
+    figure:
+      image_credit: 'Crédito de la imagen: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -92,6 +92,8 @@ et:
       what_doing: Mida te tegite?
       what_wrong: Mis läks valesti?
       'yes': Jah
+    figure:
+      image_credit: 'Pildi autoriõigus: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -88,6 +88,8 @@ fa:
       what_doing: داشتید چه کار می‌کردید؟
       what_wrong: چه مشکلی پیش آمد؟
       'yes': بله
+    figure:
+      image_credit: 'اعتبار تصویر: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -91,6 +91,8 @@ fi:
       what_doing: Mitä olit tekemässä?
       what_wrong: Mikä meni vikaan?
       'yes': Kyllä
+    figure:
+      image_credit: 'Kuvaluotto: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -89,6 +89,8 @@ fr:
       what_doing: Que faisiez-vous ?
       what_wrong: Qu'est-ce qui n'a pas marché ?
       'yes': Oui
+    figure:
+      image_credit: Crédit d'image : %{credit}
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -91,6 +91,8 @@ gd:
       what_doing: Cad atá á dhéanamh agat ?
       what_wrong: Cad a chuaigh mícheart?
       'yes': Sea
+    figure:
+      image_credit: 'Creidmheas íomhá: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -89,6 +89,8 @@ gu:
       what_doing: તમે શું કરી રહ્યા હતા?
       what_wrong: શું ગરબડ થઈ?
       'yes': હા
+    figure:
+      image_credit: ઇમેજ ક્રેડિટ:%{credit}
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -89,6 +89,8 @@ he:
       what_doing: מה אתה עושה?
       what_wrong: מה השתבש?
       'yes': כן
+    figure:
+      image_credit: 'קרדיט תמונה: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -89,6 +89,8 @@ hi:
       what_doing: आप क्या कर रहे थे?
       what_wrong: क्या गलत हुआ?
       'yes': हां
+    figure:
+      image_credit: 'इमेज क्रेडिट: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -90,6 +90,8 @@ hr:
       what_doing: Šta ste radili?
       what_wrong: Što je pošlo po zlu?
       'yes': Da
+    figure:
+      image_credit: 'Zasluga za sliku: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -92,6 +92,8 @@ hu:
       what_doing: Mit csinált?
       what_wrong: Milyen hiba lépett fel?
       'yes': Igen
+    figure:
+      image_credit: 'Képaláírás: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -93,6 +93,8 @@ hy:
       what_doing: Ի՞նչ էիք փնտրում։
       what_wrong: Ի՞նչը խնդիր առաջացավ։
       'yes': Այո
+    figure:
+      image_credit: Նկարը՝ %{credit}
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -89,6 +89,8 @@ id:
       what_doing: Apa yang Anda lakukan?
       what_wrong: Apa yang salah?
       'yes': Ya
+    figure:
+      image_credit: 'Kredit gambar: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -89,6 +89,8 @@ is:
       what_doing: Hvað varstu að gera?
       what_wrong: Hvað fór úrskeiðis?
       'yes': Já
+    figure:
+      image_credit: Uppruni myndar %{credit}
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -89,6 +89,8 @@ it:
       what_doing: Cosa stavi facendo?
       what_wrong: Cosa è andato storto?
       'yes': Sì
+    figure:
+      image_credit: 'Credito d’immagine: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -85,6 +85,8 @@ ja:
       what_doing: 何をしましたか？
       what_wrong: どのような不具合ですか？
       'yes': はい
+    figure:
+      image_credit: 画像著作権：%{credit}
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -92,6 +92,8 @@ ka:
       what_doing: რას აკეთებდით?
       what_wrong: რა მოხდა არასწორად?
       'yes': დიახ
+    figure:
+      image_credit: 'სურათ: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -89,6 +89,8 @@ kk:
       what_doing: Сіз не істеп жатыр едіңіз?
       what_wrong: Не дұрыс болмады?
       'yes': Иә
+    figure:
+      image_credit: 'Суретті түсірген: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -84,6 +84,8 @@ ko:
       what_doing:
       what_wrong:
       'yes':
+    figure:
+      image_credit: '이미지 저작권: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -94,6 +94,8 @@ lt:
       what_doing: Ką darėte?
       what_wrong: Kas nutiko?
       'yes': Taip
+    figure:
+      image_credit: 'Nuotrauka: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -93,6 +93,8 @@ lv:
       what_doing: Ko jūs darījāt?
       what_wrong: Kādas problēmas radās?
       'yes': Jā
+    figure:
+      image_credit: 'Attēla autortiesības: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -88,6 +88,8 @@ ms:
       what_doing: Apa yang anda buat?
       what_wrong: Apa yang salah?
       'yes': Ya
+    figure:
+      image_credit: 'Imej kredit: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -91,6 +91,8 @@ mt:
       what_doing: X'kont qed tagħmel?
       what_wrong: X'mar ħażin?
       'yes': Iva
+    figure:
+      image_credit: 'Kreditu għall-immaġni:  %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -85,6 +85,8 @@ ne:
       what_doing:
       what_wrong:
       'yes':
+    figure:
+      image_credit: 'छवि श्रेय: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -89,6 +89,8 @@ nl:
       what_doing: Wat was u aan het doen?
       what_wrong: Wat ging er mis?
       'yes': Ja
+    figure:
+      image_credit: 'Image credit: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -89,6 +89,8 @@
       what_doing: Hva gjorde du?
       what_wrong: Hva gikk galt?
       'yes': Ja
+    figure:
+      image_credit: 'Bildekreditt: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -85,6 +85,8 @@ pa-pk:
       what_doing: تُسی کیہ کر رئے سو
       what_wrong: کیہ غلط ہویا اے
       'yes': جی ہاں
+    figure:
+      image_credit: 'امیج کریڈٹ: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -89,6 +89,8 @@ pa:
       what_doing: ਤੁਸੀਂ ਕੀ ਕਰ ਰਹੇ ਸੀ?
       what_wrong: ਕੀ ਗਲਤ ਹੋਇਆ?
       'yes': ਹਾਂ
+    figure:
+      image_credit: 'ਚਿੱਤਰ ਕ੍ਰੈਡਿਟ: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -93,6 +93,8 @@ pl:
       what_doing: Co robiłeś?
       what_wrong: Co poszło nie tak?
       'yes': Tak
+    figure:
+      image_credit: Obrazek:%{credit}
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -86,6 +86,8 @@ ps:
       what_doing: ته څه کوې؟
       what_wrong: څه غلط شول؟
       'yes': هو
+    figure:
+      image_credit: د انځور کریډیټ:%{credit}
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -89,6 +89,8 @@ pt:
       what_doing: O que estava a fazer?
       what_wrong: O que correu mal?
       'yes': Sim
+    figure:
+      image_credit: 'Crédito da imagem: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -90,6 +90,8 @@ ro:
       what_doing: Ce făceați?
       what_wrong: Ce eroare a survenit?
       'yes': Da
+    figure:
+      image_credit: 'Autor imagine: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -93,6 +93,8 @@ ru:
       what_doing: Что вы делали?
       what_wrong: Что пошло не так?
       'yes': Да
+    figure:
+      image_credit: 'Графические материалы предоставлены: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -89,6 +89,8 @@ si:
       what_doing: ඔබ කුමක් ද කරමින් සිටියේ?
       what_wrong: වැරදුණේ කුමක්ද?
       'yes': ඔව්
+    figure:
+      image_credit: 'රූප සඳහා ස්තූතියි: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -94,6 +94,8 @@ sk:
       what_doing: Čo ste robili?
       what_wrong: Čo sa pokazilo?
       'yes': Áno
+    figure:
+      image_credit: 'Obrázok: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -96,6 +96,8 @@ sl:
       what_doing: Kaj ste počeli?
       what_wrong: Kaj je šlo narobe?
       'yes': Da
+    figure:
+      image_credit: 'Avtor slike: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -89,6 +89,8 @@ so:
       what_doing: Maxaad doonaysaa inuu laguu qabto?
       what_wrong: Maxaa qaldamay?
       'yes': Haa
+    figure:
+      image_credit: 'Xuquuqda sawirka: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -89,6 +89,8 @@ sq:
       what_doing: Cfare po bënit?
       what_wrong: Çfarë shkoi keq?
       'yes': Po
+    figure:
+      image_credit: 'Kreditet e imazhit: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -90,6 +90,8 @@ sr:
       what_doing: Šta ste radili?
       what_wrong: Koji problem se javio?
       'yes': Da
+    figure:
+      image_credit: 'Vlasnik slike: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -89,6 +89,8 @@ sv:
       what_doing: Vad gjorde du?
       what_wrong: Vad gick fel?
       'yes': Ja
+    figure:
+      image_credit: 'Bild: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -89,6 +89,8 @@ sw:
       what_doing: Ulikuwa unafanya nini?
       what_wrong: Tatizo lipi lililotokea?
       'yes': Ndiyo
+    figure:
+      image_credit: 'Mpiga picha: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -90,6 +90,8 @@ ta:
       what_doing: நீங்கள் என்ன செய்து கொண்டிருந்தீர்கள்?
       what_wrong: என்ன தவறு நடந்தது?
       'yes': ஆம்
+    figure:
+      image_credit: 'பட உதவி: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -87,6 +87,8 @@ th:
       what_doing: คุณทำอะไรอยู่ในขณะนั้น
       what_wrong: มีสิ่งใดผิดปกติ
       'yes': ใช่
+    figure:
+      image_credit: 'เครดิตภาพ: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -90,6 +90,8 @@ tk:
       what_doing: Näme edýärdiňiz?
       what_wrong: Näme nädogry boldy?
       'yes': Hawa
+    figure:
+      image_credit: 'Surat krediti: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -90,6 +90,8 @@ tr:
       what_doing: Ne yapmaktaydınız?
       what_wrong: Nasıl bir sorun oldu?
       'yes': Evet
+    figure:
+      image_credit: 'Resim sahibi: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -96,6 +96,8 @@ uk:
       what_doing: Що ви робили?
       what_wrong: Що пішло не так?
       'yes': Так
+    figure:
+      image_credit: 'Зображення: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -86,6 +86,8 @@ ur:
       what_doing: آپ کیا کر رہے تھے؟
       what_wrong: کیا غلط ہوا؟
       'yes': جی ہاں
+    figure:
+      image_credit: 'تصویری کریڈٹ: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -91,6 +91,8 @@ uz:
       what_doing: Сиз нима қилаётган эдингиз?
       what_wrong: Қандай хатолик бўлди?
       'yes': Ҳа
+    figure:
+      image_credit: 'График материаллар тақдим этилган: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -88,6 +88,8 @@ vi:
       what_doing: Bạn đang làm gì?
       what_wrong: Sự cố gì đã xảy ra?
       'yes': Có
+    figure:
+      image_credit: 'Nguồn hình ảnh: %{credit}'
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -87,6 +87,8 @@ zh-hk:
       what_doing: 您剛才在做什麼？
       what_wrong: 出現什麼錯誤？
       'yes': 是
+    figure:
+      image_credit: 圖片來源： %{credit}
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -87,6 +87,8 @@ zh-tw:
       what_doing: 你做了什麼？
       what_wrong: 哪出錯了？
       'yes': 是的
+    figure:
+      image_credit: 圖片來源： %{credit}
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -87,6 +87,8 @@ zh:
       what_doing: 您在干什么？
       what_wrong: 发生了哪些错误？
       'yes': 是
+    figure:
+      image_credit: 图片提供：%{credit}
     intervention:
       accessible_link_text_suffix:
     layout_footer:

--- a/spec/components/figure_spec.rb
+++ b/spec/components/figure_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+describe "Figure", type: :view do
+  def component_name
+    "figure"
+  end
+
+  it "fails to render a figure when no data is given" do
+    assert_raises do
+      render_component({})
+    end
+  end
+
+  it "fails to render an image when no source is given" do
+    render_component(src: "", alt: "")
+    assert_select "img", false, "Should not have drawn img tag with no src"
+  end
+
+  it "renders a figure correctly" do
+    render_component(src: "/image", alt: "image alt text")
+    assert_select ".gem-c-figure__image[src=\"/image\"]"
+    assert_select ".gem-c-figure__image[alt=\"image alt text\"]"
+  end
+
+  it "renders a figure with caption correctly" do
+    render_component(src: "/image", alt: "image alt text", caption: "This is a caption")
+    assert_select ".gem-c-figure__image[src=\"/image\"]"
+    assert_select ".gem-c-figure__image[alt=\"image alt text\"]"
+    assert_select ".gem-c-figure__figcaption .gem-c-figure__figcaption-text", text: "This is a caption"
+  end
+
+  it "renders a figure with credit correctly" do
+    render_component(src: "/image", alt: "image alt text", credit: "Creative Commons")
+    assert_select ".gem-c-figure__image[src=\"/image\"]"
+    assert_select ".gem-c-figure__image[alt=\"image alt text\"]"
+    assert_select ".gem-c-figure__figcaption .gem-c-figure__figcaption-text", text: "Image credit: Creative Commons"
+  end
+
+  it "renders a figure with caption and credit correctly" do
+    render_component(src: "/image", alt: "image alt text", caption: "This is a caption", credit: "Creative Commons")
+    assert_select ".gem-c-figure__image[src=\"/image\"]"
+    assert_select ".gem-c-figure__image[alt=\"image alt text\"]"
+    assert_select ".gem-c-figure__figcaption .gem-c-figure__figcaption-text", text: "This is a caption"
+    assert_select ".gem-c-figure__figcaption .gem-c-figure__figcaption-text", text: "Image credit: Creative Commons"
+  end
+end

--- a/spec/lib/govuk_publishing_components/app_helpers/asset_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/app_helpers/asset_helper_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe GovukPublishingComponents::AppHelpers::AssetHelper do
     end
 
     it "detect the total number of stylesheet paths" do
-      expect(get_component_css_paths.count).to be(83)
+      expect(get_component_css_paths.count).to be(84)
     end
 
     it "initialize empty asset helper" do


### PR DESCRIPTION
## What /Why
<!-- What are the reasons behind this change being made? -->
- Migrate the figure component from [government-frontend](https://govuk-government-frontend.herokuapp.com/component-guide/figure) to [the gem]()
- Also migrates the translation files over. 
- Trello card: https://trello.com/c/eF1B4BDf/513-migrate-government-frontend-components-to-the-gem

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

There should be none - you can do a comparison here: [government-frontend](https://govuk-government-frontend.herokuapp.com/component-guide/figure/preview) vs [this PR](https://components-gem-pr-4688.herokuapp.com/component-guide/figure/preview)
