### PR TITLE
Remove the `no_border` option from the search component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Add back to top link component translations ([PR #4689](https://github.com/alphagov/govuk_publishing_components/pull/4689))
 * Remove IE8 support from action-link component ([PR #4690](https://github.com/alphagov/govuk_publishing_components/pull/4690))
 * **BREAKING** Remove search from the layout header component ([PR #4687](https://github.com/alphagov/govuk_publishing_components/pull/4687))
+* Remove the `no_border` option from the search component ([PR #4693](https://github.com/alphagov/govuk_publishing_components/pull/4693))
 
 ## 54.0.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -232,27 +232,6 @@ $large-input-size: 50px;
   color: govuk-colour("white");
 }
 
-.gem-c-search--no-border {
-  .gem-c-search__label {
-    color: govuk-colour("white");
-  }
-
-  .gem-c-search__input[type="search"] {
-    border: 0;
-
-    &:focus {
-      @include gem-c-search-input-focus;
-      box-shadow: inset 0 0 0 4px;
-    }
-  }
-
-  .govuk-frontend-supported & {
-    .gem-c-search__label {
-      color: $govuk-secondary-text-colour;
-    }
-  }
-}
-
 .gem-c-search--large {
   @include large-mode;
 }

--- a/app/views/govuk_publishing_components/components/_search.html.erb
+++ b/app/views/govuk_publishing_components/components/_search.html.erb
@@ -15,7 +15,6 @@
   label_custom_class ||= nil
   name ||= "q"
   homepage ||= false
-  no_border ||= false
   size ||= ""
   value ||= ""
   local_assigns[:margin_bottom] ||= 6
@@ -25,7 +24,6 @@
   component_helper.add_class("gem-c-search govuk-!-display-none-print")
   component_helper.add_class("gem-c-search--large") if size == "large"
   component_helper.add_class("gem-c-search--homepage") if homepage
-  component_helper.add_class("gem-c-search--no-border") if no_border
   component_helper.add_class("gem-c-search--on-govuk-blue") if local_assigns[:on_govuk_blue].eql?(true)
   component_helper.add_class("gem-c-search--on-white") unless local_assigns[:on_govuk_blue].eql?(true)
   component_helper.add_class("gem-c-search--separate-label") if local_assigns.include?(:inline_label) or local_assigns.include?(:label_size)
@@ -33,7 +31,7 @@
   label_classes = []
   if (shared_helper.valid_heading_size?(label_size))
     label_classes << "govuk-label govuk-label--#{label_size}"
-    label_classes << "gem-c-search__label--white" if no_border || homepage
+    label_classes << "gem-c-search__label--white" if homepage
   else
     label_classes << "gem-c-search__label"
   end

--- a/app/views/govuk_publishing_components/components/docs/search.yml
+++ b/app/views/govuk_publishing_components/components/docs/search.yml
@@ -22,12 +22,6 @@ examples:
   stop_the_label_appearing_inline:
     data:
       inline_label: false
-  no_border:
-    description: Sometimes we don't need the grey border surrounding the input field, such as when the component is used on a black background
-    data:
-      no_border: true
-    context:
-      black_background: true
   for_use_on_govuk_blue_background:
     data:
       on_govuk_blue: true

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -76,11 +76,6 @@ describe "Search", type: :view do
     assert_select '.gem-c-search.govuk-\!-margin-bottom-2'
   end
 
-  it "renders a search box with no border" do
-    render_component(no_border: true)
-    assert_select ".gem-c-search--no-border"
-  end
-
   it "renders a search box with default button text" do
     render_component({})
     assert_select ".gem-c-search__submit", text: "Search"


### PR DESCRIPTION
## What

Remove the `no_border` option from the search component

## Why

https://trello.com/c/RSta9bQP