### PR TITLE
Release version 55.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 55.0.0
 
 * Remove search large-mobile option ([PR #4682](https://github.com/alphagov/govuk_publishing_components/pull/4682))
 * Add back to top link component from government-frontend ([PR #4666](https://github.com/alphagov/govuk_publishing_components/pull/4666))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (54.0.1)
+    govuk_publishing_components (55.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "54.0.1".freeze
+  VERSION = "55.0.0".freeze
 end


### PR DESCRIPTION
## 55.0.0

* Remove search large-mobile option ([PR #4682](https://github.com/alphagov/govuk_publishing_components/pull/4682))
* Add back to top link component from government-frontend ([PR #4666](https://github.com/alphagov/govuk_publishing_components/pull/4666))
* Add back to top link component translations ([PR #4689](https://github.com/alphagov/govuk_publishing_components/pull/4689))
* Remove IE8 support from action-link component ([PR #4690](https://github.com/alphagov/govuk_publishing_components/pull/4690))
* **BREAKING** Remove search from the layout header component ([PR #4687](https://github.com/alphagov/govuk_publishing_components/pull/4687))
* Remove the `no_border` option from the search component ([PR #4693](https://github.com/alphagov/govuk_publishing_components/pull/4693))
* Migrate banner component from government-frontend as 'Summary banner' ([PR #4681](https://github.com/alphagov/govuk_publishing_components/pull/4681))
* Add 'contents list with body' component from government-frontend ([PR #4686](https://github.com/alphagov/govuk_publishing_components/pull/4686))
* Migrate figure component from government-frontend ([PR #4688](https://github.com/alphagov/govuk_publishing_components/pull/4688))
* Migrate published dates component from government-frontend ([PR #4691](https://github.com/alphagov/govuk_publishing_components/pull/4691))