### PR TITLE
Shift footnotes above 100/1000 further to the left

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Shift footnotes above 100/1000 further to the left ([PR #4705](https://github.com/alphagov/govuk_publishing_components/pull/4705))
+
 ## 55.0.0
 
 * Remove search large-mobile option ([PR #4682](https://github.com/alphagov/govuk_publishing_components/pull/4682))

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_footnotes.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_footnotes.scss
@@ -21,5 +21,13 @@
     a {
       overflow-wrap: break-word;
     }
+
+    ol li:nth-of-type(99) ~ li {
+      margin-left: 11px;
+    }
+
+    ol li:nth-of-type(999) ~ li {
+      margin-left: 22px;
+    }
   }
 }


### PR DESCRIPTION
## What / Why
<!-- What are the reasons behind this change being made? -->
- On [this page in production](https://www.gov.uk/government/publications/independent-investigation-of-the-nhs-in-england/independent-investigation-of-the-national-health-service-in-england-accessible-version) the footnotes are being covered by another element once the footnote number exceeds `100`.
- This is because the list styles act similar to `absolute` positioning, so the numbers are not being factored in to the `<ol>` element width.
- I did try to fix this by using `list-style-position: inside`, which would make the list styles act like `position: relative`, but this caused issues with the list item content itself as long URLs would then need `display: inline-block` to sit on the same line as the numbers - which then affected the positioning of the `↩` link.
- Therefore, I've added some CSS to shift these list items to the left for `100-999` and `1000-9999`. I included  `1000-9999` just for future proofing, so in the event a document with 1000 footnotes is published there shouldn't be an issue.
- Note: I haven't updated the footnotes example in the component guide to include 100 (or 1000!) footnotes as I wasn't sure if that would add too much clutter to the component example. Happy to add the example with more items if you think it's worth adding though.
- Trello card: https://trello.com/c/qxyusuLI/527-footnotes-labelled-with-numbers-over-100-not-displaying-properly

### How to test
- To test this, you can run `government-frontend` locally with this gem, and visit [this page](http://127.0.0.1:3090/government/publications/independent-investigation-of-the-nhs-in-england/independent-investigation-of-the-national-health-service-in-england-accessible-version). 
- To test 1000 footnotes, you could add extra footnotes to the DOM on that page in `government-frontend`, or add 1000 footnotes to the [component example](https://components.publishing.service.gov.uk/component-guide/govspeak/footnotes/preview)

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

| Before    | After |
| -------- | ------- |
| <img width="943" alt="image" src="https://github.com/user-attachments/assets/a99e3c0e-40ec-4f71-9cdd-962225974ecb" />  | <img width="943" alt="image" src="https://github.com/user-attachments/assets/c0986d13-740a-4332-b58b-43f63ce1e560" />

#### 999 to 1000 alignment example

<img width="943" alt="image" src="https://github.com/user-attachments/assets/cedcdcf1-9a19-498f-96da-d55e8cf4e37f" />

