### PR TITLE
Release version 55.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 55.0.1
 
 * Shift footnotes above 100/1000 further to the left ([PR #4705](https://github.com/alphagov/govuk_publishing_components/pull/4705))
-* Delete unused CSS from layout super navigation component ([PR #4702](https://github.com/alphagov/govuk_publishing_components/pull/4682))
+* Delete unused CSS from layout super navigation component ([PR #4702](https://github.com/alphagov/govuk_publishing_components/pull/4702))
 
 ## 55.0.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (55.0.0)
+    govuk_publishing_components (55.0.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "55.0.0".freeze
+  VERSION = "55.0.1".freeze
 end


### PR DESCRIPTION
## 55.0.1

* Shift footnotes above 100/1000 further to the left ([PR #4705](https://github.com/alphagov/govuk_publishing_components/pull/4705))
* Delete unused CSS from layout super navigation component ([PR #4702](https://github.com/alphagov/govuk_publishing_components/pull/4702))