### PR TITLE
Limit organisation logos to 320px/240px width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Limit organisation logos to 320px/240px width ([PR #4708](https://github.com/alphagov/govuk_publishing_components/pull/4708))
+
 ## 55.0.1
 
 * Shift footnotes above 100/1000 further to the left ([PR #4705](https://github.com/alphagov/govuk_publishing_components/pull/4705))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_organisation-logo.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_organisation-logo.scss
@@ -33,9 +33,12 @@
   padding-right: govuk-spacing(1);
 }
 
-// Scale images on smaller viewports
 .gem-c-organisation-logo__image {
-  max-width: 100%;
+  max-width: 320px;
+  @include govuk-media-query($until: tablet) {
+    width: 100%;
+    max-width: 240px;
+  }
 }
 
 .gem-c-organisation-logo__crest {


### PR DESCRIPTION
## What / Why
<!-- What are the reasons behind this change being made? -->
- Currently custom organisation logos are rendering at a large size on multiple organisation pages. These include:
    - https://www.gov.uk/government/organisations/defence-equipment-and-support
    - https://www.gov.uk/government/organisations/forensic-science-regulator
    - https://www.gov.uk/government/organisations/sellafield-ltd
    - https://www.gov.uk/government/organisations/national-data-guardian
    - https://www.gov.uk/government/organisations/government-chemist
    - https://www.gov.uk/government/organisations/subsidy-advice-unit
- Any organisation can suffer from this issue if they add a large "Featured" document to their page, as that seems to alter the spacing a logo gets to render in. For example, the [UK Space Agency](https://webarchive.nationalarchives.gov.uk/ukgwa/20250305161148/https://www.gov.uk/government/organisations/uk-space-agency) used to have a large logo until they removed their featured news story.
- Therefore, limit organisation logos to a maximum of `320px` width on desktop/tablet, and `240px` on mobile. I picked this width as the `whitehall` guidance says to upload logos at `960px`, so this width is just dividing that by 3 for desktop/tablet, and 4 for mobile.
- Closes https://github.com/alphagov/govuk_publishing_components/issues/4675

## How to test

- To test locally, you can run `collections` with this gem checked out, and go to the above organisation URLs. 

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

| Before    | After |
| -------- | ------- |
| ![logo1](https://github.com/user-attachments/assets/7f3cc563-863b-4073-9244-a0531faee715) |  ![logo2](https://github.com/user-attachments/assets/bec17a50-78a1-4452-82d2-6a5753998f85) |
| ![logo3](https://github.com/user-attachments/assets/a33bedfb-c98d-4f27-95cc-2a3ca3a7edfa) | ![logo4](https://github.com/user-attachments/assets/5454b6cc-313a-4612-b9f5-f5a3f41827c9) |
| ![Screenshot 2025-03-14 at 14-33-32 National Data Guardian - GOV UK](https://github.com/user-attachments/assets/f927d130-344b-482d-b6fa-07977bee60a2) | ![Screenshot 2025-03-14 at 14-33-18 National Data Guardian - GOV UK](https://github.com/user-attachments/assets/72eb8894-7502-4fd2-b3d5-e685e795b971) |
| Tablet/Mobile ![Screenshot 2025-03-14 at 15-05-42 Defence Equipment and Support - GOV UK](https://github.com/user-attachments/assets/5890e446-550e-4909-933e-f25074abd967) | Tablet/Mobile ![Screenshot 2025-03-14 at 15-06-05 Defence Equipment and Support - GOV UK](https://github.com/user-attachments/assets/325d746c-7a6a-4145-a7ab-5d89d8dc8c13) |