### PR TITLE
Update styles dependency in super navigation component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Limit organisation logos to 320px/240px width ([PR #4708](https://github.com/alphagov/govuk_publishing_components/pull/4708))
+* Update styles dependency in super navigation component ([PR #4709](https://github.com/alphagov/govuk_publishing_components/pull/4709))
 
 ## 55.0.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -1,4 +1,5 @@
 @import "govuk_publishing_components/individual_component_support";
+@import "govuk/components/header/header";
 @import "mixins/prefixed-transform";
 @import "mixins/grid-helper";
 

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -1,5 +1,4 @@
 <%
-  add_gem_component_stylesheet("layout-header")
   add_gem_component_stylesheet("layout-super-navigation-header")
 
   logo_link ||= "https://www.gov.uk/"


### PR DESCRIPTION
## What

Remove the call to `add_gem_component_stylesheet("layout-header")` and import the styles required from the design system directly in `_layout-super-navigation-header.scss`.

[Trello card](https://trello.com/c/lAZzmCG9)

## Why

The super navigation layout header component is dependant on the styles from the `header` component in the design system and only needs the styles to ensure the logo is rendered correctly.

The `layout-header` component from the gem not only imports the `header` styles from the design system, but also lots of other components such as `search`, `skip-link` and `tag`, these styles are not required to render the super navigation component.