### PR TITLE
Add 'requires JavaScript' text to feedback component survey link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Limit organisation logos to 320px/240px width ([PR #4708](https://github.com/alphagov/govuk_publishing_components/pull/4708))
 * Update styles dependency in super navigation component ([PR #4709](https://github.com/alphagov/govuk_publishing_components/pull/4709))
+* Add 'requires JavaScript' text to feedback component survey link ([PR #4710](https://github.com/alphagov/govuk_publishing_components/pull/4710))
 
 ## 55.0.1
 

--- a/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
@@ -6,7 +6,7 @@
       <h3 class="gem-c-feedback__form-heading"><%= t("components.feedback.help_us_improve_govuk") %></h3>
       <p id="survey_explanation" class="gem-c-feedback__form-paragraph">
         <%= t("components.feedback.more_about_visit") %>
-        <a href="https://www.smartsurvey.co.uk/s/gov-uk-banner/?c=no-js" class="govuk-link" target="_blank" rel="noopener noreferrer external">Please fill in this survey (opens in a new tab)</a>.
+        <a href="https://www.smartsurvey.co.uk/s/gov-uk-banner/?c=no-js" class="govuk-link" target="_blank" rel="noopener noreferrer external">Please fill in this survey (opens in a new tab<noscript> and requires JavaScript</noscript>)</a>.
       </p>
       <button
         class="govuk-button govuk-button--secondary js-close-form"

--- a/spec/components/feedback_spec.rb
+++ b/spec/components/feedback_spec.rb
@@ -83,9 +83,15 @@ describe "Feedback", type: :view do
     assert_select "#survey_explanation a[href='https://www.smartsurvey.co.uk/s/gov-uk-banner/?c=no-js']"
   end
 
-  it "The survey link opens in a new tab, with rel='noopener noreferrer external' and the new tab guidance text" do
+  it "The survey link opens in a new tab, with rel='noopener noreferrer external' and the new tab/no JS guidance text" do
     render_component({})
 
-    assert_select "#survey_explanation a[target='_blank'][rel='noopener noreferrer external']", text: "Please fill in this survey (opens in a new tab)"
+    assert_select "#survey_explanation a[target='_blank'][rel='noopener noreferrer external']", text: "Please fill in this survey (opens in a new tab and requires JavaScript)"
+  end
+
+  it "The survey link 'requires JavaScript' text is within a noscript tag" do
+    render_component({})
+
+    assert_select "#survey_explanation a[target='_blank'][rel='noopener noreferrer external'] noscript", text: "and requires JavaScript"
   end
 end


### PR DESCRIPTION
## What / Why
<!-- What are the reasons behind this change being made? -->
- Adds `requires JavaScript` text to the `feedback` component smartsurvey link that appears when you select 'No' on the 'Is this page useful?' 
- Context: https://trello.com/c/V7mSQffS/530-fix-feedback-without-javascript

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

Adds some extra text.


| Before | After |
|---|---|
| <img width="973" alt="image" src="https://github.com/user-attachments/assets/fde2e75a-30b4-4dde-9e64-619167abf1d4" /> | <img width="973" alt="image" src="https://github.com/user-attachments/assets/3db36483-ee81-463e-9c76-4bb8e1646fd5" /> |