### PR TITLE
Release version 55.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 55.1.0
 
 * Limit organisation logos to 320px/240px width ([PR #4708](https://github.com/alphagov/govuk_publishing_components/pull/4708))
 * Update styles dependency in super navigation component ([PR #4709](https://github.com/alphagov/govuk_publishing_components/pull/4709))
@@ -18,7 +18,6 @@
 
 * Shift footnotes above 100/1000 further to the left ([PR #4705](https://github.com/alphagov/govuk_publishing_components/pull/4705))
 * Delete unused CSS from layout super navigation component ([PR #4702](https://github.com/alphagov/govuk_publishing_components/pull/4702))
-
 
 ## 55.0.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (55.0.1)
+    govuk_publishing_components (55.1.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "55.0.1".freeze
+  VERSION = "55.1.0".freeze
 end


### PR DESCRIPTION
## 55.1.0

* Limit organisation logos to 320px/240px width ([PR #4708](https://github.com/alphagov/govuk_publishing_components/pull/4708))
* Update styles dependency in super navigation component ([PR #4709](https://github.com/alphagov/govuk_publishing_components/pull/4709))
* Add 'requires JavaScript' text to feedback component survey link ([PR #4710](https://github.com/alphagov/govuk_publishing_components/pull/4710))
* Bump govuk-frontend from 5.8.0 to 5.9.0 ([PR #4677](https://github.com/alphagov/govuk_publishing_components/pull/4677))