### PR TITLE
Update auditing for email-alert-frontend

### DIFF
--- a/app/models/govuk_publishing_components/audit_comparer.rb
+++ b/app/models/govuk_publishing_components/audit_comparer.rb
@@ -6,7 +6,6 @@ module GovukPublishingComponents
       if gem_data[:gem_found]
         @applications_using_static = %w[
           collections
-          email-alert-frontend
           feedback
           finder-frontend
           frontend


### PR DESCRIPTION
## What / why
- removes this app from the list that use static, because it no longer does

## Visual Changes
Component guide auditing now looks slightly different for this app, but no real changes.

Before

![Screenshot 2025-03-20 at 15 58 53](https://github.com/user-attachments/assets/cac31703-15af-4d0e-a32e-18cb474dd9cb)

After

![Screenshot 2025-03-20 at 15 59 08](https://github.com/user-attachments/assets/544ea14d-3b07-46d2-803d-f229c0d36a28)
