### PR TITLE
Add data attributes to `<select>` elements within the Select component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Make minor improvements to the `figure` and `published_dates` components ([PR #4718](https://github.com/alphagov/govuk_publishing_components/pull/4718))
 * **BREAKING:** Rename sticky-element-container to contents-list-with-body ([PR #4719](https://github.com/alphagov/govuk_publishing_components/pull/4719))
+* Add `data-attributes` to the `<select>` element in the `select` component ([PR #4723](https://github.com/alphagov/govuk_publishing_components/pull/4723))
 
 ## 55.1.0
 

--- a/app/views/govuk_publishing_components/components/_select.html.erb
+++ b/app/views/govuk_publishing_components/components/_select.html.erb
@@ -6,6 +6,7 @@
   label ||= false
   name ||= id
   is_page_heading ||= false
+  data_attributes ||= {}
 
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
   heading_size = false unless shared_helper.valid_heading_size?(heading_size)
@@ -39,6 +40,6 @@
       } %>
     <% end %>
 
-    <%= select_tag name, options_for_select(select_helper.option_markup, select_helper.selected_option), id: id, class: select_helper.select_classes, aria: aria_describedby %>
+    <%= select_tag name, options_for_select(select_helper.option_markup, select_helper.selected_option), id: id, class: select_helper.select_classes, aria: aria_describedby, data: data_attributes %>
   <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/select.yml
+++ b/app/views/govuk_publishing_components/components/docs/select.yml
@@ -55,7 +55,22 @@ examples:
       - text: Something else
         value: option2
   with_data_attributes:
-    description: Other data attributes can be passed to the component if needed.
+    description: Data attributes can be passed to the select component if needed.
+    data:
+      id: dropdown4-3
+      label: With data attributes
+      data_attributes:
+        another_attribute: attribute 1
+        something_else: attribute 2
+      options:
+        - text: Option one
+          value: option1
+        - text: Option two
+          value: option2
+        - text: Option three
+          value: option3
+  with_data_attributes_for_options:
+    description: Other data attributes can be passed to the select component options if needed.
     data:
       id: dropdown4
       label: With data attributes

--- a/spec/components/select_spec.rb
+++ b/spec/components/select_spec.rb
@@ -123,6 +123,24 @@ describe "Select", type: :view do
     render_component(
       id: "mydropdown",
       label: "attributes",
+      data_attributes: {
+        an_attribute: "some_value",
+      },
+      options: [
+        {
+          value: 1,
+          text: "One",
+        },
+      ],
+    )
+
+    assert_select ".govuk-select[data-an-attribute='some_value']"
+  end
+
+  it "renders a select with options that have data attributes" do
+    render_component(
+      id: "mydropdown",
+      label: "attributes",
       options: [
         {
           value: 1,

--- a/spec/components/select_spec.rb
+++ b/spec/components/select_spec.rb
@@ -119,7 +119,7 @@ describe "Select", type: :view do
     assert_select ".govuk-select option[value=medium][selected]"
   end
 
-  it "renders a select with data attributes" do
+  it "renders a select element with data attributes applied to contained option element" do
     render_component(
       id: "mydropdown",
       label: "attributes",


### PR DESCRIPTION
## What

This PR:

* Provides the ability for data attributes to be passed to the `<select>` elements rendered by the select component (See commit 2ae88ad78ee7bfd5dfb0ffb93e6836e435cd252b)
* Updates a pre-existing test description to make it clear it tested for the ability to add data attributes to the `<option>` elements

## Why

To enable the provision of data attributes relied on by JavaScript analytics tracking in Whitehall (see related PR below)

## Visual Changes

This PR visually changes the component guide to provide an example 

<details>

<summary>Screenshot</summary>
<img width="1015" alt="Data attributes passed to select component example" src="https://github.com/user-attachments/assets/1e5eb556-97f9-48d8-ab87-82bd9bbfc009" />

</details>

## Related PRs

* https://github.com/alphagov/whitehall/pull/10069