### PR TITLE
Fix tests

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-settings.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-settings.js
@@ -29,21 +29,19 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     var currentConsentCookie = window.GOVUK.cookie('cookies_policy')
     if (currentConsentCookie) {
       var currentConsentCookieJSON = JSON.parse(currentConsentCookie)
-
-      // We don't need the essential value as this cannot be changed by the user
-      delete currentConsentCookieJSON.essential
-
-      for (var cookieType in currentConsentCookieJSON) {
-        var radioButton
-
-        if (currentConsentCookieJSON[cookieType]) {
-          radioButton = document.querySelector('input[name=cookies-' + cookieType + '][value=on]')
-        } else {
-          radioButton = document.querySelector('input[name=cookies-' + cookieType + '][value=off]')
-        }
-
-        if (radioButton) {
-          radioButton.checked = true
+      if (currentConsentCookieJSON) {
+        // We don't need the essential value as this cannot be changed by the user
+        delete currentConsentCookieJSON.essential
+        for (var cookieType in currentConsentCookieJSON) {
+          var radioButton
+          if (currentConsentCookieJSON[cookieType]) {
+            radioButton = document.querySelector('input[name=cookies-' + cookieType + '][value=on]')
+          } else {
+            radioButton = document.querySelector('input[name=cookies-' + cookieType + '][value=off]')
+          }
+          if (radioButton) {
+            radioButton.checked = true
+          }
         }
       }
     }

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
@@ -67,6 +67,9 @@ describe('Google Tag Manager page view tracking', function () {
         canonical_url: undefined
       }
     }
+    if (window.location.search) {
+      expected.page_view.query_string = window.location.search.substring(1) // get the '?something' bit of the URL and remove the '?'
+    }
     spyOn(GOVUK.analyticsGa4.core, 'getTimestamp').and.returnValue('123456')
     window.dataLayer = []
   })
@@ -682,6 +685,7 @@ describe('Google Tag Manager page view tracking', function () {
     it('functions correctly when there is no query string or data-ga4-search-query attribute', function () {
       spyOn(GOVUK.analyticsGa4.core.trackFunctions, 'getSearch').and.returnValue('')
       expected.page_view.search_term = undefined
+      expected.page_view.query_string = undefined
       GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
       expect(window.dataLayer[0]).toEqual(expected)
     })


### PR DESCRIPTION
## What / why
Fixes a few problems with the JavaScript tests.

Firstly:

- if you're running the JavaScript tests in a browser using `yarn run jasmine:browser` and click anything like the seed link, this test would fail
- because it expected a pageview object with nothing in the query string part of the URL e.g. ?search=
- this updates these tests to allow for this possibility, meaning they no longer fail when clicking a specific seed during testing

Secondly:

- when all tests are run with seed 54426 an error to do with handling an undefined variable occurred
- tracked it down to this line in `cookie-settings.js` - `delete currentConsentCookieJSON.essential`
- seems like in some circumstances currentConsentCookieJSON doesn't exist, which explains why an attribute can't be deleted from it
- wrapping the code in a check fixes the failing test

## Visual Changes
None.