### PR TITLE
Update LUX to 4.0.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Fix govspeak print styles ([PR #4730](https://github.com/alphagov/govuk_publishing_components/pull/4730))
+* Update LUX to 4.0.32 ([PR #4725](https://github.com/alphagov/govuk_publishing_components/pull/4725))
 
 ## 56.0.0
 


### PR DESCRIPTION
## What / why

Update LUX to 4.0.32.

## Visual Changes
None.

## Testing
Parsed debug output (14 events)
```
0 ms: Navigation started at 24/03/2025 10:53:10
2,841 ms: lux.js v4.0.32 is initialising. Hover to view configuration.
2,842 ms: POST beacon initialised.
2,842 ms: Sample rate is 1%. This session is not being sampled.
2,842 ms: Onload handler was triggered after 2842 ms.
2,842 ms: lux.js has finished initialising.
2,968 ms: LUX.addData("http-protocol", "http/1.1")
2,986 ms: Received layout shift at 2981 ms with value of 0.001
2,988 ms: Received paint entry at 2988 ms
2,988 ms: Received paint entry at 2988 ms
3,076 ms: Received layout shift at 3076 ms with value of 0.006
3,090 ms: Received LCP entry at 3088 ms
3,126 ms: Received layout shift at 3125 ms with value of 0.006
5,912 ms: Unload handler was triggered.
5,912 ms: This beacon was not sent because the page visibility was hidden.
5,913 ms: POST beacon send() called.
60,583 ms: POST beacon maximum measure timeout reached.
60,583 ms: POST beacon is no longer recording metrics. Metrics received after this point may be ignored.
60,583 ms: POST beacon send() called.
```
