### PR TITLE
Release version 56.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 56.0.0
 
 * Make minor improvements to the `figure` and `published_dates` components ([PR #4718](https://github.com/alphagov/govuk_publishing_components/pull/4718))
 * **BREAKING:** Rename sticky-element-container to contents-list-with-body ([PR #4719](https://github.com/alphagov/govuk_publishing_components/pull/4719))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (55.1.0)
+    govuk_publishing_components (56.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "55.1.0".freeze
+  VERSION = "56.0.0".freeze
 end


### PR DESCRIPTION
# 56.0.0 

* Make minor improvements to the `figure` and `published_dates` components ([PR #4718](https://github.com/alphagov/govuk_publishing_components/pull/4718))
* **BREAKING:** Rename sticky-element-container to contents-list-with-body ([PR #4719](https://github.com/alphagov/govuk_publishing_components/pull/4719))
* Add `data-attributes` to the `<select>` element in the `select` component ([PR #4723](https://github.com/alphagov/govuk_publishing_components/pull/4723))
