### PR TITLE
Fix govspeak print styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Make minor improvements to the `figure` and `published_dates` components ([PR #4718](https://github.com/alphagov/govuk_publishing_components/pull/4718))
 * **BREAKING:** Rename sticky-element-container to contents-list-with-body ([PR #4719](https://github.com/alphagov/govuk_publishing_components/pull/4719))
 * Add `data-attributes` to the `<select>` element in the `select` component ([PR #4723](https://github.com/alphagov/govuk_publishing_components/pull/4723))
+* Fix govspeak print styles ([PR #4730](https://github.com/alphagov/govuk_publishing_components/pull/4730))
 
 ## 55.1.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
@@ -106,6 +106,10 @@ $thumbnail-icon-border-colour: govuk-colour("mid-grey");
     padding: 0;
   }
 
+  .gem-c-attachment__metadata {
+    color: $govuk-print-text-colour;
+  }
+
   .gem-c-attachment__metadata,
   .gem-c-attachment__metadata .govuk-link::after {
     font-size: 12pt;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_govspeak.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_govspeak.scss
@@ -55,15 +55,6 @@
       }
     }
 
-    .legislative-list {
-      padding-left: 0;
-
-      &,
-      ol {
-        list-style: none;
-      }
-    }
-
     .mc-toggle-button,
     .mc-chart-container {
       display: none;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_govspeak.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_govspeak.scss
@@ -66,34 +66,6 @@
       }
     }
 
-    .attachment {
-      margin: govuk-spacing(6) 0;
-
-      &:first-child {
-        margin-top: 0;
-      }
-
-      .attachment-thumb {
-        display: none;
-      }
-
-      .attachment-details {
-        .download {
-          display: block;
-        }
-      }
-
-      .accessibility-warning {
-        h2 {
-          @include govuk-font(16);
-        }
-
-        .toggler {
-          display: none;
-        }
-      }
-    }
-
     .footnotes {
       border-top: 1px solid $govuk-text-colour;
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_govspeak.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_govspeak.scss
@@ -39,15 +39,6 @@
       word-wrap: break-word;
     }
 
-    .info-notice,
-    .help-notice {
-      margin: govuk-spacing(3) 0;
-    }
-
-    .help-notice p {
-      font-weight: 700;
-    }
-
     .fraction {
       img {
         display: inline-block;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_govspeak.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_govspeak.scss
@@ -40,15 +40,8 @@
     }
 
     .info-notice,
-    .help-notice,
-    .call-to-action {
+    .help-notice {
       margin: govuk-spacing(3) 0;
-    }
-
-    .call-to-action {
-      background: none;
-      border: 1pt solid $govuk-border-colour;
-      padding: govuk-spacing(3);
     }
 
     .help-notice p {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_govspeak.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_govspeak.scss
@@ -39,10 +39,6 @@
       word-wrap: break-word;
     }
 
-    .media-player {
-      display: none;
-    }
-
     .info-notice,
     .help-notice,
     .call-to-action {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_govspeak.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_govspeak.scss
@@ -28,15 +28,3 @@
     text-align: start;
   }
 }
-
-@include govuk-media-query($media-type: print) {
-  // stylelint-disable max-nesting-depth
-
-  .gem-c-govspeak {
-    a[href^="/"]:after,a[href^="http://"]:after,a[href^="https://"]:after {
-      content: " (" attr(href) ")";
-      font-size: 90%;
-      word-wrap: break-word;
-    }
-  }
-}

--- a/app/assets/stylesheets/govuk_publishing_components/components/_govspeak.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_govspeak.scss
@@ -55,14 +55,6 @@
       }
     }
 
-    .footnotes {
-      border-top: 1px solid $govuk-text-colour;
-
-      a[role="doc-backlink"] {
-        display: none;
-      }
-    }
-
     .legislative-list {
       padding-left: 0;
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_govspeak.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_govspeak.scss
@@ -38,12 +38,5 @@
       font-size: 90%;
       word-wrap: break-word;
     }
-
-    .fraction {
-      img {
-        display: inline-block;
-        margin-bottom: -7px;
-      }
-    }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_govspeak.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_govspeak.scss
@@ -45,10 +45,5 @@
         margin-bottom: -7px;
       }
     }
-
-    .mc-toggle-button,
-    .mc-chart-container {
-      display: none;
-    }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
@@ -86,8 +86,8 @@
         }
       }
 
-      .download {
-        @include govuk-media-query($media-type: print) {
+      @include govuk-media-query($media-type: print) {
+        .download {
           display: block;
         }
       }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
@@ -19,6 +19,10 @@
 
     @include govuk-media-query($media-type: print) {
       padding-left: 0;
+
+      &:first-child {
+        margin-top: 0;
+      }
     }
 
     .attachment-thumb {
@@ -44,7 +48,7 @@
       }
 
       @include govuk-media-query($media-type: print) {
-        margin-left: 0;
+        display: none;
       }
     }
 
@@ -82,6 +86,12 @@
         }
       }
 
+      .download {
+        @include govuk-media-query($media-type: print) {
+          display: block;
+        }
+      }
+
       .preview {
         padding-right: govuk-spacing(3);
       }
@@ -97,6 +107,12 @@
         h2 {
           margin: 0;
           @include govuk-font($size: 16);
+        }
+
+        @include govuk-media-query($media-type: print) {
+          .toggler {
+            display: none;
+          }
         }
       }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_call-to-action.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_call-to-action.scss
@@ -13,5 +13,12 @@
     background-color: govuk-colour("light-grey");
     padding: govuk-spacing(6);
     padding-bottom: govuk-spacing(2);
+
+    @include govuk-media-query($media-type: print) {
+      background: none;
+      border: 1pt solid $govuk-border-colour;
+      padding: govuk-spacing(3);
+      margin: govuk-spacing(3) 0;
+    }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_charts.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_charts.scss
@@ -310,4 +310,11 @@
     // It's reapplied to captions because Firefox can't hide
     // table captions unless it's applied directly to it. Go figure.
   }
+
+  @include govuk-media-query($media-type: print) {
+    .mc-toggle-button,
+    .mc-chart-container {
+      display: none;
+    }
+  }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_charts.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_charts.scss
@@ -316,5 +316,12 @@
     .mc-chart-container {
       display: none;
     }
+
+    // stylelint-disable selector-no-qualifying-type
+    // Displays the original table when printing
+    table.js-barchart-table,
+    table.js-barchart-table caption {
+      display: block;
+    }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_footnotes.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_footnotes.scss
@@ -29,5 +29,13 @@
     ol li:nth-of-type(999) ~ li {
       margin-left: 22px;
     }
+
+    @include govuk-media-query($media-type: print) {
+      border-top: 1px solid $govuk-text-colour;
+
+      a[role="doc-backlink"] {
+        display: none;
+      }
+    }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_fraction.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_fraction.scss
@@ -6,6 +6,8 @@
 // - alphagov/whitehall: ✔︎
 // - alphagov/govspeak: ✘
 
+// stylelint-disable max-nesting-depth
+
 .govspeak, // Legacy class name that's still used in some content items - needs to be kept until `.govspeak` is removed from the content items.
 .gem-c-govspeak {
   .fraction {
@@ -18,6 +20,10 @@
       display: inline-block;
       width: auto;
       margin: 0 0 -5px;
+
+      @include govuk-media-query($media-type: print) {
+        margin-bottom: -7px;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_information-callout.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_information-callout.scss
@@ -12,5 +12,9 @@
     border-left: 10px solid govuk-colour("mid-grey");
     padding: govuk-spacing(4) 0 0.1234px govuk-spacing(4); // non-zero padding on bottom keeps margin of last element inside parent, simulating padding
     margin: 0 0 govuk-spacing(4) 0;
+
+    @include govuk-media-query($media-type: print) {
+      margin: govuk-spacing(3) 0;
+    }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
@@ -106,4 +106,8 @@
     @include govuk-link-common;
     @include govuk-link-style-inverse;
   }
+
+  @include govuk-media-query($media-type: print) {
+    color: $govuk-print-text-colour;
+  }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
@@ -117,5 +117,9 @@
 
   @include govuk-media-query($media-type: print) {
     color: $govuk-print-text-colour;
+
+    a:link {
+      color: $govuk-print-text-colour;
+    }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
@@ -97,6 +97,14 @@
     font-style: normal;
     font-weight: inherit;
   }
+
+  @include govuk-media-query($media-type: print) {
+    a[href^="/"]:after,a[href^="http://"]:after,a[href^="https://"]:after {
+      content: " (" attr(href) ")";
+      font-size: 90%;
+      word-wrap: break-word;
+    }
+  }
 }
 
 .gem-c-govspeak--inverse {

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_warning-callout.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_warning-callout.scss
@@ -6,6 +6,8 @@
 // - alphagov/whitehall: ✔︎
 // - alphagov/govspeak: ✔︎
 
+// stylelint-disable max-nesting-depth
+
 .govspeak, // Legacy class name that's still used in some content items - needs to be kept until `.govspeak` is removed from the content items.
 .gem-c-govspeak {
   @import "govuk/components/warning-text/warning-text";
@@ -30,6 +32,11 @@
 
     @include govuk-media-query($media-type: print) {
       margin: govuk-spacing(3) 0;
+
+      &::before {
+        background-color: govuk-colour("white");
+        color: $govuk-print-text-colour;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_warning-callout.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_warning-callout.scss
@@ -27,5 +27,9 @@
     p {
       @include govuk-font($size: 19, $weight: bold);
     }
+
+    @include govuk-media-query($media-type: print) {
+      margin: govuk-spacing(3) 0;
+    }
   }
 }

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -680,40 +680,40 @@ examples:
 
         <ul>
         <li>recognise, find, name and write fractions <span class="fraction">
-          <img alt="1/3" height="27" src="https://assets.digital.cabinet-office.gov.uk/government/assets/fractions/1_3-9003d7f3d7cd4433647a5f6525aa7eda.png"></span>
+          <img alt="1/3" height="27" src="https://www.gov.uk/assets/whitehall/fractions/1_3-fe69761729c6cdf616c7982b834026ddcac0bd05f5260eec5786a64000b31871.png"></span>
         , <span class="fraction">
-          <img alt="1/4" height="27" src="https://assets.digital.cabinet-office.gov.uk/government/assets/fractions/1_4-b6128849c8da3b46b9cb5a6918cfe084.png"></span>
+          <img alt="1/4" height="27" src="https://www.gov.uk/assets/whitehall/fractions/1_4-052eceefaa4c6b9ceb93a968cd43c98abda997f5cc0921cba6da54a6939e27be.png"></span>
         , <span class="fraction">
-          <img alt="2/4" height="27" src="https://assets.digital.cabinet-office.gov.uk/government/assets/fractions/2_4-e071530a44f0d7980f3442c23e3edd3b.png"></span>
+          <img alt="2/4" height="27" src="https://www.gov.uk/assets/whitehall/fractions/2_4-36475f1a745ea7815d30bb31eef87e8f4986a7a3114eda2b3f381051a07e01e0.png"></span>
          and <span class="fraction">
-          <img alt="3/4" height="27" src="https://assets.digital.cabinet-office.gov.uk/government/assets/fractions/3_4-cded12d0389211f864dcb27e640c64d4.png"></span>
+          <img alt="3/4" height="27" src="https://www.gov.uk/assets/whitehall/fractions/3_4-281b1fd73cc0a0d5c11f7b2c413ae1d8186d41b31413cad7d7ee3c6f495c7f02.png"></span>
          of a length, shape, set of objects or quantity</li>
           <li>write simple fractions, for example <span class="fraction">
-          <img alt="1/2" height="27" src="https://assets.digital.cabinet-office.gov.uk/government/assets/fractions/1_2-6e6f542bec97cb8ea3acf39cd25690ee.png"></span>
+          <img alt="1/2" height="27" src="https://www.gov.uk/assets/whitehall/fractions/1_2-fd84dcded290cee401a0758d5f78a2e031b1c601271d74c7e783e31dfce026d0.png"></span>
          of 6 = 3 and recognise the equivalence of <span class="fraction">
-          <img alt="2/4" height="27" src="https://assets.digital.cabinet-office.gov.uk/government/assets/fractions/2_4-e071530a44f0d7980f3442c23e3edd3b.png"></span>
+          <img alt="2/4" height="27" src="https://www.gov.uk/assets/whitehall/fractions/2_4-36475f1a745ea7815d30bb31eef87e8f4986a7a3114eda2b3f381051a07e01e0.png"></span>
         and <span class="fraction">
-          <img alt="1/2" height="27" src="https://assets.digital.cabinet-office.gov.uk/government/assets/fractions/1_2-6e6f542bec97cb8ea3acf39cd25690ee.png"></span>
+          <img alt="1/2" height="27" src="https://www.gov.uk/assets/whitehall/fractions/1_2-fd84dcded290cee401a0758d5f78a2e031b1c601271d74c7e783e31dfce026d0.png"></span>
         </li>
         </ul>
         <div class="call-to-action">
           <h4>Notes and guidance (non-statutory)</h4>
 
           <p>Pupils use fractions as ‘fractions of’ discrete and continuous quantities by solving problems using shapes, objects and quantities. They connect unit fractions to equal sharing and grouping, to numbers when they can be calculated, and to measures, finding fractions of lengths, quantities, sets of objects or shapes. They meet <span class="fraction">
-            <img alt="3/4" height="27" src="https://assets.digital.cabinet-office.gov.uk/government/assets/fractions/3_4-cded12d0389211f864dcb27e640c64d4.png"></span>
+            <img alt="3/4" height="27" src="https://www.gov.uk/assets/whitehall/fractions/3_4-281b1fd73cc0a0d5c11f7b2c413ae1d8186d41b31413cad7d7ee3c6f495c7f02.png"></span>
            as the first example of a non-unit fraction.<br><br>
           Pupils should count in fractions up to 10, starting from any number and using the <span class="fraction">
-              <img alt="1/2" height="27" src="https://assets.digital.cabinet-office.gov.uk/government/assets/fractions/1_2-6e6f542bec97cb8ea3acf39cd25690ee.png"></span>
+              <img alt="1/2" height="27" src="https://www.gov.uk/assets/whitehall/fractions/1_2-fd84dcded290cee401a0758d5f78a2e031b1c601271d74c7e783e31dfce026d0.png"></span>
            and <span class="fraction">
-              <img alt="2/4" height="27" src="https://assets.digital.cabinet-office.gov.uk/government/assets/fractions/2_4-e071530a44f0d7980f3442c23e3edd3b.png"></span>
+              <img alt="2/4" height="27" src="https://www.gov.uk/assets/whitehall/fractions/2_4-36475f1a745ea7815d30bb31eef87e8f4986a7a3114eda2b3f381051a07e01e0.png"></span>
             equivalence on the number line (for example, 1<span class="fraction">
-              <img alt="1/4" height="27" src="https://assets.digital.cabinet-office.gov.uk/government/assets/fractions/1_4-b6128849c8da3b46b9cb5a6918cfe084.png"></span>
+              <img alt="1/4" height="27" src="https://www.gov.uk/assets/whitehall/fractions/1_4-052eceefaa4c6b9ceb93a968cd43c98abda997f5cc0921cba6da54a6939e27be.png"></span>
           , 1<span class="fraction">
-              <img alt="2/4" height="27" src="https://assets.digital.cabinet-office.gov.uk/government/assets/fractions/2_4-e071530a44f0d7980f3442c23e3edd3b.png"></span>
+              <img alt="2/4" height="27" src="https://www.gov.uk/assets/whitehall/fractions/2_4-36475f1a745ea7815d30bb31eef87e8f4986a7a3114eda2b3f381051a07e01e0.png"></span>
            (or 1<span class="fraction">
-              <img alt="1/2" height="27" src="https://assets.digital.cabinet-office.gov.uk/government/assets/fractions/1_2-6e6f542bec97cb8ea3acf39cd25690ee.png"></span>
+              <img alt="1/2" height="27" src="https://www.gov.uk/assets/whitehall/fractions/1_2-fd84dcded290cee401a0758d5f78a2e031b1c601271d74c7e783e31dfce026d0.png"></span>
           ), 1<span class="fraction">
-              <img alt="3/4" height="27" src="https://assets.digital.cabinet-office.gov.uk/government/assets/fractions/3_4-cded12d0389211f864dcb27e640c64d4.png"></span>
+              <img alt="3/4" height="27" src="https://www.gov.uk/assets/whitehall/fractions/3_4-281b1fd73cc0a0d5c11f7b2c413ae1d8186d41b31413cad7d7ee3c6f495c7f02.png"></span>
           , 2). This reinforces the concept of fractions as numbers and that they can add up to more than 1.
           </p>
         </div>


### PR DESCRIPTION
## What
This PR moves specific govspeak print styles into their corresponding sass files (as opposed to being in the parent govspeak sass file).

Additionally, a general review of the govspeak print styles has been included in this PR and any issues/redundancies have been fixed/removed. I also came across a few things during the review that I thought I'd enquire about - I've posted the questions on the [trello card](https://trello.com/c/utTxlaKP/531-restructure-and-fix-govspeak-print-styles).

## Why
[Trello card](https://trello.com/c/utTxlaKP/531-restructure-and-fix-govspeak-print-styles)