### PR TITLE
Add service navigation component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Fix HTML validation bug in cookie banner ([PR #4743](https://github.com/alphagov/govuk_publishing_components/pull/4743))
+* Add service navigation component ([PR #4731](https://github.com/alphagov/govuk_publishing_components/pull/4731))
 
 ## 56.1.0
 

--- a/app/assets/javascripts/govuk_publishing_components/components/service-navigation.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/service-navigation.js
@@ -1,0 +1,5 @@
+// This component relies on JavaScript from GOV.UK Frontend
+// = require govuk/components/service-navigation/service-navigation.bundle.js
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {}
+window.GOVUK.Modules.GovukServiceNavigation = window.GOVUKFrontend.ServiceNavigation

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -75,6 +75,7 @@
 @import "components/search";
 @import "components/secondary-navigation";
 @import "components/select";
+@import "components/service-navigation";
 @import "components/share-links";
 @import "components/signup-link";
 @import "components/single-page-notification-button";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_service-navigation.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_service-navigation.scss
@@ -1,0 +1,2 @@
+@import "govuk_publishing_components/individual_component_support";
+@import "govuk/components/service-navigation/service-navigation";

--- a/app/views/govuk_publishing_components/components/_service_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_service_navigation.html.erb
@@ -1,0 +1,42 @@
+<%
+  add_gem_component_stylesheet("service-navigation")
+
+  service_name ||= nil
+  navigation_items ||= []
+%>
+<% if navigation_items.present? %>
+  <section aria-label="Service information" class="gem-c-service-navigation govuk-service-navigation"
+    data-module="govuk-service-navigation">
+    <div class="govuk-width-container">
+      <div class="govuk-service-navigation__container">
+        <% if service_name %>
+          <span class="govuk-service-navigation__service-name">
+            <a href="#" class="govuk-service-navigation__link">
+              <%= service_name %>
+            </a>
+          </span>
+        <% end %>
+
+        <% if navigation_items.present? %>
+          <nav aria-label="<%= t("components.layout_header.menu") %>" class="govuk-service-navigation__wrapper">
+            <button type="button" class="govuk-service-navigation__toggle govuk-js-service-navigation-toggle" aria-controls="navigation" hidden>
+              Menu
+            </button>
+            <ul class="govuk-service-navigation__list" id="navigation">
+              <% navigation_items.each do |nav| %>
+                <% 
+                  nav_classes = %w(govuk-service-navigation__item)
+                  nav_classes << "govuk-service-navigation__item--active" if nav[:active]
+                  aria_current = nav[:active]
+                %>
+                <%= tag.li nav[:text], class: nav_classes do %>
+                  <%= link_to nav[:text], nav[:href], class: "govuk-service-navigation__link", aria: { current: aria_current } %>
+                <% end %>
+              <% end %>
+            </ul>
+          </nav>
+        <% end %>
+      </div>
+    </div>
+  </section>
+<% end %>

--- a/app/views/govuk_publishing_components/components/_service_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_service_navigation.html.erb
@@ -2,23 +2,26 @@
   add_gem_component_stylesheet("service-navigation")
 
   service_name ||= nil
+  service_name_url ||= nil
   navigation_items ||= []
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-service-navigation govuk-service-navigation")
-  component_helper.add_aria_attribute({ label: "Service information" })
+  component_helper.add_aria_attribute({ label: "Service information" }) if service_name.present?
   component_helper.add_data_attribute({ module: "govuk-service-navigation" })
 %>
-<% if navigation_items.present? %>
-  <%= tag.section(**component_helper.all_attributes) do %>
+<% if service_name.present? || navigation_items.present? %>
+  <% service_navigation_content = capture do %>
     <div class="govuk-width-container">
       <div class="govuk-service-navigation__container">
         <% if service_name %>
-          <span class="govuk-service-navigation__service-name">
-            <a href="#" class="govuk-service-navigation__link">
-              <%= service_name %>
-            </a>
-          </span>
+          <% if service_name_url %>
+            <%= tag.span(class: "govuk-service-navigation__service-name") do %>
+              <%= link_to(service_name, service_name_url, class: "govuk-service-navigation__link") %>
+            <% end %>
+          <% else %>
+            <%= tag.span(service_name, class: "govuk-service-navigation__service-name") %>
+          <% end %>
         <% end %>
 
         <% if navigation_items.present? %>
@@ -28,13 +31,19 @@
             </button>
             <ul class="govuk-service-navigation__list" id="navigation">
               <% navigation_items.each do |nav| %>
-                <% 
+                <%
                   nav_classes = %w(govuk-service-navigation__item)
                   nav_classes << "govuk-service-navigation__item--active" if nav[:active]
                   aria_current = nav[:active]
                 %>
                 <%= tag.li nav[:text], class: nav_classes do %>
-                  <%= link_to nav[:text], nav[:href], class: "govuk-service-navigation__link", aria: { current: aria_current } %>
+                  <% if nav[:active] %>
+                    <%= link_to(nav[:href], class: "govuk-service-navigation__link", aria: { current: aria_current }) do %>
+                      <%= tag.strong(nav[:text], class: "govuk-service-navigation__active-fallback") %>
+                    <% end %>
+                  <% else %>
+                    <%= link_to nav[:text], nav[:href], class: "govuk-service-navigation__link" %>
+                  <% end %>
                 <% end %>
               <% end %>
             </ul>
@@ -42,5 +51,11 @@
         <% end %>
       </div>
     </div>
+  <% end %>
+
+  <% if service_name.present? %>
+    <%= tag.section(service_navigation_content, **component_helper.all_attributes) %>
+  <% else %>
+    <%= tag.div(service_navigation_content, **component_helper.all_attributes) %>
   <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/_service_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_service_navigation.html.erb
@@ -3,10 +3,14 @@
 
   service_name ||= nil
   navigation_items ||= []
+
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("gem-c-service-navigation govuk-service-navigation")
+  component_helper.add_aria_attribute({ label: "Service information" })
+  component_helper.add_data_attribute({ module: "govuk-service-navigation" })
 %>
 <% if navigation_items.present? %>
-  <section aria-label="Service information" class="gem-c-service-navigation govuk-service-navigation"
-    data-module="govuk-service-navigation">
+  <%= tag.section(**component_helper.all_attributes) do %>
     <div class="govuk-width-container">
       <div class="govuk-service-navigation__container">
         <% if service_name %>
@@ -38,5 +42,5 @@
         <% end %>
       </div>
     </div>
-  </section>
+  <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/service_navigation.yml
+++ b/app/views/govuk_publishing_components/components/docs/service_navigation.yml
@@ -8,6 +8,8 @@ accessibility_excluded_rules:
   - duplicate-id-aria
   - landmark-unique
 uses_component_wrapper_helper: true
+govuk_frontend_components:
+  - service-navigation
 shared_accessibility_criteria:
   - link
 examples:
@@ -24,6 +26,10 @@ examples:
   with_service_name:
     data:
       service_name: My service name
+  with_service_name_and_service_name_url:
+    data:
+      service_name: My service name
+      service_name_url: "#"
   with_service_name_and_navigation_links:
     data:
       service_name: My service name

--- a/app/views/govuk_publishing_components/components/docs/service_navigation.yml
+++ b/app/views/govuk_publishing_components/components/docs/service_navigation.yml
@@ -1,0 +1,33 @@
+name: Service Navigation
+description: Renders a box with a link to sign up for email notifications
+accessibility_criteria: |
+  - the component must use the correct heading level for the page
+  - text should have a text contrast ratio higher than 4.5:1 against the background colour to meet WCAG AA
+  - the icon must not be focusable or shown to screenreaders
+uses_component_wrapper_helper: true
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      navigation_items:
+      - text: Navigation item 1
+        href: "#"
+        active: true
+      - text: Navigation item 2
+        href: "#"
+      - text: Navigation item 3
+        href: "#"
+  with_service_name:
+    data:
+      service_name: My service name
+  with_service_name_and_navigation_links:
+    data:
+      service_name: My service name
+      navigation_items:
+      - text: Navigation item 1
+        href: "#"
+      - text: Navigation item 2
+        href: "#"
+      - text: Navigation item 3
+        href: "#"

--- a/app/views/govuk_publishing_components/components/docs/service_navigation.yml
+++ b/app/views/govuk_publishing_components/components/docs/service_navigation.yml
@@ -4,6 +4,9 @@ accessibility_criteria: |
   - the component must use the correct heading level for the page
   - text should have a text contrast ratio higher than 4.5:1 against the background colour to meet WCAG AA
   - the icon must not be focusable or shown to screenreaders
+accessibility_excluded_rules:
+  - duplicate-id-aria
+  - landmark-unique
 uses_component_wrapper_helper: true
 shared_accessibility_criteria:
   - link

--- a/spec/components/service_navigation_spec.rb
+++ b/spec/components/service_navigation_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+describe "Service navigation", type: :view do
+  def component_name
+    "service_navigation"
+  end
+
+  def navigation_items
+    [
+      {
+        text: "Navigation item 1",
+        href: "#",
+      },
+      {
+        text: "Navigation item 2",
+        href: "#",
+      },
+      {
+        text: "Navigation item 3",
+        href: "#",
+      },
+    ]
+  end
+
+  it "renders nothing when no navigation items provided" do
+    assert_empty render_component({})
+  end
+
+  it "renders with navigation items" do
+    render_component({ navigation_items: })
+
+    assert_select(".gem-c-service-navigation")
+
+    assert_select(".govuk-service-navigation__item:nth-child(1) .govuk-service-navigation__link", text: "Navigation item 1")
+    assert_select(".govuk-service-navigation__item:nth-child(2) .govuk-service-navigation__link", text: "Navigation item 2")
+    assert_select(".govuk-service-navigation__item:nth-child(3) .govuk-service-navigation__link", text: "Navigation item 3")
+  end
+
+  it "renders with active and current navigation item" do
+    updated_navigation_items = navigation_items.map { |item| item[:text] == "Navigation item 2" ? item.merge(active: true) : item }
+    render_component({ navigation_items: updated_navigation_items })
+
+    assert_select(".govuk-service-navigation__item:nth-child(2).govuk-service-navigation__item--active .govuk-service-navigation__link[aria-current]", text: "Navigation item 2")
+  end
+
+  it "renders a service name when provided" do
+    render_component({ navigation_items:, service_name: "My service name" })
+
+    assert_select(".govuk-service-navigation__service-name .govuk-service-navigation__link", text: "My service name")
+  end
+end

--- a/spec/components/service_navigation_spec.rb
+++ b/spec/components/service_navigation_spec.rb
@@ -29,7 +29,7 @@ describe "Service navigation", type: :view do
   it "renders with navigation items" do
     render_component({ navigation_items: })
 
-    assert_select(".gem-c-service-navigation")
+    assert_select("div.gem-c-service-navigation")
 
     assert_select(".govuk-service-navigation__item:nth-child(1) .govuk-service-navigation__link", text: "Navigation item 1")
     assert_select(".govuk-service-navigation__item:nth-child(2) .govuk-service-navigation__link", text: "Navigation item 2")
@@ -40,12 +40,24 @@ describe "Service navigation", type: :view do
     updated_navigation_items = navigation_items.map { |item| item[:text] == "Navigation item 2" ? item.merge(active: true) : item }
     render_component({ navigation_items: updated_navigation_items })
 
-    assert_select(".govuk-service-navigation__item:nth-child(2).govuk-service-navigation__item--active .govuk-service-navigation__link[aria-current]", text: "Navigation item 2")
+    assert_select(".govuk-service-navigation__item:nth-child(2).govuk-service-navigation__item--active
+      .govuk-service-navigation__link[aria-current]
+      strong.govuk-service-navigation__active-fallback", text: "Navigation item 2")
   end
 
   it "renders a service name when provided" do
     render_component({ navigation_items:, service_name: "My service name" })
 
-    assert_select(".govuk-service-navigation__service-name .govuk-service-navigation__link", text: "My service name")
+    assert_select("section.gem-c-service-navigation")
+
+    assert_select("span.govuk-service-navigation__service-name", text: "My service name")
+  end
+
+  it "renders a service name and service name url when provided" do
+    render_component({ navigation_items:, service_name: "My service name", service_name_url: "#" })
+
+    assert_select("section.gem-c-service-navigation")
+
+    assert_select("span.govuk-service-navigation__service-name .govuk-service-navigation__link", text: "My service name")
   end
 end

--- a/spec/lib/govuk_publishing_components/app_helpers/asset_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/app_helpers/asset_helper_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe GovukPublishingComponents::AppHelpers::AssetHelper do
     end
 
     it "detect the total number of stylesheet paths" do
-      expect(get_component_css_paths.count).to be(85)
+      expect(get_component_css_paths.count).to be(86)
     end
 
     it "initialize empty asset helper" do


### PR DESCRIPTION
## What

Add Service navigation component

**Review URL**: https://components-gem-pr-4731.herokuapp.com/component-guide/service_navigation

## Why

The `product name` and `navigation_items` options are now deprecated features of GOV.UK Frontend. These features are used by various GOV.UK apps (see publishing and utility apps).

The Service navigation component is recommended to show your service name and navigation links instead of the GOV.UK header. See https://design-system.service.gov.uk/components/header/#previous-variants-of-the-govuk-header.

https://trello.com/c/f27IC8zY/3387-create-service-navigation-component

## Anything else

The Cross service (One Login) header component closely resembles the implementation of the Service navigation component, as much of it is derived from the One Login header component. See https://github.com/alphagov/govuk-design-system-backlog/issues/76. It should be investigated whether these can be consolidated into a single component.