### PR TITLE
Add NI numbers to GA4 PII redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Update LUX to 4.0.32 ([PR #4725](https://github.com/alphagov/govuk_publishing_components/pull/4725))
 * Fix print styles ([PR #4738](https://github.com/alphagov/govuk_publishing_components/pull/4738))
 * Use govuk-frontend mixin on attachment URL text ([PR #4737](https://github.com/alphagov/govuk_publishing_components/pull/4737))
+* Add NI numbers to GA4 PII redaction ([PR #4732](https://github.com/alphagov/govuk_publishing_components/pull/4732))
 
 ## 56.0.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.js
@@ -32,6 +32,10 @@
   var VISA_PATTERN_GWF = /GWF\d{9}/g
   var VISA_PATTERN_GB = /GB\d{12}/g
 
+  // 2 valid letters - optional +/space - 6 digits with optional +/spaces every 2 digits (to account for '12 34 56') - optional +/space - 1 valid letter. Case insensitive.
+  // e.g. 'AB123456A', 'AB 12 34 56 A', 'ab 123456 a', 'ab 12 34 56 a', 'AB+12+34+56+A'
+  var NATIONAL_INSURANCE_NUMBER = /[A-CEGHJ-OPR-TW-Z]{2}(\s+|\++)?(\d{2}(\s+|\++)?){3}[A-D]/gi
+
   function shouldStripDates () {
     var metas = document.querySelectorAll('meta[name="govuk:ga4-strip-dates"]')
     return metas.length > 0
@@ -104,6 +108,7 @@
     stripped = stripped.replace(STATE_PATTERN, 'state=[state]')
     stripped = stripped.replace(VISA_PATTERN_GWF, '[gwf number]')
     stripped = stripped.replace(VISA_PATTERN_GB, '[gb eori number]')
+    stripped = stripped.replace(NATIONAL_INSURANCE_NUMBER, '[ni number]')
     stripped = this.stripQueryStringParameters(stripped)
 
     if (this.stripDatePII === true) {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
@@ -296,8 +296,8 @@ describe('GA4 core', function () {
     })
 
     it('standardises search terms for consistency across trackers', function () {
-      var searchTerm = 'NO UPPERCASE, NO %2B plus + signs, NO PII email@example.com SW1A 2AA 1st Jan 1990 and    NO    extra    spaces \n \r      '
-      var expected = 'no uppercase, no plus signs, no pii [email] [postcode] 1st jan 1990 and no extra spaces'
+      var searchTerm = 'NO UPPERCASE, NO %2B plus + signs, NO PII email@example.com SW1A 2AA AA123456A 1st Jan 1990 and    NO    extra    spaces \n \r      '
+      var expected = 'no uppercase, no plus signs, no pii [email] [postcode] [ni number] 1st jan 1990 and no extra spaces'
 
       searchTerm = GOVUK.analyticsGa4.core.trackFunctions.standardiseSearchTerm(searchTerm)
       expect(searchTerm).toEqual(expected)

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
@@ -584,8 +584,8 @@ describe('Google Tag Manager page view tracking', function () {
   })
 
   it('correctly sets the query_string parameter with PII and _ga/_gl values redacted', function () {
-    spyOn(GOVUK.analyticsGa4.core.trackFunctions, 'getSearch').and.returnValue('?query1=hello&query2=world&email=email@example.com&postcode=SW12AA&birthday=1990-01-01&_ga=19900101.567&_gl=19900101.567')
-    expected.page_view.query_string = 'query1=hello&query2=world&email=[email]&postcode=[postcode]&birthday=[date]&_ga=[id]&_gl=[id]'
+    spyOn(GOVUK.analyticsGa4.core.trackFunctions, 'getSearch').and.returnValue('?query1=hello&query2=world&email=email@example.com&postcode=SW12AA&birthday=1990-01-01&_ga=19900101.567&_gl=19900101.567&ni_number=AA+123456+A')
+    expected.page_view.query_string = 'query1=hello&query2=world&email=[email]&postcode=[postcode]&birthday=[date]&_ga=[id]&_gl=[id]&ni_number=[ni number]'
     GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
     expect(window.dataLayer[0]).toEqual(expected)
   })


### PR DESCRIPTION
## What / Why
<!-- What are the reasons behind this change being made? -->
- Adds national insurance redaction to the GA4 PII remover so that it doesn't have to be redacted further down the line
- The regex I wrote is based partly on this guidance https://www.gov.uk/hmrc-internal-manuals/national-insurance-manual/nim39110 and https://github.com/alphagov/govuk-chat-private-beta/blob/2add98c736e68f630d825cbbf00e1db11a42e68d/app/validators/pii_validator.rb#L27
- For the tests I wrote some code to randomly generate numbers, just so we aren't actually storing any in the code.
- Trello card: https://trello.com/c/ndiVNNuG

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
