### PR TITLE
Use govuk-frontend mixin on attachment URL text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fix govspeak print styles ([PR #4730](https://github.com/alphagov/govuk_publishing_components/pull/4730))
 * Update LUX to 4.0.32 ([PR #4725](https://github.com/alphagov/govuk_publishing_components/pull/4725))
 * Fix print styles ([PR #4738](https://github.com/alphagov/govuk_publishing_components/pull/4738))
+* Use govuk-frontend mixin on attachment URL text ([PR #4737](https://github.com/alphagov/govuk_publishing_components/pull/4737))
 
 ## 56.0.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
@@ -67,16 +67,10 @@ $thumbnail-icon-border-colour: govuk-colour("mid-grey");
   margin: 0 0 govuk-spacing(3);
   color: $govuk-secondary-text-colour;
   @include govuk-font($size: 19);
+  @include govuk-text-break-word;
 
   &:last-of-type {
     margin-bottom: 0;
-  }
-
-  .gem-c-attachment__attribute {
-    // From the Design System
-    // Automatic wrapping for unbreakable text (e.g. URLs)
-    word-wrap: break-word; // Fallback for older browsers only
-    overflow-wrap: break-word;
   }
 }
 

--- a/app/views/govuk_publishing_components/components/docs/attachment.yml
+++ b/app/views/govuk_publishing_components/components/docs/attachment.yml
@@ -225,8 +225,10 @@ examples:
         url: https://www.gov.uk/government/publications/smart-meters-unlocking-the-future/smart-meters-unlocking-the-future
         type: html
   external_attachment:
+    description: |
+      The word break helper (`govuk-text-break-word`) is used from the design system to forcibly break URLs across multiple lines when they wouldn't otherwise fit.
     data:
       attachment:
         title: "Architects Registration Board annual report 2021"
-        url: https://arb.org.uk/wp-content/uploads/ARB-Annual-Report-and-Financial-Statement-2021-published.pdf
+        url: https://arb.org.uk/wpcontent/uploads/ARBAnnualReportandFinancialStatement2021published.pdf
         type: external


### PR DESCRIPTION
## What

Update the [attachment component](https://components.publishing.service.gov.uk/component-guide/attachment) to:
- Use the `govuk-text-break-word` mixin from the design system to forcibly break URLs across multiple lines when they wouldn't otherwise fit, moved to `.gem-c-attachment__metadata` to ensure the fix works as expected in IE11
- Update the external attachment example to reference the word break helper used from the design system, the hyphens have been removed from the url text to capture any visual regression issues in the future

## Why

By aligning our approach with the design system, we will benefit from any future updates to the [word break helper](https://github.com/alphagov/govuk-frontend/blob/main/CHANGELOG.md#stop-long-words-breaking-out-of-components-with-govuk--text-break-word). The updated external URL example in the documentation should also help capture any issues with the approach in the future, at the moment the URL example includes hyphens, so the text would automatically break.

## Visual Changes

### Fixed issue in IE11

Related issue: https://github.com/alphagov/govuk_publishing_components/issues/3503

| Before | After |
| --- | --- |
| <img width="999" alt="ie11-before" src="https://github.com/user-attachments/assets/186149cb-d50d-4c72-a3b4-200aa6be0ffb" /> | <img width="975" alt="ie11-after" src="https://github.com/user-attachments/assets/5ae1ba25-b1fd-48e0-bb7e-4ed83d66d2f4" /> |

### Percy
- The visual change in shown in Percy is expected as the hyphens have been removed from the url text to capture any visual regression issues in the future