### PR TITLE
Fix print styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Fix govspeak print styles ([PR #4730](https://github.com/alphagov/govuk_publishing_components/pull/4730))
 * Update LUX to 4.0.32 ([PR #4725](https://github.com/alphagov/govuk_publishing_components/pull/4725))
+* Fix print styles ([PR #4738](https://github.com/alphagov/govuk_publishing_components/pull/4738))
 
 ## 56.0.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_heading.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_heading.scss
@@ -51,5 +51,12 @@
   .gem-c-heading--padding[class*="--border-top"] {
     padding-top: govuk-spacing(3);
   }
+
+  .gem-c-heading--inverse {
+    .gem-c-heading__context,
+    .gem-c-heading__text {
+      color: $govuk-print-text-colour;
+    }
+  }
 }
 // stylelint-enable declaration-no-important

--- a/app/assets/stylesheets/govuk_publishing_components/components/_metadata.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_metadata.scss
@@ -99,5 +99,15 @@
       color: $govuk-print-text-colour !important;
     }
   }
+
+  .gem-c-metadata--inverse-padded,
+  .gem-c-metadata--inverse-padded .gem-c-metadata__title {
+    padding: 0;
+  }
+
+  .gem-c-metadata--inverse-padded .gem-c-metadata__list {
+    margin-left: 0;
+    margin-right: 0;
+  }
 }
 // stylelint-enable declaration-no-important


### PR DESCRIPTION
## What
This PR fixes the following print styles:
 - Inverse heading print styles: previously, the inverse heading was not visible in print as it was rendering white text on a white background - this PR changes the text colour to black (this should fix the issue in the metadata component where this problem was originally identified)
 - Metadata component print styles: the inverse version of the metadata component introduces additional spacing however this additional spacing is unnecessary in print and therefore it has been removed

## Why
[Trello card](https://trello.com/c/t7PaPZd9/547-improvements-for-print)

## Visual Changes

| Inverse heading print styles - before | Inverse heading print styles - after |
|------------------------------------------|----------------------------------------|
| ![image](https://github.com/user-attachments/assets/466c0729-fc98-439c-9e5e-fe92298d75ca) | ![image](https://github.com/user-attachments/assets/d38dd421-5a6a-4261-b904-c287316f9682) |

| Inverse metadata print styles - before | Inverse metadata print styles - after |
|-------------------------------------------|------------------------------------------|
| ![image](https://github.com/user-attachments/assets/da97a5db-faac-4dde-ab2e-f34d203c0e5e) | ![image](https://github.com/user-attachments/assets/ff39f76d-f954-4505-b87c-236ff23c6b23) |