### PR TITLE
Fix govspeak blockquotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Fix govspeak blockquotes ([PR #4739](https://github.com/alphagov/govuk_publishing_components/pull/4739))
 * Fix govspeak print styles ([PR #4730](https://github.com/alphagov/govuk_publishing_components/pull/4730))
 
 ## 56.0.0

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
@@ -33,29 +33,20 @@
   // Block quotes
 
   blockquote {
-    padding: 0 0 0 govuk-spacing(4);
-    margin: 0;
+    padding: 0 0 0 govuk-spacing(6);
+    margin: 0 0 govuk-spacing(4) 0;
     border: 0;
 
-    @include govuk-media-query($from: desktop) {
-      margin: 0 0 0 (- govuk-spacing(6));
-    }
-
     p {
-      padding-left: govuk-spacing(3);
+      position: relative;
 
-      @include govuk-media-query($from: tablet) {
-        padding-left: govuk-spacing(6);
-      }
-
-      &::before {
+      &:first-of-type::before {
         content: "\201C";
-        float: left;
-        clear: both;
-        margin-left: (- govuk-spacing(3));
+        position: absolute;
+        right: 100%;
       }
 
-      &:last-child::after {
+      &:last-of-type::after {
         content: "\201D";
       }
     }

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -50,7 +50,12 @@ examples:
         </ul>
         <p>A paragraph of text following the list. I'm not going to talk about the words anymore.</p>
         <blockquote>
-          <p>This text is inside a blockquote.</p>
+          <p>This text is inside a blockquote. It is being made deliberately long so as to wrap onto a second line, which hopefully has happened by now.</p>
+        </blockquote>
+        <blockquote>
+          <p>This text is inside a blockquote with a citation.</p>
+          <p>It contains more than one paragraph, and also has extra words in order to make it wrap onto a second line so we can check that everything's okay.</p>
+          <cite>John Blockquote, inventor of the blockquote</cite>
         </blockquote>
         <p>Yet another paragraph of text. This is starting to sound familiar.</p>
         <ol>
@@ -465,8 +470,9 @@ examples:
     data:
       block: |
         <blockquote>
-          <p>My quote</p>
-          <p class="last-child">about things</p>
+          <p>This text is inside a blockquote with a citation.</p>
+          <p>It contains more than one paragraph, and also has extra words in order to make it wrap onto a second line so we can check that everything's okay.</p>
+          <cite>John Blockquote, inventor of the blockquote</cite>
         </blockquote>
   buttons:
     data:


### PR DESCRIPTION
## What
Fix the appearance of govspeak blockquotes, primarily to remove the negative left margin that means blockquotes escape from their parent element as shown below (red outline added for clarity)

![Screenshot 2025-03-27 at 10 46 02](https://github.com/user-attachments/assets/4e3f51ac-9390-4650-942c-bab05d1a99b9)

Example in the wild on this page, note how the `cite` element is sticking out to the left: https://www.gov.uk/government/history/10-downing-street

![Screenshot 2025-03-27 at 14 25 31](https://github.com/user-attachments/assets/dfea78c1-7986-4bf7-821e-1313c5cd8eeb)

I've also fixed a few other things (see commits for details) and generally tried to clean up and simplify these styles.

## Why
As often happens, I was working on something else and noticed that this was a bit broken.

## Visual Changes

Before | After
------ | ------
![Screenshot 2025-03-27 at 14 20 37](https://github.com/user-attachments/assets/467c09c2-13ab-4856-b262-fd8a3cae9397) | ![Screenshot 2025-03-27 at 14 20 45](https://github.com/user-attachments/assets/a80c7314-8c21-475b-9818-723f5474144e)
