### PR TITLE
Release Version 56.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 56.1.0
 
 * Fix govspeak blockquotes ([PR #4739](https://github.com/alphagov/govuk_publishing_components/pull/4739))
 * Fix govspeak print styles ([PR #4730](https://github.com/alphagov/govuk_publishing_components/pull/4730))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (56.0.0)
+    govuk_publishing_components (56.1.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "56.0.0".freeze
+  VERSION = "56.1.0".freeze
 end


### PR DESCRIPTION
## 56.1.0

* Fix govspeak blockquotes ([PR #4739](https://github.com/alphagov/govuk_publishing_components/pull/4739))
* Fix govspeak print styles ([PR #4730](https://github.com/alphagov/govuk_publishing_components/pull/4730))
* Update LUX to 4.0.32 ([PR #4725](https://github.com/alphagov/govuk_publishing_components/pull/4725))
* Fix print styles ([PR #4738](https://github.com/alphagov/govuk_publishing_components/pull/4738))
* Use govuk-frontend mixin on attachment URL text ([PR #4737](https://github.com/alphagov/govuk_publishing_components/pull/4737))
* Add NI numbers to GA4 PII redaction ([PR #4732](https://github.com/alphagov/govuk_publishing_components/pull/4732))