### PR TITLE
Add a more descriptive accessible label to summary banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Fix HTML validation bug in cookie banner ([PR #4743](https://github.com/alphagov/govuk_publishing_components/pull/4743))
 * Add service navigation component ([PR #4731](https://github.com/alphagov/govuk_publishing_components/pull/4731))
+* Add a more descriptive accessible label to summary banner ([PR #4742](https://github.com/alphagov/govuk_publishing_components/pull/4742))
 
 ## 56.1.0
 

--- a/app/views/govuk_publishing_components/components/_summary_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_summary_banner.html.erb
@@ -2,13 +2,14 @@
   add_gem_component_stylesheet("summary-banner")
 
   title ||= false
+  title_id = "summary-banner-title-#{SecureRandom.hex(4)}"
   text ||= false
   secondary_text ||= false
   local_assigns[:margin_bottom] ||= 7
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-summary-banner")
-  component_helper.add_aria_attribute({ label: "Notice" })
+  component_helper.add_aria_attribute({ labelledby: title_id })
   component_helper.set_lang("en")
   component_helper.add_data_attribute({ module: "ga4-link-tracker" })
   component_helper.add_data_attribute({ ga4_track_links_only: "" })
@@ -16,7 +17,7 @@
 %>
 <% if title.present? && text.present? %>
   <%= tag.section(**component_helper.all_attributes) do %>
-    <h2 class="gem-c-summary-banner__title govuk-heading-m"><%= title %></h2>
+    <h2 class="gem-c-summary-banner__title govuk-heading-m" id="<%= title_id %>"><%= title %></h2>
     <p class="gem-c-summary-banner__text">
       <%= text %>
     </p>

--- a/spec/components/summary_banner_spec.rb
+++ b/spec/components/summary_banner_spec.rb
@@ -5,6 +5,8 @@ describe "Summary banner", type: :view do
     "summary_banner"
   end
 
+  before { allow(SecureRandom).to receive(:hex).and_return("1234") }
+
   it "fails to render a banner when nothing is passed to it" do
     assert_empty render_component({})
   end
@@ -21,9 +23,13 @@ describe "Summary banner", type: :view do
     assert_select ".gem-c-summary-banner__text", text: "This call for evidence will inform the development of the financial services sector plan, a key part of the government’s modern industrial strategy."
   end
 
-  it "renders a banner with an aria label" do
+  it "renders a banner with matching aria-labelledby and title id" do
+    title_id = "summary-banner-title-1234"
+
     render_component(title: "Summary", text: "Text")
-    assert_select "section[aria-label]"
+
+    assert_select "section[aria-labelledby='#{title_id}']"
+    assert_select ".gem-c-summary-banner__title##{title_id}"
   end
 
   it "renders a banner with title, text and secondary text correctly" do


### PR DESCRIPTION
## What
Use the title text of the summary banner as the accessible label for the summary banner which is used as the label for the landmark region, by adding an aria-labelledby and link it to the summary banner title ID. Since we have no unique ID to use, use an approach similar to the notice and password input components to generate a unique ID for the title.

[Trello](https://trello.com/c/165G7d6U/3360-investigate-and-fix-accessibility-issues-on-the-gem-summary-banner-component)

## Why
 We currently use the same aria-label value ("notice") on the summary banner as is already used by the notice component. This doesn't comply with the ARIA authoring practise for each landmark to have a unique label, since the notice and the summary banner often appear on the same page. The current value "notice" also doesn't describe what the summary banner is or does very well. The change in this PR should make the label unique in most cases since we shouldn't have more than one summary banner on a page and if we do, they shouldn't have the same heading text to help the user differentiate them. 

## Screen reader testing results

Correctly announces the title text of the summary banner as the label for the landmark region:

✅ NVDA 2024 with Chrome
✅ Jaws 2025 with Chrome
