### PR TITLE
Fix HTML validation bug in cookie banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix HTML validation bug in cookie banner ([PR #4743](https://github.com/alphagov/govuk_publishing_components/pull/4743))
+
 ## 56.1.0
 
 * Fix govspeak blockquotes ([PR #4739](https://github.com/alphagov/govuk_publishing_components/pull/4739))

--- a/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
@@ -44,7 +44,7 @@
       <div class="govuk-grid-column-two-thirds">
         <h2 class="govuk-cookie-banner__heading govuk-heading-m"><%= title %></h2>
         <div tabindex="-1" class="govuk-cookie-banner__content gem-c-cookie-banner__confirmation">
-          <span class="gem-c-cookie-banner__content"><%= text %></span>
+          <div class="gem-c-cookie-banner__content"><%= text %></div>
           <p class="gem-c-cookie-banner__confirmation-message--accepted govuk-body" hidden
           <% unless disable_ga4 %>
             data-ga4-cookie-banner <%# GA4 pageview JS looks for data-ga4-cookie-banner %>

--- a/spec/javascripts/components/cookie-banner-spec.js
+++ b/spec/javascripts/components/cookie-banner-spec.js
@@ -18,11 +18,11 @@ describe('Cookie banner', function () {
                   '<div class="govuk-grid-column-two-thirds">' +
                       '<h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on GOV.UK</h2>' +
                       '<div tabindex="-1" class="govuk-cookie-banner__content gem-c-cookie-banner__confirmation">' +
-                          '<span class="gem-c-cookie-banner__content">' +
+                          '<div class="gem-c-cookie-banner__content">' +
                               '<p class="govuk-body">We use some essential cookies to make this website work.</p>' +
                               '<p class="govuk-body">We’d like to set additional cookies to understand how you use GOV.UK, remember your settings and improve government services.</p>' +
                               '<p class="govuk-body">We also use cookies set by other sites to help us deliver content from their services.</p>' +
-                          '</span>' +
+                          '</div>' +
                           '<p class="gem-c-cookie-banner__confirmation-message--accepted govuk-body" hidden="">You have accepted additional cookies. <span class="gem-c-cookie-banner__confirmation-message">You can <a class="govuk-link" href="/help/cookies">change your cookie settings</a> at any time.</span></p>' +
                           '<p class="gem-c-cookie-banner__confirmation-message--rejected govuk-body" hidden="">You have rejected additional cookies. <span class="gem-c-cookie-banner__confirmation-message">You can <a class="govuk-link" href="/help/cookies">change your cookie settings</a> at any time.</span></p>' +
                       '</div>' +


### PR DESCRIPTION
## What

Fix HTML validation bug in cookie banner

See [https://validator.w3.org HTML checker results](https://validator.w3.org/nu/?doc=https%3A%2F%2Fcomponents-gem-pr-4743.herokuapp.com%2Fcomponent-guide%2Fcookie_banner%2Fdefault%2Fpreview)

## Why

https://github.com/alphagov/govuk_publishing_components/issues/3559.

Additionally, the change aligns with the Design System implementation; see https://design-system.service.gov.uk/components/cookie-banner/default/.