### PR TITLE
Fix super navigation menu styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix super navigation menu styling ([PR #4744](https://github.com/alphagov/govuk_publishing_components/pull/4744))
+
 ## 56.2.1
 
 * Adjust govspeak blockquotes quote marks ([PR #4755](https://github.com/alphagov/govuk_publishing_components/pull/4755))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -5,7 +5,7 @@
 
 $chevron-indent-spacing: 7px;
 $black-bar-height: 50px;
-$search-width-or-height: $black-bar-height;
+$search-toggle-button-height: $black-bar-height;
 $pseudo-underline-height: 3px;
 $button-pipe-colour: darken(govuk-colour("mid-grey"), 20%);
 
@@ -597,10 +597,10 @@ $after-button-padding-left: govuk-spacing(4);
   border: 0;
   color: govuk-colour("white");
   cursor: pointer;
-  height: $search-width-or-height;
+  height: $search-toggle-button-height;
   padding: govuk-spacing(3);
   position: relative;
-  width: $search-width-or-height;
+  width: 51px;
 
   &.gem-c-layout-super-navigation-header__search-toggle-button--blue-background {
     background: $govuk-brand-colour;
@@ -846,7 +846,7 @@ $after-button-padding-left: govuk-spacing(4);
 .gem-c-layout-super-navigation-header__search-toggle-button--large-navbar {
   padding-left: 24px;
   padding-right: 24px;
-  width: 68px;
+  width: 69px;
 }
 
 .gem-c-layout-super-navigation-header__navigation-second-item-description {
@@ -888,8 +888,8 @@ $after-button-padding-left: govuk-spacing(4);
   // isn't a multiple of 5 :(
   .gem-c-layout-super-navigation-header__navigation-item-link--large-navbar,
   .gem-c-layout-super-navigation-header__search-item-link--large-navbar {
-    padding-top: 33px;
-    padding-bottom: 33px;
+    padding-top: 26px;
+    padding-bottom: 26px;
   }
 
   .gem-c-layout-super-navigation-header__logotype-crown--large-navbar {
@@ -917,7 +917,8 @@ $after-button-padding-left: govuk-spacing(4);
   .gem-c-layout-super-navigation-header__search-toggle-button--large-navbar {
     height: $large-navbar-height;
     // to stop the search icon moving on hover
-    padding-bottom: 12px;
+    padding-top: 26px;
+    padding-bottom: 26px;
   }
 
   .gem-c-layout-super-navigation-header__button-container--large-navbar {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -137,7 +137,7 @@ $after-button-padding-left: govuk-spacing(4);
   padding: 0;
 }
 
-// Top level navigation links and search link.
+// Top level navigation links and search link, used when JavaScript is not available
 .gem-c-layout-super-navigation-header__navigation-item-link,
 .gem-c-layout-super-navigation-header__search-item-link {
   display: inline-block;
@@ -305,6 +305,14 @@ $after-button-padding-left: govuk-spacing(4);
 
 .gem-c-layout-super-navigation-header__navigation-item-link-inner {
   padding: govuk-spacing(1) $after-link-padding;
+  border-right: 1px solid $button-pipe-colour;
+}
+
+.gem-c-layout-super-navigation-header__navigation-item-link--large-navbar {
+  & .gem-c-layout-super-navigation-header__navigation-item-link-inner {
+    padding-left: 26px;
+    padding-right: 26px;
+  }
 }
 
 .gem-c-layout-super-navigation-header__navigation-item-link-inner--blue-background {
@@ -359,6 +367,11 @@ $after-button-padding-left: govuk-spacing(4);
       }
     }
   }
+}
+
+.gem-c-layout-super-navigation-header__search-item-link--large-navbar {
+  padding-left: 24px;
+  padding-right: 24px;
 }
 
 .gem-c-layout-super-navigation-header__search-item-link-icon,

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -329,8 +329,6 @@ $after-button-padding-left: govuk-spacing(4);
 
   &:link,
   &:visited {
-    background: $govuk-brand-colour;
-
     &:hover {
       &::before {
         left: 0;
@@ -350,10 +348,6 @@ $after-button-padding-left: govuk-spacing(4);
       left: 0;
       right: 0;
       width: 100%;
-    }
-
-    @include focus-not-focus-visible {
-      background: $govuk-link-colour;
     }
 
     @include focus-and-focus-visible {


### PR DESCRIPTION
## What

- Fix the super navigation menu styling when JavaScript is not available by making the changes below:
  - Add the missing right border to the menu link (the same as when JS is enabled)
  - Update the link padding used for the large variation
  - Remove the blue background from the search icon link, the search icon now only has a blue background when used on the blue background variation of the super nav menu
- Fix the search button width by updating the width from `50px` to `51px`, and `68px` to `69px` for desktop devices
  - The search icon width is set to `21px`, and has `15px` of left and right padding by default, `51px` in total
  - The large-navbar variation of the search toggle button has `24px` of padding to the left and right, 69px in total
- Fix the search button height when used on the large variation

## Why

- The rendering of the super navigation component is not as intended
- Contributes to a small layout shift on page load

[Trello card](https://trello.com/c/BkatAIQC)

## Visual Changes

### Without JavaScript

#### Super navigation menu - default

- Blue background removed from the search icon
- Border added to the right of the Menu link (the same as when JS is enabled)

| Before | After |
| --- | --- |
| <img width="197" alt="super-nav-default-before" src="https://github.com/user-attachments/assets/12fe97c6-7992-4668-a99a-8c0a02f07935" /> | <img width="171" alt="super-nav-default-after" src="https://github.com/user-attachments/assets/e8da354a-d478-4648-968e-847ad38b885f" /> |

#### Super navigation menu - homepage/large

- Menu and Search links have the correct spacing, closely matching the button styles when JS is enabled
- Menu links no longer overlap the main header

| Before | After |
| --- | --- |
| <img width="640" alt="super-nav-homepage-no-js-before" src="https://github.com/user-attachments/assets/6a6ddfaf-1957-444b-99f8-800a23ef9bdf" /> | <img width="640" alt="super-nav-homepage-no-js-after" src="https://github.com/user-attachments/assets/0894e741-0d91-4790-98a2-be4951a059ab" /> |

### With JavaScript

#### Search toggle button

| Link (no JS) | Button before (JS) | Button after (JS) |
| --- | --- | --- |
| <img width="319" alt="search-link" src="https://github.com/user-attachments/assets/3d5d0ac5-2c5a-4750-8b5d-779bea2b7042" /> | <img width="342" alt="search-button-before" src="https://github.com/user-attachments/assets/3044f53c-496c-44ee-9606-71ad75a1ae5f" /> | <img width="322" alt="search-button-after" src="https://github.com/user-attachments/assets/26b32646-c645-468a-a27b-14b6d12cdbde" /> |

#### Search toggle button - large variation

The search icon is now correctly positioned for the large variation, matching the default alignment of the icon

| Default | Before | After |
| --- | --- | --- |
| <img width="240" alt="Screenshot 2025-04-01 at 16 18 45" src="https://github.com/user-attachments/assets/f03e8d81-1058-4573-a9c7-c90ad04c4475" /> | <img width="240" alt="Screenshot 2025-04-01 at 16 14 22" src="https://github.com/user-attachments/assets/0fcc6da0-992b-4bcd-afa8-96ffa6b83f39" /> | <img width="240" alt="Screenshot 2025-04-01 at 16 17 27" src="https://github.com/user-attachments/assets/e4753d43-e511-44d1-97ea-7ed5a36292ff" /> |

### Rendering differences

#### 3G connection example - homepage

Before

https://github.com/user-attachments/assets/a81315c7-4dae-4a0a-8a2b-d40903e45d56

After

https://github.com/user-attachments/assets/d9327a43-f3b4-4896-8399-fcff46000133

#### 4G connection example - default

Before

https://github.com/user-attachments/assets/a996c450-2b0d-4c6e-a793-5c2b7b0b88be

After

https://github.com/user-attachments/assets/069dbcec-4a8f-4622-bf37-2bff30b4712e

## Browser Testing

### Grade A
- [x] Chrome 134
- [x] Safari 18.3
- [x] Firefox 136

### Grade B
- [x] Chrome 130
- [x] Safari 18.1

### Grade C
- [x] Chrome 70
- [x] Safari v14.0 - iPhone
- [x] Safari v11.1

### Grade X
- [x] IE11 - JS not supported
