### PR TITLE
Add an aria-label to the devolved nations component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add an aria-label to the devolved nations component ([PR #4751](https://github.com/alphagov/govuk_publishing_components/pull/4751))
+
+
 ## 56.2.0
 
 * Remove unused labels for tracking-key in super navigation header ([PR #4745](https://github.com/alphagov/govuk_publishing_components/pull/4745))

--- a/app/views/govuk_publishing_components/components/_devolved_nations.html.erb
+++ b/app/views/govuk_publishing_components/components/_devolved_nations.html.erb
@@ -10,6 +10,7 @@
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-devolved-nations")
+  component_helper.add_aria_attribute({ label: t("components.devolved_nations.aria_label") })
 
   unless disable_ga4
     component_helper.add_data_attribute({

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -62,6 +62,7 @@ ar:
       title: ملفات تعريف الارتباط على GOV.UK
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -59,6 +59,7 @@ az:
       title: GOV.UK-dəki kukilər
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -65,6 +65,7 @@ be:
       title: Файлы cookie на GOV.UK
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -63,6 +63,7 @@ bg:
       title: Бисквитки на GOV.UK
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -60,6 +60,7 @@ bn:
       title: GOV.UK-তে কুকিজ
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -64,6 +64,7 @@ cs:
       title: Soubory cookie na GOV.UK
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -63,6 +63,7 @@ cy:
       title: Cwcis ar GOV.UK
     devolved_nations:
       applies_to: Yn berthnasol i
+      aria_label:
       connectors:
         last_word: " a "
         two_words: " a "

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -60,6 +60,7 @@ da:
       title: Cookies på GOV.UK
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -63,6 +63,7 @@ de:
       title: Cookies auf GOV.UK
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -61,6 +61,7 @@ dr:
       title: کوکی ها در GOV.UK
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -59,6 +59,7 @@ el:
       title: Cookies στο GOV.UK
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,6 +58,7 @@ en:
       title: Cookies on GOV.UK
     devolved_nations:
       applies_to: Applies to
+      aria_label: Nation
       connectors:
         last_word: " and "
         two_words: " and "

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -59,6 +59,7 @@ es-419:
       title: Cookies de GOV.UK
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -59,6 +59,7 @@ es:
       title: Cookies en GOV.UK
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -62,6 +62,7 @@ et:
       title: Küpsised saidil GOV.UK
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -58,6 +58,7 @@ fa:
       title: کوکی‌ها در GOV.UK
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -61,6 +61,7 @@ fi:
       title: Evästeet sivustolla GOV.UK
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -59,6 +59,7 @@ fr:
       title: Cookies sur GOV.UK
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -61,6 +61,7 @@ gd:
       title: Fianáin ar GOV.UK
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -59,6 +59,7 @@ gu:
       title: GOV.UK પર કુકીઝ
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -59,6 +59,7 @@ he:
       title: עוגיות ב- GOV.UK
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -59,6 +59,7 @@ hi:
       title: GOV.UK पर कुकीज़
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -60,6 +60,7 @@ hr:
       title: Kolačići na GOV.UK
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -62,6 +62,7 @@ hu:
       title: Sütik a GOV.UK weboldalon
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -63,6 +63,7 @@ hy:
       title: Քուքիներ GOV.UK կայքում
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -59,6 +59,7 @@ id:
       title: Cookie di situs GOV.UK
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -59,6 +59,7 @@ is:
       title: Vafrakökur á GOV.UK
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -59,6 +59,7 @@ it:
       title: Cookie su GOV.UK
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -55,6 +55,7 @@ ja:
       title: GOV.UKのCookie
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -62,6 +62,7 @@ ka:
       title: ქუქი ფაილები GOV.UK-ზე
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -59,6 +59,7 @@ kk:
       title: GOV.UK веб-сайтындағы cookie файлдары
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -54,6 +54,7 @@ ko:
       title:
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -64,6 +64,7 @@ lt:
       title: GOV.UK slapukai
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -63,6 +63,7 @@ lv:
       title: Sīkfaili vietnē GOV.UK
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -58,6 +58,7 @@ ms:
       title: Kuki di GOV.UK
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -61,6 +61,7 @@ mt:
       title: Cookies fuq GOV.UK
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -55,6 +55,7 @@ ne:
       title:
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -59,6 +59,7 @@ nl:
       title: Cookies op GOV.UK
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -59,6 +59,7 @@
       title: Informasjonskapsler på GOV.UK
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -55,6 +55,7 @@ pa-pk:
       title: 'GOV.UK تے کوکیز '
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -59,6 +59,7 @@ pa:
       title: GOV.UK ਤੇ ਕੂਕੀਜ਼
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -63,6 +63,7 @@ pl:
       title: Pliki cookies na GOV.UK
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -56,6 +56,7 @@ ps:
       title: په GOV.UK کې کوکیز
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -59,6 +59,7 @@ pt:
       title: Cookies em GOV.UK
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -60,6 +60,7 @@ ro:
       title: Cookie-uri pe GOV.UK
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -63,6 +63,7 @@ ru:
       title: Файлы "cookie" на GOV.UK
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -59,6 +59,7 @@ si:
       title: GOV.UK මත කුකීස්
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -64,6 +64,7 @@ sk:
       title: Súbory cookie na GOV.UK
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -66,6 +66,7 @@ sl:
       title: Piškotki na GOV.UK
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -59,6 +59,7 @@ so:
       title: Xog kaydinta GOV.UK
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -59,6 +59,7 @@ sq:
       title: Cookies në GOV.UK
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -60,6 +60,7 @@ sr:
       title: Kolačići na sajtu GOV.UK
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -59,6 +59,7 @@ sv:
       title: Cookies på GOV.UK
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -59,6 +59,7 @@ sw:
       title: Vidakuzi kwenye tovuti ya GOV.UK
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -60,6 +60,7 @@ ta:
       title: GOV.UK குக்கீஸ்கள்
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -57,6 +57,7 @@ th:
       title: คุกกี้ใน GOV.UK
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -60,6 +60,7 @@ tk:
       title: Kukiler GOV.UK-da
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -60,6 +60,7 @@ tr:
       title: GOV.UK üzerindeki çerezler
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -66,6 +66,7 @@ uk:
       title: Файли cookie на GOV.UK
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -56,6 +56,7 @@ ur:
       title: GOV.UK پر کوکیز
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -61,6 +61,7 @@ uz:
       title: GOV.UKда cookie файллари
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -58,6 +58,7 @@ vi:
       title: Cookie trên GOV.UK
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -57,6 +57,7 @@ zh-hk:
       title: 在 GOV.UK 的 Cookies
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -57,6 +57,7 @@ zh-tw:
       title: 英國政府網站的cookie
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -57,6 +57,7 @@ zh:
       title: GOV.UK上的Cookies
     devolved_nations:
       applies_to:
+      aria_label:
       connectors:
         last_word:
         two_words:

--- a/spec/components/devolved_nations_spec.rb
+++ b/spec/components/devolved_nations_spec.rb
@@ -158,6 +158,17 @@ describe "Devolved Nations", type: :view do
     assert_select ".gem-c-devolved-nations > h3", text: "Applies to England"
   end
 
+  it "renders a devolved nations component with an aria label of 'Nation'" do
+    render_component(
+      national_applicability: {
+        england: {
+          applicable: true,
+        },
+      },
+    )
+    assert_select ".gem-c-devolved-nations[aria-label=\"Nation\"]"
+  end
+
   it "renders a devolved nations component, with ga4 tracking, correctly" do
     render_component(
       national_applicability: {


### PR DESCRIPTION
## What
Add an aria-label to the devolved nations component. The attribute value was agreed with our content designer.

## Why
The devolved nations component currently uses the section tag but doesn't have an aria-label. This might have been an oversight since it means the component doesn't get announced as a landmark region by screen readers. Both the notice and summary banner components are currently set as landmark regions since they are deemed to contain important information that it might be useful for the user to know about when they inspect the outline of the page. To be consistent, it makes sense to make devolved nations into a landmark region as well as it often appears on the same page with the components.

## Background
There has been some conversation though about whether some of these components could be consolidated to reduce the number of landmark regions and to generally help to to improve the information hierarchy on document pages. Our team have tickets in our backlog to look at wider related improvements for this.

[Trello](https://trello.com/c/piJlXt43/3356-fix-issue-on-consultations-and-statistics-announcements-where-notice-and-banner-components-and-metadata-and-notice-components-do?filter=member:hannalaakso4)
