### PR TITLE
Adjust govspeak blockquotes quote marks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
 
 ## Unreleased
 
+* Adjust govspeak blockquotes quote marks ([PR #4755](https://github.com/alphagov/govuk_publishing_components/pull/4755))
 * Add an aria-label to the devolved nations component ([PR #4751](https://github.com/alphagov/govuk_publishing_components/pull/4751))
-
 
 ## 56.2.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
@@ -40,7 +40,7 @@
     p {
       position: relative;
 
-      &:first-of-type::before {
+      &::before {
         content: "\201C";
         position: absolute;
         right: 100%;

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -470,9 +470,14 @@ examples:
     data:
       block: |
         <blockquote>
-          <p>This text is inside a blockquote with a citation.</p>
-          <p>It contains more than one paragraph, and also has extra words in order to make it wrap onto a second line so we can check that everything's okay.</p>
-          <cite>John Blockquote, inventor of the blockquote</cite>
+          <p>This is a blockquote with one line in it. It should have quote marks around it.</p>
+          <cite>Jane Blockquote</cite>
+        </blockquote>
+        <blockquote>
+          <p>This is a multi line blockquote with a citation.</p>
+          <p>It contains extra words such as 'wood' and 'primly' in order to make it wrap onto a second line so we can check that everything's okay.</p>
+          <p>This is a third paragraph, and the last one, so it should have both an opening and a closing quote mark.</p>
+          <cite>John Blockquote</cite>
         </blockquote>
   buttons:
     data:


### PR DESCRIPTION
## What / why
- a recent change omitted opening quote marks from multi line blockquote paragraphs that weren't the first paragraph
- GOV.UK content style is that all paragraphs in a blockquote should start with an opening quote, and only the final paragraph should end with a closing quote: https://www.gov.uk/guidance/style-guide/a-to-z#quotes-speech-marks

## Visual Changes
All paras in a blockquote should now have an opening quote mark. Only the final one should have a closing quote mark.