### PR TITLE
Version 56.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 56.2.1
 
 * Adjust govspeak blockquotes quote marks ([PR #4755](https://github.com/alphagov/govuk_publishing_components/pull/4755))
 * Add an aria-label to the devolved nations component ([PR #4751](https://github.com/alphagov/govuk_publishing_components/pull/4751))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (56.2.0)
+    govuk_publishing_components (56.2.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "56.2.0".freeze
+  VERSION = "56.2.1".freeze
 end


### PR DESCRIPTION
## 56.2.1

* Adjust govspeak blockquotes quote marks ([PR #4755](https://github.com/alphagov/govuk_publishing_components/pull/4755))
* Add an aria-label to the devolved nations component ([PR #4751](https://github.com/alphagov/govuk_publishing_components/pull/4751))
