### PR TITLE
Table: add ability to specify column width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Table: add ability to specify column width ([PR #4760](https://github.com/alphagov/govuk_publishing_components/pull/4760))
+
 ## 56.2.2
 
 * Fix super navigation menu styling ([PR #4744](https://github.com/alphagov/govuk_publishing_components/pull/4744))

--- a/app/views/govuk_publishing_components/components/_table.html.erb
+++ b/app/views/govuk_publishing_components/components/_table.html.erb
@@ -31,7 +31,8 @@
             format: item[:format],
             href: item[:href],
             data_attributes: item[:data_attributes],
-            sort_direction: item[:sort_direction]
+            sort_direction: item[:sort_direction],
+            width: item[:width],
           } %>
         <% end %>
       <% end %>

--- a/app/views/govuk_publishing_components/components/docs/table.yml
+++ b/app/views/govuk_publishing_components/components/docs/table.yml
@@ -200,3 +200,26 @@ examples:
           format: numeric
         - text: £125
           format: numeric
+  with_custom_width:
+    description: >
+      You can use `width` on a header cell to set the width of a table column if you do not want the
+      width to be inferred by the browser based on the content of its cells.
+    data:
+      head:
+        - text: Phrase
+        - text: Rating
+          width: one-half
+      rows:
+      -
+        - text: Lorem ipsum
+        - text: good
+      -
+        - text: dolor sit amet, consectetur adipiscing elit
+        - text: okay
+      -
+        - text: >
+            sed do eiusmod tempor incididunt ut labore et dolore magna aliqua duis aute irure dolor
+            in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur
+            molestiae non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam
+            quaerat voluptatem!!!
+        - text: bad

--- a/lib/govuk_publishing_components/app_helpers/table_helper.rb
+++ b/lib/govuk_publishing_components/app_helpers/table_helper.rb
@@ -20,6 +20,14 @@ module GovukPublishingComponents
       end
 
       class TableBuilder
+        ALLOWABLE_COLUMN_WIDTHS = %w[
+          three-quarters
+          two-thirds
+          one-half
+          one-third
+          one-quarter
+        ].freeze
+
         include ActionView::Helpers::UrlHelper
         include ActionView::Helpers::TagHelper
 
@@ -53,6 +61,7 @@ module GovukPublishingComponents
           classes = %w[govuk-table__header]
           classes << "govuk-table__header--#{opt[:format]}" if opt[:format]
           classes << "govuk-table__header--active" if opt[:sort_direction]
+          classes << "govuk-!-width-#{opt[:width]}" if ALLOWABLE_COLUMN_WIDTHS.include?(opt[:width])
           link_classes = %w[app-table__sort-link]
           link_classes << "app-table__sort-link--#{opt[:sort_direction]}" if opt[:sort_direction]
           str = link_to str, opt[:href], class: link_classes, data: opt[:data_attributes] if opt[:href]

--- a/spec/components/table_spec.rb
+++ b/spec/components/table_spec.rb
@@ -153,4 +153,25 @@ describe "Table", type: :view do
     assert_select ".js-gem-c-table__filter"
     assert_select ".js-gem-c-table__message"
   end
+
+  it "accepts a width value for head cells" do
+    render_component(
+      head: [
+        {
+          text: "Month you apply",
+          width: "one-third",
+        },
+      ],
+      rows: [
+        [
+          {
+            text: "January",
+          },
+        ],
+      ],
+    )
+
+    # This needs [class=...] attribute syntax as Nokogiri doesn't like the `!` in the class name
+    assert_select ".govuk-table th[class='govuk-table__header govuk-!-width-one-third']", "Month you apply"
+  end
 end

--- a/spec/lib/govuk_publishing_components/app_helpers/table_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/app_helpers/table_helper_spec.rb
@@ -53,5 +53,19 @@ RSpec.describe GovukPublishingComponents::AppHelpers::TableHelper do
         expect(table).to match("<table class=\"gem-c-table govuk-table\">")
       end
     end
+
+    it "can be given a custom width on headers" do
+      table = described_class.helper(view_context, "A pretty table") do |builder|
+        view_context.concat(builder.head do
+          view_context.concat builder.header("Hello", width: "one-third")
+          view_context.concat builder.header("Hallo", width: "two-millionths")
+        end)
+      end
+
+      # Valid with is added
+      expect(table).to match(/<th class="govuk-table__header govuk-!-width-one-third" scope="col">Hello<\/th>/)
+      # Invalid with is ignored
+      expect(table).to match(/<th class="govuk-table__header" scope="col">Hallo<\/th>/)
+    end
   end
 end


### PR DESCRIPTION
## What
This enhances the `table` component with the ability to give columns a specific width by assigning the header cell a width override class from the width scale as suggested by the [upstream table component].

## Why
This is useful when:
* the width of a column is always static and less than the automatically inferred width (for example, a set of action links or buttons), or
* a certain column often contains long and/or irregular content, throwing the visual balance of the table out of whack

[upstream table component]: https://design-system.service.gov.uk/components/table/

## Visual Changes
### Before
<img width="921" alt="image" src="https://github.com/user-attachments/assets/8201a013-8fd9-4c0d-8793-108dd850ab90" />

### After
<img width="921" alt="image" src="https://github.com/user-attachments/assets/5ee46c82-cea3-4dcc-8739-e60233367d05" />

[upstream table component]: https://design-system.service.gov.uk/components/table/
