### PR TITLE
Update super navigation menu button toggle states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Update to LUX 4.1.1 ([PR #4778](https://github.com/alphagov/govuk_publishing_components/pull/4778))
 * Table: add ability to specify column width ([PR #4760](https://github.com/alphagov/govuk_publishing_components/pull/4760))
 * Move `Ga4FinderTracker` back into `govuk_publishing_components` ([PR #4774](https://github.com/alphagov/govuk_publishing_components/pull/4774))
+* Update super navigation menu button toggle states ([PR #4771](https://github.com/alphagov/govuk_publishing_components/pull/4771))
 
 ## 56.2.2
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -627,18 +627,21 @@ $after-button-padding-left: govuk-spacing(4);
     border-color: $govuk-focus-colour;
     box-shadow: none;
     z-index: 11;
+
+    &:hover {
+      &::after {
+        background: none;
+      }
+    }
   }
 
-  &:focus:not(:focus-visible) {
+  @include focus-not-focus-visible {
     background: none;
-    border-color: govuk-colour("white");
     box-shadow: none;
     color: govuk-colour("white");
   }
 
   &.gem-c-layout-super-navigation-header__search-toggle-button--blue-background {
-    background: $govuk-brand-colour;
-
     &:hover {
       color: govuk-colour("white");
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -58,6 +58,9 @@ $after-button-padding-left: govuk-spacing(4);
   }
 }
 
+// Using `:focus-visible` means that in supporting browsers the focus state won't
+// be visible when a user clicks on the element, but the focus state will still be
+// useful for those who use the keyboard to navigate around the page.
 @mixin focus-and-focus-visible {
   &:focus {
     @content;
@@ -68,6 +71,11 @@ $after-button-padding-left: govuk-spacing(4);
   }
 }
 
+// For browsers that don't support `:focus-visible`, this defaults to using
+// `:focus` with a CSS-only fallback strategy.
+//
+// Undoes the :focus styles *only* for browsers that support :focus-visible.
+// See https://www.tpgi.com/focus-visible-and-backwards-compatibility/
 @mixin focus-not-focus-visible {
   & {
     @content;
@@ -465,8 +473,6 @@ $after-button-padding-left: govuk-spacing(4);
     // stylelint-enable max-nesting-depth
   }
 
-  // Undoes the :focus styles *only* for browsers that support :focus-visible.
-  // See https://www.tpgi.com/focus-visible-and-backwards-compatibility/
   @include focus-not-focus-visible {
     background: none;
     box-shadow: none;
@@ -505,6 +511,8 @@ $after-button-padding-left: govuk-spacing(4);
   }
 }
 
+// JS available - targets the "Menu" toggle button
+// Styles the "Menu" open state
 .gem-c-layout-super-navigation-header__navigation-top-toggle-button.gem-c-layout-super-navigation-header__navigation-top-toggle-button--blue-background,
 .gem-c-layout-super-navigation-header__navigation-top-toggle-button {
   // Open button modifier
@@ -554,6 +562,7 @@ $after-button-padding-left: govuk-spacing(4);
   }
 }
 
+// JS available - targets the "Menu" toggle button used on a blue background
 .gem-c-layout-super-navigation-header__navigation-top-toggle-button--blue-background {
   @include focus-not-focus-visible {
     &:hover {
@@ -572,6 +581,7 @@ $after-button-padding-left: govuk-spacing(4);
   }
 }
 
+// JS available - targets the "Menu" toggle button inner text
 .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
   display: inline-block;
   border-right: 1px solid govuk-colour("white");
@@ -585,7 +595,7 @@ $after-button-padding-left: govuk-spacing(4);
   }
 }
 
-// Styles for search toggle button.
+// JS available - targets the search toggle button
 .gem-c-layout-super-navigation-header__search-toggle-button {
   background: none;
   border: 0;
@@ -707,6 +717,7 @@ $after-button-padding-left: govuk-spacing(4);
   }
 }
 
+// JS available - styles the close icon, used when the search menu is in the open state
 .gem-c-layout-super-navigation-header__navigation-top-toggle-close-icon {
   color: $govuk-text-colour;
   display: none;
@@ -728,7 +739,7 @@ $after-button-padding-left: govuk-spacing(4);
   padding-bottom: govuk-spacing(7);
 }
 
-// Dropdown menu.
+// JS available - dropdown menu
 .gem-c-layout-super-navigation-header__navigation-dropdown-menu {
   background: govuk-colour("light-grey");
   border-bottom: 1px govuk-colour("mid-grey") solid;
@@ -743,6 +754,7 @@ $after-button-padding-left: govuk-spacing(4);
   }
 }
 
+// JS available - adds a custom margin to the wrapper for the search items in the search dropdown
 .gem-c-layout-super-navigation-header__navigation-dropdown-menu--large-navbar {
   @include govuk-media-query($until: "desktop") {
     .gem-c-layout-super-navigation-header__search-items {
@@ -751,6 +763,7 @@ $after-button-padding-left: govuk-spacing(4);
   }
 }
 
+// JS available - adds custom padding to the services and information and government activity sections in the menu dropdown
 @include govuk-media-query($until: "tablet") {
   // padding to make it the same as the padding for the redesign of the homepage
   .gem-c-layout-super-navigation-header__navigation-dropdown-menu--large-navbar .gem-c-layout-super-navigation-header__column--services-and-information,
@@ -759,7 +772,7 @@ $after-button-padding-left: govuk-spacing(4);
   }
 }
 
-// Dropdown menu items.
+// JS available - styles the links in the dropdown menu
 .gem-c-layout-super-navigation-header__dropdown-list-item {
   box-sizing: border-box;
   padding: 0 0 govuk-spacing(3) 0;
@@ -771,7 +784,7 @@ $after-button-padding-left: govuk-spacing(4);
   }
 }
 
-// Navigation menu items.
+// JS available - wraps the `dropdown-list-item` navigation menu items
 .gem-c-layout-super-navigation-header__navigation-second-items {
   list-style: none;
   margin: 0;
@@ -783,6 +796,7 @@ $after-button-padding-left: govuk-spacing(4);
   }
 }
 
+// JS available - styling for the "government-activity" group of links
 .gem-c-layout-super-navigation-header__column--government-activity {
   position: relative;
 
@@ -791,6 +805,7 @@ $after-button-padding-left: govuk-spacing(4);
   }
 }
 
+// JS available - styling for the "services-and-information" group of links
 .gem-c-layout-super-navigation-header__navigation-second-items--services-and-information {
   @include govuk-media-query($until: "desktop") {
     border-bottom: 1px solid govuk-colour("mid-grey");

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -411,16 +411,18 @@ $after-button-padding-left: govuk-spacing(4);
     @include pseudo-underline($left: $after-button-padding-left, $right: $after-button-padding-right);
   }
 
-  &:hover {
-    color: govuk-colour("mid-grey");
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      color: govuk-colour("mid-grey");
 
-    &::after {
-      background: govuk-colour("mid-grey");
-    }
+      &::after {
+        background: govuk-colour("mid-grey");
+      }
 
-    .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
-      &::before {
-        border-color: govuk-colour("mid-grey");
+      .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
+        &::before {
+          border-color: govuk-colour("mid-grey");
+        }
       }
     }
   }
@@ -456,9 +458,11 @@ $after-button-padding-left: govuk-spacing(4);
 
     box-shadow: none;
 
-    &:hover {
-      &::after {
-        background-color: govuk-colour("black");
+    @media (hover: hover) and (pointer: fine) {
+      &:hover {
+        &::after {
+          background-color: govuk-colour("black");
+        }
       }
     }
 
@@ -482,17 +486,19 @@ $after-button-padding-left: govuk-spacing(4);
     color: govuk-colour("white");
 
     // stylelint-disable max-nesting-depth
-    &:hover {
-      .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
-        color: govuk-colour("mid-grey");
+    @media (hover: hover) and (pointer: fine) {
+      &:hover {
+        .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
+          color: govuk-colour("mid-grey");
 
-        &::before {
-          @include chevron(govuk-colour("mid-grey"), true);
+          &::before {
+            @include chevron(govuk-colour("mid-grey"), true);
+          }
         }
-      }
 
-      &::after {
-        background: govuk-colour("mid-grey");
+        &::after {
+          background: govuk-colour("mid-grey");
+        }
       }
     }
 
@@ -568,16 +574,18 @@ $after-button-padding-left: govuk-spacing(4);
 // JS available - targets the "Menu" toggle button used on a blue background
 .gem-c-layout-super-navigation-header__navigation-top-toggle-button--blue-background {
   @include focus-not-focus-visible {
-    &:hover {
-      &::after {
-        background: govuk-colour("white");
-      }
+    @media (hover: hover) and (pointer: fine) {
+      &:hover {
+        &::after {
+          background: govuk-colour("white");
+        }
 
-      .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
-        color: govuk-colour("white");
+        .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
+          color: govuk-colour("white");
 
-        &::before {
-          border-color: govuk-colour("white");
+          &::before {
+            border-color: govuk-colour("white");
+          }
         }
       }
     }
@@ -614,11 +622,13 @@ $after-button-padding-left: govuk-spacing(4);
     @include pseudo-underline($left: 0, $right: 0);
   }
 
-  &:hover {
-    color: govuk-colour("mid-grey");
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      color: govuk-colour("mid-grey");
 
-    &::after {
-      background: govuk-colour("mid-grey");
+      &::after {
+        background: govuk-colour("mid-grey");
+      }
     }
   }
 
@@ -628,9 +638,11 @@ $after-button-padding-left: govuk-spacing(4);
     box-shadow: none;
     z-index: 11;
 
-    &:hover {
-      &::after {
-        background: none;
+    @media (hover: hover) and (pointer: fine) {
+      &:hover {
+        &::after {
+          background: none;
+        }
       }
     }
   }
@@ -642,11 +654,13 @@ $after-button-padding-left: govuk-spacing(4);
   }
 
   &.gem-c-layout-super-navigation-header__search-toggle-button--blue-background {
-    &:hover {
-      color: govuk-colour("white");
+    @media (hover: hover) and (pointer: fine) {
+      &:hover {
+        color: govuk-colour("white");
 
-      &::after {
-        background: govuk-colour("white");
+        &::after {
+          background: govuk-colour("white");
+        }
       }
     }
 
@@ -657,11 +671,13 @@ $after-button-padding-left: govuk-spacing(4);
         background: govuk-colour("black");
       }
 
-      &:hover {
-        color: govuk-colour("black");
+      @media (hover: hover) and (pointer: fine) {
+        &:hover {
+          color: govuk-colour("black");
 
-        &::after {
-          background: govuk-colour("black");
+          &::after {
+            background: govuk-colour("black");
+          }
         }
       }
     }
@@ -671,9 +687,11 @@ $after-button-padding-left: govuk-spacing(4);
         background: none;
       }
 
-      &:hover {
-        &::after {
-          background: govuk-colour("white");
+      @media (hover: hover) and (pointer: fine) {
+        &:hover {
+          &::after {
+            background: govuk-colour("white");
+          }
         }
       }
     }
@@ -682,8 +700,10 @@ $after-button-padding-left: govuk-spacing(4);
   // Open button modifier
   &.gem-c-layout-super-navigation-header__open-button {
     &.gem-c-layout-super-navigation-header__search-toggle-button--blue-background {
-      &:hover {
-        color: govuk-colour("white");
+      @media (hover: hover) and (pointer: fine) {
+        &:hover {
+          color: govuk-colour("white");
+        }
       }
 
       &:focus-visible {
@@ -704,9 +724,11 @@ $after-button-padding-left: govuk-spacing(4);
       outline: 1px solid govuk-colour("light-grey"); // overlap the border of the nav menu so it won't appear when menu open
 
       // stylelint-disable max-nesting-depth
-      &:hover {
-        &::after {
-          background: none;
+      @media (hover: hover) and (pointer: fine) {
+        &:hover {
+          &::after {
+            background: none;
+          }
         }
       }
       // stylelint-enable max-nesting-depth

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -663,7 +663,19 @@ $after-button-padding-left: govuk-spacing(4);
 
   &:focus-visible {
     &.gem-c-layout-super-navigation-header__search-toggle-button--blue-background {
-      border-bottom: $pseudo-underline-height solid govuk-colour("black");
+      color: govuk-colour("black");
+
+      &::after {
+        background: govuk-colour("black");
+      }
+
+      &:hover {
+        color: govuk-colour("black");
+
+        &::after {
+          background: govuk-colour("black");
+        }
+      }
     }
   }
 
@@ -676,17 +688,6 @@ $after-button-padding-left: govuk-spacing(4);
       border-bottom: 1px solid transparent;
       border-left: none;
       position: relative;
-    }
-
-    &:focus-visible {
-      &.gem-c-layout-super-navigation-header__search-toggle-button--blue-background {
-        color: govuk-colour("black");
-
-        &:hover {
-          border-bottom: $pseudo-underline-height solid govuk-colour("black");
-          color: govuk-colour("black");
-        }
-      }
     }
 
     @include focus-and-focus-visible {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -681,18 +681,6 @@ $after-button-padding-left: govuk-spacing(4);
     border: 0;
     margin: 0;
     right: 0;
-
-    @include focus-not-focus-visible {
-      border-bottom: 1px solid transparent;
-      border-left: none;
-      position: relative;
-    }
-
-    @include focus-and-focus-visible {
-      @include govuk-focused-text;
-      border-bottom-color: $govuk-focus-colour;
-      box-shadow: none;
-    }
   }
 
   // Open button modifier

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -632,6 +632,22 @@ $after-button-padding-left: govuk-spacing(4);
       }
     }
 
+    &:focus-visible {
+      color: govuk-colour("black");
+
+      &::after {
+        background: govuk-colour("black");
+      }
+
+      &:hover {
+        color: govuk-colour("black");
+
+        &::after {
+          background: govuk-colour("black");
+        }
+      }
+    }
+
     @include focus-not-focus-visible {
       &::after {
         background: none;
@@ -659,24 +675,6 @@ $after-button-padding-left: govuk-spacing(4);
     border-color: govuk-colour("white");
     box-shadow: none;
     color: govuk-colour("white");
-  }
-
-  &:focus-visible {
-    &.gem-c-layout-super-navigation-header__search-toggle-button--blue-background {
-      color: govuk-colour("black");
-
-      &::after {
-        background: govuk-colour("black");
-      }
-
-      &:hover {
-        color: govuk-colour("black");
-
-        &::after {
-          background: govuk-colour("black");
-        }
-      }
-    }
   }
 
   @include govuk-media-query($from: "desktop") {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -4,11 +4,10 @@
 @import "mixins/grid-helper";
 
 $chevron-indent-spacing: 7px;
-$black-bar-height: 50px;
-$search-toggle-button-height: $black-bar-height;
 $pseudo-underline-height: 3px;
 $button-pipe-colour: darken(govuk-colour("mid-grey"), 20%);
 
+$navbar-height: 50px;
 $large-navbar-height: 72px;
 
 $pale-blue-colour: #d2e2f1;
@@ -112,7 +111,7 @@ $after-button-padding-left: govuk-spacing(4);
 }
 
 .gem-c-layout-super-navigation-header__button-container {
-  top: -$black-bar-height;
+  top: -$navbar-height;
   position: absolute;
   right: 0;
 
@@ -397,7 +396,7 @@ $after-button-padding-left: govuk-spacing(4);
   box-sizing: border-box;
   color: govuk-colour("white");
   cursor: pointer;
-  height: $black-bar-height;
+  height: $navbar-height;
   padding: 0;
   position: relative;
   margin: 0;
@@ -601,7 +600,7 @@ $after-button-padding-left: govuk-spacing(4);
   border: 0;
   color: govuk-colour("white");
   cursor: pointer;
-  height: $search-toggle-button-height;
+  height: $navbar-height;
   padding: govuk-spacing(3);
   position: relative;
   width: 51px;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -609,6 +609,18 @@ $after-button-padding-left: govuk-spacing(4);
   position: relative;
   width: 51px;
 
+  &::after {
+    @include pseudo-underline($left: 0, $right: 0);
+  }
+
+  &:hover {
+    color: govuk-colour("mid-grey");
+
+    &::after {
+      background: govuk-colour("mid-grey");
+    }
+  }
+
   &.gem-c-layout-super-navigation-header__search-toggle-button--blue-background {
     background: $govuk-brand-colour;
   }
@@ -644,11 +656,6 @@ $after-button-padding-left: govuk-spacing(4);
       border-bottom: 1px solid transparent;
       border-left: none;
       position: relative;
-    }
-
-    &:hover {
-      border-bottom: $pseudo-underline-height solid govuk-colour("mid-grey");
-      color: govuk-colour("mid-grey");
     }
 
     &.gem-c-layout-super-navigation-header__search-toggle-button--blue-background {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -683,12 +683,10 @@ $after-button-padding-left: govuk-spacing(4);
   &.gem-c-layout-super-navigation-header__open-button {
     &.gem-c-layout-super-navigation-header__search-toggle-button--blue-background {
       &:hover {
-        border-bottom: $pseudo-underline-height solid govuk-colour("light-grey");
         color: govuk-colour("white");
       }
 
       &:focus-visible {
-        border-bottom: $pseudo-underline-height solid govuk-colour("black");
         color: govuk-colour("black");
       }
     }
@@ -702,13 +700,16 @@ $after-button-padding-left: govuk-spacing(4);
 
     @include focus-not-focus-visible {
       background: govuk-colour("light-grey");
-      border-bottom-color: govuk-colour("light-grey");
       color: govuk-colour("light-grey");
       outline: 1px solid govuk-colour("light-grey"); // overlap the border of the nav menu so it won't appear when menu open
 
+      // stylelint-disable max-nesting-depth
       &:hover {
-        border-bottom: $pseudo-underline-height solid govuk-colour("light-grey");
+        &::after {
+          background: none;
+        }
       }
+      // stylelint-enable max-nesting-depth
     }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -608,6 +608,7 @@ $after-button-padding-left: govuk-spacing(4);
   padding: govuk-spacing(3);
   position: relative;
   width: 51px;
+  @include govuk-font($size: 19, $weight: "bold", $line-height: 20px);
 
   &::after {
     @include pseudo-underline($left: 0, $right: 0);
@@ -619,6 +620,20 @@ $after-button-padding-left: govuk-spacing(4);
     &::after {
       background: govuk-colour("mid-grey");
     }
+  }
+
+  @include focus-and-focus-visible {
+    @include govuk-focused-text;
+    border-color: $govuk-focus-colour;
+    box-shadow: none;
+    z-index: 11;
+  }
+
+  &:focus:not(:focus-visible) {
+    background: none;
+    border-color: govuk-colour("white");
+    box-shadow: none;
+    color: govuk-colour("white");
   }
 
   &.gem-c-layout-super-navigation-header__search-toggle-button--blue-background {
@@ -659,22 +674,6 @@ $after-button-padding-left: govuk-spacing(4);
         }
       }
     }
-  }
-
-  @include govuk-font($size: 19, $weight: "bold", $line-height: 20px);
-
-  @include focus-and-focus-visible {
-    @include govuk-focused-text;
-    border-color: $govuk-focus-colour;
-    box-shadow: none;
-    z-index: 11;
-  }
-
-  &:focus:not(:focus-visible) {
-    background: none;
-    border-color: govuk-colour("white");
-    box-shadow: none;
-    color: govuk-colour("white");
   }
 
   // Open button modifier

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -623,6 +623,26 @@ $after-button-padding-left: govuk-spacing(4);
 
   &.gem-c-layout-super-navigation-header__search-toggle-button--blue-background {
     background: $govuk-brand-colour;
+
+    &:hover {
+      color: govuk-colour("white");
+
+      &::after {
+        background: govuk-colour("white");
+      }
+    }
+
+    @include focus-not-focus-visible {
+      &::after {
+        background: none;
+      }
+
+      &:hover {
+        &::after {
+          background: govuk-colour("white");
+        }
+      }
+    }
   }
 
   @include govuk-font($size: 19, $weight: "bold", $line-height: 20px);
@@ -656,23 +676,6 @@ $after-button-padding-left: govuk-spacing(4);
       border-bottom: 1px solid transparent;
       border-left: none;
       position: relative;
-    }
-
-    &.gem-c-layout-super-navigation-header__search-toggle-button--blue-background {
-      &:hover {
-        border-bottom: $pseudo-underline-height solid govuk-colour("white");
-        color: govuk-colour("white");
-      }
-
-      // stylelint-disable max-nesting-depth
-      @include focus-not-focus-visible {
-        border-bottom: $pseudo-underline-height solid $govuk-brand-colour;
-
-        &:hover {
-          border-bottom: $pseudo-underline-height solid govuk-colour("white");
-        }
-      }
-      // stylelint-enable max-nesting-depth
     }
 
     &:focus-visible {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -3,14 +3,16 @@
 @import "mixins/prefixed-transform";
 @import "mixins/grid-helper";
 
+$pale-blue-colour: #d2e2f1;
+
 $chevron-indent-spacing: 7px;
 $pseudo-underline-height: 3px;
-$button-pipe-colour: darken(govuk-colour("mid-grey"), 20%);
 
 $navbar-height: 50px;
 $large-navbar-height: 72px;
 
-$pale-blue-colour: #d2e2f1;
+$button-pipe-colour: darken(govuk-colour("mid-grey"), 20%);
+$button-pipe-colour-blue-background: $pale-blue-colour;
 
 $after-link-padding: govuk-spacing(4);
 $after-button-padding-right: govuk-spacing(4);
@@ -323,7 +325,7 @@ $after-button-padding-left: govuk-spacing(4);
 }
 
 .gem-c-layout-super-navigation-header__navigation-item-link-inner--blue-background {
-  border-right: 1px solid $pale-blue-colour;
+  border-right: 1px solid $button-pipe-colour-blue-background;
 }
 
 // Search link and dropdown.
@@ -496,7 +498,7 @@ $after-button-padding-left: govuk-spacing(4);
       border-color: $button-pipe-colour;
 
       &.gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner--blue-background {
-        border-color: $pale-blue-colour;
+        border-color: $button-pipe-colour-blue-background;
       }
 
       @include govuk-media-query($from: 360px) {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -677,12 +677,6 @@ $after-button-padding-left: govuk-spacing(4);
     color: govuk-colour("white");
   }
 
-  @include govuk-media-query($from: "desktop") {
-    border: 0;
-    margin: 0;
-    right: 0;
-  }
-
   // Open button modifier
   &.gem-c-layout-super-navigation-header__open-button {
     &.gem-c-layout-super-navigation-header__search-toggle-button--blue-background {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -5,7 +5,9 @@
 
 $pale-blue-colour: #d2e2f1;
 
+$chevron-breakpoint: 360px;
 $chevron-indent-spacing: 7px;
+
 $pseudo-underline-height: 3px;
 
 $navbar-height: 50px;
@@ -501,7 +503,7 @@ $after-button-padding-left: govuk-spacing(4);
         border-color: $button-pipe-colour-blue-background;
       }
 
-      @include govuk-media-query($from: 360px) {
+      @include govuk-media-query($from: $chevron-breakpoint) {
         &::before {
           @include chevron(govuk-colour("white"), true);
         }
@@ -531,7 +533,7 @@ $after-button-padding-left: govuk-spacing(4);
         color: govuk-colour("black");
         border-color: $govuk-focus-colour;
 
-        @include govuk-media-query($from: 360px) {
+        @include govuk-media-query($from: $chevron-breakpoint) {
           &::before {
             @include chevron(govuk-colour("black"), true);
             @include prefixed-transform($rotate: 225deg, $translateY: 1px);
@@ -551,7 +553,7 @@ $after-button-padding-left: govuk-spacing(4);
         color: $govuk-link-colour;
         border-color: govuk-colour("light-grey");
 
-        @include govuk-media-query($from: 360px) {
+        @include govuk-media-query($from: $chevron-breakpoint) {
           &::before {
             @include chevron($govuk-link-colour);
             @include prefixed-transform($rotate: 225deg, $translateY: 1px);
@@ -589,7 +591,7 @@ $after-button-padding-left: govuk-spacing(4);
   margin: 0;
   padding: govuk-spacing(1) govuk-spacing(4);
 
-  @include govuk-media-query($from: 360px) {
+  @include govuk-media-query($from: $chevron-breakpoint) {
     &::before {
       @include chevron(govuk-colour("white"));
     }


### PR DESCRIPTION
## What

- Updated the styles in the super navigation menu to ensure the "Menu" and "Search" toggle buttons use a consistent approach
- Fix an issue where the hover styles would stick when toggling a menu button in the super navigation menu on touchscreen devices
  - https://trello.com/c/6YteIa3f/687-top-nav-hover-state-doesnt-disappear-on-touch-screens

### Search toggle button

The styling of the "Search" button toggle states have been updated to align with the approach used in the "Menu" toggle button: 

- Now uses the `pseudo-underline` mixin instead of applying `border-bottom`
- Styles are now applied on all screen sizes, not just desktop

### Improved documentation and readability
 
- Added/updated comments to clearly indicate the purpose of each section of code
- Update Sass variables to be more descriptive and consistent with existing variable names

## Why

Using the same approach to style button states makes it easier to maintain the code by ensuring styles are applied in a more predictable way.

[Trello card](https://trello.com/c/VVOnzVdk/3420-ensure-nav-menu-button-toggle-states-are-consistent)

## Visual Changes

### Mobile and Tablet - `:hover` state

The hover state will no long appear on most touchscreen devices such as mobile and tablet, this [fixes an issue](https://trello.com/c/6YteIa3f/687-top-nav-hover-state-doesnt-disappear-on-touch-screens) where the hover styles would stick when toggling a menu button in the super navigation menu.

https://github.com/user-attachments/assets/da712cad-d6b6-44b5-a8b0-114abd18ee04

The hover state will still appear on touch screen devices if the primary input mechanism allows the user to hover elements and is an accurate pointing device as shown in the screenshots below.

| variation | before | after |
| --- | --- | --- |
| default | <img width="377" alt="mobile-default-before" src="https://github.com/user-attachments/assets/bd0fa497-09ad-4901-97a0-5e029aa4c999" /> | <img width="446" alt="mobile-default-after" src="https://github.com/user-attachments/assets/e4511897-6795-4488-bf0c-42b47ebd4f99" /> |
| homepage | <img width="380" alt="mobile-homepage-before" src="https://github.com/user-attachments/assets/745d11e4-1c6e-482d-bbfe-30ae14c3ffa2" /> | <img width="448" alt="mobile-homepage-after" src="https://github.com/user-attachments/assets/3b75de97-493f-449a-a2a3-bd7af09255e0" /> |

Further info on this solution:
- https://css-tricks.com/solving-sticky-hover-states-with-media-hover-hover/
- https://developer.mozilla.org/en-US/docs/Web/CSS/:hover
- https://developer.mozilla.org/en-US/docs/Web/CSS/@media/pointer
- [Example of a similar approach in the design system](https://github.com/alphagov/govuk-frontend/blob/38c319b1224c34695baebfe669d0b3fac82a0866/packages/govuk-frontend/src/govuk/components/radios/_index.scss#L310-L324)

### All screen sizes - `:hover` state

| before | after |
| --- | --- |
| <img width="151" alt="default-focus-hover-before" src="https://github.com/user-attachments/assets/4af78d42-114c-4558-bc82-91345adcde77" /> | <img width="149" alt="default-focus-hover-after" src="https://github.com/user-attachments/assets/1504d7a7-a055-4021-98fe-ab6a15e968ba" /> |

### High contrast

| variation | before | after |
| --- | --- | --- |
| default | <img width="162" alt="high-contrast-before" src="https://github.com/user-attachments/assets/8b926c1c-3bbb-4772-9030-3210158d1248" /> | <img width="154" alt="high-contrast-after" src="https://github.com/user-attachments/assets/9c3f6022-8e59-4a83-82f0-4c4f1c792855" /> |
| homepage | <img width="185" alt="high-contrast-homepage-before" src="https://github.com/user-attachments/assets/5efde5f7-feef-4464-843f-45e9dc29539b" /> | <img width="184" alt="high-contrast-homepage-after" src="https://github.com/user-attachments/assets/cc96f0ba-dac2-4271-bf2d-5a9d739657e8" /> | 

## Browser Testing

### Grade A
- [x] Chrome 135
- [x] Safari 18.4
- [x] Safari 18.4 iOS 
- [x] Firefox 137

### Grade B
- [x] Chrome 131
- [x] Chrome 133 for Android
- [x] Safari 18.0 iOS

### Grade C
- [x] Chrome 70
- [x] Safari v14.0 - iPhone
- [x] Safari v11.1

### Grade X
- [x] IE11 - JS not supported
