### PR TITLE
add back ga4 finder tracker

### DIFF
--- a/app/assets/javascripts/analytics-ga4/ga4-finder-tracker.js
+++ b/app/assets/javascripts/analytics-ga4/ga4-finder-tracker.js
@@ -1,0 +1,167 @@
+;(function (global) {
+  'use strict'
+
+  const GOVUK = global.GOVUK || {}
+  GOVUK.analyticsGa4 = GOVUK.analyticsGa4 || {}
+
+  GOVUK.analyticsGa4.Ga4FinderTracker = {
+    // Called when the search results updates. Takes the event target, and a string containing the type of change and element type. Creates the GTM schema and pushes it.
+    // changeEventMetadata is a string referring to the type of form change and the element type that triggered it. For example 'update-filter checkbox'.
+    trackChangeEvent: function (eventTarget, changeEventMetadata) {
+      changeEventMetadata = changeEventMetadata.split(' ')
+      const filterParent = eventTarget.closest('[data-ga4-filter-parent]')
+      const section = eventTarget.closest('[data-ga4-section]')
+      const changeType = changeEventMetadata[0]
+      const elementType = changeEventMetadata[1]
+
+      if ((!changeType || !elementType) && changeType !== 'clear-all-filters') {
+        console.warn('GA4 Finder tracker incorrectly configured for element: ' + eventTarget)
+        return
+      }
+
+      let data = {}
+      data.type = 'finder'
+      data.event_name = 'select_content'
+
+      const elementInfo = this.getElementInfo(eventTarget, elementType, section)
+      if (!elementInfo) {
+        return
+      }
+      const elementValue = elementInfo.elementValue
+      data.text = elementValue
+      const wasFilterRemoved = elementInfo.wasFilterRemoved
+      data = this.setSchemaBasedOnChangeType(data, elementValue, elementType, wasFilterRemoved, changeType, section, filterParent)
+
+      const schemas = new window.GOVUK.analyticsGa4.Schemas()
+      const schema = schemas.mergeProperties(data, 'event_data')
+
+      window.GOVUK.analyticsGa4.core.sendData(schema)
+    },
+
+    // Grabs the value from the eventTarget. Checks if the filter was removed if the eventTarget is unchecked, set back to default, or has its user input removed. Returns the results as an object.
+    getElementInfo: function (eventTarget, elementType, section) {
+      let elementValue = ''
+      let defaultValue
+      let wasFilterRemoved = false
+
+      switch (elementType) {
+        case 'checkbox': {
+          const checkboxId = eventTarget.id
+
+          // The "value" we need for a checkbox is the label text that the user sees beside the checkbox.
+          elementValue = document.querySelector("label[for='" + checkboxId + "']").textContent
+
+          // If the checkbox is unchecked, the filter was removed.
+          wasFilterRemoved = !eventTarget.checked
+          break
+        }
+        case 'radio': {
+          const radioId = eventTarget.id
+
+          // The "value" we need for a radio is the label text that the user sees beside the checkbox.
+          elementValue = document.querySelector("label[for='" + radioId + "']").textContent
+          defaultValue = section.querySelector('input[type=radio]:first-of-type')
+
+          if (eventTarget.id === defaultValue.id) {
+            // Radio elements being reverted to their first option (i.e. their default value) count as a "removed filter".
+            wasFilterRemoved = true
+          }
+          break
+        }
+        case 'select':
+          // The value of a <select> is the value attribute of the selected <option>, which is a hyphenated key. We need to grab the human readable label instead for tracking.
+          elementValue = eventTarget.querySelector("option[value='" + eventTarget.value + "']").textContent
+          defaultValue = eventTarget.querySelector('option:first-of-type').textContent
+
+          if (elementValue === defaultValue) {
+            // <select> elements being reverted to their first option (i.e. their default value) count as a "removed filter". (This will be used on the filter <select>s but not the sort by <select>, as you can't "remove" the sort by filter.)
+            wasFilterRemoved = true
+          }
+          break
+
+        case 'text':
+          elementValue = eventTarget.value
+          if (elementValue === '') {
+            // If our custom date filters are reset, they become an empty text box, so we count this as a "removed filter". This boolean won't be used for the keyword search box, as deleting the keyword isn't considered removing a filter.
+            wasFilterRemoved = true
+          }
+          break
+
+        case 'date': {
+          // The GOV.UK Design System date input consists of three grouped but separate fields (day,
+          // month, year). We want to fire a single event when all three fields are filled in to
+          // avoid firing excessive events.
+          const inputs = [...eventTarget.closest('.govuk-date-input').querySelectorAll('input')]
+          const allInputsSet = inputs.every(input => input.value)
+          const noInputsSet = inputs.every(input => !input.value)
+
+          if (allInputsSet) {
+            elementValue = inputs.map(input => input.value).join('/')
+          } else if (noInputsSet) {
+            wasFilterRemoved = true
+          } else {
+            // Do not track partially filled in fields
+            return null
+          }
+          break
+        }
+      }
+
+      return { elementValue: elementValue, wasFilterRemoved: wasFilterRemoved }
+    },
+
+    // Takes the GTM schema, the event target value, the event target HTML type, whether the filter was removed, the type of filter change it was, and the parent section heading. Populates the GTM object based on these values.
+    setSchemaBasedOnChangeType: function (schema, elementValue, elementType, wasFilterRemoved, changeType, section, filterParent) {
+      switch (changeType) {
+        case 'update-filter': {
+          if (section) {
+            schema.section = section.getAttribute('data-ga4-section')
+          }
+
+          const index = this.getSectionIndex(filterParent)
+          if (wasFilterRemoved) {
+            schema.action = 'remove'
+            schema.text = elementType === 'text' ? undefined : elementValue
+          } else {
+            schema.action = elementType === 'text' ? 'search' : 'select'
+          }
+          schema.index_link = index.index_link || undefined
+          schema.index_section = index.index_section || undefined
+          schema.index_section_count = index.index_section_count || undefined
+          break
+        }
+        case 'update-keyword':
+          schema.event_name = 'search'
+          schema.url = window.location.pathname
+          schema.section = 'Search'
+          schema.action = 'search'
+          schema.text = GOVUK.analyticsGa4.core.trackFunctions.standardiseSearchTerm(schema.text)
+          break
+
+        case 'clear-all-filters':
+          schema.action = 'remove'
+          schema.text = 'Clear all filters'
+          break
+
+        case 'update-sort':
+          schema.action = 'sort'
+          schema.section = 'Sort by'
+          break
+      }
+      return schema
+    },
+
+    // Takes a filter section's div, and grabs the index value from it.
+    getSectionIndex: function (sectionElement) {
+      try {
+        let index = sectionElement.getAttribute('data-ga4-index')
+        index = JSON.parse(index)
+        return index
+      } catch (e) {
+        console.error('GA4 configuration error: ' + e.message, window.location)
+      }
+    }
+  }
+
+  global.GOVUK = GOVUK
+})(window)

--- a/docs/analytics-ga4/ga4-finder-tracker.md
+++ b/docs/analytics-ga4/ga4-finder-tracker.md
@@ -1,0 +1,125 @@
+# Google Analytics 4 finder tracker
+
+This script is used to add GA4 tracking to the GOVUK finders in `finder-frontend` such as https://www.gov.uk/search/all. These finders use client side JavaScript to update their results in response to a change in the search term or filters. Therefore, this tracker hooks in to the JavaScript `change` event that fires whenever a user updates their search. A GA4 schema is then built depending on what change was made to their search. This differs from the `ga4-form-tracker`. Firstly, this is because our finders are all contained in one large form. The `ga4-form-tracker` only allows for one GTM object per `<form>` when we need multiple for each element that can change the search results. Secondly, the `ga4-form-tracker` relies on a JavaScript `submit` event. Our finder pages use a `change` event to update their results.
+
+## Basic use
+
+```html
+<form id="myForm">
+  <div data-ga4-filter-container>
+    <div data-ga4-filter-parent>
+        <select data-ga4-change-category="update-filter select" data-ga4-section="Topic">
+            <option value="1">Default option</option>
+            <option value="2">Option 1</option>
+            <option value="3">Option 2</option>
+        </select>
+    </div>
+  </div>
+  <input type="search" data-ga4-change-category="update-keyword text" />
+</form>
+```
+
+```JavaScript
+var myForm = document.querySelector('#myForm')
+
+window.GOVUK.analyticsGa4.Ga4FinderTracker.setFilterIndexes()
+
+myForm.addEventListener('change', function(event) {
+    var ga4ChangeCategory = event.target.closest('[data-ga4-change-category]').getAttribute('data-ga4-change-category')
+    window.GOVUK.analyticsGa4.Ga4FinderTracker.trackChangeEvent(event.target, ga4ChangeCategory)
+})
+```
+
+The tracker is not a regular module. Instead it is called manually where needed. This is to allow the tracker to be called at the appropriate time in our finder's code. In our case, we only call `Ga4FinderTracker.trackChangeEvent()` when our search successfully displays new results to the user. This stops erroring change events (i.e. the user inputting non-dates into the date filter) from being tracked as an "added filter" event. Therefore we only track updates to the finders if they result in a successful update to the search results.
+
+The flow of the tracker is:
+
+1. On the finder results page, tag your elements with the appropriate `data` attributes.
+
+    a. Tag the parent `<div>` or wrapper element for your filters with `data-ga4-filter-container`. This tells our code where to look for filter sections, so that we can set an `index_section` for each filter.
+
+    b. Tag each filter's wrapper element with a `data-ga4-filter-parent` attribute, so that indexes can be set. Tag each individual filter with `data-ga4-section="Topics"` to populate the GA4 section value for that filter.
+
+    c. Tag each element of the form that can trigger a `change` event with a `data-ga4-change-category`. This will contain some metadata about what the change is. The current categories are: `update-filter`, `update-sort`, `clear-all-filters` and `update-keyword`. As well as this, add the type of element that the filter is (further details on what types are tracked is documented below.) This assists with our tracker extracting the value of the filter. For example, a `<select>` element that updates a filter would have `data-ga4-change-category="update-filter select"`. A search box would have `data-ga4-change-category="update-keyword text"`.
+
+2. When the finder page loads, call `Ga4FinderTracker.setFilterIndexes()`. This will grab the `data-ga4-filter-container` element. It will then look for every instance of `data-ga4-section` inside this element, then loop through them and assign an `index` to the section based on its position in the NodeList.
+
+3. In the finder's JavaScript code, find where it updates your search results, and call `Ga4FinderTracker.trackChangeEvent()`. Pass through the `event.target` of the element that triggered the change. Also grab and pass through the `data-ga4-change-category` that was set on the event target or its parent.
+
+4. The `ga4-finder-tracker` will then grab the "value" of the event target, using the metadata passed through to help categorise what type of element the change came from. The value in this case is the name of the filter that was set, the keyword that was input. For filters, it will also determine whether the change was the filter being "added" or "removed".
+For example if the event target is a checkbox, `<input type="checkbox" data-ga4-change-category="update-filter checkbox">`, and it is `checked`, then we know the filter was added. If it isn't `checked`, we know the filter was removed.
+
+5. Using the `data-ga4-change-category`, the value of the event target, and whether it is a removed filter or not, we then build the GTM object and push it to the `dataLayer`.
+
+## Element types tracked
+
+### Checkbox (`<input type="checkbox" />`)
+
+Checkboxes have `data-ga4-change-category="update-filter checkbox"` on them. If a change event is fired on the element, and the checkbox is `checked`, the `update-filter` event will build an "Add filter" GTM Object. If the checkbox is not `checked`, it will build a "Remove filter" GTM Object. The value we grab for a checkbox is the user friendly label associated with the `<input>`.
+
+### Select (`<select>`)
+
+The value we grab from a `<select>` is the user friendly text of the selected option.
+
+Filter selects have  `data-ga4-change-category="update-filter select"` on them.
+
+If the filter `<select>` element changes and is set to their _first option_, we treat this as a "Filter removed" event. This is because the first `<option>` in a `<select>` is their default state in our use case. Therefore if the select has changed, and we're on the first option, we can safely assume we've moved from a "Added filter" option, back to the default option, so it's treated as a "Removed filter."
+
+"Sort by" selects have  `data-ga4-change-category="update-sort select"` on them. They send a separate "Sort event", so checking whether the filter was added or removed is irrelevant in this case.
+
+### Radio buttons (`<input type="radio">`)
+
+Radio buttons have `data-ga4-change-category="update-filter radio"` on them. If the changed radio button is not the _first radio button_ (i.e. the default selection), then, the `update-filter` event will build an "Filter added" GTM Object. If the changed radio button is the _first radio button_, it will build a "Filter removed" GTM Object. This is because the first radio button in a list is typically the default "All XYZ" filter state. The value we grab for a radio button is the user friendly label associated with the `<input>`.
+
+### Date filters with single input field (`<input type="text">`)
+
+Our date filters have `data-ga4-change-category="update-filter text"` on them. The value we grab is the text that is input into its text field. If the text is an empty string, we treat this as a "Filter removed" event, as this means the date was removed. If text is available in the text box, we treat this as a "Filter added" event.
+
+### Date filters with three input fields (day/month/year)
+These use the GOV.UK Design System date input pattern/component and have `data-ga4-change-category="update-filter date"` on them. To avoid excessive events and cardinality, despite technically allowing partial values, we expect users to mostly fill in complete dates and only track them as an entire value triggered by all fields being present, and combine the three into a single D/M/Y string. Conversely, it only counts as removed if all fields have been cleared.
+
+### Search keyword changes (`<input type="text">`)
+
+Search boxes have `data-ga4-change-category="update-keyword text"` on them. The value we grab on change is the text that was input into the text box.  Regardless if text is available in the text box, we always treat it as a "search" event. This is because an empty search box is still as search event but it just searches for everything in our database.
+
+The search value is sanitised with PII removal, + characters converted to spaces, spaces and new lines trimmed, and downcasing.
+
+
+### Clear all filters button
+
+On mobile, there is a "Clear all filters" button. This triggers a `change` event on the whole `<form>` element when clicked. Therefore, we have added `data-ga4-change-category="clear-all-filters"` on the parent `<form>` in our finders. The value pushed to GTM is hard coded in `Ga4FinderTracker` as "Clear all filters", so an element type is not passed through to `data-ga4-change-category` as we don't need to do any value extraction.
+
+## Example GTM Objects
+
+```JSON
+{
+    "event": "event_data",
+    "event_data": {
+        "event_name": "select_content",
+        "type": "finder",
+        "text": "Environment",
+        "index": {
+            "index_section": 2,
+            "index_section_count": 5
+        },
+        "section": "Topic",
+        "action": "select"
+    },
+    "govuk_gem_version": "35.3.1",
+}
+```
+
+```JSON
+{
+    "event": "event_data",
+    "event_data": {
+        "event_name": "search",
+        "type": "finder",
+        "url": "/search/research-and-statistics",
+        "text": "hello world",
+        "section": "Search",
+        "action": "search"
+    },
+    "govuk_gem_version": "35.3.1",
+}
+```

--- a/spec/javascripts/analytics-ga4/ga4-finder-tracker.spec.js
+++ b/spec/javascripts/analytics-ga4/ga4-finder-tracker.spec.js
@@ -1,0 +1,427 @@
+/* eslint-env jasmine */
+
+describe('GA4 finder change tracker', function () {
+  var GOVUK = window.GOVUK
+  var form
+  var inputParent
+  var input
+  var label
+  var label2
+  var option1
+  var option2
+  var expected
+
+  function agreeToCookies () {
+    GOVUK.setCookie('cookies_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true}')
+  }
+
+  beforeAll(function () {
+    window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
+    window.GOVUK.analyticsGa4.vars = window.GOVUK.analyticsGa4.vars || {}
+    window.GOVUK.analyticsGa4.vars.gem_version = 'aVersion'
+  })
+
+  beforeEach(function () {
+    window.dataLayer = []
+    form = document.createElement('form')
+    document.body.appendChild(form)
+
+    form.addEventListener('change', function (e) {
+      var ga4ChangeCategory = e.target.closest('[data-ga4-change-category]')
+      if (ga4ChangeCategory) {
+        ga4ChangeCategory = ga4ChangeCategory.getAttribute('data-ga4-change-category')
+        window.GOVUK.analyticsGa4.Ga4FinderTracker.trackChangeEvent(e.target, ga4ChangeCategory)
+      }
+    })
+
+    expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
+    expected.govuk_gem_version = 'aVersion'
+    expected.event = 'event_data'
+    expected.event_data.type = 'finder'
+    expected.timestamp = '123456'
+
+    agreeToCookies()
+    spyOn(GOVUK.analyticsGa4.core, 'getTimestamp').and.returnValue('123456')
+  })
+
+  afterEach(function () {
+    document.body.removeChild(form)
+  })
+
+  afterAll(function () {
+    window.dataLayer = []
+  })
+
+  it('creates the correct GA4 object for a search box keyword update', function () {
+    inputParent = document.createElement('div')
+    inputParent.setAttribute('data-ga4-change-category', 'update-keyword text')
+
+    input = document.createElement('input')
+    input.setAttribute('type', 'search')
+    input.value = 'Hello world my postcode is SW1A 0AA. My email is email@example.com'
+
+    inputParent.appendChild(input)
+    form.appendChild(inputParent)
+
+    window.GOVUK.triggerEvent(input, 'change')
+
+    expected.event_data.event_name = 'search'
+    expected.event_data.url = window.location.pathname
+    expected.event_data.text = 'hello world my postcode is [postcode]. my email is [email]'
+    expected.event_data.section = 'Search'
+    expected.event_data.action = 'search'
+
+    expect(window.dataLayer[0]).toEqual(expected)
+  })
+
+  it('trims extra spaces and converts downcases characters on a search box keyword update', function () {
+    inputParent = document.createElement('div')
+    inputParent.setAttribute('data-ga4-change-category', 'update-keyword text')
+
+    input = document.createElement('input')
+    input.setAttribute('type', 'search')
+    input.value = ' I    have a lot of   SPACES   in a lot of PLACES         \n \r'
+
+    inputParent.appendChild(input)
+    form.appendChild(inputParent)
+
+    window.GOVUK.triggerEvent(input, 'change')
+
+    expected.event_data.event_name = 'search'
+    expected.event_data.url = window.location.pathname
+    expected.event_data.text = 'i have a lot of spaces in a lot of places'
+    expected.event_data.section = 'Search'
+    expected.event_data.action = 'search'
+
+    expect(window.dataLayer[0]).toEqual(expected)
+  })
+
+  it('replaces + characters with spaces on a search box keyword update', function () {
+    inputParent = document.createElement('div')
+    inputParent.setAttribute('data-ga4-change-category', 'update-keyword text')
+
+    input = document.createElement('input')
+    input.setAttribute('type', 'search')
+    input.value = 'i+have%2Bspaces+in+places'
+
+    inputParent.appendChild(input)
+    form.appendChild(inputParent)
+
+    window.GOVUK.triggerEvent(input, 'change')
+
+    expected.event_data.event_name = 'search'
+    expected.event_data.url = window.location.pathname
+    expected.event_data.text = 'i have spaces in places'
+    expected.event_data.section = 'Search'
+    expected.event_data.action = 'search'
+
+    expect(window.dataLayer[0]).toEqual(expected)
+  })
+
+  it('creates the correct GA4 object for adding/removing a checkbox filter', function () {
+    inputParent = document.createElement('div')
+    inputParent.setAttribute('data-ga4-change-category', 'update-filter checkbox')
+    inputParent.setAttribute('data-ga4-filter-parent', '')
+    inputParent.setAttribute('data-ga4-section', 'Your favourite chocolate')
+    var index = { index_section: 1, index_section_count: 1 }
+    inputParent.setAttribute('data-ga4-index', JSON.stringify(index))
+
+    input = document.createElement('input')
+    input.setAttribute('type', 'checkbox')
+    input.id = 'checkbox'
+    input.checked = true
+    label = document.createElement('label')
+    label.setAttribute('for', 'checkbox')
+    label.innerText = 'All types of chocolate'
+
+    inputParent.appendChild(input)
+    inputParent.appendChild(label)
+    form.appendChild(inputParent)
+
+    window.GOVUK.triggerEvent(input, 'change')
+
+    expected.event_data.event_name = 'select_content'
+    expected.event_data.section = 'Your favourite chocolate'
+    expected.event_data.text = 'All types of chocolate'
+    expected.event_data.action = 'select'
+    expected.event_data.index = { index_section: '1', index_section_count: '1', index_link: undefined }
+
+    expect(window.dataLayer[0]).toEqual(expected)
+
+    input.checked = false
+    window.GOVUK.triggerEvent(input, 'change')
+
+    expected.event_data.action = 'remove'
+    expected.event_data.index = { index_section: '1', index_section_count: '1', index_link: undefined }
+
+    expect(window.dataLayer[1]).toEqual(expected)
+  })
+
+  it('creates the correct GA4 object for adding/removing a radio filter', function () {
+    inputParent = document.createElement('div')
+    inputParent.setAttribute('data-ga4-change-category', 'update-filter radio')
+    inputParent.setAttribute('data-ga4-filter-parent', '')
+    inputParent.setAttribute('data-ga4-section', 'Your favourite chocolate')
+    var index = { index_section: 1, index_section_count: 1 }
+    inputParent.setAttribute('data-ga4-index', JSON.stringify(index))
+
+    option1 = document.createElement('input')
+    option1.setAttribute('type', 'radio')
+    option1.id = 'radio1'
+    option1.setAttribute('name', 'chocolates')
+    label = document.createElement('label')
+    label.setAttribute('for', 'radio1')
+    label.innerText = 'All types of chocolate (default)'
+
+    option2 = document.createElement('input')
+    option2.setAttribute('type', 'radio')
+    option2.setAttribute('name', 'chocolates')
+    option2.id = 'radio2'
+    label2 = document.createElement('label')
+    label2.setAttribute('for', 'radio2')
+    label2.innerText = 'Belgian chocolate'
+
+    inputParent.appendChild(option1)
+    inputParent.appendChild(label)
+    inputParent.appendChild(option2)
+    inputParent.appendChild(label2)
+    form.appendChild(inputParent)
+
+    option1.checked = false
+    option2.checked = true
+
+    window.GOVUK.triggerEvent(option2, 'change')
+
+    expected.event_data.event_name = 'select_content'
+    expected.event_data.section = 'Your favourite chocolate'
+    expected.event_data.text = 'Belgian chocolate'
+    expected.event_data.action = 'select'
+    expected.event_data.index = { index_section: '1', index_section_count: '1', index_link: undefined }
+
+    expect(window.dataLayer[0]).toEqual(expected)
+
+    option1.checked = true
+    option2.checked = false
+    window.GOVUK.triggerEvent(option1, 'change')
+
+    expected.event_data.action = 'remove'
+    expected.event_data.index = { index_section: '1', index_section_count: '1', index_link: undefined }
+    expected.event_data.text = 'All types of chocolate (default)'
+
+    expect(window.dataLayer[1]).toEqual(expected)
+  })
+
+  it('creates the correct GA4 object for adding/removing a <select> filter', function () {
+    inputParent = document.createElement('div')
+    inputParent.setAttribute('data-ga4-change-category', 'update-filter select')
+    inputParent.setAttribute('data-ga4-filter-parent', '')
+    inputParent.setAttribute('data-ga4-section', 'Your favourite chocolate')
+    var index = { index_section: 5, index_section_count: 15 }
+    inputParent.setAttribute('data-ga4-index', JSON.stringify(index))
+
+    input = document.createElement('select')
+    input.setAttribute('name', 'chocolates')
+    input.id = 'chocolates'
+
+    // This is the first/default option, so "adding a filter" means selecting any <option> other than this one.
+    option1 = document.createElement('option')
+    option1.value = 'all-types'
+    option1.innerText = 'All types of chocolate (default)'
+    input.appendChild(option1)
+
+    option2 = document.createElement('option')
+    option2.setAttribute('value', 'belgian-chocolate')
+    option2.innerText = 'Belgian chocolate'
+    input.appendChild(option2)
+
+    input.value = 'belgian-chocolate'
+
+    inputParent.appendChild(input)
+    form.appendChild(inputParent)
+
+    window.GOVUK.triggerEvent(input, 'change')
+
+    expected.event_data.event_name = 'select_content'
+    expected.event_data.section = 'Your favourite chocolate'
+    expected.event_data.text = 'Belgian chocolate'
+    expected.event_data.action = 'select'
+    expected.event_data.index = { index_section: '5', index_section_count: '15', index_link: undefined }
+
+    expect(window.dataLayer[0]).toEqual(expected)
+
+    input.value = 'all-types'
+    window.GOVUK.triggerEvent(input, 'change')
+
+    expected.event_data.action = 'remove'
+    expected.event_data.index = { index_link: undefined, index_section: '5', index_section_count: '15' }
+    expected.event_data.text = 'All types of chocolate (default)'
+
+    expect(window.dataLayer[1]).toEqual(expected)
+
+    // Ensure the section changes when data-ga4-section is set on individual inputs within the same data-ga4-filter-parent
+    var input2 = document.createElement('select')
+    input2.setAttribute('name', 'chocolates')
+    input2.setAttribute('data-ga4-section', 'Your second favourite chocolate')
+    input2.id = 'chocolates2'
+    input2.appendChild(option1)
+    input2.appendChild(option2)
+    inputParent.appendChild(input2)
+
+    window.GOVUK.triggerEvent(input2, 'change')
+
+    expected.event_data.event_name = 'select_content'
+    expected.event_data.section = 'Your second favourite chocolate'
+    expected.event_data.text = 'Belgian chocolate'
+    expected.event_data.action = 'select'
+    expected.event_data.index = { index_section: 5, index_section_count: 15, index_link: undefined }
+  })
+
+  it('creates the correct GA4 object for adding/removing a text filter', function () {
+    inputParent = document.createElement('div')
+    inputParent.setAttribute('data-ga4-change-category', 'update-filter text')
+    inputParent.setAttribute('data-ga4-filter-parent', '')
+    inputParent.setAttribute('data-ga4-section', 'Your favourite chocolate')
+    var index = { index_section: 2, index_section_count: 2 }
+    inputParent.setAttribute('data-ga4-index', JSON.stringify(index))
+
+    input = document.createElement('input')
+    input.setAttribute('type', 'text')
+    input.value = 'Here is an email that should not get redacted email@example.com'
+
+    inputParent.appendChild(input)
+    form.appendChild(inputParent)
+
+    window.GOVUK.triggerEvent(input, 'change')
+
+    expected.event_data.event_name = 'select_content'
+    expected.event_data.section = 'Your favourite chocolate'
+    expected.event_data.text = 'Here is an email that should not get redacted email@example.com'
+    expected.event_data.action = 'search'
+    expected.event_data.index = { index_section: '2', index_section_count: '2', index_link: undefined }
+
+    expect(window.dataLayer[0]).toEqual(expected)
+
+    input.value = ''
+    window.GOVUK.triggerEvent(input, 'change')
+
+    expected.event_data.action = 'remove'
+    expected.event_data.index = { index_section: '2', index_section_count: '2', index_link: undefined }
+    expected.event_data.text = undefined
+
+    expect(window.dataLayer[1]).toEqual(expected)
+  })
+
+  it('creates the correct GA4 object for adding/removing a date filter', function () {
+    inputParent = document.createElement('div')
+    inputParent.setAttribute('class', 'govuk-date-input')
+    inputParent.setAttribute('data-ga4-change-category', 'update-filter date')
+    inputParent.setAttribute('data-ga4-filter-parent', '')
+    inputParent.setAttribute('data-ga4-section', 'Last time you ate chocolate')
+    const index = { index_section: 3, index_section_count: 3 }
+    inputParent.setAttribute('data-ga4-index', JSON.stringify(index))
+
+    const legend = document.createElement('legend')
+    inputParent.appendChild(legend)
+    const dayInput = document.createElement('input')
+    dayInput.setAttribute('type', 'number')
+    inputParent.appendChild(dayInput)
+    const monthInput = document.createElement('input')
+    monthInput.setAttribute('type', 'number')
+    inputParent.appendChild(monthInput)
+    const yearInput = document.createElement('input')
+    yearInput.setAttribute('type', 'number')
+    inputParent.appendChild(yearInput)
+    form.appendChild(inputParent)
+
+    // Filling in just day does not trigger event
+    dayInput.value = '13'
+    window.GOVUK.triggerEvent(dayInput, 'change')
+    expect(window.dataLayer.length).toEqual(0)
+
+    // Filling in month still does not trigger event
+    monthInput.value = '12'
+    window.GOVUK.triggerEvent(monthInput, 'change')
+    expect(window.dataLayer.length).toEqual(0)
+
+    // Finally filling in year triggers event
+    yearInput.value = '1989'
+    window.GOVUK.triggerEvent(yearInput, 'change')
+
+    expected.event_data.event_name = 'select_content'
+    expected.event_data.section = 'Last time you ate chocolate'
+    expected.event_data.text = '13/12/1989'
+    expected.event_data.action = 'select'
+    expected.event_data.index = { index_section: '3', index_section_count: '3', index_link: undefined }
+    expect(window.dataLayer.length).toEqual(1)
+    expect(window.dataLayer[0]).toEqual(expected)
+
+    dayInput.value = ''
+    monthInput.value = ''
+    window.GOVUK.triggerEvent(yearInput, 'change')
+
+    // Clearing two out of three fields does not trigger an event
+    expect(window.dataLayer.length).toEqual(1)
+
+    yearInput.value = ''
+    window.GOVUK.triggerEvent(yearInput, 'change')
+
+    // Removing the final field triggers an event
+    expected.event_data.action = 'remove'
+    expected.event_data.text = ''
+    expect(window.dataLayer.length).toEqual(2)
+    expect(window.dataLayer[1]).toEqual(expected)
+  })
+
+  it('creates the correct GA4 object for clearing all filters', function () {
+    form.setAttribute('data-ga4-change-category', 'clear-all-filters')
+
+    window.GOVUK.triggerEvent(form, 'change')
+
+    expected.event_data.event_name = 'select_content'
+    expected.event_data.action = 'remove'
+    expected.event_data.text = 'Clear all filters'
+
+    expect(window.dataLayer[0]).toEqual(expected)
+  })
+
+  it('creates the correct GA4 object for changing the sort selection', function () {
+    inputParent = document.createElement('div')
+    inputParent.setAttribute('data-ga4-change-category', 'update-sort select')
+    var index = { index_section: 1, index_section_count: 1, index_link: undefined }
+    inputParent.setAttribute('data-ga4-index', JSON.stringify(index))
+
+    input = document.createElement('select')
+    input.setAttribute('name', 'sort')
+    input.id = 'sort'
+
+    option1 = document.createElement('option')
+    option1.value = 'most-viewed'
+    option1.innerText = 'Most viewed'
+    input.appendChild(option1)
+
+    inputParent.appendChild(input)
+    form.appendChild(inputParent)
+
+    window.GOVUK.triggerEvent(input, 'change')
+
+    expected.event_data.event_name = 'select_content'
+    expected.event_data.section = 'Sort by'
+    expected.event_data.text = 'Most viewed'
+    expected.event_data.action = 'sort'
+
+    expect(window.dataLayer[0]).toEqual(expected)
+  })
+
+  it('does nothing if the elementType or changeType does not exist', function () {
+    inputParent = document.createElement('div')
+    input = document.createElement('input')
+    input.setAttribute('type', 'text')
+    input.id = 'textInput'
+
+    inputParent.appendChild(input)
+    form.appendChild(inputParent)
+
+    window.GOVUK.triggerEvent(input, 'change')
+    expect(window.dataLayer.length).toEqual(0)
+  })
+})


### PR DESCRIPTION
- **Migrate ga4-finder-tracker into this repo**
- **Add documentation**
- **Add GA4 tracking to finder filters expanding/collapsing**
- **Remove extra spaces and uppercase on finder search terms**
- **Fix failing tests**
- **Split data-ga4-section into two attributes so that sections can be set on individual filter inputs**
- **Move GA4 test**
- **Finder tracker flatten GA4 attributes**
- **Fix failing test**
- **Run search term standardise function on GA4 search event**
- **WIP: Add ga4-index data attrs in Ruby vs JS**
- **Pass GA4 tracking attributes to components**
- **Fix test failures**
- **Update path for closest.js polyfill**
- **Remove polyfill**
- **Update `govuk_publishing_components` to 43.4.1; fix GA4 spec**
- **GA4 finder tracker: Include index details on removal**
- **GA4 finder tracker: Handle new three-field date facets**
- **GA4 Finder tracker: Use `let`/`const` instead of `var`**

## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
<!-- What are the reasons behind this change being made? -->

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

### Before


### After
