### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+    ignore:
+      - dependency-name: "govuk-frontend"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## What
Temporarily prevent dependabot raising a PR to bump to version 5.10 on govuk-frontend

## Why
Because the Navigation team is managing the release of this version

https://trello.com/c/jVOUaVEZ/3460-pin-govuk-publishing-components-on-version-59-of-govuk-frontend