### PR TITLE
`populateEcommerceSchema` can use `data-ga4-ecommerce-item-name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Table: add ability to specify column width ([PR #4760](https://github.com/alphagov/govuk_publishing_components/pull/4760))
 * Move `Ga4FinderTracker` back into `govuk_publishing_components` ([PR #4774](https://github.com/alphagov/govuk_publishing_components/pull/4774))
 * Update super navigation menu button toggle states ([PR #4771](https://github.com/alphagov/govuk_publishing_components/pull/4771))
+* `populateEcommerceSchema` can use `data-ga4-ecommerce-item-name` ([PR #4786](https://github.com/alphagov/govuk_publishing_components/pull/4786))
 
 ## 56.2.2
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -364,7 +364,7 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
           ecommerceSchema.search_results.ecommerce.items.push({
             item_id: target.getAttribute('data-ga4-ecommerce-path'),
             item_content_id: target.getAttribute('data-ga4-ecommerce-content-id') || undefined,
-            item_name: target.textContent,
+            item_name: target.getAttribute('data-ga4-ecommerce-item-name') || target.textContent,
             item_list_name: listTitle,
             index: window.GOVUK.analyticsGa4.core.ecommerceHelperFunctions.getIndex(target, startPosition)
           })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-ecommerce-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-ecommerce-tracker.spec.js
@@ -280,6 +280,7 @@ describe('Google Analytics 4 ecommerce tracking', function () {
       }
 
       resultToBeClicked = document.querySelector("[data-ga4-ecommerce-path='/foreign-travel-advice']")
+      resultToBeClicked.removeAttribute('data-ga4-ecommerce-item-name')
       GOVUK.analyticsGa4.analyticsModules.Ga4SpecialistLinkTracker.internalLinksDomain = 'www.gov.uk/'
       GOVUK.analyticsGa4.analyticsModules.Ga4SpecialistLinkTracker.internalLinksDomainWithoutWww = 'gov.uk/'
     })
@@ -317,6 +318,18 @@ describe('Google Analytics 4 ecommerce tracking', function () {
 
     it('should set the remaining properties appropriately', function () {
       GOVUK.analyticsGa4.Ga4EcommerceTracker.init()
+
+      resultToBeClicked.click()
+      expect(window.dataLayer[3].event).toBe(onSearchResultClickExpected.event)
+      expect(window.dataLayer[3].search_results).toEqual(onSearchResultClickExpected.search_results)
+    })
+
+    it('should use data-ga4-ecommerce-item-name to set item_name property if present', function () {
+      GOVUK.analyticsGa4.Ga4EcommerceTracker.init()
+
+      var differentListItemName = 'different list item name'
+      onSearchResultClickExpected.search_results.ecommerce.items[0].item_name = differentListItemName
+      resultToBeClicked.dataset.ga4EcommerceItemName = differentListItemName
 
       resultToBeClicked.click()
       expect(window.dataLayer[3].event).toBe(onSearchResultClickExpected.event)


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

`populateEcommerceSchema` can populate the `item_name` of the fired event data with a data attribute (`data-ga4-ecommerce-item-name`) assigned to the clicked target or the text of the clicked target if the data attribute is not defined.

## Why
<!-- What are the reasons behind this change being made? -->

There are instances in which the link being clicked might not have text which describes the item it is associated with. In whitehall and other publishing applications, the search results are in a table and the link can be one of several to be displayed depending on the user and the content. This is also in line with the other attributes of the event data that can be set using data attributes.
