### PR TITLE
Add line separator between open search button and cookie banner

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -92,8 +92,6 @@ $after-button-padding-left: govuk-spacing(4);
 // Header layout - black bar and logo.
 .gem-c-layout-super-navigation-header {
   background: govuk-colour("black");
-  border-top: 1px solid govuk-colour("black");
-  margin-top: -1px;
   position: relative;
 
   [hidden] {
@@ -103,7 +101,6 @@ $after-button-padding-left: govuk-spacing(4);
 
 .gem-c-layout-super-navigation-header--blue-background {
   background: $govuk-brand-colour;
-  border-top: 1px solid $govuk-brand-colour;
 }
 
 .gem-c-layout-super-navigation-header__container {
@@ -146,6 +143,24 @@ $after-button-padding-left: govuk-spacing(4);
   float: left;
   margin: 0;
   padding: 0;
+  position: relative;
+
+  &::before {
+    background-color: govuk-colour("black");
+    content: "";
+    height: 1px;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 100%;
+    z-index: 1;
+  }
+
+  .gem-c-layout-super-navigation-header--blue-background & {
+    &::before {
+      background-color: $govuk-brand-colour;
+    }
+  }
 }
 
 // Top level navigation links and search link, used when JavaScript is not available
@@ -636,7 +651,6 @@ $after-button-padding-left: govuk-spacing(4);
     @include govuk-focused-text;
     border-color: $govuk-focus-colour;
     box-shadow: none;
-    z-index: 11;
 
     @media (hover: hover) and (pointer: fine) {
       &:hover {


### PR DESCRIPTION
## What

- Add line separator between open search button and cookie banner
- Reduce height of menu slightly to be consistent with the [GOV.UK Header](https://design-system.service.gov.uk/components/header/)

## Why

Fix an old issue https://github.com/alphagov/govuk_publishing_components/issues/2331 where a 1px separator appeared between the open search button and the cookie banner. This separator was previously only visible for the open menu button, not the search button.

## Visual Changes

### Mobile, open

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/33263967-bd8e-4960-899a-ac146b33c668">
</td>
<td><img src="https://github.com/user-attachments/assets/f002ccf2-0408-4b5f-9562-7c19c87f19bd">
</td>
</tr>
</table>

### Mobile, open, focused, no difference

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/0154783a-877f-4d67-9485-fe735bbd8df6">
</td>
<td><img src="https://github.com/user-attachments/assets/de00c126-28de-4352-a545-6e3ac525a899">
</td>
</tr>
</table>

### Before, Tablet, open

![www gov uk_(iPad Air)](https://github.com/user-attachments/assets/a7467cdb-7a2e-4363-b8f2-d0a1b53a1b28)

### After, Tablet, open

![127 0 0 1_3005_(iPad Air)](https://github.com/user-attachments/assets/ed042135-3305-4031-8368-169dcffb76d5)

### Before, Tablet, open, focused, no difference

![www gov uk_(iPad Air) (1)](https://github.com/user-attachments/assets/0ae6129d-8d7a-49fd-91e9-76a2b90077e4)

### After, Tablet, open, focused, no difference

![127 0 0 1_3005_(iPad Air) (1)](https://github.com/user-attachments/assets/a78e8523-6918-4def-974b-5faed9358b74)

## Anything else

I removed the `z-index: 11` style from `gem-c-layout-super-navigation-header__search-toggle-button` in the focus-and-focus-visible mixin. Previously, this seems to have been used to let the focused button overlap the vertical pipe separator, but that behaviour no longer appears to be present. Whether that change was intentional i'm not sure. Currently, the z-index has no visible effect but interferes with new styles, preventing the top line from appearing when the button is focused.

### Before, with z-index enabled

<img width="1567" alt="Screenshot 2025-05-08 at 13 17 33" src="https://github.com/user-attachments/assets/700d6e4f-ff06-4a90-b5c1-cbf8d4545405" />

### After, with z-index disabled

<img width="1567" alt="Screenshot 2025-05-08 at 13 17 44" src="https://github.com/user-attachments/assets/02fa6d35-7151-4191-9f2f-45ff276a314c" />