### PR TITLE
Stop YouTube links being enhanced when they shouldn't

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Stop YT links being enhanced when they shouldn't ([PR #4798](https://github.com/alphagov/govuk_publishing_components/pull/4798))
+
 ## 56.3.0
 
 * Update to LUX 4.1.1 ([PR #4778](https://github.com/alphagov/govuk_publishing_components/pull/4778))

--- a/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
@@ -23,6 +23,12 @@
     for (var i = 0; i < $youtubeLinks.length; ++i) {
       var $link = $youtubeLinks[i]
       var $linkParent = $link.closest('p')
+
+      // Only replace the <p> with a YT embed if the YT link is the only thing in the <p>.
+      // This prevents other content in the <p> being lost.
+      if ($linkParent.innerHTML !== $link.outerHTML) {
+        continue
+      }
       var href = $link.getAttribute('href')
       var text = $link.textContent
       var placeholder = document.createElement('p')
@@ -88,6 +94,12 @@
 
     var parentPara = $link.parentNode
     var parentContainer = parentPara.parentNode
+
+    // Only replace the <p> with a YT embed if the YT link is the only thing in the <p>.
+    // This prevents other content in the <p> being lost.
+    if (parentPara.innerHTML !== $link.outerHTML) {
+      return
+    }
 
     var youtubeVideoContainer = document.createElement('div')
     youtubeVideoContainer.className += this.$classOverride

--- a/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
@@ -22,6 +22,11 @@
     var $youtubeLinks = this.$element.querySelectorAll('a[href*="youtube.com"], a[href*="youtu.be"]')
     for (var i = 0; i < $youtubeLinks.length; ++i) {
       var $link = $youtubeLinks[i]
+
+      if (this.hasDisabledEmbed($link)) {
+        continue
+      }
+
       var $linkParent = $link.closest('p')
 
       // Only replace the <p> with a YT embed if the YT link is the only thing in the <p>.

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -1027,12 +1027,22 @@ examples:
       block: |
         <p>This content has a YouTube video link, converted to an accessible embedded player by component JavaScript. Bear in mind that the link will not convert if the paragraph it is in contains other content.</p>
         <p><a href="https://www.youtube.com/watch?v=y6hbrS3DheU">Operations: a developer's guide, by Anna Shipman</a></p>
-  youtube_embed_disabled:
+  youtube_embed_disabled_by_component:
     data:
       disable_youtube_expansions: true
       block: |
-        <p>This content has a YouTube video link, where the govspeak expansion has been disabled</p>
+        <p>This content has a YouTube video link, where the govspeak expansion has been disabled by the render statement for the component.</p>
         <p><a href="https://www.youtube.com/watch?v=y6hbrS3DheU">Operations: a developer's guide, by Anna Shipman</a></p>
+  youtube_embed_disabled_by_content:
+    description: YouTube links should not become an embed if the YouTube link is in a paragraph with other content.
+    data:
+      block: |
+        <p>This youtube video titled <a href="https://www.youtube.com/watch?v=y6hbrS3DheU">Operations: a developer's guide, by Anna Shipman</a> should stay as a link due to this non-link text existing in the paragraph.</p>
+  youtube_embed_disabled_by_editors:
+    description: Editors can disable YouTube link enhancement by using the `data-youtube-player="off"` HTML attribute.
+    data:
+      block: |
+        <p><a href="https://www.youtube.com/watch?v=y6hbrS3DheU" data-youtube-player="off">Operations: a developer's guide, by Anna Shipman</a></p>
   youtube_livestream:
     data:
       block: |

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -1025,7 +1025,7 @@ examples:
   youtube_embed:
     data:
       block: |
-        <p>This content has a YouTube video link, converted to an accessible embedded player by component JavaScript.</p>
+        <p>This content has a YouTube video link, converted to an accessible embedded player by component JavaScript. Bear in mind that the link will not convert if the paragraph it is in contains other content.</p>
         <p><a href="https://www.youtube.com/watch?v=y6hbrS3DheU">Operations: a developer's guide, by Anna Shipman</a></p>
   youtube_embed_disabled:
     data:
@@ -1036,5 +1036,5 @@ examples:
   youtube_livestream:
     data:
       block: |
-        <p>This content has a YouTube livestream link, converted to an accessible embedded player by component JavaScript.</p>
+        <p>This content has a YouTube livestream link, converted to an accessible embedded player by component JavaScript. Bear in mind that the link will not convert if the paragraph it is in contains other content.</p>
         <p><a href="https://www.youtube.com/embed/live_stream?channel=UCoMdktPbSTixAyNGwb-UYkQ">Livestream video</a></p>

--- a/spec/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement-spec.js
@@ -165,6 +165,63 @@ describe('Youtube link enhancement', function () {
       expect(document.querySelectorAll('.gem-c-govspeak__youtube-placeholder a[href="https://youtu.be/_cyI7DMhgYc?si=A3Z-BiCIDRtOu27t"]').length).toBe(1)
       expect(document.querySelector('.gem-c-govspeak__youtube-placeholder a[href="https://youtu.be/_cyI7DMhgYc?si=A3Z-BiCIDRtOu27t"]').textContent).toBe('What are the Discovery, Alpha, Beta and Live stages in developing a service?')
     })
+
+    it('doesn\'t add "How to watch this video" when embedding is set to disabled', function () {
+      window.GOVUK.cookie('cookies_policy', JSON.stringify({ campaigns: false }))
+
+      container.innerHTML = `
+        <div class="gem-c-govspeak">
+          <p><a href="https://www.youtube.com/watch?v=0XpAtr24uUQ" data-youtube-player="off">Agile at GDS</a></p>
+          <p><a href="https://youtu.be/_cyI7DMhgYc?si=A3Z-BiCIDRtOu27t" data-youtube-player="off">What are the Discovery, Alpha, Beta and Live stages in developing a service?</a></p>
+        </div>
+      `
+      document.body.appendChild(container)
+
+      var element = document.querySelector('.gem-c-govspeak')
+      var enhancement = new GOVUK.GovspeakYoutubeLinkEnhancement(element)
+      enhancement.init()
+
+      expect(document.querySelectorAll('.gem-c-govspeak__youtube-video').length).toBe(0)
+      expect(document.querySelectorAll('.gem-c-govspeak .gem-c-govspeak__youtube-placeholder-link').length).toBe(0)
+      expect(document.querySelectorAll('.gem-c-govspeak__youtube-placeholder').length).toBe(0)
+
+      expect(document.querySelectorAll('.gem-c-govspeak a[href="https://www.youtube.com/watch?v=0XpAtr24uUQ"]').length).toBe(1)
+      expect(document.querySelector('.gem-c-govspeak a[href="https://www.youtube.com/watch?v=0XpAtr24uUQ"]').textContent).toBe('Agile at GDS')
+
+      expect(document.querySelectorAll('.gem-c-govspeak a[href="https://youtu.be/_cyI7DMhgYc?si=A3Z-BiCIDRtOu27t"]').length).toBe(1)
+      expect(document.querySelector('.gem-c-govspeak a[href="https://youtu.be/_cyI7DMhgYc?si=A3Z-BiCIDRtOu27t"]').textContent).toBe('What are the Discovery, Alpha, Beta and Live stages in developing a service?')
+    })
+
+    it('doesn\'t add "How to watch this video" to some links when only a few are set to disabled', function () {
+      window.GOVUK.cookie('cookies_policy', JSON.stringify({ campaigns: false }))
+
+      container.innerHTML = `
+        <div class="gem-c-govspeak">
+          <p><a href="https://www.youtube.com/watch?v=0XpAtr24uUQ">Agile at GDS</a></p>
+          <p><a href="https://www.youtube.com/watch?v=0XpAtr24uUQ?example=2" data-youtube-player="off">Agile at GDS Part 2</a></p>
+          <p><a href="https://youtu.be/_cyI7DMhgYc?si=A3Z-BiCIDRtOu27t">What are the Discovery, Alpha, Beta and Live stages in developing a service?</a></p>
+        </div>
+      `
+      document.body.appendChild(container)
+
+      var element = document.querySelector('.gem-c-govspeak')
+      var enhancement = new GOVUK.GovspeakYoutubeLinkEnhancement(element)
+      enhancement.init()
+
+      expect(document.querySelectorAll('.gem-c-govspeak__youtube-video').length).toBe(0)
+      expect(document.querySelectorAll('.gem-c-govspeak .gem-c-govspeak__youtube-placeholder-link').length).toBe(2)
+      expect(document.querySelectorAll('.gem-c-govspeak__youtube-placeholder').length).toBe(2)
+
+      expect(document.querySelectorAll('.gem-c-govspeak__youtube-placeholder a[href="https://www.youtube.com/watch?v=0XpAtr24uUQ"]').length).toBe(1)
+      expect(document.querySelector('.gem-c-govspeak__youtube-placeholder a[href="https://www.youtube.com/watch?v=0XpAtr24uUQ"]').textContent).toBe('Agile at GDS')
+
+      expect(document.querySelectorAll('.gem-c-govspeak__youtube-placeholder a[href="https://www.youtube.com/watch?v=0XpAtr24uUQ?example=2"]').length).toBe(0)
+      expect(document.querySelectorAll('.gem-c-govspeak a[href="https://www.youtube.com/watch?v=0XpAtr24uUQ?example=2"]').length).toBe(1)
+      expect(document.querySelector('.gem-c-govspeak a[href="https://www.youtube.com/watch?v=0XpAtr24uUQ?example=2"]').textContent).toBe('Agile at GDS Part 2')
+
+      expect(document.querySelectorAll('.gem-c-govspeak__youtube-placeholder a[href="https://youtu.be/_cyI7DMhgYc?si=A3Z-BiCIDRtOu27t"]').length).toBe(1)
+      expect(document.querySelector('.gem-c-govspeak__youtube-placeholder a[href="https://youtu.be/_cyI7DMhgYc?si=A3Z-BiCIDRtOu27t"]').textContent).toBe('What are the Discovery, Alpha, Beta and Live stages in developing a service?')
+    })
   })
 
   describe('parseVideoId', function () {

--- a/spec/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement-spec.js
@@ -74,6 +74,74 @@ describe('Youtube link enhancement', function () {
       expect(document.querySelectorAll('.gem-c-govspeak p, .gem-c-govspeak a').length).toBe(2)
     })
 
+    it('doesn\'t replace links when other content is in the paragraph (cookies enabled)', function () {
+      container.innerHTML =
+        '<div class="gem-c-govspeak" data-module="govspeak">' +
+          '<p>We use <a href="https://www.youtube.com/watch?v=0XpAtr24uUQ">agile at GDS</a> instead of waterfall.</p>' +
+        '</div>'
+      document.body.appendChild(container)
+
+      var element = document.querySelector('.gem-c-govspeak')
+      var enhancement = new GOVUK.GovspeakYoutubeLinkEnhancement(element)
+      enhancement.init()
+      expect(document.querySelectorAll('.gem-c-govspeak__youtube-video').length).toBe(0)
+      expect(document.querySelectorAll('.gem-c-govspeak p, .gem-c-govspeak a').length).toBe(2)
+      expect(document.querySelector('.gem-c-govspeak p').innerText).toBe('We use agile at GDS instead of waterfall.')
+    })
+
+    it('doesn\'t replace links when other HTML is in the paragraph (cookies enabled)', function () {
+      container.innerHTML =
+        '<div class="gem-c-govspeak" data-module="govspeak">' +
+          '<p><img src="agile-gds.png" alt="A sprint board"><a href="https://www.youtube.com/watch?v=0XpAtr24uUQ">agile at GDS</a></p>' +
+        '</div>'
+      document.body.appendChild(container)
+
+      var element = document.querySelector('.gem-c-govspeak')
+      var enhancement = new GOVUK.GovspeakYoutubeLinkEnhancement(element)
+      enhancement.init()
+
+      expect(document.querySelectorAll('.gem-c-govspeak__youtube-video').length).toBe(0)
+      expect(document.querySelectorAll('.gem-c-govspeak p, .gem-c-govspeak img, .gem-c-govspeak a').length).toBe(3)
+      expect(document.querySelector('.gem-c-govspeak p').innerText).toBe('agile at GDS')
+    })
+
+    it('doesn\'t replace links when other content is in the paragraph (cookies disabled)', function () {
+      window.GOVUK.cookie('cookies_policy', JSON.stringify({ campaigns: false }))
+      container.innerHTML =
+        '<div class="gem-c-govspeak" data-module="govspeak">' +
+          '<p>We use <a href="https://www.youtube.com/watch?v=0XpAtr24uUQ">agile at GDS</a> instead of waterfall.</p>' +
+        '</div>'
+      document.body.appendChild(container)
+
+      var element = document.querySelector('.gem-c-govspeak')
+      var enhancement = new GOVUK.GovspeakYoutubeLinkEnhancement(element)
+      enhancement.init()
+      expect(document.querySelectorAll('.gem-c-govspeak__youtube-video').length).toBe(0)
+      expect(document.querySelectorAll('.gem-c-govspeak p, .gem-c-govspeak a').length).toBe(2)
+      expect(document.querySelector('.gem-c-govspeak p').innerText).toBe('We use agile at GDS instead of waterfall.')
+      expect(document.querySelectorAll('.gem-c-govspeak .gem-c-govspeak__youtube-placeholder-link').length).toBe(0)
+      expect(document.querySelectorAll('.gem-c-govspeak__youtube-placeholder').length).toBe(0)
+    })
+
+    it('doesn\'t replace links when other HTML is in the paragraph (cookies disabled)', function () {
+      window.GOVUK.cookie('cookies_policy', JSON.stringify({ campaigns: false }))
+      container.innerHTML =
+        '<div class="gem-c-govspeak" data-module="govspeak">' +
+          '<p><img src="agile-gds.png" alt="A sprint board"><a href="https://www.youtube.com/watch?v=0XpAtr24uUQ">agile at GDS</a></p>' +
+        '</div>'
+      document.body.appendChild(container)
+
+      var element = document.querySelector('.gem-c-govspeak')
+      var enhancement = new GOVUK.GovspeakYoutubeLinkEnhancement(element)
+      enhancement.init()
+
+      expect(document.querySelectorAll('.gem-c-govspeak__youtube-video').length).toBe(0)
+      expect(document.querySelectorAll('.gem-c-govspeak p, .gem-c-govspeak img, .gem-c-govspeak a').length).toBe(3)
+      expect(document.querySelector('.gem-c-govspeak p').innerText).toBe('agile at GDS')
+      expect(document.querySelectorAll('.gem-c-govspeak .gem-c-govspeak__youtube-placeholder-link').length).toBe(0)
+      expect(document.querySelectorAll('.gem-c-govspeak__youtube-placeholder').length).toBe(0)
+    })
+
     it('doesn\'t replace links when a user has revoked campaign cookie consent', function () {
       window.GOVUK.cookie('cookies_policy', JSON.stringify({ campaigns: false }))
 


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- A user reported that a YouTube link they had added to their `govspeak` content was replacing a whole paragraph of their content with our JS YouTube embed, even though they added `data-youtube-player="off"` to the link.
- This has surfaced an issue where paragraphs on pages are being replaced entirely when cookies are disabled.
- There are two reasons for this:
   - Firstly, in general we don't have a check in place to stop paragraphs being replaced when a YouTube link is in a paragraph containing other content. The YouTube link enhancement works by replacing the entire paragraph it's in with the enhancement, but it should only do this if the YouTube link is the only thing in the paragraph. Therefore, there's a risk that bugs (like this one) end up replacing page content.
   - More specifically, currently our cookies rejected "How to watch this video" box is ignoring the `data-youtube-player="off"` attribute and replacing HTML when it shouldn't.
   - These two things combined has led to this bug.

- Therefore, as the user's YouTube link was disabled AND within a paragraph containing other content, our `youtube-link-enhancement` code replaced a whole paragraph of their content with the "How to watch this video" box, hence the user complaint.
- To fix this, I've changed the code so that `data-youtube-player="off"` is checked before rendering the cookies disabled message.
- I've also added a check that ensures our YouTube link enhancement only replaces HTML when the YouTube link is the only thing inside the paragraph.
    - As an aside, you may wonder why we don't just replace the YouTube `<a>` tag with the embed, instead of replacing the parent paragraph. I considered this, but realised that would break content. Editors write sentences like `We have produced an explainer video about the [new project we are working on.]`. If `[new project we are working on]` was a YouTube link and became an embed, the sentence would no longer make sense as it would read as `We have produced an explainer video about the` and then have a YouTube embed.

- A less impactful example of the disabled cookies message showing up when it shouldn't is here: https://www.gov.uk/government/publications/code-compliance-officer-contact-details see how the YouTube video link appears when cookies are accepted vs on incognito mode/rejected cookies.
- Another example is here - they have social media links towards the bottom, which are entirely replaced by the cookies disabled message if your cookies are disabled: https://www.gov.uk/government/news/applications-open-for-fully-funded-opportunities-to-study-in-the-uk

## Why
<!-- What are the reasons behind this change being made? -->
- Trello card: https://trello.com/c/FRxTPCkl/92-govspeak-youtube-embed-replaces-content-paragraph

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

"How to watch this video" boxes shouldn't exist when `data-youtube-player-off` exists or a YouTube link is within other content. Therefore some content on GOVUK may resurface as it'll no longer be replaced by our YouTube embed code.

New examples have been added to the component guide too.