### PR TITLE
`Ga4FormTracker` handles `selectedIndex` of `-1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* `Ga4FormTracker` handles `selectedIndex` of `-1` ([PR #4803](https://github.com/alphagov/govuk_publishing_components/pull/4803))
+
 ## 56.3.1
 
 * Stop YT links being enhanced when they shouldn't ([PR #4798](https://github.com/alphagov/govuk_publishing_components/pull/4798))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
@@ -86,7 +86,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
       if (inputType === 'checkbox' && elem.checked) {
         input.answer = labelText
-      } else if (inputNodename === 'SELECT' && elem.options[elem.selectedIndex].value) {
+      } else if (inputNodename === 'SELECT' && elem.options[elem.selectedIndex] && elem.options[elem.selectedIndex].value) {
         input.answer = elem.options[elem.selectedIndex].text
       } else if (inputTypes.indexOf(inputType) !== -1 && elem.value) {
         if (this.includeTextInputValues || elem.hasAttribute('data-ga4-form-include-input')) {


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

`getInputValues` checks if the option of a `select` at `selectedIndex` exists before accessing `value`.

## Why

If `Ga4FormTracker` ran `getInputValues` on a form with an unselected select, then it would cause an error (as the `selectedIndex` would be equal to `-1`).
