### PR TITLE
Extra meta tags for `PageViewTracker`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * `Ga4FormTracker` handles `selectedIndex` of `-1` ([PR #4803](https://github.com/alphagov/govuk_publishing_components/pull/4803))
+* Extra meta tags for `PageViewTracker` ([PR #4804](https://github.com/alphagov/govuk_publishing_components/pull/4804/))
 
 ## 56.3.1
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
@@ -67,7 +67,11 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
             tool_name: this.getToolName(),
             spelling_suggestion: this.getMetaContent('spelling-suggestion'),
             discovery_engine_attribution_token: this.getMetaContent('discovery-engine-attribution-token'),
-            canonical_url: this.getCanonicalHref()
+            canonical_url: this.getCanonicalHref(),
+
+            user_created_at: this.getMetaContent('user-created-at'),
+            user_organisation_name: this.getMetaContent('user-organisation-name'),
+            user_role: this.getMetaContent('user-role')
           }
         }
         window.GOVUK.analyticsGa4.core.sendData(data)

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
@@ -64,7 +64,11 @@ describe('Google Tag Manager page view tracking', function () {
         tool_name: undefined,
         spelling_suggestion: undefined,
         discovery_engine_attribution_token: undefined,
-        canonical_url: undefined
+        canonical_url: undefined,
+
+        user_created_at: undefined,
+        user_organisation_name: undefined,
+        user_role: undefined
       }
     }
     if (window.location.search) {


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

Add additional meta tags for tracking in `PageViewTracker`.

## Why
<!-- What are the reasons behind this change being made? -->

These meta tags are used in `page_view` events in publishing applications.