### PR TITLE
Fix edge cases with YouTube link enhancement JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * `Ga4FormTracker` handles `selectedIndex` of `-1` ([PR #4803](https://github.com/alphagov/govuk_publishing_components/pull/4803))
 * Extra meta tags for `PageViewTracker` ([PR #4804](https://github.com/alphagov/govuk_publishing_components/pull/4804/))
+* Fix edge cases with YouTube link enhancement JS ([PR #4808](https://github.com/alphagov/govuk_publishing_components/pull/4808))
 
 ## 56.3.1
 

--- a/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
@@ -27,8 +27,7 @@
     var $youtubeLinks = this.$element.querySelectorAll('a[href*="youtube.com"], a[href*="youtu.be"]')
     for (var i = 0; i < $youtubeLinks.length; ++i) {
       var $link = $youtubeLinks[i]
-
-      if (this.hasDisabledEmbed($link)) {
+      if (this.hasDisabledEmbed($link) || $link.getAttribute('href').includes('/playlist')) {
         continue
       }
 

--- a/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
@@ -6,6 +6,7 @@
   var YoutubeLinkEnhancement = function ($element, $classOverride) {
     this.$element = $element
     this.$classOverride = typeof $classOverride !== 'undefined' ? $classOverride : 'gem-c-govspeak__youtube-video'
+    this.punctuationRegex = /[\.!\?"']/g // eslint-disable-line no-useless-escape
   }
 
   YoutubeLinkEnhancement.prototype.init = function () {
@@ -16,6 +17,10 @@
       return
     }
     this.startModule()
+  }
+
+  YoutubeLinkEnhancement.prototype.paragraphHasOtherContent = function (paragraph, link) {
+    return paragraph.innerHTML.replaceAll(this.punctuationRegex, '') !== link.outerHTML.replaceAll(this.punctuationRegex, '')
   }
 
   YoutubeLinkEnhancement.prototype.decorateLink = function () {
@@ -31,7 +36,8 @@
 
       // Only replace the <p> with a YT embed if the YT link is the only thing in the <p>.
       // This prevents other content in the <p> being lost.
-      if ($linkParent.innerHTML !== $link.outerHTML) {
+      // However, if a <p> exists with only a YT link and punctuation, we do allow the punctuation characters to be lost to the YT embed.
+      if (this.paragraphHasOtherContent($linkParent, $link)) {
         continue
       }
       var href = $link.getAttribute('href')
@@ -102,7 +108,8 @@
 
     // Only replace the <p> with a YT embed if the YT link is the only thing in the <p>.
     // This prevents other content in the <p> being lost.
-    if (parentPara.innerHTML !== $link.outerHTML) {
+    // However, if a <p> exists with only a YT link and punctuation, we do allow the punctuation characters to be lost to the YT embed.
+    if (this.paragraphHasOtherContent(parentPara, $link)) {
       return
     }
 

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -1027,6 +1027,11 @@ examples:
       block: |
         <p>This content has a YouTube video link, converted to an accessible embedded player by component JavaScript. Bear in mind that the link will not convert if the paragraph it is in contains other content.</p>
         <p><a href="https://www.youtube.com/watch?v=y6hbrS3DheU">Operations: a developer's guide, by Anna Shipman</a></p>
+  youtube_embed_with_punctuation:
+    description: YouTube links should still be enhanced if punctuation is in the same paragraph but outside the YT <a> tag.
+    data:
+      block: |
+        <p>"<a href="https://www.youtube.com/watch?v=y6hbrS3DheU">Operations: a developer's guide, by Anna Shipman</a>."</p>
   youtube_embed_disabled_by_component:
     data:
       disable_youtube_expansions: true

--- a/spec/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement-spec.js
@@ -89,6 +89,57 @@ describe('Youtube link enhancement', function () {
       expect(document.querySelector('.gem-c-govspeak p').innerText).toBe('We use agile at GDS instead of waterfall.')
     })
 
+    it('does replace links when other punctuation is in the paragraph (cookies enabled)', function () {
+      container.innerHTML =
+        '<div class="gem-c-govspeak" data-module="govspeak">' +
+          '<p><a href="https://www.youtube.com/watch?v=0XpAtr24uUQ">agile at GDS</a>.</p>' +
+          '<p><a href="https://www.youtube.com/watch?v=0XpAtr24uUQ">agile at GDS</a>!</p>' +
+          '<p><a href="https://www.youtube.com/watch?v=0XpAtr24uUQ">agile at GDS</a>?</p>' +
+          '<p>"<a href="https://www.youtube.com/watch?v=0XpAtr24uUQ">agile at GDS</a>"</p>' +
+          '<p>\'<a href="https://www.youtube.com/watch?v=0XpAtr24uUQ">agile at GDS</a>\'</p>' +
+          '<p>"<a href="https://www.youtube.com/watch?v=0XpAtr24uUQ">agile at GDS</a>.?!"</p>' +
+        '</div>'
+      document.body.appendChild(container)
+
+      var element = document.querySelector('.gem-c-govspeak')
+      var enhancement = new GOVUK.GovspeakYoutubeLinkEnhancement(element)
+      enhancement.init()
+      expect(document.querySelectorAll('.gem-c-govspeak__youtube-video').length).toBe(6)
+      expect(document.querySelectorAll('.gem-c-govspeak p, .gem-c-govspeak a').length).toBe(0)
+    })
+
+    it('does replace links when other punctuation is in the paragraph (cookies disabled)', function () {
+      window.GOVUK.cookie('cookies_policy', JSON.stringify({ campaigns: false }))
+
+      container.innerHTML =
+        '<div class="gem-c-govspeak" data-module="govspeak">' +
+          '<p><a href="https://www.youtube.com/watch?v=0XpAtr24uUQ">agile at GDS</a>.</p>' +
+          '<p><a href="https://www.youtube.com/watch?v=0XpAtr24uUQ">agile at GDS</a>!</p>' +
+          '<p><a href="https://www.youtube.com/watch?v=0XpAtr24uUQ">agile at GDS</a>?</p>' +
+          '<p>"<a href="https://www.youtube.com/watch?v=0XpAtr24uUQ">agile at GDS</a>"</p>' +
+          '<p>\'<a href="https://www.youtube.com/watch?v=0XpAtr24uUQ">agile at GDS</a>\'</p>' +
+          '<p>"<a href="https://www.youtube.com/watch?v=0XpAtr24uUQ">agile at GDS</a>.?!"</p>' +
+        '</div>'
+      document.body.appendChild(container)
+
+      var element = document.querySelector('.gem-c-govspeak')
+      var enhancement = new GOVUK.GovspeakYoutubeLinkEnhancement(element)
+      enhancement.init()
+
+      var links = document.querySelectorAll('.gem-c-govspeak .gem-c-govspeak__youtube-placeholder-link')
+      expect(links.length).toBe(6)
+
+      expect(document.querySelectorAll('.gem-c-govspeak__youtube-video').length).toBe(0)
+      expect(document.querySelectorAll('.gem-c-govspeak__youtube-placeholder').length).toBe(6)
+      expect(document.querySelectorAll('.gem-c-govspeak__youtube-placeholder a[href="https://www.youtube.com/watch?v=0XpAtr24uUQ"]').length).toBe(6)
+
+      var expectedLinkText = ['agile at GDS.', 'agile at GDS!', 'agile at GDS?', '"agile at GDS"', '\'agile at GDS\'', '"agile at GDS.?!"']
+
+      for (var i = 0; i < links.length; i++) {
+        expect(links[i].textContent).toBe(expectedLinkText[i])
+      }
+    })
+
     it('doesn\'t replace links when other HTML is in the paragraph (cookies enabled)', function () {
       container.innerHTML =
         '<div class="gem-c-govspeak" data-module="govspeak">' +

--- a/spec/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement-spec.js
@@ -273,6 +273,41 @@ describe('Youtube link enhancement', function () {
       expect(document.querySelectorAll('.gem-c-govspeak__youtube-placeholder a[href="https://youtu.be/_cyI7DMhgYc?si=A3Z-BiCIDRtOu27t"]').length).toBe(1)
       expect(document.querySelector('.gem-c-govspeak__youtube-placeholder a[href="https://youtu.be/_cyI7DMhgYc?si=A3Z-BiCIDRtOu27t"]').textContent).toBe('What are the Discovery, Alpha, Beta and Live stages in developing a service?')
     })
+
+    it('doesn\'t add "How to watch this video" to links that are YT playlists', function () {
+      window.GOVUK.cookie('cookies_policy', JSON.stringify({ campaigns: false }))
+
+      container.innerHTML = `
+        <div class="gem-c-govspeak">
+          <p><a href="https://www.youtube.com/watch?v=0XpAtr24uUQ">Agile at GDS</a></p>
+          <p><a href="https://www.youtube.com/playlist?list=PLFNWGffju2p3CPjLC9eIA3uNmfWjNQjrf">This is a playlist</a></p>
+          <p><a href="https://youtu.be/_cyI7DMhgYc?si=A3Z-BiCIDRtOu27t">What are the Discovery, Alpha, Beta and Live stages in developing a service?</a></p>
+        </div>
+      `
+      document.body.appendChild(container)
+
+      var element = document.querySelector('.gem-c-govspeak')
+      var enhancement = new GOVUK.GovspeakYoutubeLinkEnhancement(element)
+      enhancement.init()
+
+      // Should be zero video enhancements and two cookies disabled messages
+      expect(document.querySelectorAll('.gem-c-govspeak__youtube-video').length).toBe(0)
+      expect(document.querySelectorAll('.gem-c-govspeak .gem-c-govspeak__youtube-placeholder-link').length).toBe(2)
+      expect(document.querySelectorAll('.gem-c-govspeak__youtube-placeholder').length).toBe(2)
+
+      // First link should get the cookies disabled message
+      expect(document.querySelectorAll('.gem-c-govspeak__youtube-placeholder a[href="https://www.youtube.com/watch?v=0XpAtr24uUQ"]').length).toBe(1)
+      expect(document.querySelector('.gem-c-govspeak__youtube-placeholder a[href="https://www.youtube.com/watch?v=0XpAtr24uUQ"]').textContent).toBe('Agile at GDS')
+
+      // Playlist link shouldn't get the cookies disabled message
+      expect(document.querySelectorAll('.gem-c-govspeak__youtube-placeholder a[href="https://www.youtube.com/playlist?list=PLFNWGffju2p3CPjLC9eIA3uNmfWjNQjrf"]').length).toBe(0)
+      expect(document.querySelectorAll('.gem-c-govspeak a[href="https://www.youtube.com/playlist?list=PLFNWGffju2p3CPjLC9eIA3uNmfWjNQjrf"]').length).toBe(1)
+      expect(document.querySelector('.gem-c-govspeak a[href="https://www.youtube.com/playlist?list=PLFNWGffju2p3CPjLC9eIA3uNmfWjNQjrf"]').textContent).toBe('This is a playlist')
+
+      // Third link should get the cookies disabled message
+      expect(document.querySelectorAll('.gem-c-govspeak__youtube-placeholder a[href="https://youtu.be/_cyI7DMhgYc?si=A3Z-BiCIDRtOu27t"]').length).toBe(1)
+      expect(document.querySelector('.gem-c-govspeak__youtube-placeholder a[href="https://youtu.be/_cyI7DMhgYc?si=A3Z-BiCIDRtOu27t"]').textContent).toBe('What are the Discovery, Alpha, Beta and Live stages in developing a service?')
+    })
   })
 
   describe('parseVideoId', function () {


### PR DESCRIPTION
## What/Why
<!-- What are the reasons behind this change being made? -->
- There are a couple of edge cases in our YouTube embed code which this PR addresses.
- The first one was the result of something I introduced in https://github.com/alphagov/govuk_publishing_components/pull/4798. In this PR, I made it so that a YouTube link would only enhance into an embed if the YouTube link was the only thing within a `<p>` tag. This was because of a bug on production that was replacing content with YouTube embeds, so this was added as a safety check.
    -  However, there's a use case where editors have a `<p>` that contains a YouTube link and punctuation only. Therefore the existence of the punctuation meant that the safety code was triggerring, and therefore the YouTube link was not turning into an embed. Therefore, I've fixed this by removing punctuation entirely when the string equality check takes place. 
    - Example of the issue in production: 
<img width="469" alt="image" src="https://github.com/user-attachments/assets/9bed774f-4aef-40f2-a5f1-3113ccce706d" />

- The second thing I discovered recently was that YouTube playlist links enhance to the "How to watch this YouTube video" message when cookies aren't accepted. This shouldn't be the case, as YouTube playlist links never enhance into an embed. See an example on production here if you disable cookies/go into incognito mode: https://www.gov.uk/government/publications/code-compliance-officer-contact-details - that cookies disabled message ideally shouldn't exist. Therefore I've added a simple check to stop this happening. 
- Trello card: https://trello.com/c/nwnUVPao/618-allow-youtube-embeds-to-also-work-when-theres-punctuation-in-the-same-paragraph-but-outside-the-link
- More context on Slack: https://gds.slack.com/archives/C06TXUDS5G8/p1747230836274189
## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

- Pages like this one, where a YT link exists with punctuation, should turn into an embed again: https://www.gov.uk/guidance/download-the-hmrc-app
- I've added another example to the govspeak component, just so it's clear exactly that our YT enhancement works with punctuation.
- Pages like this one shouldn't show a cookies disabled message for YouTube playlist links: https://www.gov.uk/government/publications/code-compliance-officer-contact-details


