### PR TITLE
Bump govuk frontend to 5.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "accessible-autocomplete": "^3.0.1",
     "axe-core": "^4.10.3",
-    "govuk-frontend": "5.10.0",
+    "govuk-frontend": "5.10.1",
     "govuk-single-consent": "^3.0.9",
     "sortablejs": "^1.15.6"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1565,10 +1565,10 @@ gopd@^1.2.0:
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
   integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
 
-govuk-frontend@5.10.0:
-  version "5.10.0"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-5.10.0.tgz#812a5a14e4466130603b60b9da3d43a6b06b7069"
-  integrity sha512-9tjpB8PDwsDqutkQPJXfDalLvNOeKxzFhV7me21s/oyn7HcTg/ei/GC3Y4JvNsXauzjOkxv4eeCHntKeySkdMg==
+govuk-frontend@5.10.1:
+  version "5.10.1"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-5.10.1.tgz#5534357267919e26e72cdc028bbad1906b4c9ba1"
+  integrity sha512-VmzKE+pkuOqEXhit0cGqic4i2mOQwflfXDiEcsa6Lrqs//rxV5AYf+C71jbREPwQLH4wYSJAlz/GlGoO5nik7Q==
 
 govuk-single-consent@^3.0.9:
   version "3.0.9"


### PR DESCRIPTION
## What

Bump govuk frontend to 5.10.1

## Why

https://trello.com/c/OtRpnkGg/3473-upgrade-to-govuk-frontend-v5101

## Visual Changes

### Before (Fix unnecessary whitespace after logo)

![127 0 0 1_3005_](https://github.com/user-attachments/assets/bf291ee3-2bc2-49b9-825c-2abeb457cd77)

### After

![127 0 0 1_3005_ (1)](https://github.com/user-attachments/assets/acefc8f8-9ebc-4e99-9c91-ee588a1505b6)

### Before (Fix colour of refreshed GOV.UK logo's dot)

<img width="400" alt="Screenshot 2025-05-15 at 14 20 55" src="https://github.com/user-attachments/assets/8eb2c14a-9db7-4560-80ff-2cc65351e6b0" />

### After

<img width="400" alt="Screenshot 2025-05-15 at 14 24 20" src="https://github.com/user-attachments/assets/f8567f6d-6a58-45a6-8a27-2793684a18b1" />