### PR TITLE
Release version 56.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 56.3.2
 
 * `Ga4FormTracker` handles `selectedIndex` of `-1` ([PR #4803](https://github.com/alphagov/govuk_publishing_components/pull/4803))
 * Extra meta tags for `PageViewTracker` ([PR #4804](https://github.com/alphagov/govuk_publishing_components/pull/4804/))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (56.3.1)
+    govuk_publishing_components (56.3.2)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "56.3.1".freeze
+  VERSION = "56.3.2".freeze
 end


### PR DESCRIPTION
## 56.3.2

* `Ga4FormTracker` handles `selectedIndex` of `-1` ([PR #4803](https://github.com/alphagov/govuk_publishing_components/pull/4803))
* Extra meta tags for `PageViewTracker` ([PR #4804](https://github.com/alphagov/govuk_publishing_components/pull/4804/))
* Fix edge cases with YouTube link enhancement JS ([PR #4808](https://github.com/alphagov/govuk_publishing_components/pull/4808))