### PR TITLE
Add middleware to optimise GA4 Attributes by reducing unnecessary escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add middleware to optimise GA4 Attributes by reducing unnecessary escaping ([PR #4813](https://github.com/alphagov/govuk_publishing_components/pull/4813))
 * Add support for exceptions to `Ga4CopyTracker` ([PR #4823](https://github.com/alphagov/govuk_publishing_components/pull/4823))
 
 ## 57.0.0

--- a/docs/analytics-ga4/middleware.md
+++ b/docs/analytics-ga4/middleware.md
@@ -1,0 +1,31 @@
+# Using our GA4 optimisation middleware in your application
+
+If you are a developer on GOV.UK working on an app that does not use the slimmer gem, ga4 data
+attributes will be quite large in the generated HTML code. This is because the attributes contain
+JSON, which has a lot of double quotes. By default these are escaped in the rails stack, resulting
+in each double quote being expanded into six characters: `&quot;`. This can add up, especially
+in long lists of tracked links like the footer or the super navigation header.
+
+In slimmer-based apps, as part of the insertion of the page into the static layout the entire HTML
+tree is parsed, manipulated, and written out again. This writing process appears to inclue some
+optimisations - the wrapping characters of these attributes are changed to single-quotes, allowing
+unescaped double quotes in the final HTML.
+
+The GovukPublishingComponents::Middleware::Ga4Optimise class replicates this effect for non-slimmer
+apps. The middleware will only optimise a [fixed list of data attributes](../../lib/govuk_publishing_components/middleware/ga4_optimise.rb).
+
+To use it, you will need to require it (it's not required by default, since not all apps will need
+it), then add the middleware in your `config/application.rb` file.
+
+```
+require "govuk_publishing_components/middleware/ga4_optimise"
+
+module MyFrontendApp
+  class Application < Rails::Application
+    #...etc...
+
+    config.middleware.use GovukPublishingComponents::Middleware::Ga4Optimise
+  end
+end
+```
+

--- a/lib/govuk_publishing_components/middleware/ga4_optimise.rb
+++ b/lib/govuk_publishing_components/middleware/ga4_optimise.rb
@@ -1,0 +1,33 @@
+module GovukPublishingComponents
+  module Middleware
+    class Ga4Optimise
+      DATA_GA4_REGEX = /data-ga4-(?:link|event|form|focus-loss)=("[^"]*")/
+
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        status, headers, response = @app.call(env)
+        return [status, headers, safe_body_from_response(response)] unless headers["content-type"]&.start_with?("text/html")
+
+        body = response.each.first
+        matched_sections = body.scan(DATA_GA4_REGEX)
+
+        if matched_sections.any?
+          matched_sections.each do |section|
+            body.sub!(section.first, section.first.gsub('"', "'").gsub("&quot\;", '"'))
+          end
+        end
+
+        [status, headers, [body]]
+      end
+
+      def safe_body_from_response(response)
+        return [response.body] if response.respond_to?(:body)
+
+        response
+      end
+    end
+  end
+end

--- a/spec/lib/govuk_publishing_components/middleware/ga4_optimise_middleware_spec.rb
+++ b/spec/lib/govuk_publishing_components/middleware/ga4_optimise_middleware_spec.rb
@@ -1,0 +1,85 @@
+require "govuk_publishing_components/middleware/ga4_optimise"
+
+describe GovukPublishingComponents::Middleware::Ga4Optimise do
+  subject(:ga4_optimise_middleware) { described_class.new(app) }
+
+  let(:env) { Rack::MockRequest.env_for }
+  let(:app) { ->(_env) { ActionDispatch::Response.create(200, { "content-type" => content_type }, html).to_a } }
+  let(:content_type) { "text/html" }
+
+  context "when the html contains an unoptimised data-ga4- attribute" do
+    let(:html) { '<a data-ga4-link="my &quot;attribute&quot;">' }
+
+    it "replaces the escaped quotes in a data-ga4- attribute with unescaped ones" do
+      expected = "<a data-ga4-link='my \"attribute\"'>"
+      (_, _, body) = ga4_optimise_middleware.call(env)
+
+      expect(body.first).to eq(expected)
+    end
+  end
+
+  context "when the html contains an optimised data-ga4- attribute" do
+    let(:html) { "<a data-ga4-link='my \"attribute\"'>" }
+
+    it "makes no changes" do
+      expected = html.dup
+      (_, _, body) = ga4_optimise_middleware.call(env)
+
+      expect(body.first).to eq(expected)
+    end
+  end
+
+  context "when the html contains an unoptimised non-data-ga4- attribute" do
+    let(:html) { '<a data-attribute="my &quot;attribute&quot;">' }
+
+    it "leaves the input alone" do
+      expected = html.dup
+      (_, _, body) = ga4_optimise_middleware.call(env)
+
+      expect(body.first).to eq(expected)
+    end
+  end
+
+  context "when the content contains an unoptimised data-ga4 attribute but isn't html" do
+    let(:content_type) { "text/plain" }
+    let(:html) { 'data-ga4-form="my &quot;attribute&quot;"' }
+
+    it "leaves the input alone" do
+      expected = html.dup
+      (_, _, body) = ga4_optimise_middleware.call(env)
+
+      expect(body.first).to eq(expected)
+    end
+  end
+
+  context "when the content contains an unoptimised data-ga4 attribute but content-type is nil" do
+    let(:null_response) do
+      response = ActionDispatch::Response.create(200, {}, html)
+      response.to_a # triggers response to auto-create the content-type header
+      response.headers.delete("content-type")
+      response
+    end
+
+    let(:app) { ->(_env) { null_response.to_a } }
+    let(:html) { 'data-ga4-form="my &quot;attribute&quot;"' }
+
+    it "leaves the input alone" do
+      expected = html.dup
+      (_, _, body) = ga4_optimise_middleware.call(env)
+
+      expect(body.first).to eq(expected)
+    end
+  end
+
+  context "when the response is a generic rack response rather than an ActionDispatch::Response" do
+    let(:app) { ->(_env) { [200, {}, [html]] } }
+    let(:html) { 'data-ga4-form="my &quot;attribute&quot;"' }
+
+    it "leaves the input alone" do
+      expected = html.dup
+      (_, _, body) = ga4_optimise_middleware.call(env)
+
+      expect(body.first).to eq(expected)
+    end
+  end
+end


### PR DESCRIPTION
## What

Optimise GA4 Attributes by removing unnecessary escaping (useful when not using Slimmer). 

## Why

Because the process by which Slimmer stitches together templates from static with views from the apps involves a complete parse of both sets of HTML into a nokogiri tree, then writing out that tree as HTML after manipulation, it optimises GA4 data attributes slightly - replacing the double-quotes around the attribute with single quotes, so that the double quotes in the JSON inside the attribute don't need to be escaped. Without this, the generated HTML can be up to 2 kB larger when Slimmer is not involved.

For apps without slimmer, we can replicate this with a lighter-weight middleware that only needs to be included on non-slimmer apps, using regex and gsub/sub to perform a similar optimisation in place in the response.

https://trello.com/c/0o6io1aA/569-remove-slimmer-feedback

## Visual Changes

No visual changes expected.