### PR TITLE
Version 57.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 57.0.0
 
 * **BREAKING:** Upgrade cross service header to v3.0.0 ([PR #4811](https://github.com/alphagov/govuk_publishing_components/pull/4811/))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (56.3.2)
+    govuk_publishing_components (57.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "56.3.2".freeze
+  VERSION = "57.0.0".freeze
 end


### PR DESCRIPTION
## 57.0.0

* **BREAKING:** Upgrade cross service header to v3.0.0 ([PR #4811](https://github.com/alphagov/govuk_publishing_components/pull/4811/))
