### PR TITLE
Add support for exceptions to `Ga4CopyTracker`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add support for exceptions to `Ga4CopyTracker` ([PR #4823](https://github.com/alphagov/govuk_publishing_components/pull/4823))
+
 ## 57.0.0
 
 * **BREAKING:** Upgrade cross service header to v3.0.0 ([PR #4811](https://github.com/alphagov/govuk_publishing_components/pull/4811/))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-copy-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-copy-tracker.js
@@ -16,8 +16,15 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
         if (!text) {
           return // do nothing if no text has been selected
         }
-        var target = event.target.tagName
-        if (target === 'INPUT' || target === 'TEXTAREA') {
+
+        var target = event.target
+
+        if (target.closest && target.closest('[data-ga4-no-copy]')) {
+          return // do nothing if data-ga4-no-copy present
+        }
+
+        var tagName = target.tagName
+        if (tagName === 'INPUT' || tagName === 'TEXTAREA') {
           return // do nothing if text is being copied from an input
         }
 

--- a/docs/analytics-ga4/trackers/ga4-copy-tracker.md
+++ b/docs/analytics-ga4/trackers/ga4-copy-tracker.md
@@ -4,6 +4,7 @@ This script creates an event when text is copied from a GOV.UK page. When initia
 
 - some text has been selected
 - the selected text is not inside an INPUT or TEXTAREA
+- the selected text is not within a parent node that has `data-ga4-no-copy` set
 
 The second check is based around concerns over PII. Text copied from the body of a GOV.UK page should not include PII, but text inside a text input is written by users, and therefore could contain PII. Note that if text is selected spanning multiple elements including a text input, the browser automatically does not include the text from inputs.
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-copy-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-copy-tracker.spec.js
@@ -64,6 +64,21 @@ describe('Google Analytics 4 copy tracker', function () {
     document.body.removeChild(element)
   })
 
+  it('does not send data if copying from an element with data-ga4-no-copy set', function () {
+    var html = '<p id="p_tag">hello</p>'
+    var element = document.createElement('div')
+    element.dataset.ga4NoCopy = 'true'
+    element.innerHTML = html
+    document.body.appendChild(element)
+    spyOn(window, 'getSelection').and.returnValue('no thankyou')
+
+    window.GOVUK.triggerEvent(document.getElementById('p_tag'), 'copy')
+
+    expect(window.dataLayer.length).toEqual(0)
+
+    document.body.removeChild(element)
+  })
+
   it('cleans line breaks and other characters from copied text', function () {
     var text = 'This is some text\n\nThis is some more\tAnd some more\n     and     some spaces    \n'
     expected.event_data.text = 'This is some text This is some'


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- `Ga4CopyTracker` will not track an event if `data-ga4-no-copy` set on parent node of element
- Add new `data-ga4-no-copy` test for `Ga4CopyTracker`
- Updae `Ga4CopyTracker` docs with this change

## Why
<!-- What are the reasons behind this change being made? -->
`Ga4CopyTracker` is initialised in `load-analytics.js`, so including this file in an application means copy tracking is always enabled. This commit adds support for marking an element with `data-ga4-no-copy` which will prevent copy tracker for that element and it's children.