### PR TITLE
Update super nav button styles

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -49,7 +49,7 @@ $search-icon-height: 20px;
   top: 0;
 }
 
-@mixin pseudo-underline($left: govuk-spacing(4), $right: govuk-spacing(4), $width: false) {
+@mixin pseudo-underline($left: govuk-spacing(2), $right: govuk-spacing(2), $width: false) {
   background: none;
   content: "";
   height: $pseudo-underline-height;
@@ -199,7 +199,7 @@ $search-icon-height: 20px;
 
     &::after {
       @include make-selectable-area-bigger;
-      @include pseudo-underline($left: $after-link-padding, $right: $after-link-padding);
+      @include pseudo-underline;
     }
 
     &::before {
@@ -261,7 +261,7 @@ $search-icon-height: 20px;
       margin: 0;
 
       &::after {
-        @include pseudo-underline($left: $after-button-padding-left, $right: $after-button-padding-right, $width: 100%);
+        @include pseudo-underline($width: 100%);
       }
     }
     // stylelint-enable max-nesting-depth
@@ -361,7 +361,7 @@ $search-icon-height: 20px;
   @include govuk-typography-common($font-family: $govuk-font-family);
 
   &::after {
-    @include pseudo-underline($left: $after-button-padding-left, $right: $after-button-padding-right);
+    @include pseudo-underline;
   }
 
   @media (hover: hover) and (pointer: fine) {
@@ -538,7 +538,7 @@ $search-icon-height: 20px;
   @include govuk-font($size: 19, $weight: "bold", $line-height: 20px);
 
   &::after {
-    @include pseudo-underline($left: 0, $right: 0);
+    @include pseudo-underline;
   }
 
   &:focus-visible {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -191,31 +191,11 @@ $search-icon-height: 20px;
         background: $govuk-focus-text-colour;
       }
     }
-
-    .js-module-initialised & {
-      // If js is initialised, we are hiding the links and
-      // making the buttons visible instead. This means we have
-      // to remove the padding added to make the links vertically
-      // aligned, as the buttons are styled vertically aligned by
-      // default.
-
-      padding: 0;
-      margin: 0;
-
-      &::after {
-        @include pseudo-underline;
-      }
-    }
   }
 }
 
 // Specific styles for the "Menu" link
 .gem-c-layout-super-navigation-header__navigation-item-link {
-  .js-module-initialised & {
-    margin-left: govuk-spacing(4);
-    @include govuk-link-style-no-underline;
-  }
-
   .gem-c-layout-super-navigation-header__navigation-item-link-inner {
     padding: govuk-spacing(1) $after-link-padding;
     border-right: 1px solid $button-pipe-colour;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -541,8 +541,20 @@ $search-icon-height: 20px;
     @include pseudo-underline;
   }
 
-  &:focus-visible {
-    color: govuk-colour("black");
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      &::after {
+        background: govuk-colour("white");
+      }
+    }
+  }
+
+  @include focus-and-focus-visible {
+    @include govuk-focused-text;
+
+    border-color: $govuk-focus-colour;
+    box-shadow: none;
+    z-index: 11;
 
     &::after {
       background: govuk-colour("black");
@@ -560,40 +572,28 @@ $search-icon-height: 20px;
   }
 
   @include focus-not-focus-visible {
-    &::after {
-      background: none;
-    }
-
-    @media (hover: hover) and (pointer: fine) {
-      &:hover {
-        &::after {
-          background: govuk-colour("white");
-        }
-      }
-    }
-  }
-
-  @include focus-and-focus-visible {
-    @include govuk-focused-text;
-    border-color: $govuk-focus-colour;
-    box-shadow: none;
-    z-index: 11;
-  }
-
-  @include focus-not-focus-visible {
     background: none;
     box-shadow: none;
     color: govuk-colour("white");
+
+    &::after {
+      background: none;
+    }
   }
 
   // Open button modifier
   &.gem-c-layout-super-navigation-header__open-button {
+    color: govuk-colour("blue");
+
     // stylelint-disable max-nesting-depth
     @include focus-and-focus-visible {
       @include govuk-focused-text;
       border-color: $govuk-focus-colour;
       box-shadow: none;
-      color: $govuk-focus-colour;
+
+      &::after {
+        background: govuk-colour("black");
+      }
 
       @media (hover: hover) and (pointer: fine) {
         &:hover {
@@ -608,10 +608,16 @@ $search-icon-height: 20px;
       background: $govuk-rebrand-template-background-colour;
       outline: 1px solid $govuk-rebrand-template-background-colour; // overlap the border of the nav menu so it won't appear when menu open
 
+      color: govuk-colour("blue");
+
+      &::after {
+        background: govuk-colour("blue");
+      }
+
       @media (hover: hover) and (pointer: fine) {
         &:hover {
           &::after {
-            background: none;
+            background: govuk-colour("blue");
           }
         }
       }
@@ -622,7 +628,6 @@ $search-icon-height: 20px;
 
 // JS available - styles the close icon, used when the search menu is in the open state
 .gem-c-layout-super-navigation-header__navigation-top-toggle-close-icon {
-  color: $govuk-text-colour;
   display: none;
   font-size: 36px;
   font-weight: normal;
@@ -632,8 +637,10 @@ $search-icon-height: 20px;
   right: 0;
   text-align: center;
   top: 0;
+}
 
-  .gem-c-layout-super-navigation-header__open-button & {
+.gem-c-layout-super-navigation-header__open-button {
+  .gem-c-layout-super-navigation-header__navigation-top-toggle-close-icon {
     display: block;
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -161,86 +161,34 @@ $search-icon-height: 20px;
     margin: 0;
   }
 
+  &::after {
+    @include pseudo-underline;
+  }
+
   &:hover {
     @include govuk-link-hover-decoration;
+
+    &::after {
+      background: govuk-colour("white");
+    }
   }
 
   &,
   &:link,
   &:visited {
+    color: govuk-colour("white");
     float: left;
     font-size: 16px;
     font-size: govuk-px-to-rem(16px);
     height: govuk-spacing(4);
+    text-decoration: none;
 
-    @include focus-and-focus-visible {
-      @include govuk-focused-text;
-    }
-
-    // Undoes the :focus styles *only* for browsers that support :focus-visible.
-    // See https://www.tpgi.com/focus-visible-and-backwards-compatibility/
-    &:focus:not(:focus-visible) {
-      background: none;
+    &:focus {
       box-shadow: none;
-      color: $govuk-link-colour;
-
-      .gem-c-layout-super-navigation-header__navigation-item-link-inner {
-        border-right-color: $button-pipe-colour;
-      }
-
-      &:hover {
-        @include govuk-link-decoration;
-        @include govuk-link-hover-decoration;
-        color: $govuk-link-hover-colour;
-      }
-    }
-
-    &::after {
-      @include make-selectable-area-bigger;
-      @include pseudo-underline;
-    }
-
-    &:hover {
-      &::after {
-        background: govuk-colour("white");
-      }
-    }
-
-    @include focus-and-focus-visible {
-      .gem-c-layout-super-navigation-header__navigation-item-link-inner {
-        border-right-color: $govuk-focus-colour;
-        background: $govuk-focus-colour;
-      }
-
-      &,
-      &:hover {
-        box-shadow: none;
-        color: $govuk-focus-text-colour;
-
-        &::after {
-          background: $govuk-focus-text-colour;
-        }
-      }
-    }
-
-    @include focus-not-focus-visible {
-      &,
-      &:hover {
-        text-decoration: none;
-      }
-
-      & {
-        color: govuk-colour("white");
-      }
-
-      &:hover {
-        &::after {
-          background: govuk-colour("white");
-        }
-      }
+      color: $govuk-focus-text-colour;
 
       &::after {
-        background: none;
+        background: $govuk-focus-text-colour;
       }
     }
 
@@ -255,72 +203,27 @@ $search-icon-height: 20px;
       margin: 0;
 
       &::after {
-        @include pseudo-underline($width: 100%);
+        @include pseudo-underline;
       }
     }
   }
-
-  &::after {
-    @include make-selectable-area-bigger;
-  }
 }
 
+// Specific styles for the "Menu" link
 .gem-c-layout-super-navigation-header__navigation-item-link {
-  @include govuk-media-query($from: "desktop") {
-    padding: govuk-spacing(4) 0;
-  }
-
   .js-module-initialised & {
     margin-left: govuk-spacing(4);
     @include govuk-link-style-no-underline;
   }
-}
 
-.gem-c-layout-super-navigation-header__navigation-item-link-inner {
-  padding: govuk-spacing(1) $after-link-padding;
-  border-right: 1px solid $button-pipe-colour;
-}
-
-// Search link and dropdown.
-.gem-c-layout-super-navigation-header__search-item-link {
-  padding: govuk-spacing(4);
-
-  @include govuk-media-query($until: "desktop") {
-    margin: 0;
+  .gem-c-layout-super-navigation-header__navigation-item-link-inner {
+    padding: govuk-spacing(1) $after-link-padding;
+    border-right: 1px solid $button-pipe-colour;
   }
 
-  &:link,
-  &:visited {
-    &:hover {
-      &::before {
-        left: 0;
-        right: 0;
-      }
-    }
-
-    &:focus {
-      background: $govuk-focus-colour;
-
-      &::before {
-        content: none;
-      }
-    }
-
-    &::after {
-      left: 0;
-      right: 0;
-      width: 100%;
-    }
-
-    @include focus-and-focus-visible {
-      &:hover {
-        background: $govuk-focus-colour;
-      }
-
-      &::after,
-      &:hover::after {
-        background: $govuk-focus-colour;
-      }
+  &:focus {
+    .gem-c-layout-super-navigation-header__navigation-item-link-inner {
+      border-right-color: $govuk-focus-colour;
     }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -3,8 +3,6 @@
 @import "mixins/prefixed-transform";
 @import "mixins/grid-helper";
 
-$pale-blue-colour: #d2e2f1;
-
 $chevron-breakpoint: 360px;
 $chevron-indent-spacing: 7px;
 
@@ -12,13 +10,13 @@ $pseudo-underline-height: 3px;
 
 $navbar-height: 60px;
 
-$button-pipe-colour: $pale-blue-colour;
+$button-pipe-colour: $govuk-blue-tint-95;
 
 $after-link-padding: govuk-spacing(4);
 $after-button-padding-right: govuk-spacing(4);
 $after-button-padding-left: govuk-spacing(4);
 
-$search-button-padding: govuk-spacing(3);
+$search-button-padding: govuk-spacing(4);
 $search-icon-width: 21px;
 $search-icon-height: 20px;
 
@@ -187,7 +185,7 @@ $search-icon-height: 20px;
       color: $govuk-link-colour;
 
       .gem-c-layout-super-navigation-header__navigation-item-link-inner {
-        border-color: $button-pipe-colour;
+        border-right-color: $button-pipe-colour;
       }
 
       &:hover {
@@ -214,7 +212,7 @@ $search-icon-height: 20px;
 
     @include focus-and-focus-visible {
       .gem-c-layout-super-navigation-header__navigation-item-link-inner {
-        border-color: $govuk-focus-colour;
+        border-right-color: $govuk-focus-colour;
         background: $govuk-focus-colour;
       }
 
@@ -331,6 +329,11 @@ $search-icon-height: 20px;
   }
 }
 
+// Specific styles for the "Search" link
+.gem-c-layout-super-navigation-header__search-item-link {
+  padding: $search-button-padding;
+}
+
 .gem-c-layout-super-navigation-header__search-item-link-icon,
 .gem-c-layout-super-navigation-header__search-toggle-button-link-icon {
   height: $search-icon-height;
@@ -387,7 +390,7 @@ $search-icon-height: 20px;
     }
 
     .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
-      border-color: $govuk-focus-colour;
+      border-right-color: $govuk-focus-colour;
 
       &::before {
         @include chevron(govuk-colour("black"));
@@ -421,7 +424,7 @@ $search-icon-height: 20px;
     }
 
     .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
-      border-color: $button-pipe-colour;
+      border-right-color: $button-pipe-colour;
 
       &::before {
         @include chevron(govuk-colour("white"));
@@ -467,7 +470,7 @@ $search-icon-height: 20px;
 
     .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
       color: govuk-colour("black");
-      border-color: $govuk-focus-colour;
+      border-right-color: $govuk-focus-colour;
 
       @include govuk-media-query($from: $chevron-breakpoint) {
         &::before {
@@ -487,7 +490,7 @@ $search-icon-height: 20px;
 
     .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
       color: $govuk-link-colour;
-      border-color: $govuk-rebrand-template-background-colour;
+      border-right-color: $button-pipe-colour;
 
       @include govuk-media-query($from: $chevron-breakpoint) {
         &::before {
@@ -502,7 +505,7 @@ $search-icon-height: 20px;
 // JS available - targets the "Menu" toggle button inner text
 .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
   display: inline-block;
-  border-right: 1px solid govuk-colour("white");
+  border-right: 1px solid $button-pipe-colour;
   margin: 0;
   padding: govuk-spacing(1) govuk-spacing(4);
 
@@ -520,7 +523,7 @@ $search-icon-height: 20px;
   color: govuk-colour("white");
   cursor: pointer;
   height: $navbar-height;
-  padding: govuk-spacing(3);
+  padding: $search-button-padding;
   position: relative;
   width: calc(($search-button-padding * 2) + $search-icon-width); // width = button container left and right padding + icon width
   @include govuk-font($size: 19, $weight: "bold", $line-height: 20px);

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -91,6 +91,7 @@ $search-icon-height: 20px;
   }
 }
 
+// stylelint-disable max-nesting-depth
 .gem-c-layout-super-navigation-header {
   background: $govuk-brand-colour;
   border-top: 1px solid $govuk-brand-colour;
@@ -169,7 +170,6 @@ $search-icon-height: 20px;
   &,
   &:link,
   &:visited {
-    // stylelint-disable max-nesting-depth
     float: left;
     font-size: 16px;
     font-size: govuk-px-to-rem(16px);
@@ -264,7 +264,6 @@ $search-icon-height: 20px;
         @include pseudo-underline($width: 100%);
       }
     }
-    // stylelint-enable max-nesting-depth
   }
 
   &::after {
@@ -372,29 +371,7 @@ $search-icon-height: 20px;
 
       .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
         &::before {
-          border-color: govuk-colour("white");
-        }
-      }
-    }
-  }
-
-  @include govuk-media-query($from: "desktop") {
-    display: block;
-    float: left;
-    right: 0;
-  }
-
-  &:focus-visible {
-    &:hover {
-      .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
-        color: govuk-colour("black");
-
-        &::after {
-          background: govuk-colour("black");
-        }
-
-        &::before {
-          @include chevron(govuk-colour("black"), true);
+          border-color: chevron(govuk-colour("white"));
         }
       }
     }
@@ -405,26 +382,33 @@ $search-icon-height: 20px;
 
     box-shadow: none;
 
+    &::after {
+      background-color: govuk-colour("black");
+    }
+
+    .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
+      border-color: $govuk-focus-colour;
+
+      &::before {
+        @include chevron(govuk-colour("black"));
+      }
+    }
+
     @media (hover: hover) and (pointer: fine) {
       &:hover {
         &::after {
           background-color: govuk-colour("black");
         }
+
+        .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
+          color: govuk-colour("black");
+
+          &::before {
+            @include chevron(govuk-colour("black"));
+          }
+        }
       }
     }
-
-    &::after {
-      background-color: govuk-colour("black");
-    }
-    // stylelint-disable max-nesting-depth
-    .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
-      border-color: $govuk-focus-colour;
-
-      &::before {
-        @include chevron(govuk-colour("black"), true);
-      }
-    }
-    // stylelint-enable max-nesting-depth
   }
 
   @include focus-not-focus-visible {
@@ -436,38 +420,43 @@ $search-icon-height: 20px;
       background: none;
     }
 
-    // stylelint-disable max-nesting-depth
-    @media (hover: hover) and (pointer: fine) {
-      &:hover {
-        .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
-          &::before {
-            @include chevron(govuk-colour("white"), true);
-          }
-        }
-
-        &::after {
-          background: govuk-colour("white");
-        }
-      }
-    }
-
     .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
       border-color: $button-pipe-colour;
 
-      @include govuk-media-query($from: $chevron-breakpoint) {
-        &::before {
-          @include chevron(govuk-colour("white"), true);
+      &::before {
+        @include chevron(govuk-colour("white"));
+      }
+    }
+
+    @media (hover: hover) and (pointer: fine) {
+      &:hover {
+        &::after {
+          background: govuk-colour("white");
+        }
+
+        .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
+          color: govuk-colour("white");
+
+          @include govuk-media-query($from: $chevron-breakpoint) {
+            &::before {
+              @include chevron(govuk-colour("white"));
+            }
+          }
         }
       }
     }
-    // stylelint-enable max-nesting-depth
+  }
+
+  @include govuk-media-query($from: "desktop") {
+    display: block;
+    float: left;
+    right: 0;
   }
 }
 
 // JS available - targets the "Menu" toggle button
 // Styles the "Menu" open state
 .gem-c-layout-super-navigation-header__navigation-top-toggle-button.gem-c-layout-super-navigation-header__open-button {
-  // stylelint-disable max-nesting-depth
   @include focus-and-focus-visible {
     @include govuk-focused-text;
     box-shadow: none;
@@ -508,7 +497,6 @@ $search-icon-height: 20px;
       }
     }
   }
-  // stylelint-enable max-nesting-depth
 }
 
 // JS available - targets the "Menu" toggle button inner text
@@ -579,13 +567,22 @@ $search-icon-height: 20px;
     &::after {
       background: none;
     }
+
+    @media (hover: hover) and (pointer: fine) {
+      &:hover {
+        color: govuk-colour("white");
+
+        &::after {
+          background: govuk-colour("white");
+        }
+      }
+    }
   }
 
   // Open button modifier
   &.gem-c-layout-super-navigation-header__open-button {
     color: govuk-colour("blue");
 
-    // stylelint-disable max-nesting-depth
     @include focus-and-focus-visible {
       @include govuk-focused-text;
       border-color: $govuk-focus-colour;
@@ -622,7 +619,6 @@ $search-icon-height: 20px;
         }
       }
     }
-    // stylelint-enable max-nesting-depth
   }
 }
 
@@ -800,3 +796,4 @@ $search-icon-height: 20px;
     padding: 10px 0 !important; // stylelint-disable-line declaration-no-important
   }
 }
+// stylelint-enable max-nesting-depth

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -200,10 +200,6 @@ $search-icon-height: 20px;
       @include pseudo-underline;
     }
 
-    &::before {
-      @include chevron(govuk-colour("white"), true);
-    }
-
     &:hover {
       &::after {
         background: govuk-colour("white");
@@ -345,7 +341,7 @@ $search-icon-height: 20px;
   display: none;
 }
 
-// Styles for top level navigation toggle button.
+// JS available - target the "Menu" toggle button
 .gem-c-layout-super-navigation-header__navigation-top-toggle-button {
   font-size: 16px;
   font-size: govuk-px-to-rem(16px);
@@ -366,6 +362,19 @@ $search-icon-height: 20px;
     @include pseudo-underline;
   }
 
+  .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
+    display: inline-block;
+    border-right: 1px solid $button-pipe-colour;
+    margin: 0;
+    padding: govuk-spacing(1) govuk-spacing(4);
+
+    @include govuk-media-query($from: $chevron-breakpoint) {
+      &::before {
+        @include chevron(govuk-colour("white"));
+      }
+    }
+  }
+
   @media (hover: hover) and (pointer: fine) {
     &:hover {
       &::after {
@@ -374,7 +383,7 @@ $search-icon-height: 20px;
 
       .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
         &::before {
-          border-color: chevron(govuk-colour("white"));
+          @include chevron(govuk-colour("white"), true);
         }
       }
     }
@@ -393,7 +402,7 @@ $search-icon-height: 20px;
       border-right-color: $govuk-focus-colour;
 
       &::before {
-        @include chevron(govuk-colour("black"));
+        @include chevron(govuk-colour("black"), true);
       }
     }
 
@@ -407,7 +416,7 @@ $search-icon-height: 20px;
           color: govuk-colour("black");
 
           &::before {
-            @include chevron(govuk-colour("black"));
+            @include chevron(govuk-colour("black"), true);
           }
         }
       }
@@ -426,8 +435,10 @@ $search-icon-height: 20px;
     .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
       border-right-color: $button-pipe-colour;
 
-      &::before {
-        @include chevron(govuk-colour("white"));
+      @include govuk-media-query($from: $chevron-breakpoint) {
+        &::before {
+          @include chevron(govuk-colour("white"), true);
+        }
       }
     }
 
@@ -440,10 +451,8 @@ $search-icon-height: 20px;
         .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
           color: govuk-colour("white");
 
-          @include govuk-media-query($from: $chevron-breakpoint) {
-            &::before {
-              @include chevron(govuk-colour("white"));
-            }
+          &::before {
+            @include chevron(govuk-colour("white"), true);
           }
         }
       }
@@ -472,11 +481,9 @@ $search-icon-height: 20px;
       color: govuk-colour("black");
       border-right-color: $govuk-focus-colour;
 
-      @include govuk-media-query($from: $chevron-breakpoint) {
-        &::before {
-          @include chevron(govuk-colour("black"), true);
-          @include prefixed-transform($rotate: 225deg, $translateY: 1px);
-        }
+      &::before {
+        @include chevron(govuk-colour("black"), true);
+        @include prefixed-transform($rotate: 225deg, $translateY: 1px);
       }
     }
   }
@@ -494,24 +501,10 @@ $search-icon-height: 20px;
 
       @include govuk-media-query($from: $chevron-breakpoint) {
         &::before {
-          @include chevron($govuk-link-colour);
+          @include chevron($govuk-link-colour, true);
           @include prefixed-transform($rotate: 225deg, $translateY: 1px);
         }
       }
-    }
-  }
-}
-
-// JS available - targets the "Menu" toggle button inner text
-.gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
-  display: inline-block;
-  border-right: 1px solid $button-pipe-colour;
-  margin: 0;
-  padding: govuk-spacing(1) govuk-spacing(4);
-
-  @include govuk-media-query($from: $chevron-breakpoint) {
-    &::before {
-      @include chevron(govuk-colour("white"));
     }
   }
 }


### PR DESCRIPTION
## What

- Update the search toggle button styles
  - left and right padding increased from `15px` to `20px`
  - the color of the "X" is now govuk-blue the same as the "menu" button in the open state
  - includes the pseudo-underline in the open state
- Fix the `:focus` style in browsers that do not support `:focus-visible`
- Fix styles when JS is not available
  -  only the `:focus` pseudo-class is used on the super navigation menu links
  - `:focus-visible` is now only used when JS is available on the super navigation buttons
- Some refactoring to make it easier to maintain and updates the super navigation menu styles in the future
- The pseudo-underline that appears beneath the menu buttons/links are have been updated to have consistent left and right values 

## Why

The search toggle button styles are now consistent with the "Menu" button and scale with the new menu height

[Trello card](https://trello.com/c/aIixDpBb)

## Visual Changes

### Search toggle button

| Before | After |
| --- | --- |
| <img width="164" alt="search-button-open-before" src="https://github.com/user-attachments/assets/72ccb86e-eb91-45a8-baa3-d61a4f548aa2" /> | <img width="168" alt="search-button-open-after" src="https://github.com/user-attachments/assets/1dc01339-4725-45ca-9ab0-ae1e4f04a7ad" /> |

### `:focus` and `:hover` state
This styling appears in browsers that do not support `:focus-visible`

| Before | After |
| --- | --- |
| <img width="171" alt="focus-hover-before" src="https://github.com/user-attachments/assets/65b5f8fd-289b-4747-bf30-6a703eda7429" /> | <img width="177" alt="focus-hover-after" src="https://github.com/user-attachments/assets/15b28458-21bb-4905-9b1d-92b1871bde2f" /> |

### Menu underline

| Before | After |
| --- | --- |
| <img width="166" alt="menu-underline-before" src="https://github.com/user-attachments/assets/0f421b22-71f5-4862-ba89-d725b2e408bb" /> | <img width="179" alt="menu-underline-after" src="https://github.com/user-attachments/assets/c20a7abe-3966-4658-88c1-bac620ece636" /> |

### Search underline

| Before | After |
| --- | --- |
| <img width="160" alt="search-underline-before" src="https://github.com/user-attachments/assets/313db092-eeab-4462-a9c4-6b6f55a12077" /> |  <img width="174" alt="search-underline-after" src="https://github.com/user-attachments/assets/eaf12fb7-bd4c-497d-ba66-2b331515d4d2" />|

## Browser Testing

### Grade A
- [x] Chrome 137
- [x] Safari 18.5
- [x] Safari 18.5 iOS 
- [x] Firefox 139

### Grade B
- [x] Chrome 132
- [x] Chrome 133 for Android
- [x] Safari 18.3 iOS

### Grade C
- [x] Chrome 70
- [x] Safari v14.0 - iPhone
- [x] Safari v11.1

### Grade X
- [x] IE11 - JS not supported