### PR TITLE
Replace use of tint mixins with hex variables

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -26,7 +26,7 @@
 }
 
 .gem-c-feedback__prompt {
-  background-color: govuk-tint(govuk-colour("blue"), 95%);
+  background-color: $govuk-rebrand-template-background-colour;
   color: govuk-colour("black");
   border-top: 1px solid govuk-tint(govuk-colour("blue"), 50%);
   outline: 0;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -1,5 +1,8 @@
 @import "govuk_publishing_components/individual_component_support";
 
+$feedback-prompt-background-colour: $govuk-blue-tint-95;
+$feedback-prompt-border-top-colour: $govuk-blue-tint-50;
+
 .gem-c-feedback {
   background: govuk-colour("white");
   margin-top: govuk-spacing(6);
@@ -26,9 +29,9 @@
 }
 
 .gem-c-feedback__prompt {
-  background-color: $govuk-rebrand-template-background-colour;
+  background-color: $feedback-prompt-background-colour;
   color: govuk-colour("black");
-  border-top: 1px solid govuk-tint(govuk-colour("blue"), 50%);
+  border-top: 1px solid $feedback-prompt-border-top-colour;
   outline: 0;
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -490,7 +490,7 @@ $search-icon-height: 20px;
   }
 
   @include focus-not-focus-visible {
-    background: govuk-tint(govuk-colour("blue"), 95%);
+    background: $govuk-rebrand-template-background-colour;
 
     &::after {
       background-color: $govuk-link-colour;
@@ -498,7 +498,7 @@ $search-icon-height: 20px;
 
     .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
       color: $govuk-link-colour;
-      border-color: govuk-tint(govuk-colour("blue"), 95%);
+      border-color: $govuk-rebrand-template-background-colour;
 
       @include govuk-media-query($from: $chevron-breakpoint) {
         &::before {
@@ -605,8 +605,8 @@ $search-icon-height: 20px;
     }
 
     @include focus-not-focus-visible {
-      background: govuk-tint(govuk-colour("blue"), 95%);
-      outline: 1px solid govuk-tint(govuk-colour("blue"), 95%); // overlap the border of the nav menu so it won't appear when menu open
+      background: $govuk-rebrand-template-background-colour;
+      outline: 1px solid $govuk-rebrand-template-background-colour; // overlap the border of the nav menu so it won't appear when menu open
 
       @media (hover: hover) and (pointer: fine) {
         &:hover {
@@ -644,7 +644,7 @@ $search-icon-height: 20px;
 
 // JS available - dropdown menu
 .gem-c-layout-super-navigation-header__navigation-dropdown-menu {
-  background: govuk-tint(govuk-colour("blue"), 95%);
+  background: $govuk-rebrand-template-background-colour;
   border-bottom: 1px govuk-colour("mid-grey") solid;
   padding-top: govuk-spacing(6);
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -3,6 +3,9 @@
 $input-size: 40px;
 $large-input-size: 50px;
 
+$search-submit-button-colour: $govuk-blue-tint-80;
+$search-submit-button-hover-colour: $govuk-blue-tint-95;
+
 @mixin large-mode {
   .gem-c-search__label {
     @include govuk-font($size: 19, $line-height: $large-input-size);
@@ -182,11 +185,11 @@ $large-input-size: 50px;
   }
 
   .gem-c-search__submit {
-    background-color: govuk-tint(govuk-colour("blue"), 80%);
+    background-color: $search-submit-button-colour;
     color: govuk-colour("blue");
 
     &:hover {
-      background-color: $govuk-rebrand-template-background-colour;
+      background-color: $search-submit-button-hover-colour;
     }
   }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -186,7 +186,7 @@ $large-input-size: 50px;
     color: govuk-colour("blue");
 
     &:hover {
-      background-color: govuk-tint(govuk-colour("blue"), 95%);
+      background-color: $govuk-rebrand-template-background-colour;
     }
   }
 

--- a/app/assets/stylesheets/govuk_publishing_components/govuk_frontend_support.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/govuk_frontend_support.scss
@@ -28,6 +28,7 @@ $gem-hover-dark-background: #dddcdb;
 // To maintain compatibility, we're defining equivalent hex color values as variables.
 
 $govuk-blue-tint-95: #f4f8fb; // govuk-tint(govuk-colour("blue"), 95%)
+$govuk-blue-tint-80: #d2e2f1; // govuk-tint(govuk-colour("blue"), 80%)
 $govuk-blue-tint-50: #8eb8dc; // govuk-tint(govuk-colour("blue"), 50%)
 
 $govuk-rebrand-template-background-colour: $govuk-blue-tint-95;

--- a/app/assets/stylesheets/govuk_publishing_components/govuk_frontend_support.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/govuk_frontend_support.scss
@@ -28,4 +28,6 @@ $gem-hover-dark-background: #dddcdb;
 // To maintain compatibility, we're defining equivalent hex color values as variables.
 
 $govuk-blue-tint-95: #f4f8fb; // govuk-tint(govuk-colour("blue"), 95%)
+$govuk-blue-tint-50: #8eb8dc; // govuk-tint(govuk-colour("blue"), 50%)
+
 $govuk-rebrand-template-background-colour: $govuk-blue-tint-95;

--- a/app/assets/stylesheets/govuk_publishing_components/govuk_frontend_support.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/govuk_frontend_support.scss
@@ -21,3 +21,11 @@ $gem-quiet-button-colour: govuk-colour("dark-grey");
 $gem-quiet-button-hover-colour: darken($gem-quiet-button-colour, 5%);
 
 $gem-hover-dark-background: #dddcdb;
+
+// Dart Sass 1.79.0 introduced support for CSS Color Level 4 color spaces.
+// Consequently, the `govuk-tint` mixin now outputs rgb values with floating-point precision,
+// leading to unsupported property value warnings in some browsers, such as Safari 11.1.1.
+// To maintain compatibility, we're defining equivalent hex color values as variables.
+
+$govuk-blue-tint-95: #f4f8fb; // govuk-tint(govuk-colour("blue"), 95%)
+$govuk-rebrand-template-background-colour: $govuk-blue-tint-95;


### PR DESCRIPTION
## What

Replace use of tint mixins with hex variables

## Why

Dart Sass 1.79.0 introduced support for CSS Color Level 4 color spaces. Consequently, the `govuk-tint` mixin now outputs rgb values with floating-point precision, leading to unsupported property value warnings in some browsers, such as Safari 11.1.1. To maintain compatibility, we're defining equivalent hex colour values as variables instead.

<img width="1343" alt="Screenshot 2025-05-14 at 14 08 19" src="https://github.com/user-attachments/assets/7d076edf-81e5-4338-bdcc-65a97685f611" />