### PR TITLE
Add tracking to `ReorderableList`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add tracking to `ReorderableList` ([PR #4835](https://github.com/alphagov/govuk_publishing_components/pull/4835))
+
 ## 57.1.0
 
 * Add middleware to optimise GA4 Attributes by reducing unnecessary escaping ([PR #4813](https://github.com/alphagov/govuk_publishing_components/pull/4813))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -211,6 +211,10 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
         return string.substring(string.length - stringToFind.length, string.length) === stringToFind
       },
 
+      toSnakeCase: function (str) {
+        return str.replace(/([a-z])([A-Z])/g, '$1_$2').toLowerCase()
+      },
+
       populateLinkDomain: function (href) {
         // We always want mailto links to have an undefined link_domain
         if (this.isMailToLink(href)) {

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.js
@@ -28,6 +28,26 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     }
   }
 
+  Ga4EventTracker.prototype.getTargetDatasetSchema = function (element) {
+    var targetDataset
+
+    try {
+      targetDataset = element.dataset
+    } catch (error) {
+      console.error(error)
+    }
+
+    var eventData = {}
+
+    Object.keys(targetDataset).forEach(function (key) {
+      var schemaKey = window.GOVUK.analyticsGa4.core.trackFunctions.toSnakeCase(key)
+
+      eventData[schemaKey] = targetDataset[key]
+    })
+
+    return eventData
+  }
+
   Ga4EventTracker.prototype.trackClick = function (event) {
     if (event.tracked) return
     var target = window.GOVUK.analyticsGa4.core.trackFunctions.findTrackingAttributes(event.target, this.trackingTrigger)
@@ -40,6 +60,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         console.error('GA4 configuration error: ' + e.message, window.location)
         return
       }
+
+      data = Object.assign(data, this.getTargetDatasetSchema(target))
 
       var text = data.text || event.target.textContent
       data.text = window.GOVUK.analyticsGa4.core.trackFunctions.removeLinesAndExtraSpaces(text)

--- a/app/assets/javascripts/govuk_publishing_components/components/reorderable-list.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/reorderable-list.js
@@ -16,6 +16,21 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       onSort: function () {
         this.updateOrderIndexes()
         this.triggerEvent(this.$module, 'reorder-drag')
+      }.bind(this),
+
+      onEnd: function (event) {
+        if (event.oldIndex !== event.newIndex) {
+          var item = event.item
+          var eventData = item.querySelector('[data-ga4-event]')
+
+          if (eventData) {
+            item.dataset.ga4Event = eventData.dataset.ga4Event
+            item.dataset.action = 'drag and drop'
+            item.dataset.text = event.newIndex > event.oldIndex ? 'Up' : 'Down'
+            this.triggerEvent(item, 'click')
+            delete item.dataset.ga4Event
+          }
+        }
       }.bind(this)
     })
 
@@ -84,10 +99,15 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   }
 
   ReorderableList.prototype.updateOrderIndexes = function () {
-    var $orderInputs = this.$module.querySelectorAll('.gem-c-reorderable-list__actions input')
-    for (var i = 0; i < $orderInputs.length; i++) {
-      $orderInputs[i].setAttribute('value', i + 1)
-    }
+    var $actions = this.$module.querySelectorAll('.gem-c-reorderable-list__actions')
+
+    $actions.forEach(function ($action, index) {
+      $action.querySelector('input').value = index + 1
+
+      $action.querySelectorAll('button[data-ga4-event]').forEach(function ($trackButton) {
+        $trackButton.dataset.indexSection = index
+      })
+    })
   }
 
   ReorderableList.prototype.triggerEvent = function (element, eventName) {

--- a/app/views/govuk_publishing_components/components/_reorderable_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_reorderable_list.html.erb
@@ -3,14 +3,30 @@
 
   items ||= []
   input_name ||= "ordering"
+  disable_ga4 ||= false
+  ga4_attributes ||= {
+    event_name: 'select_content',
+    type: 'reorderable list',
+  }
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-reorderable-list")
   component_helper.add_data_attribute({ module: "reorderable-list" })
+  component_helper.add_data_attribute({ module: "ga4-event-tracker" }) unless disable_ga4
 %>
 
 <%= tag.ol(**component_helper.all_attributes) do %>
   <% items.each_with_index do |item, index| %>
+
+    <%
+      ga4_event = nil
+
+      unless disable_ga4
+        ga4_event = ga4_attributes
+        ga4_event.merge!({ section: item[:title], index_section: index, index_section_count: items.length }) unless disable_ga4
+      end
+    %>
+
     <%= tag.li class: "gem-c-reorderable-list__item" do %>
       <%= tag.div class: "gem-c-reorderable-list__wrapper" do %>
         <%= tag.div class: "gem-c-reorderable-list__content" do %>
@@ -33,14 +49,20 @@
             type: "button",
             aria_label: "Move \"#{item[:title]}\" up",
             classes: "js-reorderable-list-up",
-            secondary_solid: true
+            secondary_solid: true,
+            data_attributes: {
+              ga4_event: ga4_event && ga4_event.merge({ action: 'Up' }).as_json
+            }
           } %>
           <%= render "govuk_publishing_components/components/button", {
             text: "Down",
             type: "button",
             aria_label: "Move \"#{item[:title]}\" down",
             classes: "js-reorderable-list-down",
-            secondary_solid: true
+            secondary_solid: true,
+            data_attributes: {
+              ga4_event: ga4_event && ga4_event.merge({ action: 'Down' }).as_json
+            }
           } %>
         <% end %>
       <% end %>

--- a/app/views/govuk_publishing_components/components/docs/reorderable_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/reorderable_list.yml
@@ -74,6 +74,22 @@ examples:
           title: "Table 2.1: Budget 2018 policy decisions"
         - id: "5ebd75d7-6c37-4b93-b444-1b7c49757fb9"
           title: "Table 2.2: Measures announced at Autumn Budget 2017 or earlier that will take effect from November 2018 or later (£ million)"
+  without_ga4_tracking:
+    description: |
+      Disables GA4 tracking on the reorderable list. Tracking is enabled by default. This adds a data module and data-attributes with JSONs to the reorderable list. See the [ga4-event-tracker documentation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-event-tracker.md) for more information.
+    data:
+      disable_ga4: true
+      items:
+        - id: "ce99dd60-67dc-11eb-ae93-0242ac130002"
+          title: "Budget 2018"
+        - id: "d321cb86-67dc-11eb-ae93-0242ac130002"
+          title: "Budget 2018 (web)"
+        - id: "63a6d29e-6b6d-4157-9067-84c1a390e352"
+          title: "Impact on households: distributional analysis to accompany Budget 2018"
+        - id: "0a4d377d-68f4-472f-b2e3-ef71dc750f85"
+          title: "Table 2.1: Budget 2018 policy decisions"
+        - id: "5ebd75d7-6c37-4b93-b444-1b7c49757fb9"
+          title: "Table 2.2: Measures announced at Autumn Budget 2017 or earlier that will take effect from November 2018 or later (£ million)"
   with_custom_input_name:
     data:
       input_name: "attachments[ordering]"

--- a/spec/components/reorderable_list_spec.rb
+++ b/spec/components/reorderable_list_spec.rb
@@ -53,6 +53,35 @@ describe "Reorderable list", type: :view do
     end
   end
 
+  it "adds correct data attributes if tracking enabled" do
+    render_component(items:)
+
+    assert_select ".gem-c-reorderable-list[data-module~='ga4-event-tracker']"
+    assert_select ".gem-c-reorderable-list__item", 5
+    assert_select ".gem-c-reorderable-list__item" do |elements|
+      elements.each_with_index do |element, index|
+        expected_dataset = {
+          event_name: "select_content",
+          type: "reorderable list",
+          section: items[index][:title],
+          index_section: index,
+          index_section_count: elements.length,
+        }
+
+        assert_select element, ".gem-c-reorderable-list__actions .js-reorderable-list-up", data_ga4_event: expected_dataset.merge({ action: "Up" }).as_json
+        assert_select element, ".gem-c-reorderable-list__actions .js-reorderable-list-down", data_ga4_event: expected_dataset.merge({ action: "Down" }).as_json
+      end
+    end
+  end
+
+  it "does not add correct data attributes if tracking disabled" do
+    render_component(items:, disable_ga4: true)
+
+    assert_select ".gem-c-reorderable-list[data-module~='ga4-event-tracker']", 0
+    assert_select ".gem-c-reorderable-list__item", 5
+    assert_select ".gem-c-reorderable-list__item [data-ga4-event]", 0
+  end
+
   it "renders allows custom input names" do
     render_component(items:, input_name: "attachments[ordering]")
 

--- a/spec/javascripts/components/reorderable-list-spec.js
+++ b/spec/javascripts/components/reorderable-list-spec.js
@@ -18,8 +18,8 @@ describe('Reorderable list component', function () {
           '</div>' +
           '<div class="gem-c-reorderable-list__actions">' +
             '<input name="new_order[]" value="1" class="gem-c-input govuk-input govuk-input--width-2" id="input-278a8924" type="text">' +
-            '<button type="button" class="js-reorderable-list-up">Up</button>' +
-            '<button type="button" class="js-reorderable-list-down">Down</button>' +
+            '<button type="button" data-ga4-event="" class="js-reorderable-list-up">Up</button>' +
+            '<button type="button" data-ga4-event="" class="js-reorderable-list-down">Down</button>' +
           '</div>' +
         '</div>' +
       '</li>' +
@@ -142,6 +142,19 @@ describe('Reorderable list component', function () {
     it('should trigger a reorder-drag event', function () {
       expect('reorder-drag').toHaveBeenTriggeredOn(element)
     })
+
+    it('should update index section data attribute of button if tracked', function () {
+      var firstItemUpButton = document.querySelector('li:nth-child(1) .js-reorderable-list-up')
+      var firstItemDownButton = document.querySelector('li:nth-child(1) .js-reorderable-list-down')
+      var secondItemUpButton = document.querySelector('li:nth-child(2) .js-reorderable-list-up')
+      var secondItemDownButton = document.querySelector('li:nth-child(2) .js-reorderable-list-down')
+
+      expect(firstItemUpButton.dataset.indexSection).not.toEqual('0')
+      expect(firstItemDownButton.dataset.indexSection).not.toEqual('0')
+
+      expect(secondItemUpButton.dataset.indexSection).toEqual('1')
+      expect(secondItemDownButton.dataset.indexSection).toEqual('1')
+    })
   })
 
   describe('when clicking the Down button on first item', function () {
@@ -172,6 +185,19 @@ describe('Reorderable list component', function () {
     it('should trigger a reorder-move-down event', function () {
       expect('reorder-move-down').toHaveBeenTriggeredOn(firstItemDownButton)
     })
+
+    it('should update index section data attribute of button if tracked', function () {
+      var firstItemUpButton = document.querySelector('li:nth-child(1) .js-reorderable-list-up')
+      var firstItemDownButton = document.querySelector('li:nth-child(1) .js-reorderable-list-down')
+      var secondItemUpButton = document.querySelector('li:nth-child(2) .js-reorderable-list-up')
+      var secondItemDownButton = document.querySelector('li:nth-child(2) .js-reorderable-list-down')
+
+      expect(firstItemUpButton.dataset.indexSection).not.toEqual('0')
+      expect(firstItemDownButton.dataset.indexSection).not.toEqual('0')
+
+      expect(secondItemUpButton.dataset.indexSection).toEqual('1')
+      expect(secondItemDownButton.dataset.indexSection).toEqual('1')
+    })
   })
 
   describe('when clicking the Up button on the second item', function () {
@@ -201,6 +227,19 @@ describe('Reorderable list component', function () {
 
     it('should trigger a reorder-move-up event', function () {
       expect('reorder-move-up').toHaveBeenTriggeredOn(secondItemUpButton)
+    })
+
+    it('should update index section data attribute of button if tracked', function () {
+      var firstItemUpButton = document.querySelector('li:nth-child(1) .js-reorderable-list-up')
+      var firstItemDownButton = document.querySelector('li:nth-child(1) .js-reorderable-list-down')
+      var secondItemUpButton = document.querySelector('li:nth-child(2) .js-reorderable-list-up')
+      var secondItemDownButton = document.querySelector('li:nth-child(2) .js-reorderable-list-down')
+
+      expect(firstItemUpButton.dataset.indexSection).not.toEqual('0')
+      expect(firstItemDownButton.dataset.indexSection).not.toEqual('0')
+
+      expect(secondItemUpButton.dataset.indexSection).toEqual('1')
+      expect(secondItemDownButton.dataset.indexSection).toEqual('1')
     })
   })
 })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.spec.js
@@ -133,6 +133,22 @@ describe('Google Analytics event tracker', function () {
       element.click()
       expect(window.dataLayer[0].not_a_schema_attribute).toEqual(undefined)
     })
+
+    it('includes data attributes assigned to the dataset that are in the schema', function () {
+      expected.event_data.index.index_section = '5'
+      element.setAttribute('data-index-section', 5)
+      element.click()
+
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+
+    it('does not include data attributes assigned to the dataset that are not in the schema', function () {
+      expected.event_data.not_a_schema_attribute = 'value'
+      element.setAttribute('data-not-a-schema-attribute', 'value')
+      element.click()
+
+      expect(window.dataLayer[0]).not.toEqual(expected)
+    })
   })
 
   describe('doing simple tracking on a nested tracked elements', function () {


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

Track when an item in the Reorderable List component is moved by button click or drag using `Ga4EventTracker`

### More details

- `ReorderableList` adds `ga4-event-tracker` to `data-module` and `data-ga4-event` data attribute to buttons unless `disable_ga4` is set to true
  - Update documentation to include `disable_ga4` attribute
- Add `getTargetDatasetSchema` to `Ga4EventTracker` to grab updated data attributes of a tracked element without the component JS needing to parse, amend and then rewrite the `data-ga4-event` attribute with each change to indexing
- `ReorderableList.updateOrderIndexes` now updates `data-index` of each item for event tracking
- Add `onEnd` event listener to `ReorderableList` to trigger `Ga4EventTracker` to record drag and drop event

## Why

As part of adding tracking to publishing applications that are using govuk_publishing_components.

https://trello.com/c/CYoorj7T/3763-track-re-orderable-list-component