### PR TITLE
Add tracking to `AddAnother`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add tracking to `ReorderableList` ([PR #4835](https://github.com/alphagov/govuk_publishing_components/pull/4835))
+* Add tracking to `AddAnother` ([PR #4836](https://github.com/alphagov/govuk_publishing_components/pull/4836))
 
 ## 57.1.0
 

--- a/app/views/govuk_publishing_components/components/_add_another.html.erb
+++ b/app/views/govuk_publishing_components/components/_add_another.html.erb
@@ -5,6 +5,7 @@
   fieldset_legend ||= ""
   add_button_text ||= "Add another"
   empty_fields ||= false
+  disable_ga4 ||= nil
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-add-another")
@@ -13,6 +14,7 @@
     add_button_text:,
     fieldset_legend:,
     empty_fields:,
+    disable_ga4:,
   })
 %>
 

--- a/app/views/govuk_publishing_components/components/docs/add_another.yml
+++ b/app/views/govuk_publishing_components/components/docs/add_another.yml
@@ -46,6 +46,31 @@ examples:
           <label for="person_1_name" class="gem-c-label govuk-label">Full name</label>
           <input class="gem-c-input govuk-input" id="person_1_name" name="person[1]name">
         </div>
+  without_ga4_tracking:
+    description: |
+      Disables GA4 tracking on the add another component. Tracking is enabled by default. This adds a data module and data-attributes with JSONs to the add another component buttons. See the [ga4-event-tracker documentation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-event-tracker.md) for more information.
+    data:
+      fieldset_legend: "Item"
+      add_button_text: "Add another item"
+      disable_ga4: true
+      items:
+        - fields: >
+            <div class="govuk-form-group">
+              <label for="item_0_name" class="gem-c-label govuk-label">Full name</label>
+              <input class="gem-c-input govuk-input" id="item_0_name" name="item[0]name">
+            </div>
+          destroy_checkbox: >
+            <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+              <div class="govuk-checkboxes__item">
+                <input type="checkbox" name="item[0][_destroy]" id="item_0__destroy" class="govuk-checkboxes__input">
+                <label for="item_0__destroy" class="govuk-label govuk-checkboxes__label">Delete</label>
+              </div>
+            </div>
+      empty:
+        <div class="govuk-form-group">
+          <label for="item_1_name" class="gem-c-label govuk-label">Full name</label>
+          <input class="gem-c-input govuk-input" id="item_1_name" name="item[1]name">
+        </div>        
   start_empty:
     description: By default no form fields are displayed when the component loads if no content is specified
     data:


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

Adds tracking to the `AddAnother` component
- `disable_ga4` option added to disable the GA4 attributes being added
- If enabled `AddAnother` will add `data-ga4-event` data attributes to the `Add` and `Remove` buttons

## Why
<!-- What are the reasons behind this change being made? -->

As part of adding GA4 Tracking to components used in Publishing applications.