### PR TITLE
Add phone numbers to GA4 PII redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Add tracking to `ReorderableList` ([PR #4835](https://github.com/alphagov/govuk_publishing_components/pull/4835))
 * Add tracking to `AddAnother` ([PR #4836](https://github.com/alphagov/govuk_publishing_components/pull/4836))
+* Add phone numbers to GA4 PII redaction ([PR #4840](https://github.com/alphagov/govuk_publishing_components/pull/4840))
 
 ## 57.1.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.js
@@ -36,6 +36,11 @@
   // e.g. 'AB123456A', 'AB 12 34 56 A', 'ab 123456 a', 'ab 12 34 56 a', 'AB+12+34+56+A'
   var NATIONAL_INSURANCE_NUMBER = /[A-CEGHJ-OPR-TW-Z]{2}(\s+|\++)?(\d{2}(\s+|\++)?){3}[A-D]/gi
 
+  var UK_MOBILE_NUMBER = /07\d{9}/g
+  var UK_MOBILE_NUMBER_INTERNATIONAL = /\+447\d{9}/g
+  var UK_LANDLINE_NUMBER = /0[1246]\d{8,9}/g
+  var UK_LANDLINE_NUMBER_INTERNATIONAL = /\+44[1246]\d{8,9}/g
+
   function shouldStripDates () {
     var metas = document.querySelectorAll('meta[name="govuk:ga4-strip-dates"]')
     return metas.length > 0
@@ -109,6 +114,11 @@
     stripped = stripped.replace(VISA_PATTERN_GWF, '[gwf number]')
     stripped = stripped.replace(VISA_PATTERN_GB, '[gb eori number]')
     stripped = stripped.replace(NATIONAL_INSURANCE_NUMBER, '[ni number]')
+    stripped = stripped.replace(UK_LANDLINE_NUMBER, '[phone number]')
+    stripped = stripped.replace(UK_LANDLINE_NUMBER_INTERNATIONAL, '[phone number]')
+    stripped = stripped.replace(UK_MOBILE_NUMBER, '[phone number]')
+    stripped = stripped.replace(UK_MOBILE_NUMBER_INTERNATIONAL, '[phone number]')
+
     stripped = this.stripQueryStringParameters(stripped)
 
     if (this.stripDatePII === true) {

--- a/docs/analytics-ga4/pii-remover.md
+++ b/docs/analytics-ga4/pii-remover.md
@@ -9,6 +9,9 @@ The values that are redacted by default are:
 - Reset password tokens become `reset_password_token=[reset_password_token]`
 - Unlock tokens become `unlock_token=[unlock_token]`
 - State values become `state=[state]`
+- Visa application values become `[gwf number]` or `[gb eori number]`
+- National Insurance numbers become `[ni number]`
+- UK phone numbers become `[phone number]`
 
 Additional values that can be redacted are:
 - Dates - `2022-02-22` becomes `[date]`

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
@@ -296,8 +296,8 @@ describe('GA4 core', function () {
     })
 
     it('standardises search terms for consistency across trackers', function () {
-      var searchTerm = 'NO UPPERCASE, NO %2B plus + signs, NO PII email@example.com SW1A 2AA AA123456A 1st Jan 1990 and    NO    extra    spaces \n \r      '
-      var expected = 'no uppercase, no plus signs, no pii [email] [postcode] [ni number] 1st jan 1990 and no extra spaces'
+      var searchTerm = 'NO UPPERCASE, NO %2B plus + signs, NO PII email@example.com SW1A 2AA AA123456A 0123456789 1st Jan 1990  and    NO    extra    spaces \n \r      '
+      var expected = 'no uppercase, no plus signs, no pii [email] [postcode] [ni number] [phone number] 1st jan 1990 and no extra spaces'
 
       searchTerm = GOVUK.analyticsGa4.core.trackFunctions.standardiseSearchTerm(searchTerm)
       expect(searchTerm).toEqual(expected)

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
@@ -354,12 +354,12 @@ describe('Google Tag Manager page view tracking', function () {
     expect(window.dataLayer[0]).toEqual(expected)
   })
 
-  it('removes email, postcode, and date pii from the title, location and referrer', function () {
-    document.title = 'example@gov.uk - SW12AA - 2020-01-01'
-    expected.page_view.title = '[email] - [postcode] - [date]'
+  it('removes email, postcode, date, and phone number pii from the title, location and referrer', function () {
+    document.title = 'example@gov.uk - SW12AA - 2020-01-01 - 0123456789'
+    expected.page_view.title = '[email] - [postcode] - [date] - [phone number]'
 
-    spyOnProperty(document, 'referrer', 'get').and.returnValue('https://gov.uk/example@gov.uk/SW12AA/2020-01-01')
-    expected.page_view.referrer = 'https://gov.uk/[email]/[postcode]/[date]'
+    spyOnProperty(document, 'referrer', 'get').and.returnValue('https://gov.uk/example@gov.uk/SW12AA/2020-01-01/0123456789')
+    expected.page_view.referrer = 'https://gov.uk/[email]/[postcode]/[date]/[phone number]'
 
     // We can't spy on location, so instead we use an anchor link to change the URL temporarily
 
@@ -369,10 +369,10 @@ describe('Google Tag Manager page view tracking', function () {
     linkForURLMock.click()
     var location = document.location.href
 
-    expected.page_view.location = location + '[email]/[postcode]/[date]'
+    expected.page_view.location = location + '[email]/[postcode]/[date]/[phone number]'
 
     // Add personally identifiable information to the current page location
-    linkForURLMock.href = '#example@gov.uk/SW12AA/2020-01-01'
+    linkForURLMock.href = '#example@gov.uk/SW12AA/2020-01-01/0123456789'
     linkForURLMock.click()
 
     GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
@@ -588,8 +588,8 @@ describe('Google Tag Manager page view tracking', function () {
   })
 
   it('correctly sets the query_string parameter with PII and _ga/_gl values redacted', function () {
-    spyOn(GOVUK.analyticsGa4.core.trackFunctions, 'getSearch').and.returnValue('?query1=hello&query2=world&email=email@example.com&postcode=SW12AA&birthday=1990-01-01&_ga=19900101.567&_gl=19900101.567&ni_number=AA+123456+A')
-    expected.page_view.query_string = 'query1=hello&query2=world&email=[email]&postcode=[postcode]&birthday=[date]&_ga=[id]&_gl=[id]&ni_number=[ni number]'
+    spyOn(GOVUK.analyticsGa4.core.trackFunctions, 'getSearch').and.returnValue('?query1=hello&query2=world&email=email@example.com&postcode=SW12AA&birthday=1990-01-01&_ga=19900101.567&_gl=19900101.567&ni_number=AA+123456+A&phone_number=0123456789')
+    expected.page_view.query_string = 'query1=hello&query2=world&email=[email]&postcode=[postcode]&birthday=[date]&_ga=[id]&_gl=[id]&ni_number=[ni number]&phone_number=[phone number]'
     GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
     expect(window.dataLayer[0]).toEqual(expected)
   })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.spec.js
@@ -320,6 +320,114 @@ describe('GOVUK.analyticsGa4.PIIRemover', function () {
     })
   })
 
+  function generatePhoneNumber (prefix, amount, suffix = '') {
+    var phoneNumber = prefix
+    for (var i = 0; i < amount; i++) {
+      phoneNumber += Math.floor(Math.random() * 10)
+    }
+    return `${phoneNumber}${suffix}`
+  }
+
+  describe('phone numbers', function () {
+    it('are stripped if they are valid UK mobile numbers', function () {
+      // Test 50 random phone numbers so we aren't storing any numbers in code.
+      for (let i = 0; i < 50; i++) {
+        const phoneNumber = generatePhoneNumber('07', 9)
+        const redactedNumber = pii.stripPIIWithOverride(phoneNumber)
+        expect(redactedNumber).toEqual('[phone number]')
+      }
+    })
+
+    it('are stripped if they are valid international UK mobile numbers', function () {
+      // Test 50 random phone numbers so we aren't storing any numbers in code.
+      for (let i = 0; i < 50; i++) {
+        const phoneNumber = generatePhoneNumber('+447', 9)
+        const redactedNumber = pii.stripPIIWithOverride(phoneNumber)
+        expect(redactedNumber).toEqual('[phone number]')
+      }
+    })
+
+    it('are stripped if they are valid UK landline numbers', function () {
+      // Test 50 random phone numbers so we aren't storing any numbers in code.
+      for (let i = 0; i < 50; i++) {
+        // A landline can start with 01, 02, 04, or 06, so we generate all 4 examples here.
+        const numbers = [
+          generatePhoneNumber('01', 9),
+          generatePhoneNumber('02', 9),
+          generatePhoneNumber('04', 9),
+          generatePhoneNumber('06', 9),
+          generatePhoneNumber('01', 8),
+          generatePhoneNumber('02', 8),
+          generatePhoneNumber('04', 8),
+          generatePhoneNumber('06', 8)]
+        for (const number of numbers) {
+          const redactedNumber = pii.stripPIIWithOverride(number)
+          expect(redactedNumber).toEqual('[phone number]')
+        }
+      }
+    })
+
+    it('are stripped if they are valid international UK landline numbers', function () {
+      // Test 50 random phone numbers so we aren't storing any numbers in code.
+      for (let i = 0; i < 50; i++) {
+        // A landline can start with 01, 02, 04, or 06, so we generate all 4 examples here.
+        const numbers = [generatePhoneNumber('+441', 9), generatePhoneNumber('+442', 9), generatePhoneNumber('+444', 9), generatePhoneNumber('+446', 9)]
+        for (const number of numbers) {
+          const redactedNumber = pii.stripPIIWithOverride(number)
+          expect(redactedNumber).toEqual('[phone number]')
+        }
+      }
+    })
+
+    it('are not stripped if they are invalid UK numbers', function () {
+      // These are numbers that are too short to be valid, or start with the wrong number.
+      const numbers = [
+        generatePhoneNumber('07', 7),
+        generatePhoneNumber('01', 7),
+        generatePhoneNumber('02', 7),
+        generatePhoneNumber('04', 7),
+        generatePhoneNumber('06', 7),
+        generatePhoneNumber('03', 9),
+        generatePhoneNumber('05', 9),
+        generatePhoneNumber('09', 9),
+        generatePhoneNumber('+1', 9),
+        generatePhoneNumber('17', 9),
+        generatePhoneNumber('21', 9),
+        generatePhoneNumber('32', 9),
+        generatePhoneNumber('54', 9),
+        generatePhoneNumber('56', 9),
+        generatePhoneNumber('+1', 9)]
+
+      for (const number of numbers) {
+        const redactedNumber = pii.stripPIIWithOverride(number)
+        expect(redactedNumber).toEqual(number)
+      }
+    })
+
+    it('are stripped even if they are surrounded by other text', function () {
+      const numbers = [
+        generatePhoneNumber('hello+07', 9, '+world'),
+        generatePhoneNumber('?01', 9, '!'),
+        generatePhoneNumber('lorem02', 9, 'ipsum'),
+        generatePhoneNumber('test04', 9, 'test'),
+        generatePhoneNumber('test06', 9, '&test'),
+        generatePhoneNumber('test+447', 9, 'test'),
+        generatePhoneNumber('test+441', 9, 'test'),
+        generatePhoneNumber('+442', 9, 'test'),
+        generatePhoneNumber('+444', 9, 'test'),
+        generatePhoneNumber('+446', 9, 'test'),
+        generatePhoneNumber('+441', 8, 'test'),
+        generatePhoneNumber('+442', 8, 'test'),
+        generatePhoneNumber('+444', 8, 'test'),
+        generatePhoneNumber('+446', 8, 'test')]
+
+      for (const number of numbers) {
+        const redactedNumber = pii.stripPIIWithOverride(number)
+        expect(redactedNumber.includes('[phone number]')).toEqual(true)
+      }
+    })
+  })
+
   function getRandomNumber (range) {
     return Math.floor(Math.random() * range)
   }


### PR DESCRIPTION
## What / Why
<!-- What are the reasons behind this change being made? -->
- Adds phone numbers to our GA4 PII redaction. 
- This includes four different regexes:
  - UK Mobile numbers `e.g. 07...`
  - UK Mobile numbers with the international code `+44`, which causes the first `0` in the mobile number to be dropped (`e.g. +447...`)
  - UK Landline numbers  `e.g. 020...`
  - UK Landline numbers with the international code `+44`, which causes the first `0` in the phone number to be dropped (`e.g. +4420...`)
  - I have these separate as I found combining the UK number/international regexes together led to an incorrect scenario where `+440...` is valid when it shouldn't be, so it was easier to separate them out.
  - Trello card: https://trello.com/c/V7q79XLH


## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
