### PR TITLE
Add extra functionality to `trackFormSubmit` of `Ga4FormTracker`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Add tracking to `AddAnother` ([PR #4836](https://github.com/alphagov/govuk_publishing_components/pull/4836))
 * Add phone numbers to GA4 PII redaction ([PR #4840](https://github.com/alphagov/govuk_publishing_components/pull/4840))
 * Add image functionality to the intervention banner ([PR #4845](https://github.com/alphagov/govuk_publishing_components/pull/4845))
+* Add extra functionality to trackFormSubmit of Ga4FormTracker ([PR #4847](https://github.com/alphagov/govuk_publishing_components/pull/4847/))
 
 ## 57.1.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
@@ -9,6 +9,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.trackingTrigger = 'data-ga4-form' // elements with this attribute get tracked
     this.includeTextInputValues = this.module.hasAttribute('data-ga4-form-include-text')
     this.recordJson = this.module.hasAttribute('data-ga4-form-record-json')
+    this.useTextCount = this.module.hasAttribute('data-ga4-form-use-text-count')
     this.redacted = false
     this.useFallbackValue = this.module.hasAttribute('data-ga4-form-no-answer-undefined') ? undefined : 'No answer given'
   }
@@ -87,6 +88,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
       input.section = labelText
 
+      var isTextField = inputTypes.indexOf(inputType) !== -1 || inputNodename === 'TEXTAREA'
+
       if (elem.checked) {
         input.answer = labelText
 
@@ -101,10 +104,14 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         }
       } else if (inputNodename === 'SELECT' && elem.options[elem.selectedIndex] && elem.options[elem.selectedIndex].value) {
         input.answer = elem.options[elem.selectedIndex].text
-      } else if (inputTypes.indexOf(inputType) !== -1 && elem.value) {
+      } else if (isTextField && elem.value) {
         if (this.includeTextInputValues || elem.hasAttribute('data-ga4-form-include-input')) {
-          var PIIRemover = new window.GOVUK.analyticsGa4.PIIRemover()
-          input.answer = PIIRemover.stripPIIWithOverride(elem.value, true, true)
+          if (this.useTextCount) {
+            input.answer = elem.value.length
+          } else {
+            var PIIRemover = new window.GOVUK.analyticsGa4.PIIRemover()
+            input.answer = PIIRemover.stripPIIWithOverride(elem.value, true, true)
+          }
         } else {
           // if recording JSON and text input not allowed
           // set the specific answer to '[REDACTED]'

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
@@ -89,8 +89,25 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       input.section = labelText
 
       var isTextField = inputTypes.indexOf(inputType) !== -1 || inputNodename === 'TEXTAREA'
+      var conditionalField = elem.closest('.govuk-checkboxes__conditional')
+      var conditionalCheckbox = conditionalField && conditionalField.querySelector('[aria-controls="' + conditionalField.id + '"]')
+      var conditionalCheckboxChecked = conditionalCheckbox && conditionalCheckbox.checked
 
-      if (elem.checked) {
+      if (conditionalField && conditionalCheckboxChecked) {
+        var conditionalCheckboxLabel = conditionalField.querySelector('[for="' + conditionalCheckbox.id + '"]')
+
+        if (conditionalCheckboxLabel) {
+          input.parentSection = conditionalCheckboxLabel.innerText
+        }
+      }
+
+      if (conditionalCheckbox && !conditionalCheckboxChecked) {
+        // don't include conditional field if condition not checked
+        inputs.splice(i, 1)
+      } else if (conditionalField && elem.hasAttribute('aria-controls')) {
+        // don't include conditional field control in text
+        inputs.splice(i, 1)
+      } else if (elem.checked) {
         input.answer = labelText
 
         var fieldset = elem.closest('fieldset')
@@ -138,9 +155,15 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       if (answer) {
         if (this.recordJson) {
           var fieldSection = data[i].section
+          var parentFieldSection = data[i].parentSection
 
           if (fieldSection) {
-            answers[fieldSection] = answer
+            if (parentFieldSection) {
+              answers[parentFieldSection] = answers[parentFieldSection] || {}
+              answers[parentFieldSection][fieldSection] = answer
+            } else {
+              answers[fieldSection] = answer
+            }
           }
         } else {
           answers.push(answer)

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
@@ -8,6 +8,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.module = module
     this.trackingTrigger = 'data-ga4-form' // elements with this attribute get tracked
     this.includeTextInputValues = this.module.hasAttribute('data-ga4-form-include-text')
+    this.recordJson = this.module.hasAttribute('data-ga4-form-record-json')
     this.redacted = false
     this.useFallbackValue = this.module.hasAttribute('data-ga4-form-no-answer-undefined') ? undefined : 'No answer given'
   }
@@ -84,8 +85,20 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       var inputNodename = elem.nodeName
       var inputTypes = ['text', 'search', 'email', 'number']
 
-      if (inputType === 'checkbox' && elem.checked) {
+      input.section = labelText
+
+      if (elem.checked) {
         input.answer = labelText
+
+        var fieldset = elem.closest('fieldset')
+
+        if (fieldset) {
+          var legend = fieldset.querySelector('legend')
+
+          if (legend) {
+            input.section = legend.innerText
+          }
+        }
       } else if (inputNodename === 'SELECT' && elem.options[elem.selectedIndex] && elem.options[elem.selectedIndex].value) {
         input.answer = elem.options[elem.selectedIndex].text
       } else if (inputTypes.indexOf(inputType) !== -1 && elem.value) {
@@ -93,10 +106,14 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
           var PIIRemover = new window.GOVUK.analyticsGa4.PIIRemover()
           input.answer = PIIRemover.stripPIIWithOverride(elem.value, true, true)
         } else {
-          this.redacted = true
+          // if recording JSON and text input not allowed
+          // set the specific answer to '[REDACTED]'
+          if (this.recordJson) {
+            input.answer = '[REDACTED]'
+          } else {
+            this.redacted = true
+          }
         }
-      } else if (inputType === 'radio' && elem.checked) {
-        input.answer = labelText
       } else {
         // remove the input from those gathered as it has no value
         inputs.splice(i, 1)
@@ -106,19 +123,32 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   }
 
   Ga4FormTracker.prototype.combineGivenAnswers = function (data) {
-    var answers = []
+    var answers = this.recordJson ? {} : []
+
     for (var i = 0; i < data.length; i++) {
       var answer = data[i].answer
+
       if (answer) {
-        answers.push(answer)
+        if (this.recordJson) {
+          var fieldSection = data[i].section
+
+          if (fieldSection) {
+            answers[fieldSection] = answer
+          }
+        } else {
+          answers.push(answer)
+        }
       }
     }
-    if (this.redacted) {
+    // default behaviour for redacted text is to omit
+    // answer and append '[REDACTED]' to final joined text
+    // if JSON being recorded then prevent this as answer
+    // will be already redacted
+    if (this.redacted && !this.recordJson) {
       answers.push('[REDACTED]')
     }
 
-    answers = answers.join(',')
-    return answers
+    return this.recordJson ? JSON.stringify(answers) : answers.join(',')
   }
 
   Modules.Ga4FormTracker = Ga4FormTracker

--- a/docs/analytics-ga4/trackers/ga4-form-tracker.md
+++ b/docs/analytics-ga4/trackers/ga4-form-tracker.md
@@ -19,7 +19,7 @@ The data attributes are used as follows:
 - `action` records the text of the form submission button e.g. `Continue`
 - `tool_name` records the overall name of the smart answer e.g. `How do I eat more healthily?`
 
-The script will automatically collect the answer submitted in the `text` field. For questions where multiple answers are possible, these will be comma separated. Where the answer is a text input, the value given is replaced with `[REDACTED]`, to avoid collecting personally identifiable information. If all inputs should not have their text redacted, add a `data-ga4-form-include-text` attribute to the form. If you only want a certain text input to be exempt from redaction, add a `data-ga4-form-include-input` attribute to that input element.
+The script will automatically collect the answer submitted in the `text` field. For questions where multiple answers are possible, these will be comma separated. Where the answer is a text input, the value given is replaced with `[REDACTED]`, to avoid collecting personally identifiable information. If all inputs should not have their text redacted, add a `data-ga4-form-include-text` attribute to the form. If you only want a certain text input to be exempt from redaction, add a `data-ga4-form-include-input` attribute to that input element. If the `data-ga4-form-use-text-count` attribute is also used then the form will use the text count of a text input instead of the value of the text field.
 
 In the example above, the following would be pushed to the dataLayer. Note that the schema automatically populates empty values, and that attributes not in the schema are ignored.
 

--- a/docs/analytics-ga4/trackers/ga4-form-tracker.md
+++ b/docs/analytics-ga4/trackers/ga4-form-tracker.md
@@ -37,4 +37,16 @@ In the example above, the following would be pushed to the dataLayer. Note that 
 }
 ```
 
+If the `data-ga4-form-record-json` attribute is set on the form then the JSON format will be used for the `text` field. So instead of the `text` being set to:
+
+```
+value,value,[REDACTED]
+```
+
+with `data-ga4-form-record-json` it will be set to:
+
+```
+{ "label1": "value", "label2": "value", "label3": "[REDACTED]" }
+```
+
 When a form is submitted with an empty input value, the tracker will set the `text` value in the dataLayer to `"No answer given"`. If you require empty input to be sent as `undefined` instead, add the `data-ga4-form-no-answer-undefined` attribute to the form.

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
@@ -2,8 +2,17 @@
 
 describe('Google Analytics form tracking', function () {
   var GOVUK = window.GOVUK
+  var schema = new GOVUK.analyticsGa4.Schemas()
   var element
   var expected
+
+  var attributes = {
+    event_name: 'form_response',
+    type: 'smart answer',
+    section: 'What is the title of this question?',
+    action: 'Continue',
+    tool_name: 'What is the title of this smart answer?'
+  }
 
   function agreeToCookies () {
     GOVUK.setCookie('cookies_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true}')
@@ -80,21 +89,8 @@ describe('Google Analytics form tracking', function () {
 
   describe('when tracking a form', function () {
     beforeEach(function () {
-      var attributes = {
-        event_name: 'form_response',
-        type: 'smart answer',
-        section: 'What is the title of this question?',
-        action: 'Continue',
-        tool_name: 'What is the title of this smart answer?'
-      }
       element.setAttribute('data-ga4-form', JSON.stringify(attributes))
-      expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
-      expected.event = 'event_data'
-      expected.event_data.event_name = 'form_response'
-      expected.event_data.type = 'smart answer'
-      expected.event_data.section = 'What is the title of this question?'
-      expected.event_data.action = 'Continue'
-      expected.event_data.tool_name = 'What is the title of this smart answer?'
+      expected = schema.mergeProperties(attributes, 'event_data')
       expected.govuk_gem_version = 'aVersion'
       expected.timestamp = '123456'
       var tracker = new GOVUK.Modules.Ga4FormTracker(element)
@@ -108,15 +104,9 @@ describe('Google Analytics form tracking', function () {
     })
 
     it('allows the text value to be overridden', function () {
-      var attributes = {
-        event_name: 'form_response',
-        type: 'smart answer',
-        section: 'What is the title of this question?',
-        action: 'Continue',
-        tool_name: 'What is the title of this smart answer?',
-        text: 'Hello World'
-      }
-      element.setAttribute('data-ga4-form', JSON.stringify(attributes))
+      var overriddenText = JSON.parse(JSON.stringify(attributes))
+      overriddenText.text = 'Hello World'
+      element.setAttribute('data-ga4-form', JSON.stringify(overriddenText))
       window.GOVUK.triggerEvent(element, 'submit')
       expected.event_data.text = 'Hello World'
       expect(window.dataLayer[0]).toEqual(expected)
@@ -254,13 +244,7 @@ describe('Google Analytics form tracking', function () {
       }
       element.setAttribute('data-ga4-form', JSON.stringify(attributes))
       element.setAttribute('data-ga4-form-no-answer-undefined', '')
-      expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
-      expected.event = 'event_data'
-      expected.event_data.event_name = 'form_response'
-      expected.event_data.type = 'smart answer'
-      expected.event_data.section = 'What is the title of this question?'
-      expected.event_data.action = 'Continue'
-      expected.event_data.tool_name = 'What is the title of this smart answer?'
+      expected = schema.mergeProperties(attributes, 'event_data')
       expected.govuk_gem_version = 'aVersion'
       expected.timestamp = '123456'
       var tracker = new GOVUK.Modules.Ga4FormTracker(element)
@@ -268,13 +252,6 @@ describe('Google Analytics form tracking', function () {
     })
 
     it('allows the fallback value when the text is empty to be undefined', function () {
-      var attributes = {
-        event_name: 'form_response',
-        type: 'smart answer',
-        section: 'What is the title of this question?',
-        action: 'Continue',
-        tool_name: 'What is the title of this smart answer?'
-      }
       element.setAttribute('data-ga4-form', JSON.stringify(attributes))
       window.GOVUK.triggerEvent(element, 'submit')
       expected.event_data.text = undefined
@@ -284,22 +261,10 @@ describe('Google Analytics form tracking', function () {
 
   describe('when tracking a form with text redaction disabled', function () {
     beforeEach(function () {
-      var attributes = {
-        event_name: 'form_response',
-        type: 'smart answer',
-        section: 'What is the title of this question?',
-        action: 'Continue',
-        tool_name: 'What is the title of this smart answer?'
-      }
       element.setAttribute('data-ga4-form', JSON.stringify(attributes))
       element.setAttribute('data-ga4-form-include-text', '')
       expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
-      expected.event = 'event_data'
-      expected.event_data.event_name = 'form_response'
-      expected.event_data.type = 'smart answer'
-      expected.event_data.section = 'What is the title of this question?'
-      expected.event_data.action = 'Continue'
-      expected.event_data.tool_name = 'What is the title of this smart answer?'
+      expected = schema.mergeProperties(attributes, 'event_data')
       expected.govuk_gem_version = 'aVersion'
       expected.timestamp = '123456'
       var tracker = new GOVUK.Modules.Ga4FormTracker(element)
@@ -350,20 +315,16 @@ describe('Google Analytics form tracking', function () {
 
   describe('when tracking search forms', function () {
     beforeEach(function () {
-      var attributes = {
+      var searchAttributes = {
         event_name: 'form_response',
         type: 'header menu bar',
         section: 'Search',
         action: 'search'
       }
-      element.setAttribute('data-ga4-form', JSON.stringify(attributes))
+      element.setAttribute('data-ga4-form', JSON.stringify(searchAttributes))
       element.setAttribute('data-ga4-form-include-text', '')
       expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
-      expected.event = 'event_data'
-      expected.event_data.event_name = 'form_response'
-      expected.event_data.type = 'header menu bar'
-      expected.event_data.section = 'Search'
-      expected.event_data.action = 'search'
+      expected = schema.mergeProperties(searchAttributes, 'event_data')
       expected.govuk_gem_version = 'aVersion'
       expected.timestamp = '123456'
       var tracker = new GOVUK.Modules.Ga4FormTracker(element)

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
@@ -301,6 +301,37 @@ describe('Google Analytics form tracking', function () {
     })
   })
 
+  describe('when tracking a form with character count enabled', function () {
+    beforeEach(function () {
+      var attributes = {
+        event_name: 'form_response',
+        type: 'smart answer',
+        section: 'What is the title of this question?',
+        action: 'Continue',
+        tool_name: 'What is the title of this smart answer?'
+      }
+      element.setAttribute('data-ga4-form', JSON.stringify(attributes))
+      element.setAttribute('data-ga4-form-include-text', '')
+      element.setAttribute('data-ga4-form-use-text-count', '')
+      expected = schema.mergeProperties(attributes, 'event_data')
+      expected.govuk_gem_version = 'aVersion'
+      expected.timestamp = '123456'
+      var tracker = new GOVUK.Modules.Ga4FormTracker(element)
+      tracker.init()
+    })
+
+    it('collects character count from a text input', function () {
+      element.innerHTML =
+        '<label for="text">Text label</label>' +
+        '<input type="text" id="text" name="test-text" value="Some text"/>'
+
+      expected.event_data.text = '9'
+
+      window.GOVUK.triggerEvent(element, 'submit')
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+  })
+
   describe('when tracking a form with undefined instead of no answer given', function () {
     beforeEach(function () {
       var attributes = {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
@@ -148,6 +148,39 @@ describe('Google Analytics form tracking', function () {
       expect(window.dataLayer[0]).toEqual(expected)
     })
 
+    it('collects data from checked conditional fields', function () {
+      element.innerHTML =
+        '<div id="conditional-field" class="govuk-checkboxes__conditional">' +
+          '<label for="c1">checkbox1</label>' +
+          '<input type="checkbox" aria-controls="conditional-field" id="c1" name="checkbox[]" value="checkbox1"/>' +
+          '<label for="c3">checkbox3</label>' +
+          '<input type="checkbox" id="c3" name="checkbox[]" value="checkbox3"/>' +
+        '</div>'
+
+      document.getElementById('c1').checked = true
+      document.getElementById('c3').checked = true
+
+      expected.event_data.text = 'checkbox3'
+
+      window.GOVUK.triggerEvent(element, 'submit')
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+
+    it('does not collect data from unchecked conditional fields', function () {
+      element.innerHTML =
+        '<div id="conditional-field" class="govuk-checkboxes__conditional">' +
+          '<label for="c1">checkbox1</label>' +
+          '<input type="checkbox" aria-controls="conditional-field" id="c1" name="checkbox[]" value="checkbox1"/>' +
+          '<label for="text">Label</label>' +
+          '<input type="text" id="text" name="test-text" value="Some text"/>' +
+        '</div>'
+
+      expected.event_data.text = 'No answer given'
+
+      window.GOVUK.triggerEvent(element, 'submit')
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+
     it('collects data from checkboxes', function () {
       element.innerHTML =
         '<label><input type="checkbox" id="c1" name="checkbox[]" value="checkbox1"/>checkbox1</label>' +
@@ -249,6 +282,44 @@ describe('Google Analytics form tracking', function () {
       expected.timestamp = '123456'
       var tracker = new GOVUK.Modules.Ga4FormTracker(element)
       tracker.init()
+    })
+
+    it('collects data from checked conditional checkboxes', function () {
+      element.innerHTML =
+        '<div id="conditional-field" class="govuk-checkboxes__conditional">' +
+          '<fieldset>' +
+          '<legend>Checkbox legend</legend>' +
+          '<label for="c3">checkbox3</label>' +
+          '<input type="checkbox" id="c3" name="checkbox[]" value="checkbox3"/>' +
+          '</fieldset>' +
+          '<input type="checkbox" aria-controls="conditional-field" id="c1" name="checkbox[]" value="checkbox1"/>' +
+          '<label for="c1">checkbox1</label>' +
+        '</div>'
+
+      document.getElementById('c1').checked = true
+      document.getElementById('c3').checked = true
+
+      expected.event_data.text = JSON.stringify({ checkbox1: { 'Checkbox legend': 'checkbox3' } })
+
+      window.GOVUK.triggerEvent(element, 'submit')
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+
+    it('collects data from checked conditional input', function () {
+      element.innerHTML =
+        '<div id="conditional-field" class="govuk-checkboxes__conditional">' +
+          '<label for="c1">checkbox1</label>' +
+          '<input type="checkbox" aria-controls="conditional-field" id="c1" name="checkbox[]" value="checkbox1"/>' +
+          '<label for="text">Text label</label>' +
+          '<input type="text" id="text" name="test-text" value="Some text"/>' +
+        '</div>'
+
+      document.getElementById('c1').checked = true
+
+      expected.event_data.text = JSON.stringify({ checkbox1: { 'Text label': '[REDACTED]' } })
+
+      window.GOVUK.triggerEvent(element, 'submit')
+      expect(window.dataLayer[0]).toEqual(expected)
     })
 
     it('collects data from a checkbox with a legend', function () {


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

New functionality and adjustments to the `Ga4FormTracker` submit tracking

### More details
- Change the `Ga4FormTracker` spec to be more DRY and easier to add tests to
- Support for adding labels to the `text` of the event fired (if `data-ga4-form-record-json` set), updated docs to reflect change
- Option to use character count instead of `[REDACTED]` for text fields (if `data-ga4-form-use-text-count` set), updated docs to reflect change
- Takes into account conditional fields (if conditional checkbox not checked, don't include conditional fields)

## Why
<!-- What are the reasons behind this change being made? -->

As part of adding tracking to Publishing Applications. Forms are more complex than those on GOV.UK and Smart Answers, so we need additional information included on a form submit to be able to get useful insights.