### PR TITLE
Use helpers in Jasmine specs

### DIFF
--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-auto-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-auto-tracker.spec.js
@@ -5,25 +5,16 @@ describe('Google Analytics auto tracker', function () {
   var element
   var expected
 
-  function agreeToCookies () {
-    GOVUK.setCookie('cookies_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true}')
-  }
-
-  function denyCookies () {
-    GOVUK.setCookie('cookies_policy', '{"essential":false,"settings":false,"usage":false,"campaigns":false}')
-  }
-
   beforeAll(function () {
     window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
     window.GOVUK.analyticsGa4.vars = window.GOVUK.analyticsGa4.vars || {}
-    window.GOVUK.analyticsGa4.vars.gem_version = 'aVersion'
   })
 
   beforeEach(function () {
     window.dataLayer = []
     element = document.createElement('form')
     document.body.appendChild(element)
-    agreeToCookies()
+    this.agreeToCookies()
     spyOn(GOVUK.analyticsGa4.core, 'getTimestamp').and.returnValue('123456')
   })
 
@@ -37,7 +28,7 @@ describe('Google Analytics auto tracker', function () {
 
   describe('when the user has a cookie consent choice', function () {
     it('starts the module if consent has already been given', function () {
-      agreeToCookies()
+      this.agreeToCookies()
       var tracker = new GOVUK.Modules.Ga4AutoTracker(element)
       spyOn(tracker, 'startModule').and.callThrough()
       tracker.init()
@@ -46,7 +37,7 @@ describe('Google Analytics auto tracker', function () {
     })
 
     it('starts the module on the same page as cookie consent is given', function () {
-      denyCookies()
+      this.denyCookies()
       var tracker = new GOVUK.Modules.Ga4AutoTracker(element)
       spyOn(tracker, 'sendEvent').and.callThrough()
       tracker.init()
@@ -63,7 +54,7 @@ describe('Google Analytics auto tracker', function () {
     })
 
     it('does not do anything if consent is not given', function () {
-      denyCookies()
+      this.denyCookies()
       var tracker = new GOVUK.Modules.Ga4AutoTracker(element)
       spyOn(tracker, 'sendEvent')
       tracker.init()

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-auto-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-auto-tracker.spec.js
@@ -5,11 +5,6 @@ describe('Google Analytics auto tracker', function () {
   var element
   var expected
 
-  beforeAll(function () {
-    window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
-    window.GOVUK.analyticsGa4.vars = window.GOVUK.analyticsGa4.vars || {}
-  })
-
   beforeEach(function () {
     window.dataLayer = []
     element = document.createElement('form')

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-copy-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-copy-tracker.spec.js
@@ -5,9 +5,6 @@ describe('Google Analytics 4 copy tracker', function () {
   var expected
 
   beforeAll(function () {
-    window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
-    window.GOVUK.analyticsGa4.vars = window.GOVUK.analyticsGa4.vars || {}
-    window.GOVUK.analyticsGa4.vars.gem_version = 'aVersion'
     GOVUK.analyticsGa4.analyticsModules.Ga4CopyTracker.init()
   })
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
@@ -15,7 +15,6 @@ describe('GA4 core', function () {
     window.GOVUK.analyticsGa4.vars.id = undefined
     window.GOVUK.analyticsGa4.vars.auth = undefined
     window.GOVUK.analyticsGa4.vars.preview = undefined
-    spyOn(GOVUK.analyticsGa4.core, 'getGemVersion').and.returnValue('aVersion')
   })
 
   afterEach(function () {
@@ -538,10 +537,6 @@ describe('GA4 core', function () {
       var results
       var expectedEcommerceObject
 
-      function agreeToCookies () {
-        GOVUK.setCookie('cookies_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true}')
-      }
-
       beforeEach(function () {
         resultsCount = document.createElement('span')
         resultsCount.id = 'result-count'
@@ -612,7 +607,7 @@ describe('GA4 core', function () {
         resultsParentEl.appendChild(results)
         resultsParentEl.appendChild(resultsCount)
         document.body.appendChild(resultsParentEl)
-        agreeToCookies()
+        this.agreeToCookies()
       })
 
       afterEach(function () {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-ecommerce-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-ecommerce-tracker.spec.js
@@ -10,10 +10,6 @@ describe('Google Analytics 4 ecommerce tracking', function () {
   var onSearchResultClickExpected
   var pageViewExpected
 
-  function agreeToCookies () {
-    GOVUK.setCookie('cookies_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true}')
-  }
-
   beforeEach(function () {
     searchResultsHeading = document.createElement('h2')
     searchResultsHeading.id = 'js-result-count'
@@ -87,7 +83,7 @@ describe('Google Analytics 4 ecommerce tracking', function () {
     searchResultsParentEl.appendChild(searchResults)
     searchResultsParentEl.appendChild(searchResultsHeading)
     document.body.appendChild(searchResultsParentEl)
-    agreeToCookies()
+    this.agreeToCookies()
   })
 
   afterEach(function () {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.spec.js
@@ -5,14 +5,6 @@ describe('Google Analytics event tracker', function () {
   var element
   var expected
 
-  function agreeToCookies () {
-    GOVUK.setCookie('cookies_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true}')
-  }
-
-  function denyCookies () {
-    GOVUK.setCookie('cookies_policy', '{"essential":false,"settings":false,"usage":false,"campaigns":false}')
-  }
-
   beforeAll(function () {
     spyOn(GOVUK.analyticsGa4.core, 'getGemVersion').and.returnValue('aVersion')
   })
@@ -20,7 +12,7 @@ describe('Google Analytics event tracker', function () {
   beforeEach(function () {
     window.dataLayer = []
     element = document.createElement('div')
-    agreeToCookies()
+    this.agreeToCookies()
     spyOn(GOVUK.analyticsGa4.core, 'getTimestamp').and.returnValue('123456')
   })
 
@@ -34,7 +26,7 @@ describe('Google Analytics event tracker', function () {
 
   describe('when the user has a cookie consent choice', function () {
     it('starts the module if consent has already been given', function () {
-      agreeToCookies()
+      this.agreeToCookies()
       document.body.appendChild(element)
       var tracker = new GOVUK.Modules.Ga4EventTracker(element)
       spyOn(tracker, 'trackClick')
@@ -45,7 +37,7 @@ describe('Google Analytics event tracker', function () {
     })
 
     it('starts the module on the same page as cookie consent is given', function () {
-      denyCookies()
+      this.denyCookies()
       document.body.appendChild(element)
       var tracker = new GOVUK.Modules.Ga4EventTracker(element)
       spyOn(tracker, 'trackClick')
@@ -67,7 +59,7 @@ describe('Google Analytics event tracker', function () {
     })
 
     it('does not do anything if consent is not given', function () {
-      denyCookies()
+      this.denyCookies()
       document.body.appendChild(element)
       var tracker = new GOVUK.Modules.Ga4EventTracker(element)
       spyOn(tracker, 'trackClick')

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.spec.js
@@ -11,10 +11,6 @@ describe('GA4 finder change tracker', function () {
   var option2
   var expected
 
-  function agreeToCookies () {
-    GOVUK.setCookie('cookies_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true}')
-  }
-
   beforeAll(function () {
     window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
     window.GOVUK.analyticsGa4.vars = window.GOVUK.analyticsGa4.vars || {}
@@ -40,7 +36,7 @@ describe('GA4 finder change tracker', function () {
     expected.event_data.type = 'finder'
     expected.timestamp = '123456'
 
-    agreeToCookies()
+    this.agreeToCookies()
     spyOn(GOVUK.analyticsGa4.core, 'getTimestamp').and.returnValue('123456')
   })
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.spec.js
@@ -11,12 +11,6 @@ describe('GA4 finder change tracker', function () {
   var option2
   var expected
 
-  beforeAll(function () {
-    window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
-    window.GOVUK.analyticsGa4.vars = window.GOVUK.analyticsGa4.vars || {}
-    window.GOVUK.analyticsGa4.vars.gem_version = 'aVersion'
-  })
-
   beforeEach(function () {
     window.dataLayer = []
     form = document.createElement('form')

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-focus-loss-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-focus-loss-tracker.spec.js
@@ -5,14 +5,6 @@ describe('GA4 focus loss tracker', function () {
   var element
   var expected
 
-  function agreeToCookies () {
-    GOVUK.setCookie('cookies_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true}')
-  }
-
-  function denyCookies () {
-    GOVUK.setCookie('cookies_policy', '{"essential":false,"settings":false,"usage":false,"campaigns":false}')
-  }
-
   beforeAll(function () {
     window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
     window.GOVUK.analyticsGa4.vars = window.GOVUK.analyticsGa4.vars || {}
@@ -23,7 +15,7 @@ describe('GA4 focus loss tracker', function () {
     window.dataLayer = []
     element = document.createElement('div')
     document.body.appendChild(element)
-    agreeToCookies()
+    this.agreeToCookies()
     spyOn(GOVUK.analyticsGa4.core, 'getTimestamp').and.returnValue('123456')
   })
 
@@ -38,7 +30,7 @@ describe('GA4 focus loss tracker', function () {
 
   describe('when the user has a cookie consent choice', function () {
     it('starts the module if consent has already been given', function () {
-      agreeToCookies()
+      this.agreeToCookies()
       var tracker = new GOVUK.Modules.Ga4FocusLossTracker(element)
       spyOn(tracker, 'startModule').and.callThrough()
       tracker.init()
@@ -47,7 +39,7 @@ describe('GA4 focus loss tracker', function () {
     })
 
     it('starts the module on the same page as cookie consent is given', function () {
-      denyCookies()
+      this.denyCookies()
       var tracker = new GOVUK.Modules.Ga4FocusLossTracker(element)
       spyOn(tracker, 'startModule').and.callThrough()
       tracker.init()
@@ -64,7 +56,7 @@ describe('GA4 focus loss tracker', function () {
     })
 
     it('does not do anything if consent is not given', function () {
-      denyCookies()
+      this.denyCookies()
       var tracker = new GOVUK.Modules.Ga4FocusLossTracker(element)
       spyOn(tracker, 'startModule')
       tracker.init()

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-focus-loss-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-focus-loss-tracker.spec.js
@@ -5,12 +5,6 @@ describe('GA4 focus loss tracker', function () {
   var element
   var expected
 
-  beforeAll(function () {
-    window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
-    window.GOVUK.analyticsGa4.vars = window.GOVUK.analyticsGa4.vars || {}
-    window.GOVUK.analyticsGa4.vars.gem_version = 'aVersion'
-  })
-
   beforeEach(function () {
     window.dataLayer = []
     element = document.createElement('div')

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
@@ -14,12 +14,6 @@ describe('Google Analytics form tracking', function () {
     tool_name: 'What is the title of this smart answer?'
   }
 
-  beforeAll(function () {
-    window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
-    window.GOVUK.analyticsGa4.vars = window.GOVUK.analyticsGa4.vars || {}
-    window.GOVUK.analyticsGa4.vars.gem_version = 'aVersion'
-  })
-
   beforeEach(function () {
     window.dataLayer = []
     element = document.createElement('form')

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
@@ -14,14 +14,6 @@ describe('Google Analytics form tracking', function () {
     tool_name: 'What is the title of this smart answer?'
   }
 
-  function agreeToCookies () {
-    GOVUK.setCookie('cookies_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true}')
-  }
-
-  function denyCookies () {
-    GOVUK.setCookie('cookies_policy', '{"essential":false,"settings":false,"usage":false,"campaigns":false}')
-  }
-
   beforeAll(function () {
     window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
     window.GOVUK.analyticsGa4.vars = window.GOVUK.analyticsGa4.vars || {}
@@ -32,7 +24,7 @@ describe('Google Analytics form tracking', function () {
     window.dataLayer = []
     element = document.createElement('form')
     document.body.appendChild(element)
-    agreeToCookies()
+    this.agreeToCookies()
     spyOn(GOVUK.analyticsGa4.core, 'getTimestamp').and.returnValue('123456')
   })
 
@@ -46,7 +38,7 @@ describe('Google Analytics form tracking', function () {
 
   describe('when the user has a cookie consent choice', function () {
     it('starts the module if consent has already been given', function () {
-      agreeToCookies()
+      this.agreeToCookies()
       var tracker = new GOVUK.Modules.Ga4FormTracker(element)
       spyOn(tracker, 'trackFormSubmit')
       tracker.init()
@@ -56,7 +48,7 @@ describe('Google Analytics form tracking', function () {
     })
 
     it('starts the module on the same page as cookie consent is given', function () {
-      denyCookies()
+      this.denyCookies()
       var tracker = new GOVUK.Modules.Ga4FormTracker(element)
       spyOn(tracker, 'trackFormSubmit')
       tracker.init()
@@ -77,7 +69,7 @@ describe('Google Analytics form tracking', function () {
     })
 
     it('does not do anything if consent is not given', function () {
-      denyCookies()
+      this.denyCookies()
       var tracker = new GOVUK.Modules.Ga4FormTracker(element)
       spyOn(tracker, 'trackFormSubmit')
       tracker.init()

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
@@ -13,14 +13,6 @@ describe('GA4 link tracker', function () {
     }
   }
 
-  function agreeToCookies () {
-    GOVUK.setCookie('cookies_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true}')
-  }
-
-  function denyCookies () {
-    GOVUK.setCookie('cookies_policy', '{"essential":false,"settings":false,"usage":false,"campaigns":false}')
-  }
-
   beforeAll(function () {
     spyOn(GOVUK.analyticsGa4.core, 'getGemVersion').and.returnValue('aVersion')
     spyOn(GOVUK.analyticsGa4.core.trackFunctions, 'getHostname').and.returnValue('www.gov.uk')
@@ -38,7 +30,7 @@ describe('GA4 link tracker', function () {
     expected.govuk_gem_version = 'aVersion'
     expected.event_data.link_domain = 'https://www.gov.uk'
     expected.timestamp = '123456'
-    agreeToCookies()
+    this.agreeToCookies()
     spyOn(GOVUK.analyticsGa4.core, 'getTimestamp').and.returnValue('123456')
   })
 
@@ -52,7 +44,7 @@ describe('GA4 link tracker', function () {
     })
 
     it('starts the module if consent has already been given', function () {
-      agreeToCookies()
+      this.agreeToCookies()
       document.body.appendChild(element)
       var tracker = new GOVUK.Modules.Ga4LinkTracker(element)
       spyOn(tracker, 'trackClick')
@@ -63,7 +55,7 @@ describe('GA4 link tracker', function () {
     })
 
     it('starts the module on the same page as cookie consent is given', function () {
-      denyCookies()
+      this.denyCookies()
       document.body.appendChild(element)
       var tracker = new GOVUK.Modules.Ga4LinkTracker(element)
       spyOn(tracker, 'trackClick')
@@ -85,7 +77,7 @@ describe('GA4 link tracker', function () {
     })
 
     it('does not do anything if consent is not given', function () {
-      denyCookies()
+      this.denyCookies()
       document.body.appendChild(element)
       var tracker = new GOVUK.Modules.Ga4LinkTracker(element)
       spyOn(tracker, 'trackClick')

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-print-intent-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-print-intent-tracker.spec.js
@@ -4,12 +4,6 @@ describe('Google Analytics 4 print intent tracker', function () {
   var GOVUK = window.GOVUK
   var expected
 
-  beforeAll(function () {
-    window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
-    window.GOVUK.analyticsGa4.vars = window.GOVUK.analyticsGa4.vars || {}
-    window.GOVUK.analyticsGa4.vars.gem_version = 'aVersion'
-  })
-
   beforeEach(function () {
     window.dataLayer = []
     expected = new GOVUK.analyticsGa4.Schemas().eventSchema()

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.spec.js
@@ -3,12 +3,6 @@
 describe('Google Analytics schemas', function () {
   var schemas
 
-  beforeAll(function () {
-    window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
-    window.GOVUK.analyticsGa4.vars = window.GOVUK.analyticsGa4.vars || {}
-    window.GOVUK.analyticsGa4.vars.gem_version = 'aVersion'
-  })
-
   beforeEach(function () {
     schemas = new window.GOVUK.analyticsGa4.Schemas()
   })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.spec.js
@@ -13,9 +13,8 @@ describe('GA4 scroll tracker', function () {
     expected.event = 'event_data'
     expected.event_data.action = 'scroll'
     expected.event_data.event_name = 'scroll'
-    expected.govuk_gem_version = 'gem-version'
+    expected.govuk_gem_version = 'aVersion'
     expected.timestamp = '123456'
-    spyOn(GOVUK.analyticsGa4.core, 'getGemVersion').and.returnValue('gem-version')
     spyOn(GOVUK.analyticsGa4.core, 'getTimestamp').and.returnValue('123456')
   })
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-smart-answer-results-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-smart-answer-results-tracker.spec.js
@@ -9,10 +9,6 @@ describe('GA4 smart answer results tracking', function () {
   var onPageLoadExpected
   var onSmartAnswerResultClickExpected
 
-  function agreeToCookies () {
-    GOVUK.setCookie('cookies_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true}')
-  }
-
   beforeEach(function () {
     smartAnswerResultsCount = document.createElement('span')
     smartAnswerResultsCount.id = 'ga4-ecommerce-result-count'
@@ -83,7 +79,7 @@ describe('GA4 smart answer results tracking', function () {
     smartAnswerResultsParentEl.appendChild(smartAnswerResults)
     smartAnswerResultsParentEl.appendChild(smartAnswerResultsCount)
     document.body.appendChild(smartAnswerResultsParentEl)
-    agreeToCookies()
+    this.agreeToCookies()
   })
 
   afterEach(function () {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-video-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-video-tracker.spec.js
@@ -8,7 +8,6 @@ describe('Google Analytics video tracker', function () {
     window.dataLayer = []
     videoTracker = window.GOVUK.analyticsGa4.analyticsModules.VideoTracker
     videoTracker.init()
-    window.GOVUK.analyticsGa4.vars.gem_version = 'aVersion'
     event = {
       target: {
         id: 1,

--- a/spec/javascripts/helpers/SpecHelper.js
+++ b/spec/javascripts/helpers/SpecHelper.js
@@ -5,7 +5,7 @@ beforeAll(function () {
   window.GOVUK.analyticsGa4.vars.id = 'test-id'
   window.GOVUK.analyticsGa4.vars.auth = 'test-auth'
   window.GOVUK.analyticsGa4.vars.preview = 'test-preview'
-  window.GOVUK.analyticsGa4.vars.gem_version = 'gem-version'
+  window.GOVUK.analyticsGa4.vars.gem_version = 'aVersion'
   window.GOVUK.analyticsGa4.vars.internalDomains = ['www.gov.uk']
   window.GOVUK.analyticsGa4.core.trackFunctions.appendDomainsWithoutWWW(window.GOVUK.analyticsGa4.vars.internalDomains)
 

--- a/spec/javascripts/helpers/SpecHelper.js
+++ b/spec/javascripts/helpers/SpecHelper.js
@@ -9,6 +9,14 @@ beforeAll(function () {
   window.GOVUK.analyticsGa4.vars.internalDomains = ['www.gov.uk']
   window.GOVUK.analyticsGa4.core.trackFunctions.appendDomainsWithoutWWW(window.GOVUK.analyticsGa4.vars.internalDomains)
 
+  this.agreeToCookies = function () {
+    GOVUK.setCookie('cookies_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true}')
+  }
+
+  this.denyCookies = function () {
+    GOVUK.setCookie('cookies_policy', '{"essential":false,"settings":false,"usage":false,"campaigns":false}')
+  }
+
   delete ga
 })
 


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

Move repeatedly defined helper functions and variables to `SpecHelper.js`

### More details

- Assign `agreeToCookies` to `this` in the Jasmine context, remove all definitions of `agreeToCookies` in individual specs
- Assign `denyCookies` to `this` in the Jasmine context, remove all definitions of `denyCookies` in individual specs 
- Use the `gem_version` that's assigned in the `beforeAll` of `SpecHelper.js`
  - Set `window.GOVUK.analyticsGa4.vars.gem_version` to `aGemVersion` (which is used in all specs) in `beforeAll` 
  - Update `scroll-tracker.spec.js` to use `aGemVersion` (only test that uses `gem-version` for `gem_version`)
  - Remove stubs or assignments to `window.GOVUK.analyticsGa4.vars.gem_version` in specs
    - Not needed because `window.GOVUK.analyticsGa4.vars.gem_version` is set before each test

## Why
<!-- What are the reasons behind this change being made? -->

Easy to maintain, write new tests and read if we use shared functions and variables.