### PR TITLE
Add more options to the select component

### DIFF
--- a/app/views/govuk_publishing_components/components/_select.html.erb
+++ b/app/views/govuk_publishing_components/components/_select.html.erb
@@ -7,12 +7,16 @@
   name ||= id
   is_page_heading ||= false
   data_attributes ||= {}
+  aria_controls ||= nil
 
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
   heading_size = false unless shared_helper.valid_heading_size?(heading_size)
   select_helper = GovukPublishingComponents::Presenters::SelectHelper.new(local_assigns)
 
-  aria_describedby = { describedby: select_helper.describedby }
+  aria_attributes = {
+    controls: aria_controls,
+    describedby: select_helper.describedby
+  }
 %>
 <% if select_helper.options.any? && id && label %>
   <%= content_tag :div, class: select_helper.css_classes do %>
@@ -40,6 +44,6 @@
       } %>
     <% end %>
 
-    <%= select_tag name, options_for_select(select_helper.option_markup, select_helper.selected_option), id: id, class: select_helper.select_classes, aria: aria_describedby, data: data_attributes %>
+    <%= select_tag name, options_for_select(select_helper.option_markup, select_helper.selected_option), id: id, class: select_helper.select_classes, aria: aria_attributes, data: data_attributes %>
   <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/select.yml
+++ b/app/views/govuk_publishing_components/components/docs/select.yml
@@ -42,6 +42,19 @@ examples:
         selected: true
       - text: Option three
         value: option3
+  with_disabled_options:
+    description: Options can be disabled using the `disabled` parameter. Note that it is possible to have an option that is both disabled and selected.
+    data:
+      id: dropdown2-0
+      label: Option 3 disabled
+      options:
+      - text: Option one
+        value: option1
+      - text: Option two
+        value: option2
+      - text: Option three
+        value: option3
+        disabled: true
   with_hint:
     description: When a hint is included the `aria-describedby` attribute of the select is included to point to the hint. When an error and a hint are present, that attribute includes the IDs of both the hint and the error.
     data:

--- a/app/views/govuk_publishing_components/components/docs/select.yml
+++ b/app/views/govuk_publishing_components/components/docs/select.yml
@@ -67,6 +67,18 @@ examples:
         value: option1
       - text: Something else
         value: option2
+  with_aria_controls:
+    data:
+      id: dropdown4-4
+      label: My Dropdown
+      aria_controls: dropdown4-3
+      options:
+      - text: Option one
+        value: option1
+      - text: Option two
+        value: option2
+      - text: Option three
+        value: option3
   with_data_attributes:
     description: Data attributes can be passed to the select component if needed.
     data:

--- a/lib/govuk_publishing_components/presenters/select_helper.rb
+++ b/lib/govuk_publishing_components/presenters/select_helper.rb
@@ -44,13 +44,15 @@ module GovukPublishingComponents
           [
             option[:text],
             option[:value],
-            options_data_attribute(option[:data_attributes]),
+            options_extra_attributes(option[:data_attributes], option[:disabled]),
           ]
         end
       end
 
-      def options_data_attribute(attributes)
-        return {} if attributes.nil?
+      def options_extra_attributes(attributes, disabled)
+        attrs = {}
+        attrs[:disabled] = true if disabled
+        return attrs if attributes.nil?
 
         attrs = {}
         attributes.each do |key, value|

--- a/spec/components/select_spec.rb
+++ b/spec/components/select_spec.rb
@@ -284,6 +284,42 @@ describe "Select", type: :view do
     assert_select ".gem-c-select .govuk-select[aria-describedby='error_id hint_id']"
   end
 
+  it "accepts an aria-controls attribute" do
+    render_component(
+      id: "mydropdown",
+      label: "My dropdown",
+      aria_controls: "js-test",
+      options: [
+        {
+          value: "government-gateway",
+          text: "Use Government Gateway",
+        },
+      ],
+    )
+
+    assert_select ".gem-c-select .govuk-select[aria-controls='js-test']"
+  end
+
+  it "applies aria-describedby if a hint and an error are present as well as aria-controls" do
+    render_component(
+      id: "mydropdown",
+      label: "attributes",
+      hint: "this is a hint",
+      hint_id: "hint_id",
+      error_id: "error_id",
+      aria_controls: "js-test",
+      options: [
+        {
+          value: 1,
+          text: "One",
+        },
+      ],
+    )
+
+    assert_select ".gem-c-select .govuk-hint", "this is a hint"
+    assert_select ".gem-c-select .govuk-select[aria-describedby='error_id hint_id'][aria-controls='js-test']"
+  end
+
   it "renders a select box full width" do
     render_component(
       id: "mydropdown",

--- a/spec/components/select_spec.rb
+++ b/spec/components/select_spec.rb
@@ -119,6 +119,62 @@ describe "Select", type: :view do
     assert_select ".govuk-select option[value=medium][selected]"
   end
 
+  it "renders a select with a disabled item" do
+    render_component(
+      id: "mydropdown",
+      label: "My dropdown",
+      options: [
+        {
+          value: "big",
+          text: "Big",
+        },
+        {
+          value: "medium",
+          text: "Medium",
+          disabled: true,
+        },
+        {
+          value: "small",
+          text: "Small",
+        },
+      ],
+    )
+
+    assert_select ".govuk-select option[value=medium][disabled]"
+  end
+
+  it "renders a select with a selected item and several disabled items" do
+    render_component(
+      id: "mydropdown",
+      label: "My dropdown",
+      options: [
+        {
+          value: "big",
+          text: "Big",
+        },
+        {
+          value: "medium",
+          text: "Medium",
+          selected: true,
+        },
+        {
+          value: "small",
+          text: "Small",
+          disabled: true,
+        },
+        {
+          value: "tiny",
+          text: "Tiny",
+          disabled: true,
+        },
+      ],
+    )
+
+    assert_select ".govuk-select option[value=medium][selected]"
+    assert_select ".govuk-select option[value=small][disabled]"
+    assert_select ".govuk-select option[value=tiny][disabled]"
+  end
+
   it "renders a select element with data attributes applied to contained option element" do
     render_component(
       id: "mydropdown",


### PR DESCRIPTION
## What
Adds some new features to the select component, specifically:

- allow individual options to be disabled/unselectable
- allow an option for `aria-controls` attribute to be passed to the component

## Why
Trying to see if the select component can be used in `finder-frontend` search pages instead of the current implementation, which uses the markup of the component but not the component itself.

## Visual Changes
None.

