### PR TITLE
Add /csv-preview/ path to GA4 download preview link tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Add phone numbers to GA4 PII redaction ([PR #4840](https://github.com/alphagov/govuk_publishing_components/pull/4840))
 * Add image functionality to the intervention banner ([PR #4845](https://github.com/alphagov/govuk_publishing_components/pull/4845))
 * Add extra functionality to trackFormSubmit of Ga4FormTracker ([PR #4847](https://github.com/alphagov/govuk_publishing_components/pull/4847/))
+* Add /csv-preview/ path to GA4 download preview link tracking ([PR #4859](https://github.com/alphagov/govuk_publishing_components/pull/4859))
 
 ## 57.1.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.js
@@ -9,7 +9,7 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
     init: function (config) {
       if (window.dataLayer) {
         config = config || {}
-        this.internalDownloadPaths = config.internalDownloadPaths || ['/government/uploads/', '/media/']
+        this.internalDownloadPaths = config.internalDownloadPaths || ['/government/uploads/', '/media/', '/csv-preview/']
         this.dedicatedDownloadDomains = config.dedicatedDownloadDomains || ['assets.publishing.service.gov.uk']
         window.GOVUK.analyticsGa4.core.trackFunctions.appendDomainsWithoutWWW(this.dedicatedDownloadDomains)
         this.handleClick = this.handleClick.bind(this)
@@ -151,7 +151,7 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
       Regex is used over JS string methods as this should work with anchor links, query string parameters and files that may have 'preview' in their name.
       */
       var previewRegex = /\.\w+\/preview/i
-      return previewRegex.test(href)
+      return previewRegex.test(href) || href.startsWith('https://www.gov.uk/csv-preview/')
     },
 
     hrefPointsToDownloadPath: function (href) {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.spec.js
@@ -372,11 +372,13 @@ describe('A specialist link tracker', function () {
             '<a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/moj-hq.csv/preview" path="/government/uploads/system/uploads/attachment_data/file/444468/moj-hq.csv/preview" link_domain="https://assets.publishing.service.gov.uk">Preview link</a>' +
             '<a href="http://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/moj-hq.csv/preview" path="/government/uploads/system/uploads/attachment_data/file/444468/moj-hq.csv/preview" link_domain="http://assets.publishing.service.gov.uk">Relative Spreadsheet link</a>' +
             '<a href="https://www.gov.uk/media/66866f8d4a94d44125d9ccc1/Management_information_-_initial_teacher_education___in_year_inspection_outcomes_1_September_2023_to_30_April_2024.csv/preview" path="/media/66866f8d4a94d44125d9ccc1/Management_information_-_initial_teacher_education___in_year_inspection_outcomes_1_September_2023_to_30_April_2024.csv/preview" link_domain="https://www.gov.uk">Relative csv link</a>' +
+            '<a href="https://www.gov.uk/csv-preview/684c036c928e5ebb68e3f963/Worker_and_Temporary_Worker.csv" path="/csv-preview/684c036c928e5ebb68e3f963/Worker_and_Temporary_Worker.csv" link_domain="https://www.gov.uk">New csv link</a>' +
           '</div>' +
           '<div class="not-a-preview-link">' +
             '<a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/preview.mp4" path="/government/uploads/system/uploads/attachment_data/file/444468/preview.mp4" link_domain="https://assets.publishing.service.gov.uk">Preview link</a>' +
             '<a href="http://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/preview.jpg&preview=false" path="/government/uploads/system/uploads/attachment_data/file/444468/preview.jpg&preview=false" link_domain="http://assets.publishing.service.gov.uk">Relative Spreadsheet link</a>' +
-'<a href="https://www.gov.uk/media/66866f8d4a94d44125d9ccc1/preview.csv" link_domain="https://www.gov.uk">Relative csv link</a>' +
+            '<a href="https://www.gov.uk/media/66866f8d4a94d44125d9ccc1/preview.csv" link_domain="https://www.gov.uk">Relative csv link</a>' +
+            '<a href="https://www.gov.uk/media/csv-preview/test.csv" link_domain="https://www.gov.uk">csv link</a>' +
           '</div>'
 
       body.appendChild(links)
@@ -511,7 +513,7 @@ describe('A specialist link tracker', function () {
 
     it('detects preview clicks on gov.uk download preview links', function () {
       var linksToTest = document.querySelectorAll('.preview-download-links a')
-      var external = ['true', 'true', 'false']
+      var external = ['true', 'true', 'false', 'false']
       for (var i = 0; i < linksToTest.length; i++) {
         window.dataLayer = []
         var link = linksToTest[i]
@@ -521,14 +523,13 @@ describe('A specialist link tracker', function () {
         expected.event_data.type = 'preview'
         expected.event_data.text = link.innerText.trim()
         expected.event_data.external = external[i]
-
         expect(window.dataLayer[0]).toEqual(expected)
       }
     })
 
     it('detects files with preview in their filename as download links instead of preview links', function () {
       var linksToTest = document.querySelectorAll('.not-a-preview-link a')
-      var external = ['true', 'true', 'false']
+      var external = ['true', 'true', 'false', 'false']
       for (var i = 0; i < linksToTest.length; i++) {
         window.dataLayer = []
         var link = linksToTest[i]
@@ -538,7 +539,6 @@ describe('A specialist link tracker', function () {
         expected.event_data.type = 'generic download'
         expected.event_data.text = link.innerText.trim()
         expected.event_data.external = external[i]
-
         expect(window.dataLayer[0]).toEqual(expected)
       }
     })


### PR DESCRIPTION
## What / Why
<!-- What are the reasons behind this change being made? -->
- Fix tracking that has broken as a result of moving assets off the assets domain
- Asset CSV previews are now on `www.gov.uk/csv-preview/` so our tracking needs to update to reflect this
- Trello card: https://trello.com/c/pxDcEFd9/

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
