### PR TITLE
Version 57.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 57.2.0
 
 * Fix welsh translations of Devolved Nations component ([PR #4807](https://github.com/alphagov/govuk_publishing_components/pull/4807))
 * Add tracking to `ReorderableList` ([PR #4835](https://github.com/alphagov/govuk_publishing_components/pull/4835))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (57.1.0)
+    govuk_publishing_components (57.2.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "57.1.0".freeze
+  VERSION = "57.2.0".freeze
 end


### PR DESCRIPTION
## 57.2.0

* Fix welsh translations of Devolved Nations component ([PR #4807](https://github.com/alphagov/govuk_publishing_components/pull/4807))
* Add tracking to `ReorderableList` ([PR #4835](https://github.com/alphagov/govuk_publishing_components/pull/4835))
* Add tracking to `AddAnother` ([PR #4836](https://github.com/alphagov/govuk_publishing_components/pull/4836))
* Add phone numbers to GA4 PII redaction ([PR #4840](https://github.com/alphagov/govuk_publishing_components/pull/4840))
* Add image functionality to the intervention banner ([PR #4845](https://github.com/alphagov/govuk_publishing_components/pull/4845))
* Add extra functionality to trackFormSubmit of Ga4FormTracker ([PR #4847](https://github.com/alphagov/govuk_publishing_components/pull/4847/))
* Add /csv-preview/ path to GA4 download preview link tracking ([PR #4859](https://github.com/alphagov/govuk_publishing_components/pull/4859))