### PR TITLE
Remove feedback from static dependent apps

### DIFF
--- a/app/models/govuk_publishing_components/audit_comparer.rb
+++ b/app/models/govuk_publishing_components/audit_comparer.rb
@@ -6,7 +6,6 @@ module GovukPublishingComponents
       if gem_data[:gem_found]
         @applications_using_static = %w[
           collections
-          feedback
           finder-frontend
           frontend
           government-frontend


### PR DESCRIPTION
## What / why
- removes feedback from the list of applications that rely on static, in the component auditing
- as feedback has recently been updated to not use static anymore
- changes the number of component usage warnings for feedback from 17 to 1

## Visual Changes
None.
