### PR TITLE
Fix GA4 tracking for asset preview links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add more options to the select component ([PR #4858](https://github.com/alphagov/govuk_publishing_components/pull/4858))
+* Fix GA4 tracking for asset preview links ([PR #4863](https://github.com/alphagov/govuk_publishing_components/pull/4863))
 
 ## 57.2.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.js
@@ -150,8 +150,8 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
       For example, .csv/preview or .mp4/preview will be matched.
       Regex is used over JS string methods as this should work with anchor links, query string parameters and files that may have 'preview' in their name.
       */
-      var previewRegex = /\.\w+\/preview/i
-      return previewRegex.test(href) || href.startsWith('https://www.gov.uk/csv-preview/')
+      var previewRegex = /\.\w+\/preview|(\/csv-preview\/)/i
+      return previewRegex.test(href)
     },
 
     hrefPointsToDownloadPath: function (href) {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.spec.js
@@ -378,7 +378,7 @@ describe('A specialist link tracker', function () {
             '<a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/preview.mp4" path="/government/uploads/system/uploads/attachment_data/file/444468/preview.mp4" link_domain="https://assets.publishing.service.gov.uk">Preview link</a>' +
             '<a href="http://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/preview.jpg&preview=false" path="/government/uploads/system/uploads/attachment_data/file/444468/preview.jpg&preview=false" link_domain="http://assets.publishing.service.gov.uk">Relative Spreadsheet link</a>' +
             '<a href="https://www.gov.uk/media/66866f8d4a94d44125d9ccc1/preview.csv" link_domain="https://www.gov.uk">Relative csv link</a>' +
-            '<a href="https://www.gov.uk/media/csv-preview/test.csv" link_domain="https://www.gov.uk">csv link</a>' +
+            '<a href="https://www.gov.uk/media/csv-preview-test.csv" link_domain="https://www.gov.uk">csv link</a>' +
           '</div>'
 
       body.appendChild(links)


### PR DESCRIPTION
## What / Why
<!-- What are the reasons behind this change being made? -->
- The previous PR https://github.com/alphagov/govuk_publishing_components/pull/4859 did not seem to work for fixing preview link tracking
- I think this has something to do with hardcoding the domain in the check. This is flawed anyway, as it means the tracking wouldn't work on integration / locally.
- Instead, just check for  the existence of `/csv-preview/` in the href
- Have tested this locally in `government-frontend` and it works
- Trello card: https://trello.com/c/Ka9dd8VG

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->
None.
