### PR TITLE
Add Select with Search component

### DIFF
--- a/app/assets/images/select-with-search/cross-icon.svg
+++ b/app/assets/images/select-with-search/cross-icon.svg
@@ -1,0 +1,6 @@
+<svg width='21' height='21' viewBox='0 0 21 21' xmlns='http://www.w3.org/2000/svg'>
+  <g fill='#000' fill-rule='evenodd'>
+    <path d='M2.592.044l18.364 18.364-2.548 2.548L.044 2.592z' />
+    <path d='M0 18.364L18.364 0l2.548 2.548L2.548 20.912z' />
+  </g>
+</svg>

--- a/app/assets/javascripts/govuk_publishing_components/components/select-with-search.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/select-with-search.js
@@ -1,0 +1,52 @@
+//= require choices.js/public/assets/scripts/choices.min.js
+'use strict'
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {}
+;(function (Modules) {
+  function SelectWithSearch (module) {
+    this.module = module
+    this.select = this.module.querySelector('select')
+  }
+
+  SelectWithSearch.prototype.init = function () {
+    if (!this.select) return
+    const placeholderOption = this.select.querySelector(
+      'option[value=""]:first-child'
+    )
+
+    if (placeholderOption && placeholderOption.textContent === '') {
+      placeholderOption.textContent = this.select.multiple
+        ? 'Select all that apply'
+        : 'Select one'
+    }
+
+    this.choices = new window.Choices(this.select, {
+      allowHTML: true,
+      searchPlaceholderValue: 'Search in list',
+      shouldSort: false, // show options and groups in the order they were given
+      itemSelectText: '',
+      searchResultLimit: 100,
+      removeItemButton: this.select.multiple,
+      labelId: this.select.id + '_label',
+      callbackOnInit: function () {
+        // For the multiple select, move the input field to
+        // the top of the feedback area, so that the selected
+        // 'lozenges' appear afterwards in a more natural flow
+        if (this.dropdown.type === 'select-multiple') {
+          const inner = this.containerInner.element
+          const input = this.input.element
+          inner.prepend(input)
+        }
+      },
+      // https://fusejs.io/api/options.html
+      fuseOptions: {
+        ignoreLocation: true, // matches any part of the string
+        threshold: 0 // only matches when characters are sequential
+      }
+    })
+
+    this.module.choices = this.choices
+  }
+
+  Modules.SelectWithSearch = SelectWithSearch
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/govuk_publishing_components/components/select-with-search.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/select-with-search.js
@@ -5,7 +5,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
 ;(function (Modules) {
   function SelectWithSearch (module) {
     this.module = module
-    this.select = this.module.querySelector('select')
+    this.select = this.module.matches('select') ? this.module : this.module.querySelector('select')
   }
 
   SelectWithSearch.prototype.init = function () {

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -75,6 +75,7 @@
 @import "components/search";
 @import "components/secondary-navigation";
 @import "components/select";
+@import "components/select-with-search";
 @import "components/service-navigation";
 @import "components/share-links";
 @import "components/signup-link";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_select-with-search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_select-with-search.scss
@@ -1,0 +1,438 @@
+@import "govuk_publishing_components/individual_component_support";
+@import "govuk/components/label/label";
+
+// Increase height of selects that have a `multiple`
+// attribute otherwise they are too small to be useful.
+// Applies only when JS is not available: the JS scenario
+// uses choices.js to replace these elements. This fix
+// could eventually go in `govuk-frontend`.
+.govuk-select[multiple] {
+  height: auto;
+}
+
+.gem-c-select-with-search {
+  //
+  // A theme for Choices.js styled to look like a GOV.UK Design System component
+  //
+  $background: #ffffff;
+  $focus-color: $govuk-focus-colour;
+  $focus-outline: $govuk-focus-width solid $govuk-focus-colour;
+
+  .choices * {
+    // Something inside .choices needs this – I'm not sure what yet
+    box-sizing: border-box;
+  }
+
+  .choices {
+    @include govuk-font($size: 19);
+    position: relative;
+    margin-bottom: 24px;
+  }
+
+  .choices:focus {
+    outline: none;
+  }
+
+  .choices:last-child {
+    margin-bottom: 0;
+  }
+
+  // Disabled state
+  .choices.is-disabled {
+    .choices__inner,
+    .choices__input {
+      background-color: #eaeaea;
+      cursor: not-allowed;
+      -webkit-user-select: none;
+      user-select: none;
+    }
+
+    .choices__item {
+      cursor: not-allowed;
+    }
+  }
+
+  // This is an intentionally high specificity selector to avoid using !important when targetting
+  // the <select hidden> element that would otherwise end up picking up `display: block` from the
+  // `.choices[data-type*="select-one"] .choices__input` rule below.
+  .choices .choices__inner select[hidden] {
+    display: none;
+  }
+
+  // Type: Single Select
+  .choices[data-type*="select-one"] {
+    cursor: pointer;
+
+    .choices__input {
+      display: block;
+      width: 100%;
+      padding: 10px;
+      border-bottom: 1px solid #dddddd;
+      background-color: $background;
+      margin: 0;
+    }
+
+    .choices__button {
+      background-image: url("select-with-search/cross-icon.svg");
+      padding: 0;
+      background-size: 8px;
+      position: absolute;
+      top: 50%;
+      right: 0;
+      margin-top: -10px;
+      margin-right: 25px;
+      height: 20px;
+      width: 20px;
+      border-radius: 10em;
+      opacity: 0.25;
+
+      &:hover,
+      &:focus {
+        opacity: 1;
+      }
+
+      &:focus {
+        outline: $focus-outline;
+      }
+    }
+
+    .choices__item[data-value=""] .choices__button {
+      display: none;
+    }
+
+    // Dropdown arrow ▼
+    &::after {
+      content: "";
+      height: 0;
+      width: 0;
+      border-style: solid;
+      border-color: #333333 transparent transparent;
+      border-width: 5px;
+      position: absolute;
+      right: 11.5px;
+      top: 50%;
+      margin-top: -2.5px;
+      pointer-events: none;
+    }
+
+    &.is-open::after {
+      border-color: transparent transparent #333333;
+      margin-top: -7.5px;
+    }
+
+    &[dir="rtl"]::after {
+      left: 11.5px;
+      right: auto;
+    }
+
+    &[dir="rtl"] .choices__button {
+      right: auto;
+      left: 0;
+      margin-left: 25px;
+      margin-right: 0;
+    }
+  }
+
+  // Type: Select Multiple / Text
+  .choices[data-type*="select-multiple"],
+  .choices[data-type*="text"] {
+    .choices__inner {
+      cursor: text;
+    }
+
+    .choices__item {
+      position: relative;
+    }
+
+    // Delete button X
+    .choices__button {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      right: 0;
+      width: 32px;
+      border-left: 1px solid govuk-colour("mid-grey");
+      border-right: 1px solid govuk-colour("mid-grey");
+      background-image: url("select-with-search/cross-icon.svg");
+      background-size: 12px;
+      border-radius: 0;
+
+      &:hover {
+        background-color: govuk-colour("mid-grey");
+        border-color: govuk-colour("dark-grey");
+        box-shadow: 0 2px 0 govuk-colour("dark-grey");
+      }
+
+      &:focus {
+        background-color: $govuk-focus-colour;
+        box-shadow: 0 2px 0 $govuk-focus-text-colour;
+      }
+    }
+  }
+
+  // Type: Select Multiple ONLY
+  .choices[data-type*="select-multiple"] {
+    .choices__input {
+      display: block;
+    }
+  }
+
+  .choices__inner {
+    display: inline-block;
+    vertical-align: top;
+    width: 100%;
+    background-color: $background;
+    padding: 5px;
+    border: 2px solid #0b0c0c;
+    font-size: 19px;
+    min-height: 44px;
+    overflow: hidden;
+  }
+
+  &.govuk-form-group--error .choices:not(.is-active):not(.is-focused):not(.is-open) .choices__inner {
+    border-color: $govuk-error-colour;
+  }
+
+  .choices.is-focused .choices__inner,
+  .choices.is-open .choices__inner {
+    outline: $focus-outline;
+    outline-offset: 0;
+    box-shadow: inset 0 0 0 2px;
+  }
+
+  .choices__list {
+    margin: 0;
+    padding-left: 0;
+    list-style: none;
+  }
+
+  .choices__list--single {
+    display: inline-block;
+    padding: 4px 16px 4px 4px;
+    width: 100%;
+  }
+
+  [dir="rtl"] .choices__list--single {
+    padding-right: 4px;
+    padding-left: 16px;
+  }
+
+  .choices__list--single .choices__item {
+    width: 100%;
+  }
+
+  .choices__list--multiple {
+    display: block;
+
+    &:not(:empty) {
+      margin-block-start: 6px;
+      border-block-start: 1px solid $govuk-border-colour;
+      padding-block-end: 5px;
+    }
+  }
+
+  .choices__list--multiple .choices__item {
+    display: inline-flex;
+    align-items: center;
+    padding: 6px 10px;
+    margin: 9px 9px 0 0;
+    background-color: govuk-colour("light-grey");
+    box-shadow: 0 2px 0 govuk-colour("mid-grey");
+    line-height: 1;
+    color: $govuk-text-colour;
+    box-sizing: border-box;
+
+    &[data-deletable] {
+      padding-right: 42px;
+    }
+
+    [dir="rtl"] & {
+      margin-right: 0;
+      margin-left: 3.75px;
+    }
+
+    .is-disabled & {
+      background-color: #aaaaaa;
+      border: 1px solid #919191;
+    }
+  }
+
+  // Dropdown
+  .choices__list--dropdown,
+  .choices__list[aria-expanded] {
+    visibility: hidden;
+    z-index: 2;
+    position: absolute;
+    width: 100%;
+    background-color: $background;
+    border: 2px solid #0b0c0c;
+    border-top-width: 0;
+    top: 100%;
+    overflow: hidden;
+    will-change: visibility;
+
+    &.is-active {
+      visibility: visible;
+    }
+
+    .is-flipped & {
+      top: auto;
+      bottom: 100%;
+      margin-top: 0;
+      margin-bottom: -1px;
+      border-top-width: 2px;
+      border-bottom-width: 0;
+    }
+  }
+
+  .choices__list--dropdown .choices__list,
+  .choices__list[aria-expanded] .choices__list {
+    position: relative;
+    max-height: 310px;
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+    will-change: scroll-position;
+  }
+
+  .choices__list--dropdown .choices__item,
+  .choices__list[aria-expanded] .choices__item {
+    position: relative;
+    padding: 10px;
+    font-size: 19px;
+    border-bottom: 1px solid #b1b4b6;
+
+    &:last-child {
+      border-bottom: 0;
+    }
+
+    &:nth-of-type(even) {
+      background-color: #fafafa;
+    }
+
+    [dir="rtl"] & {
+      text-align: right;
+    }
+  }
+
+  // prettier-ignore
+  @media (min-width: 640px) { // stylelint-disable-line media-feature-range-notation
+    .choices__list--dropdown .choices__item--selectable,
+    .choices__list[aria-expanded] .choices__item--selectable {
+      padding-right: 5px;
+    }
+
+    .choices__list--dropdown .choices__item--selectable::after,
+    .choices__list[aria-expanded] .choices__item--selectable::after {
+      content: attr(data-select-text);
+      font-size: 12px;
+      opacity: 0;
+      position: absolute;
+      right: 10px;
+      top: 50%;
+      transform: translateY(-50%);
+    }
+
+    [dir="rtl"] .choices__list--dropdown .choices__item--selectable,
+    [dir="rtl"] .choices__list[aria-expanded] .choices__item--selectable {
+      text-align: right;
+      padding-left: 100px;
+      padding-right: 10px;
+    }
+
+    [dir="rtl"] .choices__list--dropdown .choices__item--selectable::after,
+    [dir="rtl"] .choices__list[aria-expanded] .choices__item--selectable::after {
+      right: auto;
+      left: 10px;
+    }
+  }
+
+  .choices__list--dropdown .choices__item--selectable.is-highlighted,
+  .choices__list[aria-expanded] .choices__item--selectable.is-highlighted {
+    background-color: #275ca0;
+    border-color: #275ca0;
+    color: #ffffff;
+    outline: none;
+  }
+
+  .choices__list--dropdown .choices__item--selectable.is-highlighted::after,
+  .choices__list[aria-expanded] .choices__item--selectable.is-highlighted::after {
+    opacity: 0.5;
+  }
+
+  .choices__item {
+    cursor: default;
+  }
+
+  .choices__item--selectable {
+    cursor: pointer;
+  }
+
+  .choices__item--disabled {
+    cursor: not-allowed;
+    -webkit-user-select: none;
+    user-select: none;
+    opacity: 0.5;
+  }
+
+  .choices__heading {
+    font-weight: 600;
+    font-size: 19px;
+    padding: 30px 10px 10px;
+    border-bottom: 1px solid #b1b4b6;
+    background: $background;
+    cursor: default;
+  }
+
+  .choices__button {
+    text-indent: -9999px;
+    -webkit-appearance: none;
+    appearance: none;
+    border: 0;
+    background-color: transparent;
+    background-repeat: no-repeat;
+    background-position: center;
+    cursor: pointer;
+  }
+
+  .choices__button:focus {
+    outline: none;
+  }
+
+  .choices__input {
+    display: inline-block;
+    vertical-align: baseline;
+    background-color: $background;
+    font-size: 19px;
+    border: 0;
+    border-radius: 0;
+    max-width: 100%;
+    padding: 4px 0 4px 2px;
+
+    &:focus {
+      outline: 0;
+    }
+
+    &::-webkit-search-decoration,
+    &::-webkit-search-cancel-button,
+    &::-webkit-search-results-button,
+    &::-webkit-search-results-decoration {
+      display: none;
+    }
+
+    &::-ms-clear,
+    &::-ms-reveal {
+      display: none;
+      width: 0;
+      height: 0;
+    }
+
+    [dir="rtl"] & {
+      padding-right: 2px;
+      padding-left: 0;
+    }
+  }
+
+  .choices__placeholder {
+    color: #757575;
+  }
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/_select-with-search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_select-with-search.scss
@@ -1,5 +1,23 @@
+// overload the choices.js variables
+
+$font-size: 19px;
+
+$choices-bg-color: govuk-colour("white") !default;
+$choices-font-size-lg: $font-size !default;
+$choices-font-size-md: $font-size !default;
+$choices-font-size-sm: $font-size !default;
+$choices-primary-color: #ffffff !default; // can't use mixin here because of Choices.js Sass functions
+$choices-text-color: govuk-colour("black");
+$choices-icon-cross: url("select-with-search/cross-icon.svg");
+$choices-border-radius: 0 !default;
+$choices-border-radius-item: 0 !default;
+$choices-z-index: 2 !default;
+$choices-button-dimension: 12px !default;
+
 @import "govuk_publishing_components/individual_component_support";
+@import "mixins/prefixed-transform";
 @import "govuk/components/label/label";
+@import "choices.js/src/styles/choices";
 
 // Increase height of selects that have a `multiple`
 // attribute otherwise they are too small to be useful.
@@ -11,182 +29,61 @@
 }
 
 .gem-c-select-with-search {
-  //
-  // A theme for Choices.js styled to look like a GOV.UK Design System component
-  //
-  $background: #ffffff;
-  $focus-color: $govuk-focus-colour;
-  $focus-outline: $govuk-focus-width solid $govuk-focus-colour;
-
   .choices * {
     // Something inside .choices needs this – I'm not sure what yet
     box-sizing: border-box;
   }
 
-  .choices {
-    @include govuk-font($size: 19);
-    position: relative;
-    margin-bottom: 24px;
+  .choices[data-type*="select-one"]::after {
+    @include govuk-shape-arrow($direction: down, $base: 10px, $display: inline-block);
+    @include prefixed-transform($translateY: -50%);
+    margin: 0;
   }
 
-  .choices:focus {
-    outline: none;
+  .choices.is-open[data-type*="select-one"]::after {
+    margin: 0;
+    bottom: govuk-em(1px, $font-size);
+    @include prefixed-transform($translateY: -50%, $rotate: 180deg);
   }
 
-  .choices:last-child {
+  .choices[data-type*="select-multiple"] .choices__button,
+  .choices[data-type*="text"] .choices__button {
+    border-color: govuk-colour("mid-grey");
+    border-right: 1px solid govuk-colour("mid-grey");
+    padding: 10px 20px 10px 10px;
+    margin-right: 0;
+
+    &:hover {
+      background-color: govuk-colour("mid-grey");
+      border-color: govuk-colour("dark-grey");
+      box-shadow: 0 2px 0 govuk-colour("dark-grey");
+    }
+
+    &:focus {
+      background-color: $govuk-focus-colour;
+      box-shadow: 0 2px 0 $govuk-focus-text-colour;
+    }
+  }
+
+  .choices.is-disabled {
+    .choices__item[data-deletable] {
+      background-color: govuk-colour("white");
+    }
+
+    .choices__button {
+      display: none;
+    }
+  }
+
+  .choices__input {
+    display: block;
+    font-family: $govuk-font-family;
     margin-bottom: 0;
   }
 
-  // Disabled state
-  .choices.is-disabled {
-    .choices__inner,
-    .choices__input {
-      background-color: #eaeaea;
-      cursor: not-allowed;
-      -webkit-user-select: none;
-      user-select: none;
-    }
-
-    .choices__item {
-      cursor: not-allowed;
-    }
-  }
-
-  // This is an intentionally high specificity selector to avoid using !important when targetting
-  // the <select hidden> element that would otherwise end up picking up `display: block` from the
-  // `.choices[data-type*="select-one"] .choices__input` rule below.
-  .choices .choices__inner select[hidden] {
-    display: none;
-  }
-
-  // Type: Single Select
-  .choices[data-type*="select-one"] {
-    cursor: pointer;
-
-    .choices__input {
-      display: block;
-      width: 100%;
-      padding: 10px;
-      border-bottom: 1px solid #dddddd;
-      background-color: $background;
-      margin: 0;
-    }
-
-    .choices__button {
-      background-image: url("select-with-search/cross-icon.svg");
-      padding: 0;
-      background-size: 8px;
-      position: absolute;
-      top: 50%;
-      right: 0;
-      margin-top: -10px;
-      margin-right: 25px;
-      height: 20px;
-      width: 20px;
-      border-radius: 10em;
-      opacity: 0.25;
-
-      &:hover,
-      &:focus {
-        opacity: 1;
-      }
-
-      &:focus {
-        outline: $focus-outline;
-      }
-    }
-
-    .choices__item[data-value=""] .choices__button {
-      display: none;
-    }
-
-    // Dropdown arrow ▼
-    &::after {
-      content: "";
-      height: 0;
-      width: 0;
-      border-style: solid;
-      border-color: #333333 transparent transparent;
-      border-width: 5px;
-      position: absolute;
-      right: 11.5px;
-      top: 50%;
-      margin-top: -2.5px;
-      pointer-events: none;
-    }
-
-    &.is-open::after {
-      border-color: transparent transparent #333333;
-      margin-top: -7.5px;
-    }
-
-    &[dir="rtl"]::after {
-      left: 11.5px;
-      right: auto;
-    }
-
-    &[dir="rtl"] .choices__button {
-      right: auto;
-      left: 0;
-      margin-left: 25px;
-      margin-right: 0;
-    }
-  }
-
-  // Type: Select Multiple / Text
-  .choices[data-type*="select-multiple"],
-  .choices[data-type*="text"] {
-    .choices__inner {
-      cursor: text;
-    }
-
-    .choices__item {
-      position: relative;
-    }
-
-    // Delete button X
-    .choices__button {
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      right: 0;
-      width: 32px;
-      border-left: 1px solid govuk-colour("mid-grey");
-      border-right: 1px solid govuk-colour("mid-grey");
-      background-image: url("select-with-search/cross-icon.svg");
-      background-size: 12px;
-      border-radius: 0;
-
-      &:hover {
-        background-color: govuk-colour("mid-grey");
-        border-color: govuk-colour("dark-grey");
-        box-shadow: 0 2px 0 govuk-colour("dark-grey");
-      }
-
-      &:focus {
-        background-color: $govuk-focus-colour;
-        box-shadow: 0 2px 0 $govuk-focus-text-colour;
-      }
-    }
-  }
-
-  // Type: Select Multiple ONLY
-  .choices[data-type*="select-multiple"] {
-    .choices__input {
-      display: block;
-    }
-  }
-
   .choices__inner {
-    display: inline-block;
-    vertical-align: top;
-    width: 100%;
-    background-color: $background;
     padding: 5px;
-    border: 2px solid #0b0c0c;
-    font-size: 19px;
-    min-height: 44px;
-    overflow: hidden;
+    border: 2px solid govuk-colour("black");
   }
 
   &.govuk-form-group--error .choices:not(.is-active):not(.is-focused):not(.is-open) .choices__inner {
@@ -195,30 +92,13 @@
 
   .choices.is-focused .choices__inner,
   .choices.is-open .choices__inner {
-    outline: $focus-outline;
+    outline: $govuk-focus-width solid $govuk-focus-colour;
+    // Ensure outline appears outside of the element
     outline-offset: 0;
-    box-shadow: inset 0 0 0 2px;
-  }
-
-  .choices__list {
-    margin: 0;
-    padding-left: 0;
-    list-style: none;
-  }
-
-  .choices__list--single {
-    display: inline-block;
-    padding: 4px 16px 4px 4px;
-    width: 100%;
-  }
-
-  [dir="rtl"] .choices__list--single {
-    padding-right: 4px;
-    padding-left: 16px;
-  }
-
-  .choices__list--single .choices__item {
-    width: 100%;
+    // Double the border by adding its width again. Use `box-shadow` to do
+    // this instead of changing `border-width` (which changes element size)
+    // and since `outline` is already used for the yellow focus state.
+    box-shadow: inset 0 0 0 $govuk-border-width-form-element;
   }
 
   .choices__list--multiple {
@@ -234,7 +114,8 @@
   .choices__list--multiple .choices__item {
     display: inline-flex;
     align-items: center;
-    padding: 6px 10px;
+    border: 0;
+    padding: 0 0 0 10px;
     margin: 9px 9px 0 0;
     background-color: govuk-colour("light-grey");
     box-shadow: 0 2px 0 govuk-colour("mid-grey");
@@ -242,197 +123,46 @@
     color: $govuk-text-colour;
     box-sizing: border-box;
 
-    &[data-deletable] {
-      padding-right: 42px;
-    }
-
-    [dir="rtl"] & {
-      margin-right: 0;
-      margin-left: 3.75px;
-    }
-
     .is-disabled & {
-      background-color: #aaaaaa;
-      border: 1px solid #919191;
+      opacity: 0.5;
     }
   }
 
   // Dropdown
   .choices__list--dropdown,
   .choices__list[aria-expanded] {
-    visibility: hidden;
-    z-index: 2;
-    position: absolute;
-    width: 100%;
-    background-color: $background;
     border: 2px solid #0b0c0c;
     border-top-width: 0;
-    top: 100%;
-    overflow: hidden;
-    will-change: visibility;
-
-    &.is-active {
-      visibility: visible;
-    }
 
     .is-flipped & {
-      top: auto;
-      bottom: 100%;
-      margin-top: 0;
-      margin-bottom: -1px;
       border-top-width: 2px;
       border-bottom-width: 0;
     }
   }
 
-  .choices__list--dropdown .choices__list,
-  .choices__list[aria-expanded] .choices__list {
-    position: relative;
-    max-height: 310px;
-    overflow: auto;
-    -webkit-overflow-scrolling: touch;
-    will-change: scroll-position;
-  }
-
   .choices__list--dropdown .choices__item,
   .choices__list[aria-expanded] .choices__item {
     position: relative;
-    padding: 10px;
-    font-size: 19px;
-    border-bottom: 1px solid #b1b4b6;
+    border-bottom: 1px solid govuk-colour("mid-grey");
 
     &:last-child {
       border-bottom: 0;
-    }
-
-    &:nth-of-type(even) {
-      background-color: #fafafa;
-    }
-
-    [dir="rtl"] & {
-      text-align: right;
-    }
-  }
-
-  // prettier-ignore
-  @media (min-width: 640px) { // stylelint-disable-line media-feature-range-notation
-    .choices__list--dropdown .choices__item--selectable,
-    .choices__list[aria-expanded] .choices__item--selectable {
-      padding-right: 5px;
-    }
-
-    .choices__list--dropdown .choices__item--selectable::after,
-    .choices__list[aria-expanded] .choices__item--selectable::after {
-      content: attr(data-select-text);
-      font-size: 12px;
-      opacity: 0;
-      position: absolute;
-      right: 10px;
-      top: 50%;
-      transform: translateY(-50%);
-    }
-
-    [dir="rtl"] .choices__list--dropdown .choices__item--selectable,
-    [dir="rtl"] .choices__list[aria-expanded] .choices__item--selectable {
-      text-align: right;
-      padding-left: 100px;
-      padding-right: 10px;
-    }
-
-    [dir="rtl"] .choices__list--dropdown .choices__item--selectable::after,
-    [dir="rtl"] .choices__list[aria-expanded] .choices__item--selectable::after {
-      right: auto;
-      left: 10px;
     }
   }
 
   .choices__list--dropdown .choices__item--selectable.is-highlighted,
   .choices__list[aria-expanded] .choices__item--selectable.is-highlighted {
-    background-color: #275ca0;
-    border-color: #275ca0;
-    color: #ffffff;
+    background-color: govuk-colour("blue");
+    border-color: govuk-colour("blue");
+    color: govuk-colour("white");
     outline: none;
-  }
-
-  .choices__list--dropdown .choices__item--selectable.is-highlighted::after,
-  .choices__list[aria-expanded] .choices__item--selectable.is-highlighted::after {
-    opacity: 0.5;
-  }
-
-  .choices__item {
-    cursor: default;
-  }
-
-  .choices__item--selectable {
-    cursor: pointer;
-  }
-
-  .choices__item--disabled {
-    cursor: not-allowed;
-    -webkit-user-select: none;
-    user-select: none;
-    opacity: 0.5;
   }
 
   .choices__heading {
-    font-weight: 600;
-    font-size: 19px;
+    @include govuk-typography-weight-bold;
+    color: govuk-colour("black"); // Choices.js doesn't use a variable for this color for some reason :(
     padding: 30px 10px 10px;
-    border-bottom: 1px solid #b1b4b6;
-    background: $background;
+    border-bottom: 1px solid govuk-colour("mid-grey");
     cursor: default;
-  }
-
-  .choices__button {
-    text-indent: -9999px;
-    -webkit-appearance: none;
-    appearance: none;
-    border: 0;
-    background-color: transparent;
-    background-repeat: no-repeat;
-    background-position: center;
-    cursor: pointer;
-  }
-
-  .choices__button:focus {
-    outline: none;
-  }
-
-  .choices__input {
-    display: inline-block;
-    vertical-align: baseline;
-    background-color: $background;
-    font-size: 19px;
-    border: 0;
-    border-radius: 0;
-    max-width: 100%;
-    padding: 4px 0 4px 2px;
-
-    &:focus {
-      outline: 0;
-    }
-
-    &::-webkit-search-decoration,
-    &::-webkit-search-cancel-button,
-    &::-webkit-search-results-button,
-    &::-webkit-search-results-decoration {
-      display: none;
-    }
-
-    &::-ms-clear,
-    &::-ms-reveal {
-      display: none;
-      width: 0;
-      height: 0;
-    }
-
-    [dir="rtl"] & {
-      padding-right: 2px;
-      padding-left: 0;
-    }
-  }
-
-  .choices__placeholder {
-    color: #757575;
   }
 }

--- a/app/views/govuk_publishing_components/components/_select.html.erb
+++ b/app/views/govuk_publishing_components/components/_select.html.erb
@@ -6,44 +6,39 @@
   label ||= false
   name ||= id
   is_page_heading ||= false
-  data_attributes ||= {}
   aria_controls ||= nil
+  multiple ||= false
+  heading_size ||= nil
 
-  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
-  heading_size = false unless shared_helper.valid_heading_size?(heading_size)
-  select_helper = GovukPublishingComponents::Presenters::SelectHelper.new(local_assigns)
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+
+  data_attributes ||= {}
+
+  select_helper ||= GovukPublishingComponents::Presenters::SelectHelper.new(local_assigns)
 
   aria_attributes = {
     controls: aria_controls,
     describedby: select_helper.describedby
   }
 %>
-<% if select_helper.options.any? && id && label %>
+
+<% if select_helper.option_markup && id && label %>
   <%= content_tag :div, class: select_helper.css_classes do %>
-    <% if is_page_heading %>
-      <% add_gem_component_stylesheet("heading") %>
-      <%= render "govuk_publishing_components/components/heading", {
-        text: label_tag(id, label, class: select_helper.label_classes),
-        heading_level: 1
-      } %>
-    <% else %>
-      <%= label_tag(id, label, class: select_helper.label_classes) %>
-    <% end %>
+    <%= render "govuk_publishing_components/components/label", {
+      html_for: id,
+      text: label,
+      heading_size:,
+      hint_text: select_helper.hint,
+      hint_id: select_helper.hint_id,
+    } %>
 
-    <% if select_helper.hint %>
-      <%= render "govuk_publishing_components/components/hint", {
-        id: select_helper.hint_id,
-        text: hint
-      } %>
-    <% end %>
-
-    <% if select_helper.error_message %>
+    <% if select_helper.has_error? %>
       <%= render "govuk_publishing_components/components/error_message", {
         id: select_helper.error_id,
-        text: select_helper.error_message
+        items: select_helper.error_items,
       } %>
     <% end %>
 
-    <%= select_tag name, options_for_select(select_helper.option_markup, select_helper.selected_option), id: id, class: select_helper.select_classes, aria: aria_attributes, data: data_attributes %>
+    <%= select_tag name, select_helper.option_markup, id: id, class: select_helper.select_classes, aria: aria_attributes, data: component_helper.data_attributes, multiple: %>
   <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/_select_with_search.html.erb
+++ b/app/views/govuk_publishing_components/components/_select_with_search.html.erb
@@ -1,40 +1,15 @@
 <%
-  add_gem_component_stylesheet("select")
   add_gem_component_stylesheet("select-with-search")
 
-  id ||= false
-  label ||= false
-  name ||= id
-  data_attributes ||= {}
-
-  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
-  heading_size = false unless shared_helper.valid_heading_size?(heading_size)
   # select_helper.select_classes generates "gem-c-select-with-search"
   select_helper = GovukPublishingComponents::Presenters::SelectWithSearchHelper.new(local_assigns)
-  multiple = local_assigns[:select].present? ? local_assigns[:select][:multiple] : false
+
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_data_attribute({ module: "select-with-search" })
 %>
 
-<%= content_tag :div, class: select_helper.css_classes, data: select_helper.data_attributes do %>
-  <%= label_tag(id, label, class: select_helper.label_classes, id: "#{id}_label") %>
-
-  <% if select_helper.hint %>
-    <%= render "govuk_publishing_components/components/hint", {
-      id: select_helper.hint_id,
-      text: hint,
-    } %>
-  <% end %>
-
-  <% if select_helper.error_items.any? %>
-    <%= render "govuk_publishing_components/components/error_message", {
-      id: select_helper.error_id,
-      items: select_helper.error_items,
-    } %>
-  <% end %>
-
-  <%# Create null input so that the value is cleared if no options are selected %>
-  <% if multiple %>
-    <%= hidden_field_tag name, nil %>
-  <% end %>
-  <%= select_tag name, select_helper.options_html, id: id, class: select_helper.select_classes, multiple:, aria: select_helper.aria, data: data_attributes %>
-
-<% end %>
+<%= render "govuk_publishing_components/components/select", {
+  **local_assigns,
+  **component_helper.all_attributes,
+  select_helper:
+}.with_indifferent_access %>

--- a/app/views/govuk_publishing_components/components/_select_with_search.html.erb
+++ b/app/views/govuk_publishing_components/components/_select_with_search.html.erb
@@ -1,6 +1,6 @@
 <%
-  add_gem_component_stylesheet("select-with-search")
   add_gem_component_stylesheet("select")
+  add_gem_component_stylesheet("select-with-search")
 
   id ||= false
   label ||= false
@@ -9,6 +9,7 @@
 
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
   heading_size = false unless shared_helper.valid_heading_size?(heading_size)
+  # select_helper.select_classes generates "gem-c-select-with-search"
   select_helper = GovukPublishingComponents::Presenters::SelectWithSearchHelper.new(local_assigns)
   multiple = local_assigns[:select].present? ? local_assigns[:select][:multiple] : false
 %>

--- a/app/views/govuk_publishing_components/components/_select_with_search.html.erb
+++ b/app/views/govuk_publishing_components/components/_select_with_search.html.erb
@@ -1,0 +1,39 @@
+<%
+  add_gem_component_stylesheet("select-with-search")
+  add_gem_component_stylesheet("select")
+
+  id ||= false
+  label ||= false
+  name ||= id
+  data_attributes ||= {}
+
+  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+  heading_size = false unless shared_helper.valid_heading_size?(heading_size)
+  select_helper = GovukPublishingComponents::Presenters::SelectWithSearchHelper.new(local_assigns)
+  multiple = local_assigns[:select].present? ? local_assigns[:select][:multiple] : false
+%>
+
+<%= content_tag :div, class: select_helper.css_classes, data: select_helper.data_attributes do %>
+  <%= label_tag(id, label, class: select_helper.label_classes, id: "#{id}_label") %>
+
+  <% if select_helper.hint %>
+    <%= render "govuk_publishing_components/components/hint", {
+      id: select_helper.hint_id,
+      text: hint,
+    } %>
+  <% end %>
+
+  <% if select_helper.error_items.any? %>
+    <%= render "govuk_publishing_components/components/error_message", {
+      id: select_helper.error_id,
+      items: select_helper.error_items,
+    } %>
+  <% end %>
+
+  <%# Create null input so that the value is cleared if no options are selected %>
+  <% if multiple %>
+    <%= hidden_field_tag name, nil %>
+  <% end %>
+  <%= select_tag name, select_helper.options_html, id: id, class: select_helper.select_classes, multiple:, aria: select_helper.aria, data: data_attributes %>
+
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/select_with_search.yml
+++ b/app/views/govuk_publishing_components/components/docs/select_with_search.yml
@@ -1,0 +1,204 @@
+name: Select with search
+description: A dropdown select with search
+body: |
+  NOTE: this component currently fails WCAG compliance for keyboard navigation, as the total number of options are not 
+  announced when using Voice Over
+  
+  Use this component to create a JavaScript-enhanced dropdown select.
+
+  It's powered by [Choices.js][], which is similar to [Select2][] but without the jQuery dependency.
+  And it's styled to look like [Accessible Autocomplete][], or any other [GOV.UK Design System][] component.
+
+  [Choices.js]: https://choices-js.github.io/Choices/
+  [Select2]: https://select2.org/
+  [Accessible Autocomplete]: https://alphagov.github.io/accessible-autocomplete/examples/
+  [GOV.UK Design System]: https://design-system.service.gov.uk/
+accessibility_criteria: |
+  - accept focus
+  - be focusable with a keyboard
+  - be usable with a keyboard
+  - indicate when it has focus
+examples:
+  default:
+    data:
+      id: dropdown-default
+      label: My Dropdown
+      options:
+      - text: Option one
+        value: option1
+      - text: Option two
+        value: option2
+      - text: Option three
+        value: option3
+  with_blank_option:
+    description: Include a blank option
+    data:
+      id: dropdown-with-blank
+      label: With blank option
+      include_blank: true
+      options:
+      - text: Option one
+        value: option1
+      - text: Option two
+        value: option2
+      - text: Option three
+        value: option3
+  with_grouped_options:
+    description: Options can be grouped
+    data:
+      id: dropdown-with-grouped-options
+      label: Select a city
+      grouped_options:
+      - - England
+        - - text: Bath
+            value: bath
+          - text: Bristol
+            value: bristol
+          - text: London
+            value: london
+          - text: Manchester
+            value: manchester
+      - - Northern Ireland
+        - - text: Bangor
+            value: bangor
+          - text: Belfast
+            value: belfast
+      - - Scotland
+        - - text: Dundee
+            value: dundee
+          - text: Edinburgh
+            value: edinburgh
+          - text: Glasgow
+            value: glasgow
+      - - Wales
+        - - text: Cardiff
+            value: cardiff
+          - text: Swansea
+            value: swansea
+  with_grouped_options_and_blank_option:
+    description: Options can be grouped and include a blank option
+    data:
+      id: dropdown-with-grouped-options-and-blank
+      label: Select a city
+      include_blank: true
+      grouped_options:
+      - - England
+        - - text: Bath
+            value: bath
+          - text: Bristol
+            value: bristol
+          - text: London
+            value: london
+          - text: Manchester
+            value: manchester
+      - - Northern Ireland
+        - - text: Bangor
+            value: bangor
+          - text: Belfast
+            value: belfast
+      - - Scotland
+        - - text: Dundee
+            value: dundee
+          - text: Edinburgh
+            value: edinburgh
+          - text: Glasgow
+            value: glasgow
+      - - Wales
+        - - text: Cardiff
+            value: cardiff
+          - text: Swansea
+            value: swansea
+  with_different_id_and_name:
+    description: If no name is provided, name defaults to the (required) value of id.
+    data:
+      id: dropdown-with-different-id-and-name
+      label: My Dropdown
+      name: dropdown[1]
+      options:
+      - text: Option one
+        value: option1
+      - text: Option two
+        value: option2
+  with_data_attributes:
+    data:
+      id: dropdown-with-data-attributes
+      data_attributes:
+        module: not-a-module
+        loose: moose
+      label: Select your country
+      options:
+        - text: France
+          value: fr
+        - text: Germany
+          value: de
+        - text: United Kingdom
+          value: uk
+  with_preselect:
+    data:
+      id: dropdown-with-preselect
+      label: Option 2 preselected
+      options:
+      - text: Option one
+        value: option1
+      - text: Option two
+        value: option2
+        selected: true
+      - text: Option three
+        value: option3
+  with_hint:
+    description: When a hint is included the `aria-describedby` attribute of the select is included to point to the hint. When an error and a hint are present, that attribute includes the IDs of both the hint and the error.
+    data:
+      id: dropdown-with-hint
+      label: Choose your preferred thing
+      hint: You might need some more information here
+      hint_id: optional-hint-id
+      options:
+      - text: Something
+        value: option1
+      - text: Something else
+        value: option2
+  with_error:
+    description: An arbitrary number of separate error items can be passed to the component.
+    data:
+      id: dropdown-with-error
+      label: How will you be travelling to the conference?
+      error_items:
+        - text: Please choose an option
+      include_blank: true
+      options:
+      - text: Public transport
+        value: option1
+      - text: Will make own arrangements
+        value: option2
+  with_custom_label_size:
+    description: Make the label different sizes. Valid options are `s`, `m`, `l` and `xl`.
+    data:
+      id: dropdown-with-custom-label-size
+      label: Bigger!
+      heading_size: xl
+      options:
+      - text: Option one
+        value: option1
+      - text: Option two
+        value: option2
+      - text: Option three
+        value: option3
+  with_multiple_select_enabled:
+    description: Allow multiple items to be selected and de-selected.
+    data:
+      id: dropdown-with-multiple
+      label: Select your country
+      include_blank: true
+      select:
+        multiple: true
+      options:
+        - text: France
+          value: fr
+          selected: false
+        - text: Germany
+          value: de
+          selected: false
+        - text: The United Kingdom of Great Britain and Northern Ireland
+          value: uk
+        - text: Democratic Republic of the Congo
+          value: cg

--- a/app/views/govuk_publishing_components/components/docs/select_with_search.yml
+++ b/app/views/govuk_publishing_components/components/docs/select_with_search.yml
@@ -30,6 +30,17 @@ examples:
         value: option2
       - text: Option three
         value: option3
+  disabled:
+    data:
+      id: dropdown-default
+      label: My Dropdown
+      options:
+      - text: Option one
+        value: option1
+      - text: Option two
+        value: option2
+      - text: Option three
+        value: option3        
   with_blank_option:
     description: Include a blank option
     data:

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
   s.required_ruby_version = ">= 3.2"
 
-  s.files = Dir["{node_modules/accessible-autocomplete,node_modules/govuk-frontend,node_modules/axe-core,node_modules/sortablejs,node_modules/govuk-single-consent,app,config,db,lib}/**/*", "LICENCE.md", "README.md"]
+  s.files = Dir["{node_modules/accessible-autocomplete,node_modules/govuk-frontend,node_modules/axe-core,node_modules/sortablejs,node_modules/govuk-single-consent,node_modules/choices.js,app,config,db,lib}/**/*", "LICENCE.md", "README.md"]
 
   s.add_dependency "govuk_app_config"
   s.add_dependency "govuk_personalisation", ">= 0.7.0"

--- a/lib/govuk_publishing_components.rb
+++ b/lib/govuk_publishing_components.rb
@@ -28,6 +28,7 @@ require "govuk_publishing_components/presenters/content_breadcrumbs_based_on_org
 require "govuk_publishing_components/presenters/content_breadcrumbs_based_on_taxons"
 require "govuk_publishing_components/presenters/checkboxes_helper"
 require "govuk_publishing_components/presenters/select_helper"
+require "govuk_publishing_components/presenters/select_with_search_helper"
 require "govuk_publishing_components/presenters/meta_tags"
 require "govuk_publishing_components/presenters/content_item"
 require "govuk_publishing_components/presenters/translation_nav_helper"

--- a/lib/govuk_publishing_components/presenters/select_helper.rb
+++ b/lib/govuk_publishing_components/presenters/select_helper.rb
@@ -1,23 +1,26 @@
 module GovukPublishingComponents
   module Presenters
     class SelectHelper
-      attr_reader :options, :option_markup, :selected_option, :error_message, :error_id, :hint, :hint_id, :describedby
+      include ActionView::Helpers::FormOptionsHelper
+
+      attr_reader :options, :option_markup, :selected_options, :error_items, :error_id, :hint, :hint_id, :describedby
 
       def initialize(local_assigns)
         @options = local_assigns[:options] || []
-        @error_message = local_assigns[:error_message]
+        @error_items = local_assigns[:error_items] || []
+        @error_items << { text: local_assigns[:error_message] } if local_assigns[:error_message].present?
         @error_id = local_assigns[:error_id] || nil
         @hint = local_assigns[:hint] || nil
         @hint_id = local_assigns[:hint_id] || nil
         @heading_size = local_assigns[:heading_size]
         @full_width = local_assigns[:full_width] || false
-        @option_markup = get_options
+        @option_markup = options_for_select(get_options(@options))
         @describedby = get_describedby
       end
 
       def css_classes
         classes = %w[govuk-form-group gem-c-select]
-        classes << "govuk-form-group--error" if @error_message
+        classes << "govuk-form-group--error" if has_error?
         classes
       end
 
@@ -28,19 +31,15 @@ module GovukPublishingComponents
         classes
       end
 
-      def label_classes
-        classes = %w[govuk-label]
-        classes << "govuk-label--#{@heading_size}" if @heading_size
-        classes
+      def has_error?
+        @error_items.present?
       end
 
-    private
-
-      def get_options
+      def get_options(options)
         return if options.nil?
 
         options.map do |option|
-          @selected_option = option[:value] if option[:selected]
+          @selected_options << option[:value] if option[:selected]
           [
             option[:text],
             option[:value],
@@ -61,12 +60,14 @@ module GovukPublishingComponents
         end
 
         attrs
-      end
+      end      
+
+    private
 
       def get_describedby
         describedby = %w[]
 
-        if @error_message || @error_id
+        if @error_items.present? || @error_id
           @error_id ||= "error-#{SecureRandom.hex(4)}"
           describedby << @error_id
         end

--- a/lib/govuk_publishing_components/presenters/select_with_search_helper.rb
+++ b/lib/govuk_publishing_components/presenters/select_with_search_helper.rb
@@ -1,0 +1,101 @@
+##
+# Helper methods for use with the "select-with-search" component.
+# This wraps and extends the Select component's helper methods to add support for option groups.
+##
+module GovukPublishingComponents
+  module Presenters
+    class SelectWithSearchHelper
+      include ActionView::Helpers::FormOptionsHelper
+
+      attr_reader :options, :selected_options, :error_id, :error_items, :aria
+
+      delegate :describedby,
+               :hint_id,
+               :hint,
+               :label_classes,
+               :select_classes,
+               to: :@select_helper
+
+      def initialize(local_assigns)
+        @select_helper = SelectHelper.new(local_assigns.except(:options, :grouped_options))
+        @error_id = "error-#{SecureRandom.hex(4)}"
+        @error_items = local_assigns[:error_items] || []
+        @aria = @error_items.any? ? { describedby: @error_id } : @describedby
+        @options = local_assigns[:options]
+        @grouped_options = local_assigns[:grouped_options]
+        @include_blank = local_assigns[:include_blank]
+        @selected_options = []
+        @local_assigns = local_assigns
+      end
+
+      def css_classes
+        classes = %w[gem-c-select-with-search govuk-form-group]
+        classes << "govuk-form-group--error" if error_items.any?
+        classes
+      end
+
+      def options_html
+        if @grouped_options.present?
+          blank_option_if_include_blank +
+            grouped_and_ungrouped_options_for_select(@grouped_options)
+        elsif @options.present?
+          blank_option_if_include_blank +
+            options_for_select(
+              transform_options(@options),
+              selected_options,
+            )
+        end
+      end
+
+      def data_attributes
+        data_attributes = @local_assigns[:data_attributes] || {}
+        data_attributes[:module] ||= ""
+        data_attributes[:module] << " select-with-search"
+        data_attributes[:module].strip!
+        data_attributes
+      end
+
+      def grouped_and_ungrouped_options_for_select(unsorted_options)
+        # Filter out the 'single option' options and treat them as simply `<option>`
+        # The remainder should be treated as true 'grouped options', i.e. `<optgroup>`
+        single_options = []
+        grouped_options = []
+        unsorted_options.each_with_index do |(group, options), _index|
+          if group == ""
+            single_options << options
+          else
+            grouped_options << [group, options]
+          end
+        end
+        single_options.flatten!
+
+        options_for_select(transform_options(single_options), selected_options) +
+          grouped_options_for_select(transform_grouped_options(grouped_options), selected_options)
+      end
+
+    private
+
+      def transform_options(options)
+        options.map do |option|
+          @selected_options << option[:value] if option[:selected]
+          [
+            option[:text],
+            option[:value],
+          ]
+        end
+      end
+
+      def transform_grouped_options(grouped_options)
+        grouped_options.map do |(group, options)|
+          [group, transform_options(options)]
+        end
+      end
+
+      def blank_option_if_include_blank
+        return "".html_safe if @include_blank.blank?
+
+        options_for_select([["", ""]])
+      end
+    end
+  end
+end

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "accessible-autocomplete": "^3.0.1",
     "axe-core": "^4.10.3",
+    "choices.js": "^11.1.0",
     "govuk-frontend": "5.9.0",
     "govuk-single-consent": "^3.0.9",
     "sortablejs": "^1.15.6"

--- a/spec/javascripts/components/select-with-search-spec.js
+++ b/spec/javascripts/components/select-with-search-spec.js
@@ -1,0 +1,106 @@
+/* eslint-env jasmine */
+/* global GOVUK */
+
+describe('GOVUK.Modules.SelectWithSearch', function () {
+  let component, module
+
+  function getOptions () {
+    const items = component.querySelectorAll(
+      '.choices__list .choices__item--choice'
+    )
+    return Array.from(items).map((item) => item.textContent.trim())
+  }
+
+  describe('with a simple select', () => {
+    beforeEach(function () {
+      component = document.createElement('div')
+      component.innerHTML = `
+        <label for="example">Choose a colour</label>
+        <select id="example">
+          <option value="red">Red</option>
+          <option value="green">Green</option>
+          <option value="blue">Blue</option>
+        </select>
+      `
+      module = new GOVUK.Modules.SelectWithSearch(component)
+      module.init()
+    })
+
+    it('initialises Choices.js', function () {
+      expect(
+        component.querySelector('.choices[data-type="select-one"]')
+      ).toBeTruthy()
+    })
+
+    it('does not reorder the provided options', () => {
+      expect(getOptions()).toEqual(['Red', 'Green', 'Blue'])
+    })
+
+    it('shows a search field', () => {
+      expect(component.querySelector('input[type=search]').placeholder).toEqual(
+        'Search in list'
+      )
+    })
+  })
+
+  describe('simple select which can be left blank', () => {
+    beforeEach(function () {
+      component = document.createElement('div')
+      component.innerHTML = `
+        <label for="example">Choose a colour</label>
+        <select id="example">
+          <option value=""></option>
+          <option value="red">Red</option>
+          <option value="green">Green</option>
+          <option value="blue">Blue</option>
+        </select>
+      `
+      module = new GOVUK.Modules.SelectWithSearch(component)
+      module.init()
+    })
+
+    it('shows a "Select one" placeholder', () => {
+      expect(
+        component.querySelector('.choices__placeholder').textContent
+      ).toEqual('Select one')
+    })
+  })
+
+  describe('with grouped options', () => {
+    beforeEach(function () {
+      component = document.createElement('div')
+      component.innerHTML = `
+        <label for="example">Choose a city</label>
+        <select id="example">
+          <optgroup label="England">
+            <option value="bath">Bath</option>
+            <option value="bristol">Bristol</option>
+            <option value="london">London</option>
+            <option value="manchester">Manchester</option>
+          </optgroup>
+          <optgroup label="Ireland">
+            <option value="bangor">Bangor</option>
+            <option value="belfast">Belfast</option>
+          </optgroup>
+          <optgroup label="Scotland">
+            <option value="dundee">Dundee</option>
+            <option value="edinburgh">Edinburgh</option>
+            <option value="glasgow">Glasgow</option>
+          </optgroup>
+          <optgroup label="Wales">
+            <option value="cardiff">Cardiff</option>
+            <option value="swansea">Swansea</option>
+          </optgroup>
+        </select>
+      `
+      module = new GOVUK.Modules.SelectWithSearch(component)
+      module.init()
+    })
+
+    it('renders groups and options', () => {
+      const list = component.querySelector('.choices__list--dropdown')
+      expect(list.querySelectorAll('.choices__group').length).toEqual(4)
+      expect(list.querySelectorAll('.choices__item--choice').length).toEqual(11)
+    })
+  })
+})

--- a/spec/lib/govuk_publishing_components/app_helpers/asset_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/app_helpers/asset_helper_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe GovukPublishingComponents::AppHelpers::AssetHelper do
     end
 
     it "detect the total number of stylesheet paths" do
-      expect(get_component_css_paths.count).to be(86)
+      expect(get_component_css_paths.count).to be(87)
     end
 
     it "initialize empty asset helper" do

--- a/spec/lib/govuk_publishing_components/presenters/select_with_search_helper_test.rb
+++ b/spec/lib/govuk_publishing_components/presenters/select_with_search_helper_test.rb
@@ -1,0 +1,104 @@
+require_relative "../../test_helper"
+require_relative "../../../lib/govuk_publishing_components/presenters/select_with_search_helper"
+require "govuk_publishing_components/presenters/select_helper"
+
+class SelectWithSearchHelperPresenterTest < PresenterTestCase
+  test "should generate options for select" do
+    described_class = GovukPublishingComponents::Presenters::SelectWithSearchHelper
+
+    instance = described_class.new(
+      options: [
+        {
+          text: "Foo",
+          value: "Bar",
+        },
+        {
+          text: "Option",
+          value: "opt",
+          selected: true,
+        },
+        {
+          text: "Baz",
+          value: "Bam",
+        },
+      ],
+    )
+
+    expected = <<~HTML.strip
+      <option value="Bar">Foo</option>
+      <option selected="selected" value="opt">Option</option>
+      <option value="Bam">Baz</option>
+    HTML
+
+    assert_equal expected, instance.options_html
+  end
+
+  test "should generate grouped options for select" do
+    described_class = GovukPublishingComponents::Presenters::SelectWithSearchHelper
+
+    instance = described_class.new(
+      grouped_options: [
+        [
+          "",
+          [
+            {
+              text: "All organisations",
+              value: "",
+              selected: true,
+            },
+          ],
+        ],
+        [
+          "",
+          [
+            {
+              text: "All foo",
+              value: "foo",
+            },
+          ],
+        ],
+        [
+          "Live organisations",
+          %w[foo bar baz].map do |key|
+            {
+              text: key,
+              value: key,
+            }
+          end,
+        ],
+      ],
+    )
+
+    expected = <<~HTML.strip
+      <option selected="selected" value="">All organisations</option>
+      <option value="foo">All foo</option>
+      <optgroup label="Live organisations">
+      <option value="foo">foo</option>
+      <option value="bar">bar</option>
+      <option value="baz">baz</option>
+      </optgroup>
+    HTML
+
+    assert_equal expected.delete("\n"), instance.options_html.delete("\n")
+  end
+
+  test "should include a blank option when told to" do
+    described_class = GovukPublishingComponents::Presenters::SelectWithSearchHelper
+
+    instance = described_class.new(
+      include_blank: true,
+      options: [
+        {
+          text: "Foo",
+          value: "Bar",
+        },
+      ],
+    )
+
+    expected = <<~HTML.strip
+      <option value=""></option><option value="Bar">Foo</option>
+    HTML
+
+    assert_equal expected, instance.options_html
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -595,6 +595,13 @@ chalk@^4.0.0, chalk@^4.0.2:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+choices.js@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/choices.js/-/choices.js-11.1.0.tgz#4fcfb5834fdf0c7d1959f0261d1bbe526a7c9222"
+  integrity sha512-mIt0uLhedHg2ea/K2PACrVpt391vRGHuOoctPAiHcyemezwzNMxj7jOzNEk8e7EbjLh0S0sspDkSCADOKz9kcw==
+  dependencies:
+    fuse.js "^7.0.0"
+
 color-convert@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
@@ -1408,6 +1415,11 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
+
+fuse.js@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-7.1.0.tgz#306228b4befeee11e05b027087c2744158527d09"
+  integrity sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==
 
 get-intrinsic@^1.0.2:
   version "1.1.3"


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

Add the Select With Search component to govuk_publishing_components.

### More details

The Select With Search component is an autocomplete select replacement that supports selecting multiple choices. [Accessible Autocomplete](https://github.com/alphagov/accessible-autocomplete) does not support multiple choices so previously the now deprecated [Accessible Autocomplete Multiselect](https://github.com/alphagov/accessible-autocomplete-multiselect) was used.

This component uses [Choices](https://github.com/Choices-js/Choices). It is progressively enhanced, so if it fails to load or Javascript is disabled then [the Select component](https://design-system.service.gov.uk/components/select/) will be rendered.

## Why
<!-- What are the reasons behind this change being made? -->

This component is used in Whitehall and Specialist Publisher currently. It will most likely be used in other publishing applications when they move to using the GOV.UK Design System.  

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

