### PR TITLE
Release version 57.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 57.3.0
 
 * Add more options to the select component ([PR #4858](https://github.com/alphagov/govuk_publishing_components/pull/4858))
 * Fix GA4 tracking for asset preview links ([PR #4863](https://github.com/alphagov/govuk_publishing_components/pull/4863))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (57.2.0)
+    govuk_publishing_components (57.3.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "57.2.0".freeze
+  VERSION = "57.3.0".freeze
 end


### PR DESCRIPTION
## 57.3.0

* Add more options to the select component ([PR #4858](https://github.com/alphagov/govuk_publishing_components/pull/4858))
* Fix GA4 tracking for asset preview links ([PR #4863](https://github.com/alphagov/govuk_publishing_components/pull/4863))