### PR TITLE
Add Select with Search component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add Select with Search component ([PR #4879](https://github.com/alphagov/govuk_publishing_components/pull/4879))
 * Add support for specifying `input[type=search]` to `Ga4SearchTracker` ([PR #4887](https://github.com/alphagov/govuk_publishing_components/pull/4887))
 
 ## 58.1.1

--- a/app/assets/images/select-with-search/cross-icon.svg
+++ b/app/assets/images/select-with-search/cross-icon.svg
@@ -1,0 +1,6 @@
+<svg width='21' height='21' viewBox='0 0 21 21' xmlns='http://www.w3.org/2000/svg'>
+  <g fill='#000' fill-rule='evenodd'>
+    <path d='M2.592.044l18.364 18.364-2.548 2.548L.044 2.592z' />
+    <path d='M0 18.364L18.364 0l2.548 2.548L2.548 20.912z' />
+  </g>
+</svg>

--- a/app/assets/javascripts/govuk_publishing_components/components/select-with-search.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/select-with-search.js
@@ -1,0 +1,55 @@
+//= require choices.js/public/assets/scripts/choices.min.js
+'use strict'
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {}
+;(function (Modules) {
+  function SelectWithSearch (module) {
+    this.module = module
+  }
+
+  SelectWithSearch.prototype.init = function () {
+    if (!this.module.matches('select')) {
+      console.error('Module is not a select element')
+      return
+    }
+
+    const placeholderOption = this.module.querySelector(
+      'option[value=""]:first-child'
+    )
+
+    if (placeholderOption && placeholderOption.textContent === '') {
+      placeholderOption.textContent = this.module.multiple
+        ? 'Select all that apply'
+        : 'Select one'
+    }
+
+    this.choices = new window.Choices(this.module, {
+      allowHTML: true,
+      searchPlaceholderValue: 'Search in list',
+      shouldSort: false, // show options and groups in the order they were given
+      itemSelectText: '',
+      searchResultLimit: 100,
+      removeItemButton: this.module.multiple,
+      labelId: this.module.id,
+      callbackOnInit: function () {
+        // For the multiple select, move the input field to
+        // the top of the feedback area, so that the selected
+        // 'lozenges' appear afterwards in a more natural flow
+        if (this.dropdown.type === 'select-multiple') {
+          const inner = this.containerInner.element
+          const input = this.input.element
+          inner.prepend(input)
+        }
+      },
+      // https://fusejs.io/api/options.html
+      fuseOptions: {
+        ignoreLocation: true, // matches any part of the string
+        threshold: 0 // only matches when characters are sequential
+      }
+    })
+
+    this.module.choices = this.choices
+  }
+
+  Modules.SelectWithSearch = SelectWithSearch
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/govuk_publishing_components/components/select-with-search.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/select-with-search.js
@@ -23,6 +23,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
         : 'Select one'
     }
 
+    const ariaDescribedBy = this.module.getAttribute('aria-describedby') || ''
+
     this.choices = new window.Choices(this.module, {
       allowHTML: true,
       searchPlaceholderValue: 'Search in list',
@@ -30,7 +32,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
       itemSelectText: '',
       searchResultLimit: 100,
       removeItemButton: this.module.multiple,
-      labelId: this.module.id,
+      labelId: this.module.id + '-label ' + ariaDescribedBy,
       callbackOnInit: function () {
         // For the multiple select, move the input field to
         // the top of the feedback area, so that the selected

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -75,6 +75,7 @@
 @import "components/search";
 @import "components/secondary-navigation";
 @import "components/select";
+@import "components/select-with-search";
 @import "components/service-navigation";
 @import "components/share-links";
 @import "components/signup-link";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_select-with-search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_select-with-search.scss
@@ -1,0 +1,429 @@
+@import "govuk_publishing_components/individual_component_support";
+@import "govuk/components/label/label";
+
+.gem-c-select-with-search {
+  //
+  // A theme for Choices.js styled to look like a GOV.UK Design System component
+  //
+  $background: #ffffff;
+  $focus-color: $govuk-focus-colour;
+  $focus-outline: $govuk-focus-width solid $govuk-focus-colour;
+
+  .choices * {
+    // Something inside .choices needs this – I'm not sure what yet
+    box-sizing: border-box;
+  }
+
+  .choices {
+    @include govuk-font($size: 19);
+    position: relative;
+    margin-bottom: 24px;
+  }
+
+  .choices:focus {
+    outline: none;
+  }
+
+  .choices:last-child {
+    margin-bottom: 0;
+  }
+
+  // Disabled state
+  .choices.is-disabled {
+    .choices__inner,
+    .choices__input {
+      background-color: #eaeaea;
+      cursor: not-allowed;
+      -webkit-user-select: none;
+      user-select: none;
+    }
+
+    .choices__item {
+      cursor: not-allowed;
+    }
+  }
+
+  // This is an intentionally high specificity selector to avoid using !important when targetting
+  // the <select hidden> element that would otherwise end up picking up `display: block` from the
+  // `.choices[data-type*="select-one"] .choices__input` rule below.
+  .choices .choices__inner select[hidden] {
+    display: none;
+  }
+
+  // Type: Single Select
+  .choices[data-type*="select-one"] {
+    cursor: pointer;
+
+    .choices__input {
+      display: block;
+      width: 100%;
+      padding: 10px;
+      border-bottom: 1px solid #dddddd;
+      background-color: $background;
+      margin: 0;
+    }
+
+    .choices__button {
+      background-image: url("select-with-search/cross-icon.svg");
+      padding: 0;
+      background-size: 8px;
+      position: absolute;
+      top: 50%;
+      right: 0;
+      margin-top: -10px;
+      margin-right: 25px;
+      height: 20px;
+      width: 20px;
+      border-radius: 10em;
+      opacity: 0.25;
+
+      &:hover,
+      &:focus {
+        opacity: 1;
+      }
+
+      &:focus {
+        outline: $focus-outline;
+      }
+    }
+
+    .choices__item[data-value=""] .choices__button {
+      display: none;
+    }
+
+    // Dropdown arrow ▼
+    &::after {
+      content: "";
+      height: 0;
+      width: 0;
+      border-style: solid;
+      border-color: #333333 transparent transparent;
+      border-width: 5px;
+      position: absolute;
+      right: 11.5px;
+      top: 50%;
+      margin-top: -2.5px;
+      pointer-events: none;
+    }
+
+    &.is-open::after {
+      border-color: transparent transparent #333333;
+      margin-top: -7.5px;
+    }
+
+    &[dir="rtl"]::after {
+      left: 11.5px;
+      right: auto;
+    }
+
+    &[dir="rtl"] .choices__button {
+      right: auto;
+      left: 0;
+      margin-left: 25px;
+      margin-right: 0;
+    }
+  }
+
+  // Type: Select Multiple / Text
+  .choices[data-type*="select-multiple"],
+  .choices[data-type*="text"] {
+    .choices__inner {
+      cursor: text;
+    }
+
+    .choices__item {
+      position: relative;
+    }
+
+    // Delete button X
+    .choices__button {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      right: 0;
+      width: 32px;
+      border-left: 1px solid govuk-colour("mid-grey");
+      border-right: 1px solid govuk-colour("mid-grey");
+      background-image: url("select-with-search/cross-icon.svg");
+      background-size: 12px;
+      border-radius: 0;
+
+      &:hover {
+        background-color: govuk-colour("mid-grey");
+        border-color: govuk-colour("dark-grey");
+        box-shadow: 0 2px 0 govuk-colour("dark-grey");
+      }
+
+      &:focus {
+        background-color: $govuk-focus-colour;
+        box-shadow: 0 2px 0 $govuk-focus-text-colour;
+      }
+    }
+  }
+
+  // Type: Select Multiple ONLY
+  .choices[data-type*="select-multiple"] {
+    .choices__input {
+      display: block;
+    }
+  }
+
+  .choices__inner {
+    display: inline-block;
+    vertical-align: top;
+    width: 100%;
+    background-color: $background;
+    padding: 5px;
+    border: 2px solid #0b0c0c;
+    font-size: 19px;
+    min-height: 44px;
+    overflow: hidden;
+  }
+
+  &.govuk-form-group--error .choices:not(.is-active):not(.is-focused):not(.is-open) .choices__inner {
+    border-color: $govuk-error-colour;
+  }
+
+  .choices.is-focused .choices__inner,
+  .choices.is-open .choices__inner {
+    outline: $focus-outline;
+    outline-offset: 0;
+    box-shadow: inset 0 0 0 2px;
+  }
+
+  .choices__list {
+    margin: 0;
+    padding-left: 0;
+    list-style: none;
+  }
+
+  .choices__list--single {
+    display: inline-block;
+    padding: 4px 16px 4px 4px;
+    width: 100%;
+  }
+
+  [dir="rtl"] .choices__list--single {
+    padding-right: 4px;
+    padding-left: 16px;
+  }
+
+  .choices__list--single .choices__item {
+    width: 100%;
+  }
+
+  .choices__list--multiple {
+    display: block;
+
+    &:not(:empty) {
+      margin-block-start: 6px;
+      border-block-start: 1px solid $govuk-border-colour;
+      padding-block-end: 5px;
+    }
+  }
+
+  .choices__list--multiple .choices__item {
+    display: inline-flex;
+    align-items: center;
+    padding: 6px 10px;
+    margin: 9px 9px 0 0;
+    background-color: govuk-colour("light-grey");
+    box-shadow: 0 2px 0 govuk-colour("mid-grey");
+    line-height: 1;
+    color: $govuk-text-colour;
+    box-sizing: border-box;
+
+    &[data-deletable] {
+      padding-right: 42px;
+    }
+
+    [dir="rtl"] & {
+      margin-right: 0;
+      margin-left: 3.75px;
+    }
+
+    .is-disabled & {
+      background-color: #aaaaaa;
+      border: 1px solid #919191;
+    }
+  }
+
+  // Dropdown
+  .choices__list--dropdown,
+  .choices__list[aria-expanded] {
+    visibility: hidden;
+    z-index: 2;
+    position: absolute;
+    width: 100%;
+    background-color: $background;
+    border: 2px solid #0b0c0c;
+    border-top-width: 0;
+    top: 100%;
+    overflow: hidden;
+    will-change: visibility;
+
+    &.is-active {
+      visibility: visible;
+    }
+
+    .is-flipped & {
+      top: auto;
+      bottom: 100%;
+      margin-top: 0;
+      margin-bottom: -1px;
+      border-top-width: 2px;
+      border-bottom-width: 0;
+    }
+  }
+
+  .choices__list--dropdown .choices__list,
+  .choices__list[aria-expanded] .choices__list {
+    position: relative;
+    max-height: 310px;
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+    will-change: scroll-position;
+  }
+
+  .choices__list--dropdown .choices__item,
+  .choices__list[aria-expanded] .choices__item {
+    position: relative;
+    padding: 10px;
+    font-size: 19px;
+    border-bottom: 1px solid #b1b4b6;
+
+    &:last-child {
+      border-bottom: 0;
+    }
+
+    &:nth-of-type(even) {
+      background-color: #fafafa;
+    }
+
+    [dir="rtl"] & {
+      text-align: right;
+    }
+  }
+
+  // prettier-ignore
+  @media (min-width: 640px) { // stylelint-disable-line media-feature-range-notation
+    .choices__list--dropdown .choices__item--selectable,
+    .choices__list[aria-expanded] .choices__item--selectable {
+      padding-right: 5px;
+    }
+
+    .choices__list--dropdown .choices__item--selectable::after,
+    .choices__list[aria-expanded] .choices__item--selectable::after {
+      content: attr(data-select-text);
+      font-size: 12px;
+      opacity: 0;
+      position: absolute;
+      right: 10px;
+      top: 50%;
+      transform: translateY(-50%);
+    }
+
+    [dir="rtl"] .choices__list--dropdown .choices__item--selectable,
+    [dir="rtl"] .choices__list[aria-expanded] .choices__item--selectable {
+      text-align: right;
+      padding-left: 100px;
+      padding-right: 10px;
+    }
+
+    [dir="rtl"] .choices__list--dropdown .choices__item--selectable::after,
+    [dir="rtl"] .choices__list[aria-expanded] .choices__item--selectable::after {
+      right: auto;
+      left: 10px;
+    }
+  }
+
+  .choices__list--dropdown .choices__item--selectable.is-highlighted,
+  .choices__list[aria-expanded] .choices__item--selectable.is-highlighted {
+    background-color: #275ca0;
+    border-color: #275ca0;
+    color: #ffffff;
+    outline: none;
+  }
+
+  .choices__list--dropdown .choices__item--selectable.is-highlighted::after,
+  .choices__list[aria-expanded] .choices__item--selectable.is-highlighted::after {
+    opacity: 0.5;
+  }
+
+  .choices__item {
+    cursor: default;
+  }
+
+  .choices__item--selectable {
+    cursor: pointer;
+  }
+
+  .choices__item--disabled {
+    cursor: not-allowed;
+    -webkit-user-select: none;
+    user-select: none;
+    opacity: 0.5;
+  }
+
+  .choices__heading {
+    font-weight: 600;
+    font-size: 19px;
+    padding: 30px 10px 10px;
+    border-bottom: 1px solid #b1b4b6;
+    background: $background;
+    cursor: default;
+  }
+
+  .choices__button {
+    text-indent: -9999px;
+    -webkit-appearance: none;
+    appearance: none;
+    border: 0;
+    background-color: transparent;
+    background-repeat: no-repeat;
+    background-position: center;
+    cursor: pointer;
+  }
+
+  .choices__button:focus {
+    outline: none;
+  }
+
+  .choices__input {
+    display: inline-block;
+    vertical-align: baseline;
+    background-color: $background;
+    font-size: 19px;
+    border: 0;
+    border-radius: 0;
+    max-width: 100%;
+    padding: 4px 0 4px 2px;
+
+    &:focus {
+      outline: 0;
+    }
+
+    &::-webkit-search-decoration,
+    &::-webkit-search-cancel-button,
+    &::-webkit-search-results-button,
+    &::-webkit-search-results-decoration {
+      display: none;
+    }
+
+    &::-ms-clear,
+    &::-ms-reveal {
+      display: none;
+      width: 0;
+      height: 0;
+    }
+
+    [dir="rtl"] & {
+      padding-right: 2px;
+      padding-left: 0;
+    }
+  }
+
+  .choices__placeholder {
+    color: #757575;
+  }
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/_select-with-search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_select-with-search.scss
@@ -1,215 +1,105 @@
+// overload the choices.js variables
+
+$font-size: 19px;
+
+$choices-bg-color: govuk-colour("white") !default;
+$choices-font-size-lg: $font-size !default;
+$choices-font-size-md: $font-size !default;
+$choices-font-size-sm: $font-size !default;
+$choices-primary-color: #ffffff !default; // can't use mixin here because of Choices.js Sass functions
+$choices-text-color: govuk-colour("black");
+$choices-icon-cross: url("select-with-search/cross-icon.svg");
+$choices-border-radius: 0 !default;
+$choices-border-radius-item: 0 !default;
+$choices-z-index: 2 !default;
+$choices-button-dimension: 12px !default;
+
 @import "govuk_publishing_components/individual_component_support";
+@import "mixins/prefixed-transform";
 @import "govuk/components/label/label";
+@import "choices.js/src/styles/choices";
 
 .gem-c-select-with-search {
-  //
-  // A theme for Choices.js styled to look like a GOV.UK Design System component
-  //
-  $background: #ffffff;
-  $focus-color: $govuk-focus-colour;
-  $focus-outline: $govuk-focus-width solid $govuk-focus-colour;
-
   .choices * {
     // Something inside .choices needs this – I'm not sure what yet
     box-sizing: border-box;
+    font-family: $govuk-font-family;
   }
 
-  .choices {
-    @include govuk-font($size: 19);
-    position: relative;
-    margin-bottom: 24px;
+  .choices[data-type*="select-one"]::after {
+    @include govuk-shape-arrow($direction: down, $base: 10px, $display: inline-block);
+    @include prefixed-transform($translateY: -50%);
+    margin: 0;
   }
 
-  .choices:focus {
-    outline: none;
+  .choices.is-open[data-type*="select-one"]::after {
+    margin: 0;
+    bottom: govuk-em(1px, $font-size);
+    @include prefixed-transform($translateY: -50%, $rotate: 180deg);
   }
 
-  .choices:last-child {
+  .choices[data-type*="select-multiple"] .choices__button,
+  .choices[data-type*="text"] .choices__button {
+    border-color: govuk-colour("mid-grey");
+    border-right: 1px solid govuk-colour("mid-grey");
+    padding: govuk-spacing(2) govuk-spacing(4) govuk-spacing(2) govuk-spacing(2);
+    margin-right: 0;
+
+    &:hover {
+      background-color: govuk-colour("mid-grey");
+      border-color: govuk-colour("dark-grey");
+      box-shadow: 0 $govuk-border-width-form-element 0 govuk-colour("dark-grey");
+    }
+
+    &:focus {
+      background-color: $govuk-focus-colour;
+      box-shadow: 0 $govuk-border-width-form-element 0 $govuk-focus-text-colour;
+    }
+  }
+
+  .choices.is-disabled {
+    .choices__item[data-deletable] {
+      background-color: govuk-colour("white");
+    }
+
+    .choices__button {
+      display: none;
+    }
+  }
+
+  .choices__input {
+    display: block;
     margin-bottom: 0;
   }
 
-  // Disabled state
-  .choices.is-disabled {
-    .choices__inner,
-    .choices__input {
-      background-color: #eaeaea;
-      cursor: not-allowed;
-      -webkit-user-select: none;
-      user-select: none;
-    }
-
-    .choices__item {
-      cursor: not-allowed;
-    }
-  }
-
-  // This is an intentionally high specificity selector to avoid using !important when targetting
-  // the <select hidden> element that would otherwise end up picking up `display: block` from the
-  // `.choices[data-type*="select-one"] .choices__input` rule below.
-  .choices .choices__inner select[hidden] {
-    display: none;
-  }
-
-  // Type: Single Select
-  .choices[data-type*="select-one"] {
-    cursor: pointer;
-
-    .choices__input {
-      display: block;
-      width: 100%;
-      padding: 10px;
-      border-bottom: 1px solid #dddddd;
-      background-color: $background;
-      margin: 0;
-    }
-
-    .choices__button {
-      background-image: url("select-with-search/cross-icon.svg");
-      padding: 0;
-      background-size: 8px;
-      position: absolute;
-      top: 50%;
-      right: 0;
-      margin-top: -10px;
-      margin-right: 25px;
-      height: 20px;
-      width: 20px;
-      border-radius: 10em;
-      opacity: 0.25;
-
-      &:hover,
-      &:focus {
-        opacity: 1;
-      }
-
-      &:focus {
-        outline: $focus-outline;
-      }
-    }
-
-    .choices__item[data-value=""] .choices__button {
-      display: none;
-    }
-
-    // Dropdown arrow ▼
-    &::after {
-      content: "";
-      height: 0;
-      width: 0;
-      border-style: solid;
-      border-color: #333333 transparent transparent;
-      border-width: 5px;
-      position: absolute;
-      right: 11.5px;
-      top: 50%;
-      margin-top: -2.5px;
-      pointer-events: none;
-    }
-
-    &.is-open::after {
-      border-color: transparent transparent #333333;
-      margin-top: -7.5px;
-    }
-
-    &[dir="rtl"]::after {
-      left: 11.5px;
-      right: auto;
-    }
-
-    &[dir="rtl"] .choices__button {
-      right: auto;
-      left: 0;
-      margin-left: 25px;
-      margin-right: 0;
-    }
-  }
-
-  // Type: Select Multiple / Text
-  .choices[data-type*="select-multiple"],
-  .choices[data-type*="text"] {
-    .choices__inner {
-      cursor: text;
-    }
-
-    .choices__item {
-      position: relative;
-    }
-
-    // Delete button X
-    .choices__button {
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      right: 0;
-      width: 32px;
-      border-left: 1px solid govuk-colour("mid-grey");
-      border-right: 1px solid govuk-colour("mid-grey");
-      background-image: url("select-with-search/cross-icon.svg");
-      background-size: 12px;
-      border-radius: 0;
-
-      &:hover {
-        background-color: govuk-colour("mid-grey");
-        border-color: govuk-colour("dark-grey");
-        box-shadow: 0 2px 0 govuk-colour("dark-grey");
-      }
-
-      &:focus {
-        background-color: $govuk-focus-colour;
-        box-shadow: 0 2px 0 $govuk-focus-text-colour;
-      }
-    }
-  }
-
-  // Type: Select Multiple ONLY
-  .choices[data-type*="select-multiple"] {
-    .choices__input {
-      display: block;
-    }
-  }
-
   .choices__inner {
-    display: inline-block;
-    vertical-align: top;
-    width: 100%;
-    background-color: $background;
-    padding: 5px;
-    border: 2px solid #0b0c0c;
-    font-size: 19px;
-    min-height: 44px;
-    overflow: hidden;
+    padding: govuk-spacing(1);
+    border: $govuk-border-width-form-element solid govuk-colour("black");
   }
 
   &.govuk-form-group--error .choices:not(.is-active):not(.is-focused):not(.is-open) .choices__inner {
     border-color: $govuk-error-colour;
   }
 
+  .choices.is-focused,
+  .choices.is-open {
+    overflow: visible;
+  }
+
+  .choices.is-flipped .choices__list {
+    border-radius: 0; // this isn't set by a variable unlike all other border radius :(
+    border-width: $govuk-border-width-form-element;
+  }
+
   .choices.is-focused .choices__inner,
   .choices.is-open .choices__inner {
-    outline: $focus-outline;
+    outline: $govuk-focus-width solid $govuk-focus-colour;
+    // Ensure outline appears outside of the element
     outline-offset: 0;
-    box-shadow: inset 0 0 0 2px;
-  }
-
-  .choices__list {
-    margin: 0;
-    padding-left: 0;
-    list-style: none;
-  }
-
-  .choices__list--single {
-    display: inline-block;
-    padding: 4px 16px 4px 4px;
-    width: 100%;
-  }
-
-  [dir="rtl"] .choices__list--single {
-    padding-right: 4px;
-    padding-left: 16px;
-  }
-
-  .choices__list--single .choices__item {
-    width: 100%;
+    // Double the border by adding its width again. Use `box-shadow` to do
+    // this instead of changing `border-width` (which changes element size)
+    // and since `outline` is already used for the yellow focus state.
+    box-shadow: inset 0 0 0 $govuk-border-width-form-element;
   }
 
   .choices__list--multiple {
@@ -225,205 +115,54 @@
   .choices__list--multiple .choices__item {
     display: inline-flex;
     align-items: center;
-    padding: 6px 10px;
-    margin: 9px 9px 0 0;
+    border: 0;
+    padding: 0 0 0 govuk-spacing(2);
+    margin: govuk-spacing(2) govuk-spacing(2) 0 0;
     background-color: govuk-colour("light-grey");
-    box-shadow: 0 2px 0 govuk-colour("mid-grey");
+    box-shadow: 0 $govuk-border-width-form-element 0 govuk-colour("mid-grey");
     line-height: 1;
     color: $govuk-text-colour;
-    box-sizing: border-box;
-
-    &[data-deletable] {
-      padding-right: 42px;
-    }
-
-    [dir="rtl"] & {
-      margin-right: 0;
-      margin-left: 3.75px;
-    }
 
     .is-disabled & {
-      background-color: #aaaaaa;
-      border: 1px solid #919191;
+      opacity: 0.5;
     }
   }
 
   // Dropdown
   .choices__list--dropdown,
   .choices__list[aria-expanded] {
-    visibility: hidden;
-    z-index: 2;
-    position: absolute;
-    width: 100%;
-    background-color: $background;
-    border: 2px solid #0b0c0c;
+    border: $govuk-border-width-form-element solid govuk-colour("black");
     border-top-width: 0;
-    top: 100%;
-    overflow: hidden;
-    will-change: visibility;
-
-    &.is-active {
-      visibility: visible;
-    }
 
     .is-flipped & {
-      top: auto;
-      bottom: 100%;
-      margin-top: 0;
-      margin-bottom: -1px;
-      border-top-width: 2px;
+      border-top-width: $govuk-border-width-form-element;
       border-bottom-width: 0;
     }
-  }
-
-  .choices__list--dropdown .choices__list,
-  .choices__list[aria-expanded] .choices__list {
-    position: relative;
-    max-height: 310px;
-    overflow: auto;
-    -webkit-overflow-scrolling: touch;
-    will-change: scroll-position;
   }
 
   .choices__list--dropdown .choices__item,
   .choices__list[aria-expanded] .choices__item {
     position: relative;
-    padding: 10px;
-    font-size: 19px;
-    border-bottom: 1px solid #b1b4b6;
+    border-bottom: 1px solid govuk-colour("mid-grey");
 
     &:last-child {
       border-bottom: 0;
-    }
-
-    &:nth-of-type(even) {
-      background-color: #fafafa;
-    }
-
-    [dir="rtl"] & {
-      text-align: right;
-    }
-  }
-
-  // prettier-ignore
-  @media (min-width: 640px) { // stylelint-disable-line media-feature-range-notation
-    .choices__list--dropdown .choices__item--selectable,
-    .choices__list[aria-expanded] .choices__item--selectable {
-      padding-right: 5px;
-    }
-
-    .choices__list--dropdown .choices__item--selectable::after,
-    .choices__list[aria-expanded] .choices__item--selectable::after {
-      content: attr(data-select-text);
-      font-size: 12px;
-      opacity: 0;
-      position: absolute;
-      right: 10px;
-      top: 50%;
-      transform: translateY(-50%);
-    }
-
-    [dir="rtl"] .choices__list--dropdown .choices__item--selectable,
-    [dir="rtl"] .choices__list[aria-expanded] .choices__item--selectable {
-      text-align: right;
-      padding-left: 100px;
-      padding-right: 10px;
-    }
-
-    [dir="rtl"] .choices__list--dropdown .choices__item--selectable::after,
-    [dir="rtl"] .choices__list[aria-expanded] .choices__item--selectable::after {
-      right: auto;
-      left: 10px;
     }
   }
 
   .choices__list--dropdown .choices__item--selectable.is-highlighted,
   .choices__list[aria-expanded] .choices__item--selectable.is-highlighted {
-    background-color: #275ca0;
-    border-color: #275ca0;
-    color: #ffffff;
+    background-color: govuk-colour("blue");
+    border-color: govuk-colour("blue");
+    color: govuk-colour("white");
     outline: none;
-  }
-
-  .choices__list--dropdown .choices__item--selectable.is-highlighted::after,
-  .choices__list[aria-expanded] .choices__item--selectable.is-highlighted::after {
-    opacity: 0.5;
-  }
-
-  .choices__item {
-    cursor: default;
-  }
-
-  .choices__item--selectable {
-    cursor: pointer;
-  }
-
-  .choices__item--disabled {
-    cursor: not-allowed;
-    -webkit-user-select: none;
-    user-select: none;
-    opacity: 0.5;
   }
 
   .choices__heading {
-    font-weight: 600;
-    font-size: 19px;
-    padding: 30px 10px 10px;
-    border-bottom: 1px solid #b1b4b6;
-    background: $background;
+    @include govuk-typography-weight-bold;
+    color: govuk-colour("black"); // Choices.js doesn't use a variable for this color for some reason :(
+    padding: govuk-spacing(6) govuk-spacing(2) govuk-spacing(2);
+    border-bottom: 1px solid govuk-colour("mid-grey");
     cursor: default;
-  }
-
-  .choices__button {
-    text-indent: -9999px;
-    -webkit-appearance: none;
-    appearance: none;
-    border: 0;
-    background-color: transparent;
-    background-repeat: no-repeat;
-    background-position: center;
-    cursor: pointer;
-  }
-
-  .choices__button:focus {
-    outline: none;
-  }
-
-  .choices__input {
-    display: inline-block;
-    vertical-align: baseline;
-    background-color: $background;
-    font-size: 19px;
-    border: 0;
-    border-radius: 0;
-    max-width: 100%;
-    padding: 4px 0 4px 2px;
-
-    &:focus {
-      outline: 0;
-    }
-
-    &::-webkit-search-decoration,
-    &::-webkit-search-cancel-button,
-    &::-webkit-search-results-button,
-    &::-webkit-search-results-decoration {
-      display: none;
-    }
-
-    &::-ms-clear,
-    &::-ms-reveal {
-      display: none;
-      width: 0;
-      height: 0;
-    }
-
-    [dir="rtl"] & {
-      padding-right: 2px;
-      padding-left: 0;
-    }
-  }
-
-  .choices__placeholder {
-    color: #757575;
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_select.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_select.scss
@@ -1,6 +1,12 @@
 @import "govuk_publishing_components/individual_component_support";
 @import "govuk/components/select/select";
 
+// Increase height of selects that have a `multiple`
+// attribute otherwise they are too small to be useful.
+.govuk-select[multiple] {
+  height: auto;
+}
+
 .gem-c-select__select--full-width {
   min-width: 100%;
   max-width: 100%;

--- a/app/views/govuk_publishing_components/components/_select.html.erb
+++ b/app/views/govuk_publishing_components/components/_select.html.erb
@@ -28,10 +28,10 @@
       hint_id: select_helper.hint_id,
     } %>
 
-    <% if select_helper.error_message %>
+    <% if select_helper.error_items.any? %>
       <%= render "govuk_publishing_components/components/error_message", {
         id: select_helper.error_id,
-        text: select_helper.error_message
+        items: select_helper.error_items,
       } %>
     <% end %>
 

--- a/app/views/govuk_publishing_components/components/_select.html.erb
+++ b/app/views/govuk_publishing_components/components/_select.html.erb
@@ -8,9 +8,8 @@
   is_page_heading ||= false
   data_attributes ||= {}
   aria_controls ||= nil
+  heading_size ||= false
 
-  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
-  heading_size = false unless shared_helper.valid_heading_size?(heading_size)
   select_helper = GovukPublishingComponents::Presenters::SelectHelper.new(local_assigns)
 
   aria_attributes = {
@@ -20,22 +19,14 @@
 %>
 <% if select_helper.options.any? && id && label %>
   <%= content_tag :div, class: select_helper.css_classes do %>
-    <% if is_page_heading %>
-      <% add_gem_component_stylesheet("heading") %>
-      <%= render "govuk_publishing_components/components/heading", {
-        text: label_tag(id, label, class: select_helper.label_classes),
-        heading_level: 1
-      } %>
-    <% else %>
-      <%= label_tag(id, label, class: select_helper.label_classes) %>
-    <% end %>
-
-    <% if select_helper.hint %>
-      <%= render "govuk_publishing_components/components/hint", {
-        id: select_helper.hint_id,
-        text: hint
-      } %>
-    <% end %>
+    <%= render "govuk_publishing_components/components/label", {
+      html_for: id,
+      text: label,
+      heading_size:,
+      is_page_heading:,
+      hint_text: select_helper.hint,
+      hint_id: select_helper.hint_id,
+    } %>
 
     <% if select_helper.error_message %>
       <%= render "govuk_publishing_components/components/error_message", {

--- a/app/views/govuk_publishing_components/components/_select.html.erb
+++ b/app/views/govuk_publishing_components/components/_select.html.erb
@@ -22,6 +22,7 @@
 <% if select_helper.options_markup.present? && id && label %>
   <%= content_tag :div, class: select_helper.css_classes do %>
     <%= render "govuk_publishing_components/components/label", {
+      id: "#{id}-label",
       html_for: id,
       text: label,
       heading_size:,

--- a/app/views/govuk_publishing_components/components/_select.html.erb
+++ b/app/views/govuk_publishing_components/components/_select.html.erb
@@ -18,7 +18,7 @@
     describedby: select_helper.describedby
   }
 %>
-<% if select_helper.options.any? && id && label %>
+<% if select_helper.options_markup.present? && id && label %>
   <%= content_tag :div, class: select_helper.css_classes do %>
     <%= render "govuk_publishing_components/components/label", {
       html_for: id,
@@ -41,6 +41,6 @@
     <% if multiple %>
       <%= hidden_field_tag name, nil %>
     <% end %>
-    <%= select_tag name, options_for_select(select_helper.option_markup, select_helper.selected_option), id: id, class: select_helper.select_classes, aria: aria_attributes, data: data_attributes, multiple: %>
+    <%= select_tag name, select_helper.options_markup, id: id, class: select_helper.select_classes, aria: aria_attributes, data: data_attributes, multiple: %>
   <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/_select.html.erb
+++ b/app/views/govuk_publishing_components/components/_select.html.erb
@@ -9,6 +9,7 @@
   data_attributes ||= {}
   aria_controls ||= nil
   heading_size ||= false
+  multiple ||= false
 
   select_helper = GovukPublishingComponents::Presenters::SelectHelper.new(local_assigns)
 
@@ -35,6 +36,11 @@
       } %>
     <% end %>
 
-    <%= select_tag name, options_for_select(select_helper.option_markup, select_helper.selected_option), id: id, class: select_helper.select_classes, aria: aria_attributes, data: data_attributes %>
+    <%# Create null input so that the value is cleared if no options are selected %>
+    <%# https://api.rubyonrails.org/classes/ActionView/Helpers/FormOptionsHelper.html#method-i-select-label-Gotcha %>
+    <% if multiple %>
+      <%= hidden_field_tag name, nil %>
+    <% end %>
+    <%= select_tag name, options_for_select(select_helper.option_markup, select_helper.selected_option), id: id, class: select_helper.select_classes, aria: aria_attributes, data: data_attributes, multiple: %>
   <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/_select.html.erb
+++ b/app/views/govuk_publishing_components/components/_select.html.erb
@@ -10,8 +10,9 @@
   aria_controls ||= nil
   heading_size ||= false
   multiple ||= false
+  include_blank ||= false
 
-  select_helper = GovukPublishingComponents::Presenters::SelectHelper.new(local_assigns)
+  select_helper ||= GovukPublishingComponents::Presenters::SelectHelper.new(local_assigns)
 
   aria_attributes = {
     controls: aria_controls,

--- a/app/views/govuk_publishing_components/components/_select_with_search.html.erb
+++ b/app/views/govuk_publishing_components/components/_select_with_search.html.erb
@@ -1,40 +1,14 @@
 <%
-  add_gem_component_stylesheet("select")
   add_gem_component_stylesheet("select-with-search")
 
-  id ||= false
-  label ||= false
-  name ||= id
-  data_attributes ||= {}
-
-  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
-  heading_size = false unless shared_helper.valid_heading_size?(heading_size)
   # select_helper.select_classes generates "gem-c-select-with-search"
   select_helper = GovukPublishingComponents::Presenters::SelectWithSearchHelper.new(local_assigns)
-  multiple = local_assigns[:select].present? ? local_assigns[:select][:multiple] : false
+
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_data_attribute({ module: "select-with-search" })
 %>
-
-<%= content_tag :div, class: select_helper.css_classes, data: select_helper.data_attributes do %>
-  <%= label_tag(id, label, class: select_helper.label_classes, id: "#{id}_label") %>
-
-  <% if select_helper.hint %>
-    <%= render "govuk_publishing_components/components/hint", {
-      id: select_helper.hint_id,
-      text: hint,
-    } %>
-  <% end %>
-
-  <% if select_helper.error_items.any? %>
-    <%= render "govuk_publishing_components/components/error_message", {
-      id: select_helper.error_id,
-      items: select_helper.error_items,
-    } %>
-  <% end %>
-
-  <%# Create null input so that the value is cleared if no options are selected %>
-  <% if multiple %>
-    <%= hidden_field_tag name, nil %>
-  <% end %>
-  <%= select_tag name, select_helper.options_html, id: id, class: select_helper.select_classes, multiple:, aria: select_helper.aria, data: data_attributes %>
-
-<% end %>
+<%= render "govuk_publishing_components/components/select", {
+  **local_assigns,
+  **component_helper.all_attributes,
+  select_helper:
+}.with_indifferent_access %>

--- a/app/views/govuk_publishing_components/components/_select_with_search.html.erb
+++ b/app/views/govuk_publishing_components/components/_select_with_search.html.erb
@@ -1,0 +1,40 @@
+<%
+  add_gem_component_stylesheet("select")
+  add_gem_component_stylesheet("select-with-search")
+
+  id ||= false
+  label ||= false
+  name ||= id
+  data_attributes ||= {}
+
+  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+  heading_size = false unless shared_helper.valid_heading_size?(heading_size)
+  # select_helper.select_classes generates "gem-c-select-with-search"
+  select_helper = GovukPublishingComponents::Presenters::SelectWithSearchHelper.new(local_assigns)
+  multiple = local_assigns[:select].present? ? local_assigns[:select][:multiple] : false
+%>
+
+<%= content_tag :div, class: select_helper.css_classes, data: select_helper.data_attributes do %>
+  <%= label_tag(id, label, class: select_helper.label_classes, id: "#{id}_label") %>
+
+  <% if select_helper.hint %>
+    <%= render "govuk_publishing_components/components/hint", {
+      id: select_helper.hint_id,
+      text: hint,
+    } %>
+  <% end %>
+
+  <% if select_helper.error_items.any? %>
+    <%= render "govuk_publishing_components/components/error_message", {
+      id: select_helper.error_id,
+      items: select_helper.error_items,
+    } %>
+  <% end %>
+
+  <%# Create null input so that the value is cleared if no options are selected %>
+  <% if multiple %>
+    <%= hidden_field_tag name, nil %>
+  <% end %>
+  <%= select_tag name, select_helper.options_html, id: id, class: select_helper.select_classes, multiple:, aria: select_helper.aria, data: data_attributes %>
+
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/select.yml
+++ b/app/views/govuk_publishing_components/components/docs/select.yml
@@ -174,3 +174,14 @@ examples:
         value: option1
       - text: Option two
         value: option2
+  with_multiple:
+    data:
+      id: dropdown-multiple-id
+      id: dropdown-multiple
+      label: My Dropdown
+      multiple: true
+      options:
+      - text: Option one
+        value: option1
+      - text: Option two
+        value: option2

--- a/app/views/govuk_publishing_components/components/docs/select_with_search.yml
+++ b/app/views/govuk_publishing_components/components/docs/select_with_search.yml
@@ -1,0 +1,196 @@
+name: Select with search (experimental)
+description: A dropdown select with search
+body: |
+  A Javascript enhanced dropdown select. This component is progressively enhanced, if
+  Javascript is unavailable then it will use the select component.
+
+  This is an experimental component as it currently fails WCAG compliance for keyboard navigation. The total number of options are not
+  announced when using Voice Over.
+accessibility_criteria: |
+  - accept focus
+  - be focusable with a keyboard
+  - be usable with a keyboard
+  - indicate when it has focus
+examples:
+  default:
+    data:
+      id: dropdown-default
+      label: My Dropdown
+      options:
+      - text: Option one
+        value: option1
+      - text: Option two
+        value: option2
+      - text: Option three
+        value: option3
+  with_blank_option:
+    description: Include a blank option
+    data:
+      id: dropdown-with-blank
+      label: With blank option
+      include_blank: true
+      options:
+      - text: Option one
+        value: option1
+      - text: Option two
+        value: option2
+      - text: Option three
+        value: option3
+  with_grouped_options:
+    description: Options can be grouped
+    data:
+      id: dropdown-with-grouped-options
+      label: Select a city
+      grouped_options:
+      - - England
+        - - text: Bath
+            value: bath
+          - text: Bristol
+            value: bristol
+          - text: London
+            value: london
+          - text: Manchester
+            value: manchester
+      - - Northern Ireland
+        - - text: Bangor
+            value: bangor
+          - text: Belfast
+            value: belfast
+      - - Scotland
+        - - text: Dundee
+            value: dundee
+          - text: Edinburgh
+            value: edinburgh
+          - text: Glasgow
+            value: glasgow
+      - - Wales
+        - - text: Cardiff
+            value: cardiff
+          - text: Swansea
+            value: swansea
+  with_grouped_options_and_blank_option:
+    description: Options can be grouped and include a blank option
+    data:
+      id: dropdown-with-grouped-options-and-blank
+      label: Select a city
+      include_blank: true
+      grouped_options:
+      - - England
+        - - text: Bath
+            value: bath
+          - text: Bristol
+            value: bristol
+          - text: London
+            value: london
+          - text: Manchester
+            value: manchester
+      - - Northern Ireland
+        - - text: Bangor
+            value: bangor
+          - text: Belfast
+            value: belfast
+      - - Scotland
+        - - text: Dundee
+            value: dundee
+          - text: Edinburgh
+            value: edinburgh
+          - text: Glasgow
+            value: glasgow
+      - - Wales
+        - - text: Cardiff
+            value: cardiff
+          - text: Swansea
+            value: swansea
+  with_different_id_and_name:
+    description: If no name is provided, name defaults to the (required) value of id.
+    data:
+      id: dropdown-with-different-id-and-name
+      label: My Dropdown
+      name: dropdown[1]
+      options:
+      - text: Option one
+        value: option1
+      - text: Option two
+        value: option2
+  with_data_attributes:
+    data:
+      id: dropdown-with-data-attributes
+      data_attributes:
+        module: not-a-module
+        loose: moose
+      label: Select your country
+      options:
+        - text: France
+          value: fr
+        - text: Germany
+          value: de
+        - text: United Kingdom
+          value: uk
+  with_preselect:
+    data:
+      id: dropdown-with-preselect
+      label: Option 2 preselected
+      options:
+      - text: Option one
+        value: option1
+      - text: Option two
+        value: option2
+        selected: true
+      - text: Option three
+        value: option3
+  with_hint:
+    description: When a hint is included the `aria-describedby` attribute of the select is included to point to the hint. When an error and a hint are present, that attribute includes the IDs of both the hint and the error.
+    data:
+      id: dropdown-with-hint
+      label: Choose your preferred thing
+      hint: You might need some more information here
+      hint_id: optional-hint-id
+      options:
+      - text: Something
+        value: option1
+      - text: Something else
+        value: option2
+  with_error:
+    description: An arbitrary number of separate error items can be passed to the component.
+    data:
+      id: dropdown-with-error
+      label: How will you be travelling to the conference?
+      error_items:
+        - text: Please choose an option
+      include_blank: true
+      options:
+      - text: Public transport
+        value: option1
+      - text: Will make own arrangements
+        value: option2
+  with_custom_label_size:
+    description: Make the label different sizes. Valid options are `s`, `m`, `l` and `xl`.
+    data:
+      id: dropdown-with-custom-label-size
+      label: Bigger!
+      heading_size: xl
+      options:
+      - text: Option one
+        value: option1
+      - text: Option two
+        value: option2
+      - text: Option three
+        value: option3
+  with_multiple_select_enabled:
+    description: Allow multiple items to be selected and de-selected.
+    data:
+      id: dropdown-with-multiple
+      label: Select your country
+      include_blank: true
+      multiple: true
+      options:
+        - text: France
+          value: fr
+          selected: false
+        - text: Germany
+          value: de
+          selected: false
+        - text: The United Kingdom of Great Britain and Northern Ireland
+          value: uk
+        - text: Democratic Republic of the Congo
+          value: cg

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
   s.required_ruby_version = ">= 3.2"
 
-  s.files = Dir["{node_modules/accessible-autocomplete,node_modules/govuk-frontend,node_modules/axe-core,node_modules/sortablejs,node_modules/govuk-single-consent,app,config,db,lib}/**/*", "LICENCE.md", "README.md"]
+  s.files = Dir["{node_modules/accessible-autocomplete,node_modules/govuk-frontend,node_modules/axe-core,node_modules/sortablejs,node_modules/govuk-single-consent,node_modules/choices.js,app,config,db,lib}/**/*", "LICENCE.md", "README.md"]
 
   s.add_dependency "govuk_app_config"
   s.add_dependency "govuk_personalisation", ">= 0.7.0"

--- a/lib/govuk_publishing_components.rb
+++ b/lib/govuk_publishing_components.rb
@@ -27,6 +27,7 @@ require "govuk_publishing_components/presenters/content_breadcrumbs_based_on_org
 require "govuk_publishing_components/presenters/content_breadcrumbs_based_on_taxons"
 require "govuk_publishing_components/presenters/checkboxes_helper"
 require "govuk_publishing_components/presenters/select_helper"
+require "govuk_publishing_components/presenters/select_with_search_helper"
 require "govuk_publishing_components/presenters/meta_tags"
 require "govuk_publishing_components/presenters/content_item"
 require "govuk_publishing_components/presenters/translation_nav_helper"

--- a/lib/govuk_publishing_components/presenters/select_helper.rb
+++ b/lib/govuk_publishing_components/presenters/select_helper.rb
@@ -1,7 +1,9 @@
 module GovukPublishingComponents
   module Presenters
     class SelectHelper
-      attr_reader :options, :option_markup, :selected_option, :error_items, :error_id, :hint, :hint_id, :describedby
+      include ActionView::Helpers::FormOptionsHelper
+
+      attr_reader :options, :options_markup, :error_items, :error_id, :hint, :hint_id, :describedby
 
       def initialize(local_assigns)
         @options = local_assigns[:options] || []
@@ -12,7 +14,7 @@ module GovukPublishingComponents
         @hint_id = local_assigns[:hint_id] || nil
         @heading_size = local_assigns[:heading_size]
         @full_width = local_assigns[:full_width] || false
-        @option_markup = get_options
+        @options_markup = options_for_select(get_options, @selected_option)
         @describedby = get_describedby
       end
 

--- a/lib/govuk_publishing_components/presenters/select_helper.rb
+++ b/lib/govuk_publishing_components/presenters/select_helper.rb
@@ -1,11 +1,12 @@
 module GovukPublishingComponents
   module Presenters
     class SelectHelper
-      attr_reader :options, :option_markup, :selected_option, :error_message, :error_id, :hint, :hint_id, :describedby
+      attr_reader :options, :option_markup, :selected_option, :error_items, :error_id, :hint, :hint_id, :describedby
 
       def initialize(local_assigns)
         @options = local_assigns[:options] || []
-        @error_message = local_assigns[:error_message]
+        @error_items = local_assigns[:error_items] || []
+        @error_items << { text: local_assigns[:error_message] } if local_assigns[:error_message]
         @error_id = local_assigns[:error_id] || nil
         @hint = local_assigns[:hint] || nil
         @hint_id = local_assigns[:hint_id] || nil
@@ -17,7 +18,7 @@ module GovukPublishingComponents
 
       def css_classes
         classes = %w[govuk-form-group gem-c-select]
-        classes << "govuk-form-group--error" if @error_message
+        classes << "govuk-form-group--error" if @error_items.present?
         classes
       end
 
@@ -66,7 +67,7 @@ module GovukPublishingComponents
       def get_describedby
         describedby = %w[]
 
-        if @error_message || @error_id
+        if @error_items.present? || @error_id
           @error_id ||= "error-#{SecureRandom.hex(4)}"
           describedby << @error_id
         end

--- a/lib/govuk_publishing_components/presenters/select_with_search_helper.rb
+++ b/lib/govuk_publishing_components/presenters/select_with_search_helper.rb
@@ -1,0 +1,100 @@
+##
+# Helper methods for use with the "select-with-search" component.
+# This wraps and extends the Select component's helper methods to add support for option groups.
+##
+module GovukPublishingComponents
+  module Presenters
+    class SelectWithSearchHelper
+      include ActionView::Helpers::FormOptionsHelper
+
+      attr_reader :options, :selected_options, :error_id, :error_items, :aria
+
+      delegate :describedby,
+               :hint_id,
+               :hint,
+               :label_classes,
+               :select_classes,
+               :error_items,
+               :error_id,
+               to: :@select_helper
+
+      def initialize(local_assigns)
+        @select_helper = SelectHelper.new(local_assigns.except(:options, :grouped_options))
+        @options = local_assigns[:options]
+        @grouped_options = local_assigns[:grouped_options]
+        @include_blank = local_assigns[:include_blank]
+        @selected_options = []
+        @local_assigns = local_assigns
+      end
+
+      def css_classes
+        classes = %w[gem-c-select-with-search govuk-form-group]
+        classes << "govuk-form-group--error" if error_items.any?
+        classes
+      end
+
+      def options_html
+        if @grouped_options.present?
+          blank_option_if_include_blank +
+            grouped_and_ungrouped_options_for_select(@grouped_options)
+        elsif @options.present?
+          blank_option_if_include_blank +
+            options_for_select(
+              transform_options(@options),
+              selected_options,
+            )
+        end
+      end
+
+      def data_attributes
+        data_attributes = @local_assigns[:data_attributes] || {}
+        data_attributes[:module] ||= ""
+        data_attributes[:module] << " select-with-search"
+        data_attributes[:module].strip!
+        data_attributes
+      end
+
+      def grouped_and_ungrouped_options_for_select(unsorted_options)
+        # Filter out the 'single option' options and treat them as simply `<option>`
+        # The remainder should be treated as true 'grouped options', i.e. `<optgroup>`
+        single_options = []
+        grouped_options = []
+        unsorted_options.each_with_index do |(group, options), _index|
+          if group == ""
+            single_options << options
+          else
+            grouped_options << [group, options]
+          end
+        end
+        single_options.flatten!
+
+        options_for_select(transform_options(single_options), selected_options) +
+          grouped_options_for_select(transform_grouped_options(grouped_options), selected_options)
+      end
+
+    private
+
+      def transform_options(options)
+        options.map do |option|
+          @selected_options << option[:value] if option[:selected]
+          [
+            option[:text],
+            option[:value],
+          ]
+        end
+      end
+
+      def transform_grouped_options(grouped_options)
+        grouped_options.map do |(group, options)|
+          [group, transform_options(options)]
+        end
+      end
+
+      def blank_option_if_include_blank
+        return "".html_safe if @include_blank.blank?
+
+        options_for_select([["", ""]])
+      end
+    end
+  end
+end

--- a/lib/govuk_publishing_components/presenters/select_with_search_helper.rb
+++ b/lib/govuk_publishing_components/presenters/select_with_search_helper.rb
@@ -7,7 +7,7 @@ module GovukPublishingComponents
     class SelectWithSearchHelper
       include ActionView::Helpers::FormOptionsHelper
 
-      attr_reader :options, :selected_options, :error_id, :error_items, :aria
+      attr_reader :options, :selected_options, :aria, :options_markup
 
       delegate :describedby,
                :hint_id,
@@ -24,34 +24,28 @@ module GovukPublishingComponents
         @grouped_options = local_assigns[:grouped_options]
         @include_blank = local_assigns[:include_blank]
         @selected_options = []
+        @options_markup = get_options
         @local_assigns = local_assigns
       end
 
       def css_classes
-        classes = %w[gem-c-select-with-search govuk-form-group]
-        classes << "govuk-form-group--error" if error_items.any?
+        classes = @select_helper.css_classes
+        classes << "gem-c-select-with-search"
         classes
       end
 
-      def options_html
-        if @grouped_options.present?
-          blank_option_if_include_blank +
+    private
+
+      def get_options
+        blank_option_if_include_blank +
+          if @grouped_options.present?
             grouped_and_ungrouped_options_for_select(@grouped_options)
-        elsif @options.present?
-          blank_option_if_include_blank +
+          elsif @options.present?
             options_for_select(
               transform_options(@options),
               selected_options,
             )
-        end
-      end
-
-      def data_attributes
-        data_attributes = @local_assigns[:data_attributes] || {}
-        data_attributes[:module] ||= ""
-        data_attributes[:module] << " select-with-search"
-        data_attributes[:module].strip!
-        data_attributes
+          end
       end
 
       def grouped_and_ungrouped_options_for_select(unsorted_options)
@@ -71,8 +65,6 @@ module GovukPublishingComponents
         options_for_select(transform_options(single_options), selected_options) +
           grouped_options_for_select(transform_grouped_options(grouped_options), selected_options)
       end
-
-    private
 
       def transform_options(options)
         options.map do |option|

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "accessible-autocomplete": "^3.0.1",
     "axe-core": "^4.10.3",
     "govuk-frontend": "5.10.1",
+    "choices.js": "^11.1.0",
     "govuk-single-consent": "^3.0.9",
     "sortablejs": "^1.15.6"
   },

--- a/spec/components/select_spec.rb
+++ b/spec/components/select_spec.rb
@@ -367,6 +367,6 @@ describe "Select", type: :view do
     )
 
     assert_select "select[name=colour]"
-    assert_select ".gem-c-select h1.gem-c-heading__text label.govuk-label"
+    assert_select ".gem-c-select h1 label.govuk-label"
   end
 end

--- a/spec/components/select_spec.rb
+++ b/spec/components/select_spec.rb
@@ -71,6 +71,22 @@ describe "Select", type: :view do
     assert_select "select[name*='mydropdown'][id=mydropdown][multiple]"
   end
 
+  it "renders a select box with `id` assigned to label" do
+    render_component(
+      id: "mydropdown",
+      label: "My dropdown",
+      multiple: true,
+      options: [
+        {
+          value: "government-gateway",
+          text: "Use Government Gateway",
+        },
+      ],
+    )
+
+    assert_select "label[id=mydropdown-label]"
+  end
+
   it "renders a select box with multiple items" do
     render_component(
       id: "mydropdown",

--- a/spec/components/select_spec.rb
+++ b/spec/components/select_spec.rb
@@ -54,6 +54,23 @@ describe "Select", type: :view do
     assert_select ".govuk-select option[value=government-gateway]"
   end
 
+  it "renders a select box with multiple" do
+    render_component(
+      id: "mydropdown",
+      label: "My dropdown",
+      multiple: true,
+      options: [
+        {
+          value: "government-gateway",
+          text: "Use Government Gateway",
+        },
+      ],
+    )
+
+    assert_select "input[type=hidden][name*='mydropdown']"
+    assert_select "select[name*='mydropdown'][id=mydropdown][multiple]"
+  end
+
   it "renders a select box with multiple items" do
     render_component(
       id: "mydropdown",

--- a/spec/components/select_with_search_spec.rb
+++ b/spec/components/select_with_search_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+# this component renders the Select component
+# so only test the additional functionality
+
+describe "Select with search", type: :view do
+  def component_name
+    "select_with_search"
+  end
+
+  it "adds `select-with-search` to data module of select" do
+    render_component(
+      id: "mydropdown",
+      label: "My dropdown",
+      options: [
+        {
+          value: "big",
+          text: "Big",
+        },
+        {
+          value: "medium",
+          text: "Medium",
+        },
+        {
+          value: "small",
+          text: "Small",
+        },
+      ],
+    )
+
+    assert_select "select[data-module~='select-with-search']"
+  end
+end

--- a/spec/javascripts/components/select-with-search-spec.js
+++ b/spec/javascripts/components/select-with-search-spec.js
@@ -45,6 +45,32 @@ describe('GOVUK.Modules.SelectWithSearch', function () {
     })
   })
 
+  describe('select with `aria-describedby`', () => {
+    const ariaDescribedBy = 'hint-id error-id'
+
+    beforeEach(function () {
+      component = document.createElement('div')
+      component.innerHTML = `
+        <label for="example">Choose a colour</label>
+        <select aria-describedby="${ariaDescribedBy}" id="example">
+          <option value="red">Red</option>
+          <option value="green">Green</option>
+          <option value="blue">Blue</option>
+        </select>
+      `
+      select = component.querySelector('select')
+
+      module = new GOVUK.Modules.SelectWithSearch(select)
+      module.init()
+    })
+
+    it('includes `aria-describedby` of select in `aria-labelledby`', () => {
+      expect(
+        component.querySelector(`[aria-labelledby="example-label ${ariaDescribedBy}"]`)
+      ).toBeTruthy()
+    })
+  })
+
   describe('simple select which can be left blank', () => {
     beforeEach(function () {
       component = document.createElement('div')

--- a/spec/javascripts/components/select-with-search-spec.js
+++ b/spec/javascripts/components/select-with-search-spec.js
@@ -1,0 +1,111 @@
+/* eslint-env jasmine */
+/* global GOVUK */
+
+describe('GOVUK.Modules.SelectWithSearch', function () {
+  let component, module, select
+
+  function getOptions () {
+    const items = component.querySelectorAll(
+      '.choices__list .choices__item--choice'
+    )
+    return Array.from(items).map((item) => item.textContent.trim())
+  }
+
+  describe('with a simple select', () => {
+    beforeEach(function () {
+      component = document.createElement('div')
+      component.innerHTML = `
+        <label for="example">Choose a colour</label>
+        <select id="example">
+          <option value="red">Red</option>
+          <option value="green">Green</option>
+          <option value="blue">Blue</option>
+        </select>
+      `
+      select = component.querySelector('select')
+
+      module = new GOVUK.Modules.SelectWithSearch(select)
+      module.init()
+    })
+
+    it('initialises Choices.js', function () {
+      expect(
+        component.querySelector('.choices[data-type="select-one"]')
+      ).toBeTruthy()
+    })
+
+    it('does not reorder the provided options', () => {
+      expect(getOptions()).toEqual(['Red', 'Green', 'Blue'])
+    })
+
+    it('shows a search field', () => {
+      expect(component.querySelector('input[type=search]').placeholder).toEqual(
+        'Search in list'
+      )
+    })
+  })
+
+  describe('simple select which can be left blank', () => {
+    beforeEach(function () {
+      component = document.createElement('div')
+      component.innerHTML = `
+        <label for="example">Choose a colour</label>
+        <select id="example">
+          <option value=""></option>
+          <option value="red">Red</option>
+          <option value="green">Green</option>
+          <option value="blue">Blue</option>
+        </select>
+      `
+      select = component.querySelector('select')
+      module = new GOVUK.Modules.SelectWithSearch(select)
+      module.init()
+    })
+
+    it('shows a "Select one" placeholder', () => {
+      expect(
+        component.querySelector('.choices__placeholder').textContent
+      ).toEqual('Select one')
+    })
+  })
+
+  describe('with grouped options', () => {
+    beforeEach(function () {
+      component = document.createElement('div')
+      component.innerHTML = `
+        <label for="example">Choose a city</label>
+        <select id="example">
+          <optgroup label="England">
+            <option value="bath">Bath</option>
+            <option value="bristol">Bristol</option>
+            <option value="london">London</option>
+            <option value="manchester">Manchester</option>
+          </optgroup>
+          <optgroup label="Ireland">
+            <option value="bangor">Bangor</option>
+            <option value="belfast">Belfast</option>
+          </optgroup>
+          <optgroup label="Scotland">
+            <option value="dundee">Dundee</option>
+            <option value="edinburgh">Edinburgh</option>
+            <option value="glasgow">Glasgow</option>
+          </optgroup>
+          <optgroup label="Wales">
+            <option value="cardiff">Cardiff</option>
+            <option value="swansea">Swansea</option>
+          </optgroup>
+        </select>
+      `
+      select = component.querySelector('select')
+
+      module = new GOVUK.Modules.SelectWithSearch(select)
+      module.init()
+    })
+
+    it('renders groups and options', () => {
+      const list = component.querySelector('.choices__list--dropdown')
+      expect(list.querySelectorAll('.choices__group').length).toEqual(4)
+      expect(list.querySelectorAll('.choices__item--choice').length).toEqual(11)
+    })
+  })
+})

--- a/spec/lib/govuk_publishing_components/app_helpers/asset_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/app_helpers/asset_helper_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe GovukPublishingComponents::AppHelpers::AssetHelper do
     end
 
     it "detect the total number of stylesheet paths" do
-      expect(get_component_css_paths.count).to be(86)
+      expect(get_component_css_paths.count).to be(87)
     end
 
     it "initialize empty asset helper" do

--- a/spec/lib/govuk_publishing_components/presenters/select_with_search_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/select_with_search_helper_spec.rb
@@ -1,0 +1,99 @@
+require "spec_helper"
+require "action_view"
+
+RSpec.describe GovukPublishingComponents::Presenters::SelectWithSearchHelper do
+  describe "Select with search helper" do
+    it "generates options for select" do
+      instance = described_class.new(
+        options: [
+          {
+            text: "Foo",
+            value: "Bar",
+          },
+          {
+            text: "Option",
+            value: "opt",
+            selected: true,
+          },
+          {
+            text: "Baz",
+            value: "Bam",
+          },
+        ],
+      )
+
+      result = <<~HTML.strip
+        <option value="Bar">Foo</option>
+        <option selected="selected" value="opt">Option</option>
+        <option value="Bam">Baz</option>
+      HTML
+
+      expect(instance.options_markup).to eq result
+    end
+
+    it "generates grouped options for select" do
+      instance = described_class.new(
+        grouped_options: [
+          [
+            "",
+            [
+              {
+                text: "All organisations",
+                value: "",
+                selected: true,
+              },
+            ],
+          ],
+          [
+            "",
+            [
+              {
+                text: "All foo",
+                value: "foo",
+              },
+            ],
+          ],
+          [
+            "Live organisations",
+            %w[foo bar baz].map do |key|
+              {
+                text: key,
+                value: key,
+              }
+            end,
+          ],
+        ],
+      )
+
+      result = <<~HTML.strip
+        <option selected="selected" value="">All organisations</option>
+        <option value="foo">All foo</option>
+        <optgroup label="Live organisations">
+        <option value="foo">foo</option>
+        <option value="bar">bar</option>
+        <option value="baz">baz</option>
+        </optgroup>
+      HTML
+
+      expect(instance.options_markup.delete("\n")).to eq result.delete("\n")
+    end
+
+    it "includes a blank option when told to" do
+      instance = described_class.new(
+        include_blank: true,
+        options: [
+          {
+            text: "Foo",
+            value: "Bar",
+          },
+        ],
+      )
+
+      result = <<~HTML.strip
+        <option value=""></option><option value="Bar">Foo</option>
+      HTML
+
+      expect(instance.options_markup).to eq result
+    end
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -595,6 +595,13 @@ chalk@^4.0.0, chalk@^4.0.2:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+choices.js@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/choices.js/-/choices.js-11.1.0.tgz#4fcfb5834fdf0c7d1959f0261d1bbe526a7c9222"
+  integrity sha512-mIt0uLhedHg2ea/K2PACrVpt391vRGHuOoctPAiHcyemezwzNMxj7jOzNEk8e7EbjLh0S0sspDkSCADOKz9kcw==
+  dependencies:
+    fuse.js "^7.0.0"
+
 color-convert@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
@@ -1408,6 +1415,11 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
+
+fuse.js@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-7.1.0.tgz#306228b4befeee11e05b027087c2744158527d09"
+  integrity sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==
 
 get-intrinsic@^1.0.2:
   version "1.1.3"


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

Add the Select With Search component to govuk_publishing_components.

### Background

The Select With Search component is an autocomplete select replacement that supports selecting multiple choices. [Accessible Autocomplete](https://github.com/alphagov/accessible-autocomplete) does not support multiple choices so previously the now deprecated [Accessible Autocomplete Multiselect](https://github.com/alphagov/accessible-autocomplete-multiselect) was used.

This component uses [Choices](https://github.com/Choices-js/Choices). It is progressively enhanced, so if it fails to load or Javascript is disabled then [the Select component](https://design-system.service.gov.uk/components/select/) will be rendered.

This PR moves the code from https://github.com/alphagov/select-with-search-component and makes some changes to the existing select component to add additional functionality and better support the new component.

### More details

- Changes to the select component (non-breaking, either new functionality or internal reworking)
  - Use `label` in `select` component
  - Use `error_items` instead of `error_message`
  - Add `multiple` to select component
  - Move `options_for_select` to `SelectHelper` instead of partial

- Select with search component
  - Move the files from the [original repo](https://github.com/alphagov/select-with-search-component)
  - Use styles from `choices.scss` instead of including them in `_select-with-search.scss`
  - Changes to the partial and `SelectWithSearchHelper` to be able use `select` component
  - Add `select_with_search_spec.rb`

## Why
<!-- What are the reasons behind this change being made? -->

This component is used in Whitehall and Specialist Publisher currently. It will most likely be used in other publishing applications when they move to using the GOV.UK Design System.  

## Preview of component
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

<img width="938" alt="Screenshot 2025-06-20 at 16 17 41" src="https://github.com/user-attachments/assets/c2fb7621-bd92-4bcc-b880-48d9f4c4855d" />

<img width="965" alt="Screenshot 2025-06-20 at 16 19 06" src="https://github.com/user-attachments/assets/08698994-fa1b-4575-a883-477c3d382e85" />

Trello: https://trello.com/c/GYs1LCI7/3804-move-select-with-search-into-govukpublishingcomponents
