### PR TITLE
Fix extra data in YouTube URLs breaking embeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix extra data in YouTube URLs breaking embeds ([PR #4882](https://github.com/alphagov/govuk_publishing_components/pull/4882))
+
 ## 57.3.0
 
 * Add more options to the select component ([PR #4858](https://github.com/alphagov/govuk_publishing_components/pull/4858))

--- a/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
@@ -20,7 +20,7 @@
   }
 
   YoutubeLinkEnhancement.prototype.paragraphHasOtherContent = function (paragraph, link) {
-    return paragraph.innerHTML.replaceAll(this.punctuationRegex, '') !== link.outerHTML.replaceAll(this.punctuationRegex, '')
+    return paragraph.innerHTML.replaceAll(this.punctuationRegex, '').trim() !== link.outerHTML.replaceAll(this.punctuationRegex, '').trim()
   }
 
   YoutubeLinkEnhancement.prototype.decorateLink = function () {

--- a/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
@@ -222,6 +222,17 @@
     }
   }
 
+  YoutubeLinkEnhancement.sanitiseVideoId = function (pathname) {
+    // YouTube links can now contain an ?si= param in the URL.
+    // This usually only appears on youtu.be links but it's appearing for us on youtube.com URLs due to some Whitehall regex being outdated.
+    // Therefore we need to use regex to remove it from the path.
+    // E.g. youtube.com/watch?v=[video-id]?si=ABCzJtVWBAZ2o_l3
+    // ?=si in this case isn't a valid query parameter as it isn't using an &, so we can't use JS' native URL API to filter it out.
+    if (pathname) {
+      return pathname.replace(/(\?|&)(.+)=.+/g, '')
+    }
+  }
+
   // This is a public class method so it can be used outside of this embed to
   // check that user input for videos will be supported in govspeak
   YoutubeLinkEnhancement.parseVideoId = function (url) {
@@ -232,9 +243,10 @@
     } catch (e) { return undefined }
 
     if (u.host === 'www.youtube.com' || u.host === 'youtube.com') {
-      return u.searchParams.get('v') || undefined
+      return this.sanitiseVideoId(u.searchParams.get('v')) || undefined
     } else if (u.host === 'youtu.be') {
-      return u.pathname.slice(1) // Trim the leading /
+      var pathName = u.pathname.slice(1) // Trim the leading /
+      return this.sanitiseVideoId(pathName)
     }
   }
 

--- a/spec/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement-spec.js
@@ -93,7 +93,7 @@ describe('Youtube link enhancement', function () {
       container.innerHTML =
         '<div class="gem-c-govspeak" data-module="govspeak">' +
           '<p><a href="https://www.youtube.com/watch?v=0XpAtr24uUQ">agile at GDS</a>.</p>' +
-          '<p><a href="https://www.youtube.com/watch?v=0XpAtr24uUQ">agile at GDS</a>!</p>' +
+          '\n       \n<p><a href="https://www.youtube.com/watch?v=0XpAtr24uUQ">agile at GDS</a>!</p>\n\n' +
           '<p><a href="https://www.youtube.com/watch?v=0XpAtr24uUQ">agile at GDS</a>?</p>' +
           '<p>"<a href="https://www.youtube.com/watch?v=0XpAtr24uUQ">agile at GDS</a>"</p>' +
           '<p>\'<a href="https://www.youtube.com/watch?v=0XpAtr24uUQ">agile at GDS</a>\'</p>' +

--- a/spec/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement-spec.js
@@ -430,4 +430,34 @@ describe('Youtube link enhancement', function () {
       expect(id).not.toBeDefined()
     })
   })
+
+  describe('sanitise video id', function () {
+    const expected = 'qZLy91qcB7M'
+
+    it('removes ?si= like params from the path', function () {
+      const path = 'qZLy91qcB7M?si=ecMsC8hlHh9TxOnh'
+      expect(GOVUK.GovspeakYoutubeLinkEnhancement.sanitiseVideoId(path)).toEqual(expected)
+    })
+
+    it('removes &t= like params from the path', function () {
+      const path = 'qZLy91qcB7M&t=15s'
+      expect(GOVUK.GovspeakYoutubeLinkEnhancement.sanitiseVideoId(path)).toEqual(expected)
+    })
+
+    it('removes both ?=si like and &t= like params from the path', function () {
+      const path = 'qZLy91qcB7M?si=ecMsC8hlHh9TxOnh&t=15s'
+      expect(GOVUK.GovspeakYoutubeLinkEnhancement.sanitiseVideoId(path)).toEqual(expected)
+    })
+
+    it('calls sanitiseVideoId in parseVideoId for both youtu.be and youtube.com URLs', function () {
+      spyOn(GOVUK.GovspeakYoutubeLinkEnhancement, 'sanitiseVideoId').and.callThrough()
+
+      const urls = ['https://youtu.be/qZLy91qcB7M?si=ecMsC8hlHh9TxOnh&t=15s', 'https://www.youtube.com/watch?v=qZLy91qcB7M?si=ecMsC8hlHh9TxOnh&t=15s', 'https://youtube.com/watch?v=qZLy91qcB7M?si=ecMsC8hlHh9TxOnh&t=15s']
+
+      urls.forEach((url, index) => {
+        expect(GOVUK.GovspeakYoutubeLinkEnhancement.parseVideoId(url)).toEqual(expected)
+        expect(GOVUK.GovspeakYoutubeLinkEnhancement.sanitiseVideoId.calls.count()).toBe(index + 1)
+      })
+    })
+  })
 })


### PR DESCRIPTION
## What/Why
<!-- What are the reasons behind this change being made? -->
- YouTube recently added an ?si= parameter that I believe is used to track who clicks a link that you've shared. This broke our YouTube embed code as their `?si=` value isn't an actual query parameter (As that would be `&si=`), so our code to grab the video id broke as it was counting `?si=[text]` as part of the ID.
- Therefore, remove `?si=[text]` entirely from the URL before working with the URL
- More specifically, this PR:
  - Creates a `sanitiseVideoId` function (mainly so it can be easily tested)
  - Adds some regex to remove the any extra parameter that can appear
  - Also adds a slight enhancement by using `.trim()` when checking the govspeak HTML syntax is correct (so that line breaks/empty spaces in the paragraph of the link don't cause the YouTube link enhancement to break)
- Some more context: https://gds.slack.com/archives/CARGH33JS/p1750413757747069
- Trello card: https://trello.com/c/jqxpOnFd/698-fix-bug-with-no-10-org-page-youtube-video 

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
