### PR TITLE
Fix HM Prison Service logo url

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/organisation_logo.yml
+++ b/app/views/govuk_publishing_components/components/docs/organisation_logo.yml
@@ -150,7 +150,7 @@ examples:
         url: '/government/organisations/hm-prison-service'
         brand: 'ministry-of-justice'
         image:
-          url: 'https://assets.publishing.service.gov.uk/government/uploads/system/uploads/organisation/logo/321/HMPS.jpg'
+          url: 'https://assets.publishing.service.gov.uk/media/6850134301d3b0e7b62da740/hmps_25_gov_240x188.png'
           alt_text: 'HM Prison Service'
   without_a_link:
     data:


### PR DESCRIPTION
## What
Fix HM Prison Service logo url in the organisation component docs

## Why
The logo was recently updated and the old logo removed

## Visual Changes
The visual [change shown in Percy for the HM Prison Service is expected](https://percy.io/55ba5e1a/web/govuk_publishing_components/builds/41133573/changed/2207436785?browser=firefox&browser_ids=65&group_snapshots_by=similar_diff&subcategories=unreviewed%2Cchanges_requested&utm_source=github_status_public&viewLayout=overlay&viewMode=new&width=1280&widths=375%2C1280) as the logo now loads again