### PR TITLE
Add extra options to `AddAnother` component tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Make global links relative instead of absolute ([PR #4855](https://github.com/alphagov/govuk_publishing_components/pull/4855))
 * Add Kyrgyz translations ([PR #4875](https://github.com/alphagov/govuk_publishing_components/pull/4875))
 * Render contact block lists without decoration ([PR #4897](https://github.com/alphagov/govuk_publishing_components/pull/4897))
+* Add extra options to `AddAnother` component tracking ([PR #4888](https://github.com/alphagov/govuk_publishing_components/pull/4888))
 
 ## 58.0.0
 

--- a/app/assets/javascripts/govuk_publishing_components/components/add-another.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/add-another.js
@@ -7,6 +7,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.disableGa4 = this.module.dataset.disableGa4
     this.emptyFieldset = undefined
     this.addAnotherButton = undefined
+    this.startIndex = Number(this.module.dataset.ga4StartIndex) || 1
+    this.indexSectionCount = Number(this.module.dataset.ga4IndexSectionCount)
   }
 
   function createButton (textContent, additionalClass = '', dataAttributes = {}) {
@@ -105,8 +107,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       var trackedRemoveButton = field.parentNode.querySelector('.js-add-another__remove-button[data-ga4-event]')
 
       if (trackedRemoveButton) {
-        trackedRemoveButton.dataset.indexSection = index
-        trackedRemoveButton.dataset.indexSectionCount = visibleFields.length + 1
+        trackedRemoveButton.dataset.indexSection = this.startIndex + index
+        trackedRemoveButton.dataset.indexSectionCount = this.indexSectionCount || visibleFields.length
       }
     }.bind(this))
 
@@ -120,8 +122,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     var trackedAddAnotherButton = this.module.querySelector('.js-add-another__add-button[data-ga4-event]')
 
     if (trackedAddAnotherButton) {
-      trackedAddAnotherButton.dataset.indexSection = visibleFields.length
-      trackedAddAnotherButton.dataset.indexSectionCount = visibleFields.length + 1
+      trackedAddAnotherButton.dataset.indexSection = this.indexSectionCount || visibleFields.length
+      trackedAddAnotherButton.dataset.indexSectionCount = this.indexSectionCount || visibleFields.length
     }
   }
 

--- a/app/views/govuk_publishing_components/components/_add_another.html.erb
+++ b/app/views/govuk_publishing_components/components/_add_another.html.erb
@@ -11,6 +11,7 @@
   component_helper.add_class("gem-c-add-another")
   component_helper.add_data_attribute({
     module: "add-another",
+    ga4_start_index: 3,
     add_button_text:,
     fieldset_legend:,
     empty_fields:,

--- a/spec/javascripts/components/add-another-spec.js
+++ b/spec/javascripts/components/add-another-spec.js
@@ -3,7 +3,7 @@
 describe('GOVUK.Modules.AddAnother', function () {
   var fixture, addAnother, addButton, fieldset, fieldset0, fieldset1, fieldset2, fieldset3
 
-  function checkEventData (visibleFields) {
+  function checkEventData (visibleFields, startIndex = 1, indexSectionCount = null) {
     visibleFields.forEach(function (field, index) {
       var trackedRemoveButton = field.parentNode.querySelector('.js-add-another__remove-button[data-ga4-event]')
 
@@ -15,8 +15,8 @@ describe('GOVUK.Modules.AddAnother', function () {
         action: 'deleted'
       }))
 
-      expect(trackedRemoveButton.dataset.indexSection).toBe(String(index))
-      expect(trackedRemoveButton.dataset.indexSectionCount).toBe(String(visibleFields.length + 1))
+      expect(trackedRemoveButton.dataset.indexSection).toBe(String(startIndex + index))
+      expect(trackedRemoveButton.dataset.indexSectionCount).toBe(String(indexSectionCount || visibleFields.length))
     })
   }
 
@@ -397,6 +397,84 @@ describe('GOVUK.Modules.AddAnother', function () {
       expect(document.activeElement).toBe(
         document.querySelector('.js-add-another__add-button')
       )
+    })
+  })
+
+  describe('One fieldset is rendered with additional GA4 attributes set', function () {
+    beforeEach(function () {
+      fixture = document.createElement('form')
+      fixture.setAttribute('data-module', 'add-another')
+      fixture.setAttribute('data-fieldset-legend', 'Thing')
+      fixture.setAttribute('data-add-button-text', 'Add another thing')
+      fixture.setAttribute('data-ga4-start-index', '2')
+      fixture.setAttribute('data-ga4-index-section-count', '5')
+      fixture.innerHTML = `
+        <div>
+          <div class="js-add-another__fieldset">
+            <fieldset>
+              <legend>Thing 1</legend>
+              <input type="hidden" name="test[0][id]" value="test_id" />
+              <label for="test_0_foo">Foo</label>
+              <input type="text" id="test_0_foo" name="test[0][foo]" value="test foo" />
+              <label for="test_0_bar"></label>
+              <textarea id="test_0_bar" name="test[0][bar]">test bar</textarea>
+              <label for="test_0__destroy">Delete</label>
+              <div class="js-add-another__destroy-checkbox">
+                <input type="checkbox" id="test_0_destroy" name="test[0][_destroy]" />
+              </div>
+            </fieldset>
+          </div>
+          <div class="js-add-another__fieldset">
+            <fieldset>
+              <legend>Thing 2</legend>
+              <input type="hidden" name="test[1][id]" value="test_id" />
+              <label for="test_1_foo">Foo</label>
+              <input type="text" id="test_1_foo" name="test[1][foo]" value="test foo" />
+              <label for="test_1_bar"></label>
+              <textarea id="test_1_bar" name="test[1][bar]">test bar</textarea>
+              <label for="test_1__destroy">Delete</label>
+              <div class="js-add-another__destroy-checkbox">
+                <input type="checkbox" id="test_1_destroy" name="test[1][_destroy]" />
+              </div>
+            </fieldset>
+          </div>
+          <div class="js-add-another__empty">
+            <fieldset>
+              <legend>Thing 3</legend>
+              <input type="hidden" name="test[2][id]" value="test_id" />
+              <label for="test_2_foo">Foo</label>
+              <input type="text" id="test_2_foo" name="test[2][foo]" value="" />
+              <label for="test_2_bar"></label>
+              <textarea id="test_2_bar" name="test[2][bar]"></textarea>
+              <label for="test_2__destroy">Delete</label>
+            </fieldset>
+          </div>
+        </div>
+      `
+      document.body.append(fixture)
+
+      addAnother = new GOVUK.Modules.AddAnother(fixture)
+      addAnother.init()
+
+      addButton = document.querySelector('.js-add-another__add-button')
+    })
+
+    afterEach(function () {
+      document.body.removeChild(fixture)
+    })
+
+    it('should add data attributes if GA4 enabled', function () {
+      var visibleFields = document.querySelectorAll('.js-add-another__fieldset:not([hidden]) > fieldset')
+
+      checkEventData(visibleFields, 2, 5)
+    })
+
+    it('should update GA4 data attributes when the "Add" button is clicked', function () {
+      window.GOVUK.triggerEvent(addButton, 'click')
+
+      var visibleFields = document.querySelectorAll('.js-add-another__fieldset:not([hidden]) > fieldset')
+
+      checkEventData(visibleFields, 2, 5)
     })
   })
 })


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

Adds `index-start` and `index-section-count` options to the `AddAnother` tracking.

## Why
<!-- What are the reasons behind this change being made? -->

Allows overriding the default indexing behaviour, if the indexing should be a continuation of surrounding content of the page.
