### PR TITLE
Version 57.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 57.3.1
 
 * Fix extra data in YouTube URLs breaking embeds ([PR #4882](https://github.com/alphagov/govuk_publishing_components/pull/4882))
 * Fix `ReorderableList` tracking on drag and drop ([PR #4886](https://github.com/alphagov/govuk_publishing_components/pull/4886))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (57.3.0)
+    govuk_publishing_components (57.3.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "57.3.0".freeze
+  VERSION = "57.3.1".freeze
 end


### PR DESCRIPTION
## 57.3.1

* Fix extra data in YouTube URLs breaking embeds ([PR #4882](https://github.com/alphagov/govuk_publishing_components/pull/4882))
* Fix `ReorderableList` tracking on drag and drop ([PR #4886](https://github.com/alphagov/govuk_publishing_components/pull/4886))