### PR TITLE
Add extra attributes to `Schema`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Render contact block lists without decoration ([PR #4897](https://github.com/alphagov/govuk_publishing_components/pull/4897))
 * Add extra options to `AddAnother` component tracking ([PR #4888](https://github.com/alphagov/govuk_publishing_components/pull/4888))
 * Add multiple to File Upload component ([PR #4888](https://github.com/alphagov/govuk_publishing_components/pull/4888))
+* Add extra attributes to `Schema` ([PR #4893](https://github.com/alphagov/govuk_publishing_components/pull/4893))
 
 ## 58.0.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.js
@@ -33,7 +33,9 @@
         length: this.undefined,
         video_percent: this.undefined,
         autocomplete_input: this.undefined,
-        autocomplete_suggestions: this.undefined
+        autocomplete_suggestions: this.undefined,
+        content_id: this.undefined,
+        user_id: this.undefined
       }
     }
   }

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.spec.js
@@ -37,7 +37,9 @@ describe('Google Analytics schemas', function () {
         length: undefined,
         video_percent: undefined,
         autocomplete_input: undefined,
-        autocomplete_suggestions: undefined
+        autocomplete_suggestions: undefined,
+        content_id: this.undefined,
+        user_id: this.undefined
       }
     }
     var returned = schemas.mergeProperties(data, 'example')
@@ -74,7 +76,9 @@ describe('Google Analytics schemas', function () {
         length: undefined,
         video_percent: undefined,
         autocomplete_input: undefined,
-        autocomplete_suggestions: undefined
+        autocomplete_suggestions: undefined,
+        content_id: this.undefined,
+        user_id: this.undefined
       }
     }
     var returned = schemas.mergeProperties(data, 'example')
@@ -111,7 +115,9 @@ describe('Google Analytics schemas', function () {
         length: undefined,
         video_percent: undefined,
         autocomplete_input: undefined,
-        autocomplete_suggestions: undefined
+        autocomplete_suggestions: undefined,
+        content_id: this.undefined,
+        user_id: this.undefined
       }
     }
     var returned = schemas.mergeProperties(data, 'example')
@@ -149,7 +155,9 @@ describe('Google Analytics schemas', function () {
         length: undefined,
         video_percent: undefined,
         autocomplete_input: undefined,
-        autocomplete_suggestions: undefined
+        autocomplete_suggestions: undefined,
+        content_id: this.undefined,
+        user_id: this.undefined
       }
     }
     var returned = schemas.mergeProperties(data, 'example')


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

Adds `content_id` and `user_id` to `Schema`

## Why
<!-- What are the reasons behind this change being made? -->

Requested changes from the publishing PAs, track `content_id` when content is being edited (URL is too consistent to use for this) and `user_id`.