### PR TITLE
Render contact block lists without decoration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased changes
 
 * Add Kyrgyz translations ([PR #4875](https://github.com/alphagov/govuk_publishing_components/pull/4875))
+* Render contact block lists without decoration ([PR #4897](https://github.com/alphagov/govuk_publishing_components/pull/4897))
 
 ## 58.0.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_contact.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_contact.scss
@@ -21,6 +21,16 @@
     position: relative;
     @include govuk-clearfix;
 
+    ul {
+      list-style-type: none;
+      margin: 0;
+      padding: 0;
+
+      li {
+        margin-bottom: govuk-spacing(1);
+      }
+    }
+
     .content {
       float: none;
       width: 100%;

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -528,6 +528,20 @@ examples:
             </div>
           </div>
         </div>
+  contact_with_embedded_list:
+    data:
+      block: |
+        <div class="contact" id="contact_1017">
+          <div class="content">
+            <div class="vcard contact-inner">
+              <p>Media enquiries</p>
+              <ul>
+                <li>Press enquiries: 020 7XXX XXXX</li>
+                <li>Out of hours: 020 7XXX XXXX</li>
+              </ul>
+            </div>
+          </div>
+        </div>
   charts:
     description: |
       The Government Statistical Service (GSS) guidance recommends [a limit of four categories as best practice for basic data visualisations](https://gss.civilservice.gov.uk/policy-store/data-visualisation-colours-in-charts/#section-5).


### PR DESCRIPTION
When adding lists inside contact blocks, they render with bullets and padding, because the styling is overriden by the govspeak styles (see https://github.com/alphagov/govuk_publishing_components/blob/f80f91c7d19422e8a15f43cf4850b6d039d54d01/app/assets/stylesheets/govuk_publishing_components/components/helpers/_markdown-typography.scss#L74)

After some discussion, we’ve decided that the simplest thing to do is to update the list styles within contacts to remove the list styling and margin/padding.

I've also added an example to the docs.

## Visual Changes

### Before

![image](https://github.com/user-attachments/assets/e238d2af-0157-4f2d-9c20-5434bf157ce2)

### After

![image](https://github.com/user-attachments/assets/e5163473-65a5-4d7f-9341-f2dd6a805699)
