### PR TITLE
Fix quotation marks for right-to-left languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Fix `AddAnother` `ga4_start_index` bug ([PR #4900](https://github.com/alphagov/govuk_publishing_components/pull/4900))
 * Fix super navigation toggle border styling ([PR #4894](https://github.com/alphagov/govuk_publishing_components/pull/4894))
+* Fix quotation marks for right-to-left languages ([PR #4903](https://github.com/alphagov/govuk_publishing_components/pull/4903))
 
 ## 58.1.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
@@ -53,26 +53,13 @@
   }
 
   &.gem-c-govspeak--direction-rtl blockquote {
-    padding: 0 govuk-spacing(4) 0 0;
-
-    @include govuk-media-query($from: desktop) {
-      margin: 0 (- govuk-spacing(6)) 0 0;
-    }
+    padding: 0 govuk-spacing(6) 0 0;
 
     p {
-      padding-right: govuk-spacing(3);
-      padding-left: 0;
-
-      @include govuk-media-query($from: tablet) {
-        padding-right: govuk-spacing(6);
-        padding-left: 0;
-      }
-
       &::before {
         content: "\201D";
-        float: right;
-        margin-right: (- govuk-spacing(3));
-        margin-left: 0;
+        right: auto;
+        left: 100%;
       }
 
       &:last-child::after {


### PR DESCRIPTION
## What
Ensures the quotation marks are in the correct position for right-to-left languages by using the default styles in place for left-to-right languages and flipping them.

Example page: https://www.gov.uk/government/news/foreign-secretary-statement-on-the-situation-in-el-fasher-sudan-24-april-2025.ar

## Why
The quotation marks are currently in the wrong position and in some cases overlaps with the content.

[Trello card](https://trello.com/c/pcldgiOm/1977-quotation-marks-on-arabic-pages-govt-agency-general-issue)

## Visual Changes

- Quotation marks now appear in the correct position
- Spacing is now consistent with the default styles in place for left-to-right languages, this has led to:
  - a `10px` increase in spacing to the right of the block quote on desktop
  - a `5px` decrease in spacing to the right of the block quote on mobile

### Desktop

| Before | After |
| --- | --- |
| <img width="665" src="https://github.com/user-attachments/assets/bd47816e-8b59-4dbb-971c-18c6fffb7dfd" /> | <img width="682" src="https://github.com/user-attachments/assets/c8d4b2d6-5ba2-4d05-a2bd-d1758010bda8" /> |

### Mobile

| Before | After |
| --- | --- |
| <img width="420" alt="Screenshot 2025-07-02 at 09 54 21" src="https://github.com/user-attachments/assets/d7e0363e-7538-4be8-8ff1-c3fc0b7af4c6" /> | <img width="424" alt="Screenshot 2025-07-02 at 09 54 00" src="https://github.com/user-attachments/assets/81c9d079-99e0-41d7-a86b-f777f43d9553" /> | 
