### PR TITLE
Reduce specificity of `.email-url-number` rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fix `AddAnother` `ga4_start_index` bug ([PR #4900](https://github.com/alphagov/govuk_publishing_components/pull/4900))
 * Fix super navigation toggle border styling ([PR #4894](https://github.com/alphagov/govuk_publishing_components/pull/4894))
 * Fix quotation marks for right-to-left languages ([PR #4903](https://github.com/alphagov/govuk_publishing_components/pull/4903))
+*  Reduce specificity of .email-url-number rules ([PR #4906](https://github.com/alphagov/govuk_publishing_components/pull/4906))
 
 ## 58.1.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_contact.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_contact.scss
@@ -31,19 +31,19 @@
       }
     }
 
+    .email-url-number {
+      .email {
+        word-wrap: break-word;
+      }
+
+      span {
+        display: block;
+      }
+    }
+
     .content {
       float: none;
       width: 100%;
-
-      .email-url-number {
-        .email {
-          word-wrap: break-word;
-        }
-
-        span {
-          display: block;
-        }
-      }
 
       .comments {
         @include govuk-font($size: 16);


### PR DESCRIPTION
At the moment, Content Blocks that render individual telephone objects are still showing with the label and phone number adjacent to each other as they’re not wrapped in a `.content` div. This reduces the specificity of the selector, so the phone numbers appear correctly.

There should be no difference in the Govspeak output as it stands, but just for visibility, I've added some screenshots:

## Before

![image](https://github.com/user-attachments/assets/face3d19-dac1-42f5-ad63-dc05cd92f6c2)

## After

![image](https://github.com/user-attachments/assets/bb857dc1-f72f-439b-86dd-329a03087009)

