### PR TITLE
Version 58.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,12 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 58.1.1
 
 * Fix `AddAnother` `ga4_start_index` bug ([PR #4900](https://github.com/alphagov/govuk_publishing_components/pull/4900))
 * Fix super navigation toggle border styling ([PR #4894](https://github.com/alphagov/govuk_publishing_components/pull/4894))
 * Fix quotation marks for right-to-left languages ([PR #4903](https://github.com/alphagov/govuk_publishing_components/pull/4903))
-*  Reduce specificity of .email-url-number rules ([PR #4906](https://github.com/alphagov/govuk_publishing_components/pull/4906))
+* Reduce specificity of .email-url-number rules ([PR #4906](https://github.com/alphagov/govuk_publishing_components/pull/4906))
 
 ## 58.1.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (58.1.0)
+    govuk_publishing_components (58.1.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "58.1.0".freeze
+  VERSION = "58.1.1".freeze
 end


### PR DESCRIPTION
## 58.1.1

* Fix `AddAnother` `ga4_start_index` bug ([PR #4900](https://github.com/alphagov/govuk_publishing_components/pull/4900))
* Fix super navigation toggle border styling ([PR #4894](https://github.com/alphagov/govuk_publishing_components/pull/4894))
* Fix quotation marks for right-to-left languages ([PR #4903](https://github.com/alphagov/govuk_publishing_components/pull/4903))
* Reduce specificity of .email-url-number rules ([PR #4906](https://github.com/alphagov/govuk_publishing_components/pull/4906))