### PR TITLE
Remove redundant documentation

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/signup_link.yml
+++ b/app/views/govuk_publishing_components/components/docs/signup_link.yml
@@ -24,13 +24,6 @@ examples:
     data:
       link_text: 'Click right here to sign up!!'
       link_href: '/this-signs-you-up'
-  with_custom_margin_bottom:
-    description: The component accepts a number for margin bottom from `0` to `9` (`0px` to `60px`) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to having no margin bottom.
-    data:
-      heading: 'Sign up for email notifications'
-      link_text: 'Click right here to sign up!!'
-      link_href: '/this-signs-you-up'
-      margin_bottom: 8
   with_custom_heading_level:
     description: Override default heading level by passing through `heading_level` parameter (defaults to `h3`).
     data:

--- a/app/views/govuk_publishing_components/components/docs/single_page_notification_button.yml
+++ b/app/views/govuk_publishing_components/components/docs/single_page_notification_button.yml
@@ -9,7 +9,7 @@ body: |
   When the button is clicked, the `base_path` is submitted to an endpoint which proceeds to check the user's authentication status and whether they are already subscribed to the page or not. Depending on these factors, they will be routed accordingly.
 accessibility_criteria: |
   - The bell icon must be presentational and ignored by screen readers.
-uses_component_wrapper_helper: true  
+uses_component_wrapper_helper: true
 examples:
   default:
     description: By default this component prompts the user to subscribe to email notifications to this page.
@@ -33,12 +33,6 @@ examples:
             index_link: 1
           index_total: 1
           section: "Top"
-  with_margin_bottom:
-    description: |
-      The component accepts a number for margin bottom from `0` to `9` (`0px` to `60px`) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to having a margin bottom of 15px.
-    data:
-      base_path: '/current-page-path'
-      margin_bottom: 5
   with_js_enhancement:
     description: |
       If the `js-enhancement` flag is present, the component uses JavaScript to check if the user has already subscribed to email notifications on the current page and accordingly updates its tracking attribute and (optionally) button text.

--- a/app/views/govuk_publishing_components/components/docs/subscription_links.yml
+++ b/app/views/govuk_publishing_components/components/docs/subscription_links.yml
@@ -20,12 +20,6 @@ examples:
     data:
       email_signup_link: '/foreign-travel-advice/singapore/email-signup'
       feed_link: '/foreign-travel-advice/singapore.atom'
-  with_margin:
-    description: The component accepts a number for margin bottom from `0` to `9` (`0px` to `60px`) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to having no margin bottom, although some margin is supplied by the links themselves (so that when they stack on mobile there is space between them).
-    data:
-      email_signup_link: '/foreign-travel-advice/singapore/email-signup'
-      feed_link: '/foreign-travel-advice/singapore.atom'
-      margin_bottom: 9
   with_only_email_signup_link:
     data:
       email_signup_link: '/foreign-travel-advice/singapore/email-signup'
@@ -70,7 +64,7 @@ examples:
       small_form: true
   without_heading:
     description: |
-      By default the component includes an h2 heading. The component could be used anywhere on the page and could mean that it produces invalid markup or make the site unaccessible.
+      By default the component includes a visually hidden h2 heading. This option removes it, because the component could be used anywhere on the page and could otherwise break the heading structure.
     data:
       email_signup_link: '/foreign-travel-advice/singapore/email-signup'
       feed_link: '/foreign-travel-advice/singapore.atom'


### PR DESCRIPTION
## What / why
- mostly removing margin_bottom examples, as these are already covered by the standard options detailed from the component wrapper
- also some rewording improvements

## Visual Changes
None.

Relates to https://github.com/alphagov/govuk_publishing_components/issues/4912
