### PR TITLE
**BREAKING** Introduce tag component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add Bluesky and Threads logos to share_links component ([PR #4918](https://github.com/alphagov/govuk_publishing_components/pull/4918))
 * Allow skip_account to act based on boolean and string ([PR #4910](https://github.com/alphagov/govuk_publishing_components/pull/4910))
 * Make heading sizes match govuk-frontend ([PR #4620](https://github.com/alphagov/govuk_publishing_components/pull/4620))
+* **BREAKING:** Introduce tag component ([PR #4914](https://github.com/alphagov/govuk_publishing_components/pull/4914))
 
 ## 58.2.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -91,6 +91,7 @@
 @import "components/summary-list";
 @import "components/tabs";
 @import "components/table";
+@import "components/tag";
 @import "components/textarea";
 @import "components/translation-nav";
 @import "components/warning-text";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
@@ -2,24 +2,6 @@
 @import "govuk_publishing_components/components/search";
 @import "govuk_publishing_components/components/skip-link";
 @import "govuk/components/header/header";
-@import "govuk/components/tag/tag";
-
-.gem-c-layout-header--production .govuk-header__container {
-  border-bottom-color: govuk-colour("red");
-}
-
-.gem-c-layout-header--integration .govuk-header__container,
-.gem-c-layout-header--staging .govuk-header__container {
-  border-bottom-color: govuk-colour("yellow");
-}
-
-.gem-c-layout-header--example .govuk-header__container {
-  border-bottom-color: govuk-colour("bright-purple");
-}
-
-.gem-c-layout-header--development .govuk-header__container {
-  border-bottom-color: govuk-colour("dark-grey");
-}
 
 .gem-c-layout-header--no-bottom-border,
 .gem-c-layout-header--no-bottom-border .govuk-header__container {
@@ -76,6 +58,11 @@
   }
 }
 
+.gem-c-header__environment {
+  padding-top: 2px;
+  padding-bottom: 3px;
+}
+
 .gem-c-header__logo {
   @include govuk-media-query($from: desktop) {
     white-space: nowrap;
@@ -96,34 +83,6 @@
   @include govuk-media-query($from: tablet) {
     display: inline-block;
   }
-}
-
-.gem-c-environment-tag {
-  padding: 2px 5px 0;
-  margin-left: 3px;
-  margin-top: govuk-spacing(-2);
-  vertical-align: middle;
-  @include govuk-font($size: 16, $weight: "bold");
-}
-
-.gem-c-environment-tag--production {
-  background-color: govuk-colour("red");
-  color: govuk-colour("white");
-}
-
-.gem-c-environment-tag--example {
-  background-color: govuk-colour("bright-purple");
-}
-
-.gem-c-environment-tag--development {
-  background-color: govuk-colour("dark-grey");
-  color: govuk-colour("white");
-}
-
-.gem-c-environment-tag--staging,
-.gem-c-environment-tag--integration {
-  background-color: govuk-colour("yellow");
-  color: govuk-colour("black");
 }
 
 .govuk-header__navigation-item--collapsed-menu-only {
@@ -155,8 +114,7 @@
       padding: 0 2mm 2mm 0;
     }
 
-    .gem-c-header__product-name,
-    .gem-c-environment-tag {
+    .gem-c-header__product-name {
       color: $govuk-print-text-colour;
       background: none;
     }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_tag.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_tag.scss
@@ -1,0 +1,14 @@
+@import "govuk_publishing_components/individual_component_support";
+@import "govuk/components/tag/tag";
+
+.gem-c-tag {
+  max-width: none;
+}
+
+@include govuk-media-query($media-type: print) {
+  .gem-c-tag.govuk-tag {
+    color: $govuk-print-text-colour;
+    background: none;
+    border: 2px solid govuk-colour("black");
+  }
+}

--- a/app/views/govuk_publishing_components/components/_layout_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_header.html.erb
@@ -12,10 +12,8 @@
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-layout-header govuk-header")
-  component_helper.add_class("gem-c-layout-header--#{environment}") if environment
   component_helper.add_class("gem-c-layout-header--no-bottom-border") if remove_bottom_border
   component_helper.add_data_attribute({ module: "govuk-header" })
-
 %>
 
 <%= tag.header(**component_helper.all_attributes) do %>

--- a/app/views/govuk_publishing_components/components/_tag.html.erb
+++ b/app/views/govuk_publishing_components/components/_tag.html.erb
@@ -1,0 +1,20 @@
+<%
+  add_gem_component_stylesheet("tag")
+
+  text ||= nil
+  if text.blank?
+    raise ArgumentError, "The tag component requires text"
+  end
+  text = text.capitalize
+
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class('govuk-tag gem-c-tag')
+
+  colours = %w[grey green turquoise blue light-blue purple pink red orange yellow]
+  colour ||= nil
+  component_helper.add_class("govuk-tag--#{colour}") if colours.include?(colour)
+%>
+
+<%= tag.strong(**component_helper.all_attributes) do %>
+  <%= text %>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/layout_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_header.yml
@@ -42,6 +42,19 @@ examples:
       - text: Hidden on desktop
         href: "item-3"
         show_only_in_collapsed_menu: true
+  with_product_name_and_navigation:
+    data:
+      product_name: Component Guide 999.9.9
+      environment: production
+      navigation_items:
+      - text: Navigation item 1
+        href: "item-1"
+        active: true
+      - text: Navigation item 2
+        href: "item-2"
+      - text: Hidden on desktop
+        href: "item-3"
+        show_only_in_collapsed_menu: true
   with_navigation_link_data_attributes:
     description: Supports adding data attributes i.e for tracking
     data:

--- a/app/views/govuk_publishing_components/components/docs/tag.yml
+++ b/app/views/govuk_publishing_components/components/docs/tag.yml
@@ -1,0 +1,57 @@
+name: Tag
+description: Use the tag component to show users the status of something. For example, the server environment the page is being rendered from.
+accessibility_criteria: |
+  - should have a text colour contrast ratio of more than 4.5:1 with its background to be visually distinct
+  - does not use colour alone to convey information
+  - should not be used within a link, as a button, or for interactivity
+uses_component_wrapper_helper: true
+govuk_frontend_components:
+  - tag
+examples:
+  default:
+    data:
+      text: Hello world!
+  sentence_case_conversion:
+    description: The component automatically converts text to sentence case as shown.
+    data:
+      text: HELLO WORLD!
+  grey:
+    data:
+      text: Hello world!
+      colour: grey
+  green:
+    data:
+      text: Hello world!
+      colour: green
+  turquoise:
+    data:
+      text: Hello world!
+      colour: turquoise
+  blue:
+    data:
+      text: Hello world!
+      colour: blue
+  light_blue:
+    data:
+      text: Hello world!
+      colour: light-blue
+  purple:
+    data:
+      text: Hello world!
+      colour: purple
+  pink:
+    data:
+      text: Hello world!
+      colour: pink
+  red:
+    data:
+      text: Hello world!
+      colour: red
+  orange:
+    data:
+      text: Hello world!
+      colour: orange
+  yellow:
+    data:
+      text: Hello world!
+      colour: yellow

--- a/app/views/govuk_publishing_components/components/layout_header/_header_logo.html.erb
+++ b/app/views/govuk_publishing_components/components/layout_header/_header_logo.html.erb
@@ -1,14 +1,25 @@
+<%
+  colour_map = {
+    "production" => "red",
+    "staging" => "yellow",
+    "integration" => "yellow",
+    "example" => "purple",
+    "development" => "grey",
+  }
+
+  environment_exists = !environment.blank?
+%>
+<% if environment_exists %>
+  <div class="gem-c-header__environment">
+    <%= render "govuk_publishing_components/components/tag", { text: environment, colour: colour_map[environment.downcase] } %>
+  </div>
+<% end %>
 <div class="govuk-header__logo gem-c-header__logo">
   <a href="<%= logo_link %>" class="govuk-header__link govuk-header__link--homepage">
     <%= render "govuk_publishing_components/components/govuk_logo/govuk_logo" %>
     <% if product_name %>
       <span class="govuk-header__product-name gem-c-header__product-name">
         <%= product_name %>
-      </span>
-    <% end %>
-    <% if environment %>
-      <span class="gem-c-environment-tag govuk-tag gem-c-environment-tag--<%= environment %>">
-        <%= environment.titleize %>
       </span>
     <% end %>
   </a>

--- a/spec/component_guide/component_index_spec.rb
+++ b/spec/component_guide/component_index_spec.rb
@@ -79,6 +79,7 @@ describe "Component guide index", :capybara do
 @import 'govuk_publishing_components/components/step-by-step-nav-header';
 @import 'govuk_publishing_components/components/step-by-step-nav-related';
 @import 'govuk_publishing_components/components/tabs';
+@import 'govuk_publishing_components/components/tag';
 @import 'govuk_publishing_components/components/textarea';"
 
     expect(page).to have_selector(".component-doc-h2", text: "Gem components used by this app (20)")

--- a/spec/components/layout_header_spec.rb
+++ b/spec/components/layout_header_spec.rb
@@ -14,21 +14,29 @@ describe "Layout header", type: :view do
   it "renders the header without environment tag if no environment is given" do
     render_component({})
 
-    assert_select ".gem-c-environment-tag", 0
+    assert_select ".gem-c-tag", 0
   end
 
-  it "renders the header with environment tag and environment modifier class" do
+  it "renders the header with the environment tag" do
     render_component(environment: "staging")
 
-    assert_select ".govuk-header.gem-c-layout-header--staging"
-    assert_select ".gem-c-environment-tag", text: "Staging"
+    assert_select ".gem-c-tag", text: "Staging"
+  end
+
+  it "renders the header with correct environment tag colours" do
+    expected_colours = %w[red yellow yellow purple grey]
+
+    %w[production staging integration example development].each_with_index do |environment, index|
+      render_component(environment: environment)
+      assert_select ".govuk-tag--#{expected_colours[index]}"
+    end
   end
 
   it "renders the product name" do
     render_component(environment: "staging", product_name: "Product name")
 
     assert_select ".govuk-header__product-name", text: "Product name"
-    assert_select ".gem-c-environment-tag", text: "Staging"
+    assert_select ".gem-c-tag", text: "Staging"
   end
 
   it "renders at a constrained width by default" do

--- a/spec/components/tag_spec.rb
+++ b/spec/components/tag_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+describe "Tag", type: :view do
+  def component_name
+    "tag"
+  end
+
+  it "renders a standard tag component correctly" do
+    render_component({ text: "Hello" })
+    assert_select ".gem-c-tag", text: "Hello"
+    assert_select "strong.govuk-tag", text: "Hello"
+  end
+
+  it "errors if text is nil" do
+    assert_raises do
+      render_component({})
+    end
+  end
+
+  it "errors if text is empty" do
+    assert_raises do
+      render_component({ text: "" })
+    end
+  end
+
+  it "makes text sentence case" do
+    render_component({ text: "HELLO WORLD!" })
+    assert_select ".gem-c-tag", text: "Hello world!"
+  end
+
+  it "adds a colour if a valid one is supplied" do
+    colours = %w[grey green turquoise blue light-blue purple pink red orange yellow]
+    colours.each do |colour|
+      render_component({ text: "Hello", colour: colour })
+      assert_select "strong.govuk-tag.govuk-tag--#{colour}"
+    end
+  end
+
+  it "ignores invalid colours" do
+    render_component({ text: "Hello", colour: "glass" })
+    assert_select ".gem-c-tag.govuk-tag"
+    assert_select "strong.govuk-tag.govuk-tag--glass", false
+  end
+end

--- a/spec/features/asset_helper_spec.rb
+++ b/spec/features/asset_helper_spec.rb
@@ -48,7 +48,7 @@ describe "When the asset helper is configured", :capybara do
     visit "/component-guide"
 
     within(:xpath, "//head", visible: :hidden) do
-      expect(page).to have_xpath("//link[@rel=\"stylesheet\"]", visible: :hidden, count: 8)
+      expect(page).to have_xpath("//link[@rel=\"stylesheet\"]", visible: :hidden, count: 9)
 
       expect(page).to have_selector('link[href^="/assets/component_guide/application-"][rel="stylesheet"]', visible: :hidden)
       expect(page).to have_selector('link[href^="/assets/govuk_publishing_components/components/_heading-"][rel="stylesheet"]', visible: :hidden)
@@ -97,7 +97,7 @@ describe "When the asset helper is configured", :capybara do
     visit "/component-guide"
 
     within(:xpath, "//head", visible: :hidden) do
-      expect(page).to have_xpath("//link[@rel=\"stylesheet\"]", visible: :hidden, count: 8)
+      expect(page).to have_xpath("//link[@rel=\"stylesheet\"]", visible: :hidden, count: 9)
 
       expect(page).to have_selector('link[href^="/assets/component_guide/application-"][rel="stylesheet"]', visible: :hidden)
       expect(page).to have_selector('link[href^="/assets/govuk_publishing_components/components/_details-"][rel="stylesheet"]', visible: :hidden)

--- a/spec/lib/govuk_publishing_components/app_helpers/asset_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/app_helpers/asset_helper_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe GovukPublishingComponents::AppHelpers::AssetHelper do
     end
 
     it "detect the total number of stylesheet paths" do
-      expect(get_component_css_paths.count).to be(87)
+      expect(get_component_css_paths.count).to be(88)
     end
 
     it "initialize empty asset helper" do


### PR DESCRIPTION
## What / Why
<!-- What are the reasons behind this change being made? -->
- Introduces a new `Tag` component based on [the Design System component](https://design-system.service.gov.uk/components/tag/)
- Creating a tag component gives us a few benefits:
  - The default tag component can now be used elsewhere - the previous one was specifically styled for the header
  - Individual component CSS will now be used, so the tag CSS won't be downloaded where it isn't needed
  - The component has validation now and uses the component wrapper
## Breaking change
- I've put this as a breaking change as:
  - apps may need to import `@import 'govuk_publishing_components/components/tag';`
  -  the app `content-data-admin` seems to have some custom override styles for `.gem-c-environment-tag`, which no longer exists as that was a class tied to the old tag.
- Trello card: https://trello.com/c/PfnvvqX0/727-fix-our-component-guide-using-a-tag-with-poor-colour-contrast

## The tag in our header
This PR replaces the existing "environment" tag in our `layout_header` with the new component, which will fix https://github.com/alphagov/govuk_publishing_components/issues/4611 

The tag in the header now sits outside of the header `<a>` link. This is because the design system guidance states that tags should not be used as a link/an interactive thing.

As well as this, our header logo div uses `whitespace: no-wrap` which is a problem. This is because it causes the environment tag to not be calculated as part of the element's width. Therefore the environment tag doesn't wrap onto a new line currently across the `layout_header`, and leads to this visual bug that currently exists on production:

**This is now outdated - see PR discussion**
<img width="1090" height="121" alt="image" src="https://github.com/user-attachments/assets/c6ea9c58-f613-44f0-86c7-507237c470a6" />

Therefore to solve this, I've added a modifier class that makes the header logo section use `display: flex` if an environment tag exists. This means that the environment tag will sit on a new line on desktop now and won't ever overlap a menu.


**This is now outdated - see PR discussion**
<img width="1090" height="121" alt="image" src="https://github.com/user-attachments/assets/71ec04dc-8657-4e32-9899-327ebf7d442c" />


I think to fix this using other means would require refactoring the `layout_header` component, because:
- The service app name can be a varying length, and the menu items can be of a varying length, so it's hard to come up with a fix that adheres to those requirements without a large refactor
- the header is using `float: left` and `float: right` for layout, which is making things more difficult to fix (as opposed to it using `flex` or `grid`). It's probably worth raising a new issue to refactor `layout_header` and update it to use `flex` or `grid` instead.


## Visual Changes (OUTDATED - See PR discussion)

See https://components-gem-pr-4914.herokuapp.com/component-guide/tag for all examples
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->
<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->
| Before | After |
|--------|--------|
| <img width="748" height="96" alt="image" src="https://github.com/user-attachments/assets/60117586-e497-4be0-993b-3a0a84ed99dc" /> | <img width="748" height="96" alt="image" src="https://github.com/user-attachments/assets/c9a9870b-c3dd-4f35-b35b-b6bbe1723e62" /> |
| <img width="751" height="152" alt="image" src="https://github.com/user-attachments/assets/314d0851-c9c1-479a-a6e2-bb9f8c5d80ac" /> | <img width="751" height="156" alt="image" src="https://github.com/user-attachments/assets/5584eb67-874e-44ac-b1c1-caf354953fb4" /> |
| <img width="386" height="77" alt="image" src="https://github.com/user-attachments/assets/735e5b92-7d7f-4b2b-ac42-9de80405158d" /> | <img width="386" height="77" alt="image" src="https://github.com/user-attachments/assets/a3897ef7-b6ac-43c3-b5b4-900d119d6298" /> | 
| Production new red example <img width="996" height="154" alt="image" src="https://github.com/user-attachments/assets/53a11060-f1d2-4cde-be89-077978b0c760" /> | Production new red example <img width="996" height="154" alt="image" src="https://github.com/user-attachments/assets/0096936a-fb04-400c-af97-569805ba6244" /> |