### PR TITLE
Action link component updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Allow skip_account to act based on boolean and string ([PR #4910](https://github.com/alphagov/govuk_publishing_components/pull/4910))
 * Make heading sizes match govuk-frontend ([PR #4620](https://github.com/alphagov/govuk_publishing_components/pull/4620))
 * **BREAKING:** Introduce tag component ([PR #4914](https://github.com/alphagov/govuk_publishing_components/pull/4914))
+* Action link component updates ([PR #4915](https://github.com/alphagov/govuk_publishing_components/pull/4915))
 
 ## 58.2.0
 

--- a/app/assets/images/govuk_publishing_components/action-link-arrow--dark.svg
+++ b/app/assets/images/govuk_publishing_components/action-link-arrow--dark.svg
@@ -1,5 +1,0 @@
-<svg width="23" height="23" viewBox="0 0 23 23" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <circle cx="11.5" cy="11.5" r="11.5" fill="#272828"/>
-  <path fill-rule="evenodd" clip-rule="evenodd" d="M14.9429 11.7949L10.4402 7.29222L11.7327 5.99967L17.528 11.7949L11.7327 17.5902L10.4402 16.2976L14.9429 11.7949Z" fill="#ffffff"/>
-  <path fill-rule="evenodd" clip-rule="evenodd" d="M3.95631 10.881L15.4414 10.881L15.4414 12.709L3.95631 12.709L3.95631 10.881Z" fill="#ffffff"/>
-</svg>

--- a/app/assets/images/govuk_publishing_components/action-link-arrow--simple-light.svg
+++ b/app/assets/images/govuk_publishing_components/action-link-arrow--simple-light.svg
@@ -1,4 +1,0 @@
-<svg width="23" height="23" viewBox="0 0 23 23" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path fill-rule="evenodd" clip-rule="evenodd" d="M14.9429 11.7949L10.4402 7.29222L11.7327 5.99967L17.528 11.7949L11.7327 17.5902L10.4402 16.2976L14.9429 11.7949Z" fill="#ffffff"/>
-  <path fill-rule="evenodd" clip-rule="evenodd" d="M3.95631 10.881L15.4414 10.881L15.4414 12.709L3.95631 12.709L3.95631 10.881Z" fill="#ffffff"/>
-</svg>

--- a/app/assets/images/govuk_publishing_components/action-link-arrow.svg
+++ b/app/assets/images/govuk_publishing_components/action-link-arrow.svg
@@ -1,5 +1,0 @@
-<svg width="39" height="39" viewBox="0 0 39 39" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="19.5" cy="19.5" r="19.5" fill="#fff500"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M24.0343 20L14.1812 10.1469L17.0096 7.31848L29.6912 20L17.0096 32.6815L14.1812 29.8531L24.0343 20Z" fill="#272828"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M0.000423781 18L25.1328 18L25.1328 22L0.000423431 22L0.000423781 18Z" fill="#272828"/>
-</svg>

--- a/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
@@ -114,21 +114,6 @@
   }
 }
 
-.gem-c-action-link--dark-large-icon {
-  &::before {
-    background: url("govuk_publishing_components/action-link-arrow--dark.svg");
-    height: 34px;
-    width: 40px;
-    background-repeat: no-repeat;
-    background-size: 32px auto;
-    background-position: 0 2px;
-  }
-
-  @include govuk-media-query($until: tablet) {
-    margin-bottom: govuk-spacing(2);
-  }
-}
-
 .gem-c-action-link--light-icon {
   &::before {
     width: 36px;
@@ -143,23 +128,6 @@
       height: 35px;
       background-size: 35px auto;
     }
-  }
-}
-
-.gem-c-action-link--dark-icon {
-  max-width: none;
-
-  @include govuk-media-query($until: tablet) {
-    margin-bottom: govuk-spacing(2);
-  }
-
-  &::before {
-    height: 30px;
-    width: 35px;
-    background: url("govuk_publishing_components/action-link-arrow--dark.svg");
-    background-repeat: no-repeat;
-    background-size: 25px auto;
-    background-position: 0 2px;
   }
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
@@ -3,19 +3,25 @@
 .gem-c-action-link {
   display: table;
 
+  @include govuk-media-query($until: tablet) {
+    max-width: 410px;
+  }
+
   &::before {
     content: "";
     display: table-cell;
-    width: 60px;
-    height: 45px;
-    background: url("govuk_publishing_components/action-link-arrow.svg");
+    width: 36px;
+    height: 28px;
+    background: url("govuk_publishing_components/action-link-arrow--light.svg");
     background-repeat: no-repeat;
-    background-position: 0 50%;
-    background-size: 45px auto;
-  }
+    background-size: 28px auto;
+    background-position: 0 0;
 
-  @include govuk-media-query($until: tablet) {
-    max-width: 410px;
+    @include govuk-media-query($from: tablet) {
+      width: 45px;
+      height: 35px;
+      background-size: 35px auto;
+    }
   }
 }
 
@@ -111,23 +117,6 @@
     background-repeat: no-repeat;
     background-size: 25px auto;
     background-position: 0 2px;
-  }
-}
-
-.gem-c-action-link--light-icon {
-  &::before {
-    width: 36px;
-    height: 28px;
-    background: url("govuk_publishing_components/action-link-arrow--light.svg");
-    background-repeat: no-repeat;
-    background-size: 28px auto;
-    background-position: 0 0;
-
-    @include govuk-media-query($from: tablet) {
-      width: 45px;
-      height: 35px;
-      background-size: 35px auto;
-    }
   }
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
@@ -25,11 +25,6 @@
   }
 }
 
-.gem-c-action-link__contents-wrapper {
-  display: table-cell;
-  vertical-align: middle;
-}
-
 .gem-c-action-link__link-wrapper {
   display: table-cell;
   vertical-align: middle;
@@ -45,59 +40,6 @@
   }
 }
 
-.gem-c-action-link__nowrap-text {
-  white-space: nowrap;
-}
-
-.gem-c-action-link--with-subtext {
-  max-width: none;
-
-  .gem-c-action-link__link-wrapper,
-  .gem-c-action-link__subtext-wrapper {
-    display: block;
-
-    @include govuk-media-query($from: tablet) {
-      display: table-cell;
-      vertical-align: middle;
-    }
-  }
-}
-
-.gem-c-action-link--mobile-subtext {
-  .gem-c-action-link__subtext-wrapper {
-    display: block;
-  }
-
-  .gem-c-action-link__subtext {
-    padding: 0;
-
-    &::before {
-      display: none;
-    }
-  }
-}
-
-.gem-c-action-link__subtext {
-  display: block;
-  color: inherit;
-  @include govuk-font(19);
-
-  @include govuk-media-query($from: tablet) {
-    position: relative;
-    padding-left: govuk-spacing(4);
-
-    &::before {
-      content: "";
-      position: absolute;
-      top: 10%;
-      left: govuk-spacing(2);
-      width: govuk-spacing(2);
-      height: 80%;
-      border-left: solid 1px $govuk-text-colour;
-    }
-  }
-}
-
 .gem-c-action-link--simple {
   &::before {
     width: 30px;
@@ -106,27 +48,6 @@
     background-repeat: no-repeat;
     background-size: 25px auto;
     background-position: 0 2px;
-  }
-}
-
-.gem-c-action-link--simple-light {
-  &::before {
-    width: 30px;
-    height: 30px;
-    background: url("govuk_publishing_components/action-link-arrow--simple-light.svg");
-    background-repeat: no-repeat;
-    background-size: 25px auto;
-    background-position: 0 2px;
-  }
-}
-
-.gem-c-action-link--inverse {
-  color: govuk-colour("white");
-
-  .gem-c-action-link__subtext {
-    &::before {
-      border-color: govuk-colour("white");
-    }
   }
 }
 

--- a/app/views/govuk_publishing_components/components/_action_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_action_link.html.erb
@@ -11,8 +11,6 @@
   inverse ||= false
   simple ||= false
   simple_light ||= false
-  dark_icon ||= false
-  dark_large_icon ||= false
   light_icon ||= false
 
   link_classes = %w(govuk-link gem-c-action-link__link gem-c-force-print-link-styles)
@@ -21,8 +19,6 @@
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-action-link")
   component_helper.add_class("gem-c-action-link--inverse") if inverse
-  component_helper.add_class("gem-c-action-link--dark-icon") if dark_icon
-  component_helper.add_class("gem-c-action-link--dark-large-icon") if dark_large_icon
   component_helper.add_class("gem-c-action-link--light-icon") if light_icon
   component_helper.add_class("gem-c-action-link--simple") if simple
   component_helper.add_class("gem-c-action-link--simple-light") if simple_light

--- a/app/views/govuk_publishing_components/components/_action_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_action_link.html.erb
@@ -11,7 +11,6 @@
   inverse ||= false
   simple ||= false
   simple_light ||= false
-  light_icon ||= false
 
   link_classes = %w(govuk-link gem-c-action-link__link gem-c-force-print-link-styles)
   link_classes << "govuk-link--inverse" if inverse
@@ -19,7 +18,6 @@
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-action-link")
   component_helper.add_class("gem-c-action-link--inverse") if inverse
-  component_helper.add_class("gem-c-action-link--light-icon") if light_icon
   component_helper.add_class("gem-c-action-link--simple") if simple
   component_helper.add_class("gem-c-action-link--simple-light") if simple_light
   component_helper.add_class("gem-c-action-link--with-subtext") if subtext

--- a/app/views/govuk_publishing_components/components/_action_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_action_link.html.erb
@@ -15,21 +15,19 @@
   dark_large_icon ||= false
   light_icon ||= false
 
-  css_classes = %w(gem-c-action-link)
-  css_classes << "gem-c-action-link--inverse" if inverse
-  css_classes << "gem-c-action-link--dark-icon" if dark_icon
-  css_classes << "gem-c-action-link--dark-large-icon" if dark_large_icon
-  css_classes << "gem-c-action-link--light-icon" if light_icon
-  css_classes << "gem-c-action-link--simple" if simple
-  css_classes << "gem-c-action-link--simple-light" if simple_light
-  css_classes << "gem-c-action-link--with-subtext" if subtext
-  css_classes << "gem-c-action-link--mobile-subtext" if mobile_subtext
-
   link_classes = %w(govuk-link gem-c-action-link__link gem-c-force-print-link-styles)
   link_classes << "govuk-link--inverse" if inverse
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
-  component_helper.add_class(css_classes.join(" "))
+  component_helper.add_class("gem-c-action-link")
+  component_helper.add_class("gem-c-action-link--inverse") if inverse
+  component_helper.add_class("gem-c-action-link--dark-icon") if dark_icon
+  component_helper.add_class("gem-c-action-link--dark-large-icon") if dark_large_icon
+  component_helper.add_class("gem-c-action-link--light-icon") if light_icon
+  component_helper.add_class("gem-c-action-link--simple") if simple
+  component_helper.add_class("gem-c-action-link--simple-light") if simple_light
+  component_helper.add_class("gem-c-action-link--with-subtext") if subtext
+  component_helper.add_class("gem-c-action-link--mobile-subtext") if mobile_subtext
 %>
 <% if text.present? %>
   <%= tag.div(**component_helper.all_attributes) do %>

--- a/app/views/govuk_publishing_components/components/_action_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_action_link.html.erb
@@ -3,11 +3,7 @@
 
   local_assigns[:margin_bottom] ||= 0
   text ||= false
-  nowrap_text ||= false
   href ||= false
-  subtext ||= false
-  subtext_href ||= false
-  mobile_subtext ||= false
   inverse ||= false
   simple ||= false
   simple_light ||= false
@@ -19,9 +15,6 @@
   component_helper.add_class("gem-c-action-link")
   component_helper.add_class("gem-c-action-link--inverse") if inverse
   component_helper.add_class("gem-c-action-link--simple") if simple
-  component_helper.add_class("gem-c-action-link--simple-light") if simple_light
-  component_helper.add_class("gem-c-action-link--with-subtext") if subtext
-  component_helper.add_class("gem-c-action-link--mobile-subtext") if mobile_subtext
 %>
 <% if text.present? %>
   <%= tag.div(**component_helper.all_attributes) do %>
@@ -29,7 +22,6 @@
       <span class="gem-c-action-link__link-wrapper">
         <% main_text = capture do %>
           <%= text %>
-          <%= content_tag(:span, nowrap_text, class: "gem-c-action-link__nowrap-text") if nowrap_text %>
         <% end %>
 
         <% if href.present? %>
@@ -40,24 +32,7 @@
           <%= main_text %>
         <% end %>
       </span>
-
-      <% if subtext %>
-        <span class="gem-c-action-link__subtext-wrapper">
-          <% if subtext_href %>
-            <%= content_tag(:span, subtext, class: "gem-c-action-link__subtext") do %>
-              <%= link_to subtext, subtext_href, class: link_classes %>
-            <% end %>
-          <% else %>
-            <%= content_tag(:span, subtext, class: "gem-c-action-link__subtext") %>
-          <% end %>
-        </span>
-      <% end %>
     <% end %>
-
-    <% if subtext %>
-      <%= content_tag(:span, contents, class: "gem-c-action-link__contents-wrapper") %>
-    <% else %>
-      <%= contents %>
-    <% end %>
+    <%= contents %>
   <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/action_link.yml
+++ b/app/views/govuk_publishing_components/components/docs/action_link.yml
@@ -72,16 +72,6 @@ examples:
       simple_light: true
     context:
       dark_background: true
-  with_dark_icon:
-    data:
-      text: Coronavirus (COVID-19)
-      href: "/my-test-page"
-      dark_icon: true
-  with_dark_large_icon:
-    data:
-      text: Coronavirus (COVID-19)
-      href: "/my-test-page"
-      dark_large_icon: true
   with_light_icon:
     data:
       text: Coronavirus (COVID-19)

--- a/app/views/govuk_publishing_components/components/docs/action_link.yml
+++ b/app/views/govuk_publishing_components/components/docs/action_link.yml
@@ -13,49 +13,10 @@ examples:
       text: Look at this margin
       href: "/page"
       margin_bottom: 9
-  with_no_wrapping_text:
-    data:
-      text: "Coronavirus (COVID-19):"
-      nowrap_text: what you need to do
-      href: "/page"
   inverse:
     data:
       text: "Coronavirus (COVID-19)"
       href: "/page"
-      inverse: true
-    context:
-      dark_background: true
-  with_subtext:
-    data:
-      text: Emergency something
-      href: "/page"
-      subtext: This is about the emergency
-  with_subtext_on_a_dark_background:
-    data:
-      text: Emergency something
-      href: "/page"
-      subtext: This is about the emergency that is happening right now unfortunately so pay attention
-      inverse: true
-    context:
-      dark_background: true
-  mobile_subtext:
-    description: Lock the subtext beneath the main text, so the component with subtext always appears as it does on mobile.
-    data:
-      text: Try not to panic now
-      href: "/page"
-      subtext: "The thing that is happening is pretty scary but we'll get through it"
-      mobile_subtext: true
-  with_link_on_subtext:
-    description: The subtext can also be a link if required. The link on the main text is optional.
-    data:
-      text: Remain calm
-      subtext: Better things are ahead
-      subtext_href: "/page"
-  with_link_on_subtext_on_a_dark_background:
-    data:
-      text: Remain calm
-      subtext: Better things are ahead
-      subtext_href: "/page"
       inverse: true
     context:
       dark_background: true
@@ -64,11 +25,3 @@ examples:
       text: Getting financial help and keeping your business safe
       href: "/financial-help"
       simple: true
-  simple_light_arrow:
-    data:
-      text: Getting financial help and keeping your business safe
-      href: "/financial-help"
-      inverse: true
-      simple_light: true
-    context:
-      dark_background: true

--- a/app/views/govuk_publishing_components/components/docs/action_link.yml
+++ b/app/views/govuk_publishing_components/components/docs/action_link.yml
@@ -72,8 +72,3 @@ examples:
       simple_light: true
     context:
       dark_background: true
-  with_light_icon:
-    data:
-      text: Coronavirus (COVID-19)
-      href: "/my-test-page"
-      light_icon: true

--- a/spec/components/action_link_spec.rb
+++ b/spec/components/action_link_spec.rb
@@ -82,24 +82,6 @@ describe "Action link", type: :view do
     assert_select ".gem-c-action-link--simple-light"
   end
 
-  it "renders dark icon version" do
-    render_component(
-      text: "Get more info",
-      href: "/coronavirus",
-      dark_icon: true,
-    )
-    assert_select ".gem-c-action-link--dark-icon"
-  end
-
-  it "renders dark large icon version" do
-    render_component(
-      text: "Get more info",
-      href: "/coronavirus",
-      dark_large_icon: true,
-    )
-    assert_select ".gem-c-action-link--dark-large-icon"
-  end
-
   it "renders inverse version" do
     render_component(
       text: "Get more info",

--- a/spec/components/action_link_spec.rb
+++ b/spec/components/action_link_spec.rb
@@ -26,44 +26,6 @@ describe "Action link", type: :view do
     assert_select '.gem-c-action-link.govuk-\!-margin-bottom-6'
   end
 
-  it "renders non wrapping text if nowrap text is passed through" do
-    render_component(
-      text: "Get more info",
-      nowrap_text: "about COVID",
-      href: "/coronavirus",
-    )
-    assert_select ".gem-c-action-link .gem-c-action-link__nowrap-text", text: "about COVID"
-  end
-
-  it "renders subtext" do
-    render_component(
-      text: "Get more info",
-      href: "/coronavirus",
-      subtext: "because info is important",
-    )
-    assert_select ".gem-c-action-link.gem-c-action-link--with-subtext .gem-c-action-link__subtext", text: "because info is important"
-  end
-
-  it "shows subtext like on mobile" do
-    render_component(
-      text: "Get more info",
-      subtext: "because info is important",
-      mobile_subtext: true,
-    )
-    assert_select ".gem-c-action-link.gem-c-action-link--mobile-subtext"
-  end
-
-  it "can add a link to subtext" do
-    render_component(
-      text: "Get more info",
-      href: "/main-href",
-      subtext: "because info is important",
-      subtext_href: "/subtext-href",
-    )
-    assert_select ".gem-c-action-link .gem-c-action-link__link[href='/main-href']"
-    assert_select ".gem-c-action-link .gem-c-action-link__subtext .govuk-link[href='/subtext-href']"
-  end
-
   it "renders simple icon version" do
     render_component(
       text: "Get more info",
@@ -71,15 +33,6 @@ describe "Action link", type: :view do
       simple: true,
     )
     assert_select ".gem-c-action-link--simple"
-  end
-
-  it "renders simple light icon version" do
-    render_component(
-      text: "Get more info",
-      href: "/coronavirus",
-      simple_light: true,
-    )
-    assert_select ".gem-c-action-link--simple-light"
   end
 
   it "renders inverse version" do


### PR DESCRIPTION
## What

Review link: https://components-gem-pr-4915.herokuapp.com/component-guide/action_link

- Set the `light_icon` icon option as the new default
- Remove all 'yellow' variants
- Remove all 'dark' variants
- Remove other unused options for `nowrap_text`, `subtext`, `subtext_href`, `mobile_subtext`, `simple_light_arrow`.

https://trello.com/c/iiekbtY8/3561-updates-to-the-action-link-component 

## Why

Remove unused options

## Visual Changes

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td valign=top>
<img alt="components publishing service gov uk_component-guide_action_link_preview(Pixel 7) (1)" src="https://github.com/user-attachments/assets/28c4d239-1c04-47eb-b724-efd6ba91b3ce" />
</td>
<td valign=top>
<img alt="0 0 0 0_3212_component-guide_action_link_preview(Pixel 7) (2)" src="https://github.com/user-attachments/assets/8ec25cde-d8c4-4415-b2dc-7698b182684e" />
</td>
</tr>
</table>

## Anything else

Although some options have been removed and `light_icon` is now the default, this change is not breaking for any applications that use the old options. Non existent options are simply ignored, and the default is applied instead.

That said, we should clean up the unused options. I’ve opened a PR for this, which can be merged with the gem release once it’s available. Additionally, the PR includes an update to some custom styles that target action link elements on the homepage.

https://github.com/alphagov/frontend/pull/4899
https://github.com/alphagov/collections/pull/4147