### PR TITLE
Add support for using full width containers on component preview pages

### DIFF
--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -237,17 +237,6 @@ html {
   font-family: $govuk-font-family;
 }
 
-.hide-header-and-footer {
-  // stylelint-disable selector-max-id
-  #global-header,
-  #global-header-bar,
-  #global-breadcrumb,
-  #footer {
-    display: none;
-  }
-  // stylelint-enable selector-max-id
-}
-
 // wraps each component variation on the preview page
 .component-guide-preview-page {
   margin-bottom: govuk-spacing(9);

--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -140,7 +140,7 @@ $gem-guide-border-width: 1px;
 
 .component-guide-preview--simple {
   border: 0;
-  padding: govuk-spacing(2);
+  padding: 0;
 
   &::before {
     display: none;
@@ -248,14 +248,14 @@ html {
   // stylelint-enable selector-max-id
 }
 
+// wraps each component variation on the preview page
 .component-guide-preview-page {
-  padding: (govuk-spacing(6) * 1.5) 0;
-  position: relative;
+  margin-bottom: govuk-spacing(9);
 
   .preview-title {
     margin-top: 0;
-    margin-bottom: 1em;
-    @include govuk-font($size: 16, $weight: bold);
+    margin-bottom: govuk-spacing(4);
+    @include govuk-font($size: 19, $weight: bold);
 
     a {
       @include govuk-link-common;

--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -255,6 +255,14 @@ html {
   }
 }
 
+// Add spacing to the left of the component title on the preview page
+// when using the full screen width
+.govuk-full-width-container {
+  .preview-title {
+    padding-left: govuk-spacing(3);
+  }
+}
+
 // Rouge syntax highlighting
 // Based on https://github.com/alphagov/tech-docs-template/blob/master/template/source/stylesheets/palette/_syntax-highlighting.scss
 

--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -121,10 +121,12 @@ $gem-guide-border-width: 1px;
 
   &.dark-background {
     background-color: govuk-colour("blue");
+    padding: govuk-spacing(3);
   }
 
   &.black-background {
     background-color: govuk-colour("black");
+    padding: govuk-spacing(3);
   }
 
   &.component-output {

--- a/app/models/govuk_publishing_components/component_doc.rb
+++ b/app/models/govuk_publishing_components/component_doc.rb
@@ -54,8 +54,16 @@ module GovukPublishingComponents
       component[:display_preview].nil? || component[:display_preview]
     end
 
+    def capture_full_width_screenshot?
+      component[:capture_full_width_screenshot]
+    end
+
     def uses_component_wrapper_helper?
       component[:uses_component_wrapper_helper]
+    end
+
+    def get_govuk_container_class
+      capture_full_width_screenshot? ? "govuk-full-width-container" : "govuk-width-container"
     end
 
     def html_body

--- a/app/views/govuk_publishing_components/components/docs/cross_service_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/cross_service_header.yml
@@ -18,6 +18,7 @@ body: |
   The header has space to optionally add links to different parts of your service, just as the current ‘service header’ component from the Design System does. Follow the same patterns for internal service navigation links as you do with the Design System service header.
 
   Please refer to the [One Login Service Header GitHub repo](https://github.com/govuk-one-login/service-header) for further information
+capture_full_width_screenshot: true
 shared_accessibility_criteria:
   - link
 accessibility_criteria:

--- a/app/views/govuk_publishing_components/components/docs/layout_footer.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_footer.yml
@@ -3,6 +3,7 @@ description: The footer provides copyright, licensing and other information
 govuk_frontend_components:
   - footer
 uses_component_wrapper_helper: true
+capture_full_width_screenshot: true
 accessibility_criteria: |
   Text and links in the Footer must:
 

--- a/app/views/govuk_publishing_components/components/docs/layout_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_header.yml
@@ -6,6 +6,7 @@ body: |
 govuk_frontend_components:
   - header
 uses_component_wrapper_helper: true
+capture_full_width_screenshot: true
 accessibility_excluded_rules:
   - landmark-banner-is-top-level # The header element can not be top level in the examples
   - duplicate-id # IDs will be duplicated in component examples list
@@ -85,8 +86,6 @@ examples:
       - text: Worldwide
         href: "item-2"
   full_width:
-    description: |
-      This is difficult to preview because the preview windows are constrained, but the header will stretch to the size of its container.
     data:
       environment: production
       full_width: true

--- a/app/views/govuk_publishing_components/components/docs/layout_super_navigation_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_super_navigation_header.yml
@@ -27,6 +27,7 @@ accessibility_excluded_rules:
   - landmark-no-duplicate-banner
   - landmark-unique
 uses_component_wrapper_helper: true
+capture_full_width_screenshot: true
 examples:
   default:
   with_custom_logo_link:

--- a/app/views/govuk_publishing_components/components/docs/service_navigation.yml
+++ b/app/views/govuk_publishing_components/components/docs/service_navigation.yml
@@ -8,6 +8,7 @@ accessibility_excluded_rules:
   - duplicate-id-aria
   - landmark-unique
 uses_component_wrapper_helper: true
+capture_full_width_screenshot: true
 govuk_frontend_components:
   - service-navigation
 shared_accessibility_criteria:
@@ -65,7 +66,6 @@ examples:
         href: "#"
       navigation_aria_label: "Custom label"
   full_width:
-    description: This is difficult to preview because the preview windows are constrained, but nav will stretch to the size of its container. Padding left is added to prevent the first menu item from colliding with the edge of the screen. Right spacing is already provided by the menu items.
     data:
       navigation_items:
       - text: Navigation item 1

--- a/app/views/layouts/govuk_publishing_components/application.html.erb
+++ b/app/views/layouts/govuk_publishing_components/application.html.erb
@@ -1,19 +1,21 @@
 <% content_for :body do %>
   <% if @preview %>
-    <main id="wrapper" class="govuk-width-container">
-      <%= yield %>
-    </main>
+    <%= tag.div id: "wrapper", class: @component_doc.get_govuk_container_class do %>
+      <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+        <%= yield %>
+      </main>
+    <% end %>
   <% else %>
     <%= render "govuk_publishing_components/components/layout_header", {
       environment: GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment,
       product_name: "#{GovukPublishingComponents::Config.component_guide_title} #{GovukPublishingComponents::VERSION}",
       href: component_guide_path
     } %>
-    <div class="govuk-width-container app-width-container--wide">
+    <div id="wrapper" class="govuk-width-container">
       <% if @guide_breadcrumbs %>
         <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: @guide_breadcrumbs  %>
       <% end %>
-      <main id="wrapper" class="govuk-main-wrapper">
+      <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
         <%= yield %>
       </main>
     </div>

--- a/app/views/layouts/govuk_publishing_components/application.html.erb
+++ b/app/views/layouts/govuk_publishing_components/application.html.erb
@@ -45,7 +45,7 @@
     <%= render_component_stylesheets %>
     <%= yield :extra_headers %>
   </head>
-  <body class="gem-c-layout-for-admin govuk-template__body <%= 'hide-header-and-footer' if @preview %>">
+  <body class="gem-c-layout-for-admin govuk-template__body">
     <%= javascript_tag nonce: true do -%>
       document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');
     <% end -%>

--- a/docs/testing-components.md
+++ b/docs/testing-components.md
@@ -72,6 +72,12 @@ Visual regression tests are run on each pull request using a third-party tool ca
 
 The screenshots are public, so they can be checked without logging in. A BrowserStack account is needed to approve or reject any changes. It's the responsibility of the person reviewing the pull request code to approve any visual changes that Percy highlights.
 
+If you want to capture full width screenshots for a component, add the flag below to the component documentation YAML file.
+
+```yml
+capture_full_width_screenshot: true
+```
+
 Relevant Percy setup documentation:
 
 - [Using Percy with Rails and Capybara](https://docs.percy.io/docs/capybara)

--- a/spec/component_guide/audit_applications_spec.rb
+++ b/spec/component_guide/audit_applications_spec.rb
@@ -99,6 +99,13 @@ describe "Auditing the components in applications" do
             template_link: "https://github.com/alphagov/app-dir/blob/main/app/views/components/_test_component.html.erb",
           },
           {
+            name: "test component using full page width",
+            application: "app-dir",
+            template_exists: true,
+            template_lines: 4,
+            template_link: "https://github.com/alphagov/app-dir/blob/main/app/views/components/_test_component_using_full_page_width.html.erb",
+          },
+          {
             name: "test component using wrapper",
             application: "app-dir",
             template_exists: true,
@@ -196,7 +203,7 @@ describe "Auditing the components in applications" do
           javascript_test: 0,
           print_stylesheet: 0,
           stylesheet: 1,
-          template: 15,
+          template: 16,
           test: 0,
           uses_govuk_frontend_css: 0,
           uses_govuk_frontend_js: 0,

--- a/spec/component_guide/component_preview_spec.rb
+++ b/spec/component_guide/component_preview_spec.rb
@@ -4,6 +4,7 @@ describe "Component preview", :capybara do
   it "shows all component examples on a page without header or footer" do
     visit "/component-guide/test_component_with_params/preview"
     expect(page).to have_selector(".govuk-template--rebranded")
+    expect(page).to have_selector(".govuk-width-container")
 
     expect(page).not_to have_selector("body > header")
     expect(page).not_to have_selector("body > footer")
@@ -18,12 +19,26 @@ describe "Component preview", :capybara do
   it "shows a specific example on a page without header or footer" do
     visit "/component-guide/test_component_with_params/another_example/preview"
     expect(page).to have_selector(".govuk-template--rebranded")
+    expect(page).to have_selector(".govuk-width-container")
 
     expect(page).not_to have_selector("body > header")
     expect(page).not_to have_selector("body > footer")
 
     expect(page).to have_no_selector(".component-guide-preview-page .preview-title")
     expect(page).to have_selector(".component-guide-preview-page .test-component-with-params", text: "A different value")
+    expect(page).to have_selector('.component-guide-preview-page [data-module="test-a11y"]')
+  end
+
+  it "shows all component examples using the full page width without header or footer" do
+    visit "/component-guide/test_component_using_full_page_width/preview"
+    expect(page).to have_selector(".govuk-template--rebranded")
+    expect(page).to have_selector(".govuk-full-width-container")
+
+    expect(page).not_to have_selector("body > header")
+    expect(page).not_to have_selector("body > footer")
+
+    expect(page).to have_no_selector(".component-guide-preview-page .preview-title")
+    expect(page).to have_selector(".component-guide-preview-page .test-component-full-width", text: "Preview example uses the full page width")
     expect(page).to have_selector('.component-guide-preview-page [data-module="test-a11y"]')
   end
 end

--- a/spec/component_guide/component_preview_spec.rb
+++ b/spec/component_guide/component_preview_spec.rb
@@ -4,9 +4,9 @@ describe "Component preview", :capybara do
   it "shows all component examples on a page without header or footer" do
     visit "/component-guide/test_component_with_params/preview"
     expect(page).to have_selector(".govuk-template--rebranded")
-    expect(page).to have_selector(".hide-header-and-footer")
-    expect(page).not_to have_selector("#global-header")
-    expect(page).not_to have_selector("#footer")
+
+    expect(page).not_to have_selector("body > header")
+    expect(page).not_to have_selector("body > footer")
 
     expect(page).to have_selector(".component-guide-preview-page .preview-title", text: "Default")
     expect(page).to have_selector(".component-guide-preview-page .test-component-with-params", text: "Some value")
@@ -18,9 +18,9 @@ describe "Component preview", :capybara do
   it "shows a specific example on a page without header or footer" do
     visit "/component-guide/test_component_with_params/another_example/preview"
     expect(page).to have_selector(".govuk-template--rebranded")
-    expect(page).to have_selector(".hide-header-and-footer")
-    expect(page).not_to have_selector("#global-header")
-    expect(page).not_to have_selector("#footer")
+
+    expect(page).not_to have_selector("body > header")
+    expect(page).not_to have_selector("body > footer")
 
     expect(page).to have_no_selector(".component-guide-preview-page .preview-title")
     expect(page).to have_selector(".component-guide-preview-page .test-component-with-params", text: "A different value")

--- a/spec/dummy/app/views/components/_test_component_using_full_page_width.html.erb
+++ b/spec/dummy/app/views/components/_test_component_using_full_page_width.html.erb
@@ -1,0 +1,4 @@
+<div class="test-component-full-width">
+  <h1>Test component heading</h1>
+  <p class="test-component-full-width govuk-body">Preview example uses the full page width</p>
+</div>

--- a/spec/dummy/app/views/components/docs/test_component_using_full_page_width.yml
+++ b/spec/dummy/app/views/components/docs/test_component_using_full_page_width.yml
@@ -1,0 +1,6 @@
+name: Test component that uses the full page width
+description: A test component that uses the full page width for the dummy app
+capture_full_width_screenshot: true
+examples:
+  default:
+    data: {}


### PR DESCRIPTION
## What
- Add support for using full width containers on component preview pages
- Update the components below to use full width layout on the preview page
  - layout_super_navigation_header
  - layout_header
  - layout_footer
  - service_navigation
  - cross-service-header
- Update the preview page spacing to ensure the components accurately reflect how they will appear when used in application without any other stying applied

## Why
The main motivation for this change is to fix an issue on the [super navigation component preview page](https://components.publishing.service.gov.uk/component-guide/layout_super_navigation_header/preview) where the logo and menu button appear to overlap as shown in the screenshot below:

<img width="483" height="166" alt="super-nav-overlap" src="https://github.com/user-attachments/assets/2dc4e222-d9d2-445a-ad2f-f810884b8476" />

This can cause unexpected issues in Percy as it is set to take mobile screenshots at a width of `375px` by default - https://www.browserstack.com/docs/percy/references/config-options#all-configuration-options

In the case of the super navigation menu, it has styling in place so that when the available screen width is `360px` or below, the [menu buttons will be smaller](https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss#L206-L209).

At 375px this media query is not applied, but the available width is only `325px` (375px - (20px padding + 30px margin))

Allowing the super navigation menu to take up with full width of the page fixes this issue and ensures the screenshots captured in Percy are accurate, it is also consistent with the approach used in other component guide preview pages.

### Examples where full width previews are used 

#### One Login

- https://govuk-one-login.github.io/service-header/dist/preview-rebranded.html

#### Design System

- https://govuk-frontend-review.herokuapp.com/components/header/preview
- https://govuk-frontend-review.herokuapp.com/components/footer/preview
- https://govuk-frontend-review.herokuapp.com/components/service-navigation/preview

## Visual Changes

Percy is showing visual changes for 89/90 components, the exception being `/public`, this is expected as the layout and styling changes impacts all component preview pages.