### PR TITLE
Version 59.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 59.0.0
 
 * Add Bluesky and Threads logos to share_links component ([PR #4918](https://github.com/alphagov/govuk_publishing_components/pull/4918))
 * Allow skip_account to act based on boolean and string ([PR #4910](https://github.com/alphagov/govuk_publishing_components/pull/4910))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (58.2.0)
+    govuk_publishing_components (59.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "58.2.0".freeze
+  VERSION = "59.0.0".freeze
 end


### PR DESCRIPTION
## 59.0.0

* Add Bluesky and Threads logos to share_links component ([PR #4918](https://github.com/alphagov/govuk_publishing_components/pull/4918))
* Allow skip_account to act based on boolean and string ([PR #4910](https://github.com/alphagov/govuk_publishing_components/pull/4910))
* Make heading sizes match govuk-frontend ([PR #4620](https://github.com/alphagov/govuk_publishing_components/pull/4620))
* **BREAKING:** Introduce tag component ([PR #4914](https://github.com/alphagov/govuk_publishing_components/pull/4914))
* Action link component updates ([PR #4915](https://github.com/alphagov/govuk_publishing_components/pull/4915))
