### PR TITLE
Override the browser default of italics for <address> in govspeak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Change skip_account to only accept a boolean ([PR #](https://github.com/alphagov/govuk_publishing_components/pull/4927))
 * Fix opacity issue on first selected item in choices.js dropdown ([PR #4936](https://github.com/alphagov/govuk_publishing_components/pull/4936))
 * Add `user-id` to `page_view` tracked event ([PR #4935](https://github.com/alphagov/govuk_publishing_components/pull/4935))
+* Override the browser default of italics for <address> in govspeak ([PR #4923](https://github.com/alphagov/govuk_publishing_components/pull/4923))
 
 ## 59.0.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_contact.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_contact.scss
@@ -17,6 +17,11 @@
     margin: 0 0 govuk-spacing(6) 0;
   }
 
+  .address {
+    // Override the browser default of italics for <address>
+    font-style: normal;
+  }
+
   .contact {
     position: relative;
     @include govuk-clearfix;


### PR DESCRIPTION
## What
Override the browser default of italics for `<address>` in govspeak. This impacts addresses on pages like [this one](gov.uk/contact-electoral-registration-office?postcode=SW1A+2AA).

The original rule was removed [here](https://github.com/alphagov/frontend/pull/4632/commits/60fb79436b6e31d7b7d4decf4bd9c7814fe8e17c). 

I discussed making this change with Keith who confirmed that just targeting the class `.govspeak .address` is correct, even though the removed the CSS rule targeted the `<address>` element. 

(Next steps: right now, govspeak doesn't automatically produce an `<address>` tag, so the change in this PR will only impact pages like the above electoral registration one that have the `<address>` tag manually added - however, the publishing team will amend the govspeak generator so that addresses will in the future get wrapped up in `<address>` too).

## Why
Rendering addresses in italics doesn't comply with the GOV.UK style guide. 

<!-- What are the reasons behind this change being made? -->

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

### Before

<img width="780" height="766" alt="Screenshot 2025-07-23 at 09 23 14" src="https://github.com/user-attachments/assets/50e355fe-e4c2-49cb-93b1-ade5e20f3249" />


### After


<img width="783" height="780" alt="Screenshot 2025-07-23 at 09 33 56" src="https://github.com/user-attachments/assets/137741c2-692c-405c-ac42-a466654476cf" />

Fixes https://trello.com/c/Q6IkUo0R/3588-contact-electoral-registration-office-pages-address-formatted-in-italic
