### PR TITLE
Fix broken background colour on `select-with-search` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix broken background colour on Select with Search component ([PR #4924](https://github.com/alphagov/govuk_publishing_components/pull/4924))
+
 ## 59.0.0
 
 * Add Bluesky and Threads logos to share_links component ([PR #4918](https://github.com/alphagov/govuk_publishing_components/pull/4918))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_select-with-search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_select-with-search.scss
@@ -1,5 +1,7 @@
 // overload the choices.js variables
 
+@import "govuk_publishing_components/individual_component_support";
+
 $font-size: 19px;
 
 $choices-bg-color: govuk-colour("white") !default;
@@ -14,7 +16,6 @@ $choices-border-radius-item: 0 !default;
 $choices-z-index: 2 !default;
 $choices-button-dimension: 12px !default;
 
-@import "govuk_publishing_components/individual_component_support";
 @import "mixins/prefixed-transform";
 @import "govuk/components/label/label";
 @import "choices.js/src/styles/choices";


### PR DESCRIPTION
## What
Fix the background colour of the `search-with-select` component so that it always renders in white.

## Why
In Specialist Publisher the `select-with-search` component sometimes appears on a grey background. Due to the missing white background, the component rendered with a transparent background allowing the grey to show through.

This was due to a Sass compilation error leaving the Sass declaration in the compiled CSS, thus generating an invalid rule:

<img width="444" alt="image" src="https://github.com/user-attachments/assets/3b7b0e16-47e2-4b8b-8ec2-9ffefc318877" />

## Visual Changes

| Before | After |
| --- | ----------- |
| <img width="766" height="205" alt="image" src="https://github.com/user-attachments/assets/34566f86-f3f3-4214-be33-00f6c6db1c25" /> | <img width="766" height="205" alt="image" src="https://github.com/user-attachments/assets/f737d556-3148-43e2-bd60-b391da84f8b0" /> |
