### PR TITLE
Change skip_account to only accept a boolean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Change skip_account to only accept a boolean ([PR #](https://github.com/alphagov/govuk_publishing_components/pull/4927))
+
 ## 59.0.1
 
 * Fix broken background colour on Select with Search component ([PR #4924](https://github.com/alphagov/govuk_publishing_components/pull/4924))

--- a/lib/govuk_publishing_components/presenters/single_page_notification_button_helper.rb
+++ b/lib/govuk_publishing_components/presenters/single_page_notification_button_helper.rb
@@ -64,7 +64,7 @@ module GovukPublishingComponents
       end
 
       def skip_the_gov_uk_account?
-        @skip_account == "true" || @skip_account == true
+        @skip_account == true
       end
     end
   end

--- a/spec/components/single_page_notification_button_spec.rb
+++ b/spec/components/single_page_notification_button_spec.rb
@@ -74,7 +74,7 @@ describe "Single page notification button", type: :view do
   it "sets a form action of '/email-signup' and adds a hidden link param if skip_account is 'true'" do
     local_assigns = {
       base_path: "/the-current-page",
-      skip_account: "true",
+      skip_account: true,
     }
     render_component(local_assigns)
     assert_select "form[action='/email-signup']"

--- a/spec/lib/govuk_publishing_components/presenters/single_page_notification_button_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/single_page_notification_button_helper_spec.rb
@@ -52,11 +52,6 @@ RSpec.describe GovukPublishingComponents::Presenters::SinglePageNotificationButt
       expect(single_helper.skip_account_param).to eq("single_page_subscription")
     end
 
-    it "sets skip_account when skip_account is a string value of true" do
-      single_helper = described_class.new(skip_account: "true")
-      expect(single_helper.skip_the_gov_uk_account?).to be(true)
-    end
-
     it "sets skip_account when skip_account is a boolean value of true" do
       single_helper = described_class.new(skip_account: true)
       expect(single_helper.skip_the_gov_uk_account?).to be(true)
@@ -68,7 +63,7 @@ RSpec.describe GovukPublishingComponents::Presenters::SinglePageNotificationButt
     end
 
     it "doesn't set skip_account with an invalid value" do
-      single_helper = described_class.new(skip_account: "moo")
+      single_helper = described_class.new(skip_account: "true")
       expect(single_helper.skip_the_gov_uk_account?).to be(false)
     end
   end


### PR DESCRIPTION
## What / why
- following on from the work in https://github.com/alphagov/govuk_publishing_components/pull/4910 to allow the single page notification button component to allow a boolean true as well as a string true, now remove the ability for it to recognise a string true for the skip_account option
- skip_account should only be a boolean true, not a string "true"

## Visual Changes
None.

Trello card: https://trello.com/c/LTS5YNJS/725-fix-skipaccount-handling-in-components-gem