### PR TITLE
[WHIT-2318] Fix opacity issue on first selected item in choices.js dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Change skip_account to only accept a boolean ([PR #](https://github.com/alphagov/govuk_publishing_components/pull/4927))
+* Fix opacity issue on first selected item in choices.js dropdown ([PR #4936](https://github.com/alphagov/govuk_publishing_components/pull/4936))
 
 ## 59.0.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_select-with-search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_select-with-search.scss
@@ -27,6 +27,10 @@ $choices-button-dimension: 12px !default;
     font-family: $govuk-font-family;
   }
 
+  .choices[data-type="select-one"] .choices__list--dropdown .choices__list .choices__placeholder {
+    opacity: 1;
+  }
+
   .choices[data-type*="select-one"]::after {
     @include govuk-shape-arrow($direction: down, $base: 10px, $display: inline-block);
     @include prefixed-transform($translateY: -50%);


### PR DESCRIPTION
## What
Fix opacity issue on first selected item in choices.js dropdown.

Note that there are some accessibility issues with the repetition of 'Select One' which we will be addressing in a future update. A previous PR attempted an unsuccessful fix: https://github.com/alphagov/govuk_publishing_components/pull/4921

## Why
The first item in a "select one" variant of the `select-with-search` component is ghosted out due to inheriting the 50% opacity of the placeholder item.

## Visual Changes
| Before | After |
| --- | ----------- |
| <img alt="" src="https://github.com/user-attachments/assets/ca5ab006-122c-4b13-a31f-9f54ee8c9322" /> | <img alt="" src="https://github.com/user-attachments/assets/82d9e087-a8e0-4882-8f36-ef08b9d0c467" /> |

