### PR TITLE
Add spaces to phone number PII redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add spaces to phone number PII redaction ([PR #4937](https://github.com/alphagov/govuk_publishing_components/pull/4937))
+
 ## 59.1.0
 
 * Change skip_account to only accept a boolean ([PR #4927](https://github.com/alphagov/govuk_publishing_components/pull/4927))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.js
@@ -36,10 +36,12 @@
   // e.g. 'AB123456A', 'AB 12 34 56 A', 'ab 123456 a', 'ab 12 34 56 a', 'AB+12+34+56+A'
   var NATIONAL_INSURANCE_NUMBER = /[A-CEGHJ-OPR-TW-Z]{2}(\s+|\++)?(\d{2}(\s+|\++)?){3}[A-D]/gi
 
-  var UK_MOBILE_NUMBER = /07\d{9}/g
-  var UK_MOBILE_NUMBER_INTERNATIONAL = /\+447\d{9}/g
-  var UK_LANDLINE_NUMBER = /0[1246]\d{8,9}/g
-  var UK_LANDLINE_NUMBER_INTERNATIONAL = /\+44[1246]\d{8,9}/g
+  var UK_MOBILE_NUMBER = /07\d{3}\s?\d{6}/g // 07123 123456 or 07123123456
+  var UK_MOBILE_NUMBER_INTERNATIONAL = /\+447\d{3}\s?\d{6}/g // +447123 123456 or +447123123456
+  var UK_LANDLINE_NUMBER = /0[1246]\d{1}\s?\d{3,4}\s?\d{4}/g // 020 123 1234 or 020 1234 1234 or 0201231234 or 02012341234
+  var UK_LANDLINE_NUMBER_2 = /0[1246]\d{3}\s\d{6}/g // 02123 123456
+  var UK_LANDLINE_NUMBER_INTERNATIONAL = /\+44[1246]\d{1}\s?\d{3,4}\s?\d{4}/g // +4420 123 1234 or +4420 1234 1234
+  var UK_LANDLINE_NUMBER_INTERNATIONAL_2 = /\+44[1246]\d{3}\s\d{6}/g // +442123 123456
 
   function shouldStripDates () {
     var metas = document.querySelectorAll('meta[name="govuk:ga4-strip-dates"]')
@@ -115,7 +117,9 @@
     stripped = stripped.replace(VISA_PATTERN_GB, '[gb eori number]')
     stripped = stripped.replace(NATIONAL_INSURANCE_NUMBER, '[ni number]')
     stripped = stripped.replace(UK_LANDLINE_NUMBER, '[phone number]')
+    stripped = stripped.replace(UK_LANDLINE_NUMBER_2, '[phone number]')
     stripped = stripped.replace(UK_LANDLINE_NUMBER_INTERNATIONAL, '[phone number]')
+    stripped = stripped.replace(UK_LANDLINE_NUMBER_INTERNATIONAL_2, '[phone number]')
     stripped = stripped.replace(UK_MOBILE_NUMBER, '[phone number]')
     stripped = stripped.replace(UK_MOBILE_NUMBER_INTERNATIONAL, '[phone number]')
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.spec.js
@@ -320,9 +320,25 @@ describe('GOVUK.analyticsGa4.PIIRemover', function () {
     })
   })
 
-  function generatePhoneNumber (prefix, amount, suffix = '') {
+  const spaceIndexes = {
+    UK_MOBILE: [5],
+    UK_MOBILE_INTERNATIONAL: [7],
+    UK_LANDLINE_1: [3, 6],
+    UK_LANDLINE_2: [3, 7],
+    UK_LANDLINE_3: [5],
+    UK_LANDLINE_INTERNATIONAL_1: [5, 9],
+    UK_LANDLINE_INTERNATIONAL_2: [5, 8],
+    UK_LANDLINE_INTERNATIONAL_3: [7]
+  }
+
+  function generatePhoneNumber (prefix, amount, suffix = '', spaceData = []) {
     var phoneNumber = prefix
     for (var i = 0; i < amount; i++) {
+      // If current string index position is listed in the 'spaceData' array, insert a space into the string.
+      if (spaceData.indexOf(prefix.length + i) !== -1) {
+        phoneNumber += ' '
+      }
+
       phoneNumber += Math.floor(Math.random() * 10)
     }
     return `${phoneNumber}${suffix}`
@@ -338,10 +354,28 @@ describe('GOVUK.analyticsGa4.PIIRemover', function () {
       }
     })
 
+    it('are stripped if they are valid UK mobile numbers with spacing', function () {
+      // Test 50 random phone numbers so we aren't storing any numbers in code.
+      for (let i = 0; i < 50; i++) {
+        const phoneNumber = generatePhoneNumber('07', 9, '', spaceIndexes.UK_MOBILE)
+        const redactedNumber = pii.stripPIIWithOverride(phoneNumber)
+        expect(redactedNumber).toEqual('[phone number]')
+      }
+    })
+
     it('are stripped if they are valid international UK mobile numbers', function () {
       // Test 50 random phone numbers so we aren't storing any numbers in code.
       for (let i = 0; i < 50; i++) {
         const phoneNumber = generatePhoneNumber('+447', 9)
+        const redactedNumber = pii.stripPIIWithOverride(phoneNumber)
+        expect(redactedNumber).toEqual('[phone number]')
+      }
+    })
+
+    it('are stripped if they are valid international UK mobile numbers with spacing', function () {
+      // Test 50 random phone numbers so we aren't storing any numbers in code.
+      for (let i = 0; i < 50; i++) {
+        const phoneNumber = generatePhoneNumber('+447', 9, '', spaceIndexes.UK_MOBILE_INTERNATIONAL)
         const redactedNumber = pii.stripPIIWithOverride(phoneNumber)
         expect(redactedNumber).toEqual('[phone number]')
       }
@@ -367,11 +401,59 @@ describe('GOVUK.analyticsGa4.PIIRemover', function () {
       }
     })
 
+    it('are stripped if they are valid UK landline numbers with spacing', function () {
+      // Test 50 random phone numbers so we aren't storing any numbers in code.
+      for (let i = 0; i < 50; i++) {
+        // A landline can start with 01, 02, 04, or 06, so we generate all 4 examples here.
+        const numbers = [
+          generatePhoneNumber('01', 9, '', spaceIndexes.UK_LANDLINE_2),
+          generatePhoneNumber('02', 9, '', spaceIndexes.UK_LANDLINE_2),
+          generatePhoneNumber('04', 9, '', spaceIndexes.UK_LANDLINE_2),
+          generatePhoneNumber('06', 9, '', spaceIndexes.UK_LANDLINE_2),
+          generatePhoneNumber('01', 8, '', spaceIndexes.UK_LANDLINE_1),
+          generatePhoneNumber('02', 8, '', spaceIndexes.UK_LANDLINE_1),
+          generatePhoneNumber('04', 8, '', spaceIndexes.UK_LANDLINE_1),
+          generatePhoneNumber('06', 8, '', spaceIndexes.UK_LANDLINE_1),
+          generatePhoneNumber('01', 9, '', spaceIndexes.UK_LANDLINE_3),
+          generatePhoneNumber('02', 9, '', spaceIndexes.UK_LANDLINE_3),
+          generatePhoneNumber('04', 9, '', spaceIndexes.UK_LANDLINE_3),
+          generatePhoneNumber('06', 9, '', spaceIndexes.UK_LANDLINE_3)]
+        for (const number of numbers) {
+          const redactedNumber = pii.stripPIIWithOverride(number)
+          expect(redactedNumber).toEqual('[phone number]')
+        }
+      }
+    })
+
     it('are stripped if they are valid international UK landline numbers', function () {
       // Test 50 random phone numbers so we aren't storing any numbers in code.
       for (let i = 0; i < 50; i++) {
         // A landline can start with 01, 02, 04, or 06, so we generate all 4 examples here.
         const numbers = [generatePhoneNumber('+441', 9), generatePhoneNumber('+442', 9), generatePhoneNumber('+444', 9), generatePhoneNumber('+446', 9)]
+        for (const number of numbers) {
+          const redactedNumber = pii.stripPIIWithOverride(number)
+          expect(redactedNumber).toEqual('[phone number]')
+        }
+      }
+    })
+
+    it('are stripped if they are valid international UK landline numbers with spacing', function () {
+      // Test 50 random phone numbers so we aren't storing any numbers in code.
+      for (let i = 0; i < 50; i++) {
+        // A landline can start with 01, 02, 04, or 06, so we generate all 4 examples here.
+        const numbers = [
+          generatePhoneNumber('+441', 9, '', spaceIndexes.UK_LANDLINE_INTERNATIONAL_1),
+          generatePhoneNumber('+442', 9, '', spaceIndexes.UK_LANDLINE_INTERNATIONAL_1),
+          generatePhoneNumber('+444', 9, '', spaceIndexes.UK_LANDLINE_INTERNATIONAL_1),
+          generatePhoneNumber('+446', 9, '', spaceIndexes.UK_LANDLINE_INTERNATIONAL_1),
+          generatePhoneNumber('+441', 8, '', spaceIndexes.UK_LANDLINE_INTERNATIONAL_2),
+          generatePhoneNumber('+442', 8, '', spaceIndexes.UK_LANDLINE_INTERNATIONAL_2),
+          generatePhoneNumber('+444', 8, '', spaceIndexes.UK_LANDLINE_INTERNATIONAL_2),
+          generatePhoneNumber('+446', 8, '', spaceIndexes.UK_LANDLINE_INTERNATIONAL_2),
+          generatePhoneNumber('+441', 9, '', spaceIndexes.UK_LANDLINE_INTERNATIONAL_3),
+          generatePhoneNumber('+442', 9, '', spaceIndexes.UK_LANDLINE_INTERNATIONAL_3),
+          generatePhoneNumber('+444', 9, '', spaceIndexes.UK_LANDLINE_INTERNATIONAL_3),
+          generatePhoneNumber('+446', 9, '', spaceIndexes.UK_LANDLINE_INTERNATIONAL_3)]
         for (const number of numbers) {
           const redactedNumber = pii.stripPIIWithOverride(number)
           expect(redactedNumber).toEqual('[phone number]')


### PR DESCRIPTION
## What / Why
<!-- What are the reasons behind this change being made? -->
- Adds optional spaces to the regex that is detecting phone numbers in the GA4 PII
- On the [trello card](https://trello.com/c/V7q79XLH) the initial examples provided did not imply they wanted spaces redacted. However when they tested the change they were using spaces in the phone numbers. Therefore we need to add spaces to meet their requirements.
- It was easier to create new regex lines as trying to combine these extra cases into a fancy one liner caused the tests to fail and caused false positives in a way that was hard to diagnose.
- I had to make the phone number generation in the tests a bit more complex as well to account for spaces being in the test cases.

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
