### PR TITLE
Tidy up by removing redundant omit_footer_border

### DIFF
--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -16,7 +16,6 @@
   service_navigation_items ||= []
   omit_feedback_form ||= false
   omit_footer_navigation ||= false
-  omit_footer_border ||= false
   omit_header ||= false
   product_name ||= nil
   service_name ||= nil


### PR DESCRIPTION
## What
Remove the redundant `omit_footer_border` variable definition from the public layout.

I think it's best not to merge this until the PRs that remove setting this option have been merged:
- [static](https://github.com/alphagov/static/pull/3720)
- [email-alert-frontend](https://github.com/alphagov/email-alert-frontend/pull/2080) 

<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
The actual functionality was removed from govuk_publishing_components in v58.0.0 in [this commit](https://github.com/alphagov/govuk_publishing_components/commit/167b5a5dfdef603f0dceb06e80d9630874b4625b). 

This is just to tidy up post v58.0.0 going out.

Fixes https://trello.com/c/hh3oU8IX/3608-remove-omitfooterborder-option-from-gem-and-various-apps-that-pass-this-option