### PR TITLE
Version 59.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 59.1.0
 
-* Change skip_account to only accept a boolean ([PR #](https://github.com/alphagov/govuk_publishing_components/pull/4927))
+* Change skip_account to only accept a boolean ([PR #4927](https://github.com/alphagov/govuk_publishing_components/pull/4927))
 * Fix opacity issue on first selected item in choices.js dropdown ([PR #4936](https://github.com/alphagov/govuk_publishing_components/pull/4936))
 * Add `user-id` to `page_view` tracked event ([PR #4935](https://github.com/alphagov/govuk_publishing_components/pull/4935))
 * Override the browser default of italics for <address> in govspeak ([PR #4923](https://github.com/alphagov/govuk_publishing_components/pull/4923))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (59.0.1)
+    govuk_publishing_components (59.1.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "59.0.1".freeze
+  VERSION = "59.1.0".freeze
 end


### PR DESCRIPTION
## 59.1.0

* Change skip_account to only accept a boolean ([PR #4927](https://github.com/alphagov/govuk_publishing_components/pull/4927))
* Fix opacity issue on first selected item in choices.js dropdown ([PR #4936](https://github.com/alphagov/govuk_publishing_components/pull/4936))
* Add `user-id` to `page_view` tracked event ([PR #4935](https://github.com/alphagov/govuk_publishing_components/pull/4935))
* Override the browser default of italics for <address> in govspeak ([PR #4923](https://github.com/alphagov/govuk_publishing_components/pull/4923))
* Update LUX to 4.2.0 ([PR #4945](https://github.com/alphagov/govuk_publishing_components/pull/4945))
* GA4FormTracker fixes to form_response ([PR #4944](https://github.com/alphagov/govuk_publishing_components/pull/4944))