### PR TITLE
Split long `text` for `Ga4FormTracker` submit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Split long text for `Ga4FormTracker` submit ([PR #4950](https://github.com/alphagov/govuk_publishing_components/pull/4950))
+
 ## 59.2.1
 
 * Add special characters to GA4 phone number PII redaction ([PR #4955](https://github.com/alphagov/govuk_publishing_components/pull/4955))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
@@ -10,6 +10,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.includeTextInputValues = this.module.hasAttribute('data-ga4-form-include-text')
     this.recordJson = this.module.hasAttribute('data-ga4-form-record-json')
     this.useTextCount = this.module.hasAttribute('data-ga4-form-use-text-count')
+    this.splitText = this.module.hasAttribute('data-ga4-form-split-response-text')
     this.redacted = false
     this.useFallbackValue = this.module.hasAttribute('data-ga4-form-no-answer-undefined') ? undefined : 'No answer given'
   }
@@ -52,8 +53,26 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       if (data.action === 'search' && data.text) {
         data.text = window.GOVUK.analyticsGa4.core.trackFunctions.standardiseSearchTerm(data.text)
       }
+
+      if (data.text && this.splitText) {
+        data = this.splitFormResponseText(data)
+      }
+
       window.GOVUK.analyticsGa4.core.applySchemaAndSendData(data, 'event_data')
     }
+  }
+
+  Ga4FormTracker.prototype.splitFormResponseText = function (data) {
+    var text = data.text
+    var dimensions = Math.min(Math.ceil(data.text.length / 500), 5)
+
+    data.text = text.slice(0, 500)
+
+    for (var i = 1; i < dimensions; i++) {
+      data['text_' + (i + 1)] = text.slice(i * 500, i * 500 + 500)
+    }
+
+    return data
   }
 
   Ga4FormTracker.prototype.getFormInputs = function () {

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.js
@@ -16,6 +16,10 @@
         type: this.undefined,
         url: this.undefined,
         text: this.undefined,
+        text_2: this.undefined,
+        text_3: this.undefined,
+        text_4: this.undefined,
+        text_5: this.undefined,
         index: {
           index_link: this.undefined,
           index_section: this.undefined,

--- a/docs/analytics-ga4/trackers/ga4-form-tracker.md
+++ b/docs/analytics-ga4/trackers/ga4-form-tracker.md
@@ -50,3 +50,20 @@ with `data-ga4-form-record-json` it will be set to:
 ```
 
 When a form is submitted with an empty input value, the tracker will set the `text` value in the dataLayer to `"No answer given"`. If you require empty input to be sent as `undefined` instead, add the `data-ga4-form-no-answer-undefined` attribute to the form.
+
+If the `data-ga4-form-split-response-text` attribute is set on the form then the `text` value in the dataLayer will be split into 5 fields to overcome the GA4 500 character limit:
+
+```
+{
+  'event': 'event_data',
+  'event_data': {
+    'event_name': 'form_response',
+    'type': 'smart answer',
+    'tool_name': 'How do I eat more healthily?',
+    'section': 'What are your favourite puddings?',
+    'text': '500 character long text',
+    'text_2': 'More characters after the 500',
+    'action': 'Continue'
+  }
+}
+```

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.spec.js
@@ -20,6 +20,10 @@ describe('Google Analytics schemas', function () {
         type: 'test_type',
         url: undefined,
         text: undefined,
+        text_2: this.undefined,
+        text_3: this.undefined,
+        text_4: this.undefined,
+        text_5: this.undefined,
         index: {
           index_link: undefined,
           index_section: undefined,
@@ -59,6 +63,10 @@ describe('Google Analytics schemas', function () {
         type: undefined,
         url: undefined,
         text: undefined,
+        text_2: this.undefined,
+        text_3: this.undefined,
+        text_4: this.undefined,
+        text_5: this.undefined,
         index: {
           index_link: '3',
           index_section: '1',
@@ -98,6 +106,10 @@ describe('Google Analytics schemas', function () {
         type: undefined,
         url: undefined,
         text: undefined,
+        text_2: this.undefined,
+        text_3: this.undefined,
+        text_4: this.undefined,
+        text_5: this.undefined,
         index: {
           index_link: '1',
           index_section: undefined,
@@ -138,6 +150,10 @@ describe('Google Analytics schemas', function () {
         type: undefined,
         url: undefined,
         text: undefined,
+        text_2: this.undefined,
+        text_3: this.undefined,
+        text_4: this.undefined,
+        text_5: this.undefined,
         index: {
           index_link: '1',
           index_section: undefined,


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
Add optional text splitting functionality to `Ga4FormTracker` if `data-ga4-form-split-response-text` present on `module`
  - Add `this.splitText`, `this.splitFormResponseText` to `Ga4FormTracker`
  - `Ga4FormTracker` splits `text` into up to five attributes `text_n` if `text` is over 500 characters
  - Add `text_2`, `text_3`, `text_4`, `text_5` to `Schemas`

## Why

Requested change from Publishing PAs. Form responses can be significantly longer in Whitehall, so this is to ensure that the entire response is captured.