### PR TITLE
Fix miscellaneous sass compilation warnings

### DIFF
--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -1,5 +1,5 @@
 // This file contains the styles for the Component Guide.
-
+@use "sass:color";
 @import "govuk_publishing_components/govuk_frontend_support";
 @import "govuk_publishing_components/component_support";
 
@@ -267,10 +267,10 @@ html {
 // Rouge syntax highlighting
 // Based on https://github.com/alphagov/tech-docs-template/blob/master/template/source/stylesheets/palette/_syntax-highlighting.scss
 
-$code-00: scale-color(govuk-colour("light-grey"), $lightness: 50%); // Default Background
+$code-00: color.scale(govuk-colour("light-grey"), $lightness: 50%); // Default Background
 $code-01: #f5f5f5; // Lighter Background (Unused)
 $code-02: #bfc1c3; // Selection Background
-$code-03: darken($govuk-secondary-text-colour, 2%); // Comments, Invisibles, Line Highlighting
+$code-03: color.adjust($govuk-secondary-text-colour, $lightness: -2%); // Comments, Invisibles, Line Highlighting
 $code-04: #e8e8e8; // Dark Foreground (Unused)
 $code-05: $govuk-text-colour; // Default Foreground, Caret, Delimiters, Operators
 $code-06: #ffffff; // Light Foreground (Unused)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
@@ -77,8 +77,8 @@ $thumbnail-icon-border-colour: govuk-colour("mid-grey");
 .govspeak,
 .gem-c-govspeak {
   .gem-c-attachment__title {
-    @include govuk-font($size: 27, $weight: regular);
     margin: 0 0 govuk-spacing(3) 0;
+    @include govuk-font($size: 27, $weight: regular);
   }
 
   .gem-c-attachment__metadata {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -286,9 +286,9 @@ $search-icon-height: 20px;
   }
 
   @include focus-and-focus-visible {
+    // this declaration overrides govuk-focused-text but the compiler prefers @include to be last
+    box-shadow: none !important; // stylelint-disable-line declaration-no-important
     @include govuk-focused-text;
-
-    box-shadow: none;
 
     &::after {
       background-color: govuk-colour("black");
@@ -366,8 +366,9 @@ $search-icon-height: 20px;
 // Styles the "Menu" open state
 .gem-c-layout-super-navigation-header__navigation-top-toggle-button.gem-c-layout-super-navigation-header__open-button {
   @include focus-and-focus-visible {
+    // this declaration overrides govuk-focused-text because the compiler prefers @include to be last
+    box-shadow: none !important; // stylelint-disable-line declaration-no-important
     @include govuk-focused-text;
-    box-shadow: none;
 
     &::after {
       background-color: govuk-colour("black");
@@ -435,11 +436,11 @@ $search-icon-height: 20px;
   }
 
   @include focus-and-focus-visible {
-    @include govuk-focused-text;
-
-    border-color: $govuk-focus-colour;
-    box-shadow: none;
     z-index: 11;
+    // these declarations override govuk-focused-text because the compiler prefers @include to be last
+    border-color: $govuk-focus-colour !important; // stylelint-disable-line declaration-no-important
+    box-shadow: none !important; // stylelint-disable-line declaration-no-important
+    @include govuk-focused-text;
 
     &::after {
       background: govuk-colour("black");
@@ -481,9 +482,10 @@ $search-icon-height: 20px;
     color: govuk-colour("blue");
 
     @include focus-and-focus-visible {
+      // these declarations override govuk-focused-text because the compiler prefers @include to be last
+      border-color: $govuk-focus-colour !important; // stylelint-disable-line declaration-no-important
+      box-shadow: none !important; // stylelint-disable-line declaration-no-important
       @include govuk-focused-text;
-      border-color: $govuk-focus-colour;
-      box-shadow: none;
 
       &::after {
         background: govuk-colour("black");

--- a/app/assets/stylesheets/govuk_publishing_components/components/_modal-dialogue.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_modal-dialogue.scss
@@ -140,11 +140,10 @@ $govuk-modal-wide-breakpoint: $govuk-page-width + $govuk-modal-margin * 2 + $gov
 
   &:focus,
   &:hover {
-    @include govuk-focused-text;
-
     outline: none;
     box-shadow: none;
     color: govuk-colour("black");
     background: $govuk-focus-colour;
+    @include govuk-focused-text;
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_print-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_print-link.scss
@@ -49,8 +49,8 @@ $gem-c-print-link-background-height: 18px;
   margin: govuk-spacing(0);
 
   &:focus {
-    @include govuk-focused-text;
     background-color: $govuk-focus-colour;
     border-color: transparent;
+    @include govuk-focused-text;
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -1,3 +1,4 @@
+@use "sass:color";
 @import "govuk_publishing_components/individual_component_support";
 
 $input-size: 40px;
@@ -206,7 +207,7 @@ $search-submit-button-hover-colour: $govuk-blue-tint-95;
     color: govuk-colour("white");
 
     &:hover {
-      background-color: lighten(govuk-colour("blue"), 5%);
+      background-color: color.adjust(govuk-colour("blue"), $lightness: 5%);
     }
   }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_secondary-navigation.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_secondary-navigation.scss
@@ -62,11 +62,10 @@
   }
 
   .gem-c-secondary-navigation__list-item-link:focus {
-    @include govuk-focused-text;
-
     border-color: $govuk-focus-text-colour;
     border-left-color: transparent;
     position: relative;
+    @include govuk-focused-text;
 
     @include govuk-media-query($from: tablet) {
       box-shadow: none;
@@ -82,10 +81,9 @@
   }
 
   .gem-c-secondary-navigation__list-item-link:focus {
-    @include govuk-focused-text;
-
     border-color: $govuk-focus-text-colour;
     border-left-color: transparent;
+    @include govuk-focused-text;
 
     @include govuk-media-query($from: tablet) {
       box-shadow: none;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_single-page-notification-button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_single-page-notification-button.scss
@@ -9,10 +9,8 @@
   background: none;
 
   &:focus {
-    @include govuk-focused-text;
-    background-color: $govuk-focus-colour;
     border-color: transparent;
-    box-shadow: 0 $govuk-focus-width $govuk-text-colour;
+    @include govuk-focused-text;
   }
 
   &:hover {
@@ -21,6 +19,7 @@
 
     &:focus {
       color: $govuk-text-colour;
+      box-shadow: 0 $govuk-focus-width $govuk-text-colour;
     }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_charts.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_charts.scss
@@ -296,9 +296,9 @@
     }
 
     &:focus {
-      @include govuk-focused-text;
       background-color: $govuk-focus-colour;
       border-color: transparent;
+      @include govuk-focused-text;
     }
   }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/mixins/_grid-helper.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/mixins/_grid-helper.scss
@@ -1,3 +1,7 @@
+@use "sass:list";
+@use "sass:string";
+@use "sass:math";
+
 /// Set grid row or column value using the fraction unit.
 ///
 /// @param {Integer} $number - number of fractions that the grid row or column
@@ -16,7 +20,7 @@
     $fractions: $fractions + " 1fr";
   }
 
-  @return unquote($fractions);
+  @return string.unquote($fractions);
 }
 
 /// Arrange items into columns
@@ -48,7 +52,7 @@
 ///  }
 ///
 @mixin columns($items, $columns, $selector: "*", $flow: row) {
-  $rows: ceil(calc($items / $columns));
+  $rows: math.ceil(calc($items / $columns));
 
   display: -ms-grid;
   display: grid;
@@ -73,19 +77,19 @@
 
         // stylelint-disable max-nesting-depth
         @if $counter <= $items {
-          $this-row: append($this-row, $counter);
+          $this-row: list.append($this-row, $counter);
         }
         // stylelint-enable max-nesting-depth
       }
 
-      $grid: append($grid, $this-row, "comma");
+      $grid: list.append($grid, $this-row, "comma");
     }
 
-    @for $row-count from 1 through length($grid) {
-      $this-column: nth($grid, $row-count);
+    @for $row-count from 1 through list.length($grid) {
+      $this-column: list.nth($grid, $row-count);
 
-      @for $item-index from 1 through length($this-column) {
-        $this-item: nth($this-column, $item-index);
+      @for $item-index from 1 through list.length($this-column) {
+        $this-item: list.nth($this-column, $item-index);
 
         & > #{$selector}:nth-child(#{$this-item}) {
           -ms-grid-column: $item-index;
@@ -113,23 +117,23 @@
 
         // stylelint-disable max-nesting-depth
         @if $counter <= $items {
-          $this-row: append($this-row, $counter);
+          $this-row: list.append($this-row, $counter);
         }
         // stylelint-enable max-nesting-depth
       }
 
-      $grid: append($grid, $this-row, "comma");
+      $grid: list.append($grid, $this-row, "comma");
     }
 
     // Now we can loop through the list of lists to create the rules needed for
     // the older grid syntax; fist looping through the list to get the number
     // needed for the column, then looping again to get the number for the grid
     // row:
-    @for $column_index from 1 through length($grid) {
-      $this-row: nth($grid, $column_index);
+    @for $column_index from 1 through list.length($grid) {
+      $this-row: list.nth($grid, $column_index);
 
-      @for $item-index from 1 through length($this-row) {
-        $this-item: nth($this-row, $item-index);
+      @for $item-index from 1 through list.length($this-row) {
+        $this-item: list.nth($this-row, $item-index);
 
         & > #{$selector}:nth-child(#{$this-item}) {
           -ms-grid-column: $column_index;


### PR DESCRIPTION
## What
- updates some outdated syntax for colour adjustment
- declarations like `@include` have to come after other lines, otherwise the compiler complains

Moving some of these rules around caused a little bit of breakage when for some elements when focussed and hovered, should be correct now, but worth checking those states when reviewing.

## Why
Issues found as part of https://github.com/alphagov/govuk_publishing_components/pull/4931 but splitting them out into their own PR to get them done quicker.

## Visual Changes
Hopefully none.

Trello card: https://trello.com/c/8vKVSmVz/764-switch-from-import-to-use-in-sass-compilation