### PR TITLE
Remove unused import

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_accordion.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_accordion.scss
@@ -1,5 +1,4 @@
 @import "govuk_publishing_components/individual_component_support";
-@import "mixins/prefixed-transform";
 @import "govuk/components/accordion/accordion";
 
 // Prevent elements inside the button from receiving click events


### PR DESCRIPTION
## What
Remove an import that isn't in use.

## Why
Noticed during work done in https://github.com/alphagov/govuk_publishing_components/pull/4931

## Visual Changes
None.

Trello card: https://trello.com/c/8vKVSmVz/764-switch-from-import-to-use-in-sass-compilation