### PR TITLE
Use a template element to build new fieldsets for the add another component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add special characters to GA4 phone number PII redaction ([PR #4955](https://github.com/alphagov/govuk_publishing_components/pull/4955))
+* Initialise JS modules for newly added fieldset in add another component ([PR #4957](https://github.com/alphagov/govuk_publishing_components/pull/4957))
 
 ## 59.2.0
 

--- a/app/assets/javascripts/govuk_publishing_components/components/add-another.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/add-another.js
@@ -5,7 +5,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   function AddAnother (module) {
     this.module = module
     this.disableGa4 = this.module.dataset.disableGa4
-    this.emptyFieldset = undefined
     this.addAnotherButton = undefined
     this.startIndex = Number(this.module.dataset.ga4StartIndex) || 1
     this.indexSectionCount = Number(this.module.dataset.ga4IndexSectionCount)
@@ -94,8 +93,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   }
 
   AddAnother.prototype.removeEmptyFieldset = function () {
-    this.emptyFieldset = this.module.querySelector('.js-add-another__empty')
-    this.emptyFieldset.remove()
+    this.module.querySelector('.js-add-another__empty').remove()
   }
 
   AddAnother.prototype.updateFieldsetsAndButtons = function () {
@@ -129,14 +127,17 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   AddAnother.prototype.addNewFieldset = function (event) {
     var button = event.target
-    var newFieldset = this.emptyFieldset.cloneNode(true)
-    newFieldset.classList.remove('js-add-another__empty')
+    var newFieldsetTemplate = this.module.querySelector('.js-add-another__empty-template')
+    var newFieldset = newFieldsetTemplate.content.cloneNode(true).children[0]
     newFieldset.classList.add('js-add-another__fieldset')
     this.createRemoveButton(newFieldset, this.removeNewFieldset.bind(this))
     button.before(newFieldset)
 
-    this.incrementAttributes(this.emptyFieldset)
+    this.incrementAttributes(newFieldsetTemplate.content)
     this.updateFieldsetsAndButtons()
+
+    // Initialise any modules included in new fieldset
+    window.GOVUK.modules.start(newFieldset)
 
     // Move focus to first visible field in new set
     newFieldset

--- a/app/views/govuk_publishing_components/components/_add_another.html.erb
+++ b/app/views/govuk_publishing_components/components/_add_another.html.erb
@@ -40,4 +40,13 @@
   } do %>
     <%= empty %>
   <% end %>
+  <template class="js-add-another__empty-template">
+    <%= render "govuk_publishing_components/components/fieldset", {
+      classes: "js-add-another__fieldset",
+      legend_text: "#{fieldset_legend} #{items.length + 1}",
+      heading_size: "m"
+    } do %>
+      <%= empty %>
+    <% end %>
+  </template>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/add_another.yml
+++ b/app/views/govuk_publishing_components/components/docs/add_another.yml
@@ -83,3 +83,41 @@ examples:
           <label for="employee_1_name" class="gem-c-label govuk-label">Full name</label>
           <input class="gem-c-input govuk-input" id="employee_1_name" name="employee[1]name">
         </div>
+
+  with_select_with_search:
+    description: Add another with a select with search input
+    data:
+      fieldset_legend: "Organisation"
+      add_button_text: "Add another organisation"
+      items:
+        - fields: >
+            <div class="govuk-form-group">
+              <label for="organisations_1">Select Organisation 1</label>
+              <select name="organisations[0][id]" id="organisations_1" class="govuk-select" data-module="select-with-search" tabindex="-1">
+                <option value="" selected="">Select one</option>
+                <option value="4dfe21ee-acfa-4fc1-9513-cc764e814205" selected="selected">Academy for Justice Commissioning</option>
+                <option value="b854f170-53c8-4098-bf77-e8ef42f93107">Academy for Social Justice</option>
+                <option value="ce357bdb-6396-426a-9f1f-8cbfb444cffd">Academy for Social Justice Commissioning</option>
+                <option value="a0f338c5-e94c-42f8-9c26-b9c2eb6850d3">Accelerated Access Review</option>
+                <option value="92bbe2da-8d5f-480b-8da1-50b18e317654">Accelerated Capability Environment</option>
+              </select>
+            </div>
+          destroy_checkbox: >
+            <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+              <div class="govuk-checkboxes__item">
+                <input type="checkbox" name="organisations[0][_destroy]" id="organisation_0__destroy" class="govuk-checkboxes__input">
+                <label for="organisation_0__destroy" class="govuk-label govuk-checkboxes__label">Delete</label>
+              </div>
+            </div>
+      empty:
+        <div class="govuk-form-group">
+          <label for="organisations_2">Select Organisation 2</label>
+          <select name="organisations[1][id]" id="organisations_2" class="govuk-select" tabindex="-1" data-module="select-with-search">
+          <option value="" selected="">Select one</option>
+          <option value="4dfe21ee-acfa-4fc1-9513-cc764e814205">Academy for Justice Commissioning</option>
+          <option value="b854f170-53c8-4098-bf77-e8ef42f93107">Academy for Social Justice</option>
+          <option value="ce357bdb-6396-426a-9f1f-8cbfb444cffd">Academy for Social Justice Commissioning</option>
+          <option value="a0f338c5-e94c-42f8-9c26-b9c2eb6850d3">Accelerated Access Review</option>
+          <option value="92bbe2da-8d5f-480b-8da1-50b18e317654">Accelerated Capability Environment</option>
+          </select>
+        <div class="govuk-form-group">

--- a/spec/javascripts/components/add-another-spec.js
+++ b/spec/javascripts/components/add-another-spec.js
@@ -53,6 +53,19 @@ describe('GOVUK.Modules.AddAnother', function () {
               <label for="test_1__destroy">Delete</label>
             </fieldset>
           </div>
+          <template class="js-add-another__empty-template">
+            <div class=".js-add-another__fieldset">
+              <fieldset>
+                <legend>Thing 2</legend>
+                <input type="hidden" name="test[1][id]" value="test_id" />
+                <label for="test_1_foo">Foo</label>
+                <input type="text" id="test_1_foo" name="test[1][foo]" value="" />
+                <label for="test_1_bar"></label>
+                <textarea id="test_1_bar" name="test[1][bar]"></textarea>
+                <label for="test_1__destroy">Delete</label>
+              </fieldset>
+            </div>
+          </template>
         </div>
       `
       document.body.append(fixture)
@@ -122,6 +135,19 @@ describe('GOVUK.Modules.AddAnother', function () {
               <label for="test_1__destroy">Delete</label>
             </fieldset>
           </div>
+          <template class="js-add-another__empty-template">
+            <div class=".js-add-another__fieldset">
+              <fieldset>
+                <legend>Thing 2</legend>
+                <input type="hidden" name="test[1][id]" value="test_id" />
+                <label for="test_1_foo">Foo</label>
+                <input type="text" id="test_1_foo" name="test[1][foo]" value="" />
+                <label for="test_1_bar"></label>
+                <textarea id="test_1_bar" name="test[1][bar]"></textarea>
+                <label for="test_1__destroy">Delete</label>
+              </fieldset>
+            </div>
+          </template>
         </div>
       `
       document.body.append(fixture)
@@ -188,6 +214,19 @@ describe('GOVUK.Modules.AddAnother', function () {
               <label for="test_2__destroy">Delete</label>
             </fieldset>
           </div>
+          <template class="js-add-another__empty-template">
+            <div class=".js-add-another__fieldset">
+              <fieldset>
+                <legend>Thing 3</legend>
+                <input type="hidden" name="test[2][id]" value="test_id" />
+                <label for="test_2_foo">Foo</label>
+                <input type="text" id="test_2_foo" name="test[2][foo]" value="" />
+                <label for="test_2_bar"></label>
+                <textarea id="test_2_bar" name="test[2][bar]"></textarea>
+                <label for="test_2__destroy">Delete</label>
+              </fieldset>
+            </div>
+          </template>
         </div>
       `
       document.body.append(fixture)
@@ -449,6 +488,19 @@ describe('GOVUK.Modules.AddAnother', function () {
               <label for="test_2__destroy">Delete</label>
             </fieldset>
           </div>
+          <template class="js-add-another__empty-template">
+            <div class="js-add-another__fieldset">
+              <fieldset>
+                <legend>Thing 3</legend>
+                <input type="hidden" name="test[2][id]" value="test_id" />
+                <label for="test_2_foo">Foo</label>
+                <input type="text" id="test_2_foo" name="test[2][foo]" value="" />
+                <label for="test_2_bar"></label>
+                <textarea id="test_2_bar" name="test[2][bar]"></textarea>
+                <label for="test_2__destroy">Delete</label>
+              </fieldset>
+            </div>
+          </template>
         </div>
       `
       document.body.append(fixture)
@@ -475,6 +527,76 @@ describe('GOVUK.Modules.AddAnother', function () {
       var visibleFields = document.querySelectorAll('.js-add-another__fieldset:not([hidden]) > fieldset')
 
       checkEventData(visibleFields, 2, 5)
+    })
+  })
+
+  describe('starting modules on new fieldsets', function () {
+    beforeEach(function () {
+      GOVUK.Modules.TestModule = function (module) {}
+
+      fixture = document.createElement('form')
+      fixture.setAttribute('data-module', 'AddAnother')
+      fixture.setAttribute('data-fieldset-legend', 'Thing')
+      fixture.setAttribute('data-add-button-text', 'Add another thing')
+      fixture.innerHTML = `
+        <div>
+          <div class="js-add-another__fieldset">
+            <fieldset>
+              <legend>Thing 1</legend>
+              <input type="hidden" name="test[0][id]" value="test_id" />
+              <label for="test_0_foo">Foo</label>
+              <input type="text" id="test_0_foo" name="test[0][foo]" value="test foo" />
+              <label for="test_0_bar"></label>
+              <textarea id="test_0_bar" name="test[0][bar]">test bar</textarea>
+              <label for="test_0__destroy">Delete</label>
+              <div class="js-add-another__destroy-checkbox">
+                <input type="checkbox" id="test_0_destroy" name="test[0][_destroy]" />
+              </div>
+            </fieldset>
+          </div>
+          <div class="js-add-another__empty">
+            <fieldset>
+              <legend>Thing 2</legend>
+              <input type="hidden" name="test[1][id]" value="test_id" />
+              <label for="test_1_foo">Foo</label>
+              <input type="text" id="test_1_foo" name="test[1][foo]" value="" />
+              <label for="test_1_bar"></label>
+              <textarea id="test_1_bar" name="test[1][bar]"></textarea>
+              <label for="test_1__destroy">Delete</label>
+            </fieldset>
+          </div>
+          <template class="js-add-another__empty-template">
+            <div class="js-add-another__fieldset" data-module="test-module">
+              <fieldset>
+                <legend>Thing 2</legend>
+                <input type="hidden" name="test[1][id]" value="test_id" />
+                <label for="test_1_foo">Foo</label>
+                <input type="text" id="test_1_foo" name="test[1][foo]" value="" />
+                <label for="test_1_bar"></label>
+                <textarea id="test_1_bar" name="test[1][bar]"></textarea>
+                <label for="test_1__destroy">Delete</label>
+              </fieldset>
+            </div>
+          </template>
+        </div>
+      `
+      document.body.append(fixture)
+
+      addAnother = new GOVUK.Modules.AddAnother(fixture)
+      addAnother.init()
+
+      addButton = document.querySelector('.js-add-another__add-button')
+    })
+
+    afterEach(function () {
+      document.body.removeChild(fixture)
+      delete GOVUK.Modules.TestModule
+    })
+
+    it('should start modules in new fields', function () {
+      window.GOVUK.triggerEvent(addButton, 'click')
+      var newFieldset = document.querySelectorAll('.js-add-another__fieldset')[1]
+      expect(newFieldset.dataset.testModuleModuleStarted).toBeDefined()
     })
   })
 })


### PR DESCRIPTION
We want to make sure that if the content added to the DOM by the add another component has any JS modules associated with it, that these are initialised when the content is added. To achieve this, we can call `GOVUK.modules.start` after the fieldset has been added.

However, for our select with search module, this didn't work when we were removing the empty fieldset from the DOM and then cloning it and reinstating it to the DOM when the "Add another" button was clicked. It failed because ChoicesJS believed it was already initialised for that fieldset.

To work around this, we use a template element containing the empty fieldset. The template is not part of the DOM, so Choices is not initialised on page load as it is for the empty fieldset in the DOM. Now when the user clicks the add another button, we construct the new fieldset DOM from the template instead of the removed empty fieldset.

The existing empty fieldset rendered to the DOM is retained for cases where JS is disabled.

## Visual Changes

No visual changes, but there is a preview with the select with search module active inside the add another component. The CSS is missing for the select with search component, but the searching and selection does work.

<img width="1261" height="723" alt="Screenshot 2025-07-30 at 17 40 22" src="https://github.com/user-attachments/assets/28d89e72-7169-4dcd-9691-97f55628dcf6" />

