### PR TITLE
Make H3's on the feedback component into H2's to avoid them appearing subordinate to unrelated headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Remove conditional comments and styles for Internet Explorer ([PR #4966](https://github.com/alphagov/govuk_publishing_components/pull/4966))
+* Make H3's on the feedback component into H2's to avoid them appearing subordinate to unrelated headings ([PR #4958](https://github.com/alphagov/govuk_publishing_components/pull/4958))
 
 ## 60.0.0
 

--- a/app/views/govuk_publishing_components/components/feedback/_problem_form.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_problem_form.html.erb
@@ -10,7 +10,7 @@
 
       <input type="hidden" name="url" value="<%= url_without_pii %>">
 
-      <h3 class="gem-c-feedback__form-heading"><%= t("components.feedback.help_us_improve_govuk") %></h3>
+      <h2 class="gem-c-feedback__form-heading"><%= t("components.feedback.help_us_improve_govuk") %></h2>
       <p id="feedback_explanation" class="gem-c-feedback__form-paragraph"><%= t("components.feedback.dont_include_personal_info") %></p>
 
       <% # Added for spam bots only %>

--- a/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
@@ -3,7 +3,7 @@
     <div class="govuk-grid-column-two-thirds" id="survey-wrapper">
       <div class="gem-c-feedback__error-summary js-errors" tabindex="-1" hidden></div>
 
-      <h3 class="gem-c-feedback__form-heading"><%= t("components.feedback.help_us_improve_govuk") %></h3>
+      <h2 class="gem-c-feedback__form-heading"><%= t("components.feedback.help_us_improve_govuk") %></h2>
       <p id="survey_explanation" class="gem-c-feedback__form-paragraph">
         <%= t("components.feedback.more_about_visit") %>
         <a href="https://www.smartsurvey.co.uk/s/gov-uk-banner/?c=no-js" class="govuk-link" target="_blank" rel="noopener noreferrer external">Please fill in this survey (opens in a new tab<noscript> and requires JavaScript</noscript>)</a>.


### PR DESCRIPTION
## What
DAC has reported an issue where the H3 headings "Help us improve GOV.UK" on the feedback component might appear subordinate to previous, unrelated H2 headings on the page. 

The component does have its own H2 "Is this page useful?" but this is hidden when one of the H3 headings on the feedback component is unhidden.

The change in this PR doesn't result in any visual changes. 

I've tested the change on NVDA + Chrome and JAWS + Chrome, as well as Mac Voiceover and have not seen any issues. 

It should also be safe to assume that this change will not cause any issues with the existing heading hierarchy on pages where the feedback component appears since the default heading on the component has always been a H2, we've ran this past our content designer who agrees with this.

## Why
Our accessibility specialist has recommended that the H3's are changed to H2's to convey the correct heading hierarchy to screen reader users. 

Fixes https://trello.com/c/6WtHvnis/3594-dacinformationandrelationships01
