### PR TITLE
Version 59.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 59.2.0
 
 * Update Action link component markup and styles ([PR #4932](https://github.com/alphagov/govuk_publishing_components/pull/4932))
 * Update cross service header to rebranded version ([PR #4959](https://github.com/alphagov/govuk_publishing_components/pull/4959))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (59.1.1)
+    govuk_publishing_components (59.2.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "59.1.1".freeze
+  VERSION = "59.2.0".freeze
 end


### PR DESCRIPTION
## 59.2.0

* Update Action link component markup and styles ([PR #4932](https://github.com/alphagov/govuk_publishing_components/pull/4932))
* Update cross service header to rebranded version ([PR #4959](https://github.com/alphagov/govuk_publishing_components/pull/4959))