### PR TITLE
Silence sass compilation @import warnings

### DIFF
--- a/spec/dummy/config/initializers/dartsass.rb
+++ b/spec/dummy/config/initializers/dartsass.rb
@@ -8,3 +8,4 @@ all_stylesheets = APP_STYLESHEETS.merge(GovukPublishingComponents::Config.all_st
 Rails.application.config.dartsass.builds = all_stylesheets
 
 Rails.application.config.dartsass.build_options << " --quiet-deps"
+Rails.application.config.dartsass.build_options << " --silence-deprecation=import"


### PR DESCRIPTION
## What / why
- @import is deprecated and we use it in a lot of places
- currently seeing a lot of compilation warnings for @import, which is drowning out other warnings and filling up logfiles
- note that this command also allows other warnings to be silenced, but don't need any others right now
- raised as an alternative to https://github.com/alphagov/govuk_publishing_components/pull/4931

We already have the `--quiet-deps` flag, which bears some clarification:

What `quiet-deps` does is silence any warnings that are coming from dependencies, so for example where `govuk-frontend` uses `@import` you shouldn't see warnings for that in your own logs, but you would still see warnings coming from any use of `@import` in your 'own' code.

Sass defines dependencies as anything coming from a load path, so e.g. if `node_modules` is in your load paths then anything coming from there is considered a dependency.

Because we've got `govuk_publishing_components` as a separate library, we'd also expect to see this differentiation in local apps, so assuming publishing components is being imported via a load path, `--quiet-deps` should silence any warnings coming from `govuk-frontend` OR the publishing components gem, but you'd still see deprecation warnings for any use of `@import` within the Sass of the local app.

Thanks to @36degrees for the explanation 👍 

## Visual Changes
None.

Trello card: https://trello.com/c/8vKVSmVz/764-switch-from-import-to-use-in-sass-compilation