### PR TITLE
Fix failing test

### DIFF
--- a/spec/component_guide/component_example_accessibility_testing_spec.rb
+++ b/spec/component_guide/component_example_accessibility_testing_spec.rb
@@ -30,7 +30,7 @@ describe "Component example with automated testing", :capybara, :js do
   it "does not throw JavaScript errors if there are duplicate IDs" do
     visit "/component-guide/test_component_with_duplicate_ids"
 
-    expect(page.driver.browser.logs.get(:browser).map { |e| e.message if e.message.match(/Accessibility issues/) }).to be_empty
+    expect(page.driver.browser.logs.get(:browser).map { |e| e.message if e.message.match(/Accessibility issues/) }.compact).to be_empty
   end
 
   it "shows incomplete accessibility warnings on the page" do


### PR DESCRIPTION
## What
Fix a failing test.

- not clear why this is suddenly failing (adding debug into the test causes it to pass) but error was `expected '[nil, nil, nil, nil].empty?' to be truthy, got false`
- compacting array to remove nil values passes test

## Why
This was noted as failing in https://github.com/alphagov/govuk_publishing_components/pull/4931 but I've since had the exact same fail on other branches, so thought it was worth picking out and giving it its own PR.

## Visual Changes
None.

Trello card: https://trello.com/c/8vKVSmVz/764-switch-from-import-to-use-in-sass-compilation