### PR TITLE
Release Version 60.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 60.0.0
 
 * Split long text for `Ga4FormTracker` submit ([PR #4950](https://github.com/alphagov/govuk_publishing_components/pull/4950))
 * **BREAKING** Replace default layout_header menu with service navigation component ([PR #4934](https://github.com/alphagov/govuk_publishing_components/pull/4934))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (59.2.1)
+    govuk_publishing_components (60.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "59.2.1".freeze
+  VERSION = "60.0.0".freeze
 end


### PR DESCRIPTION
## 60.0.0

* Split long text for `Ga4FormTracker` submit ([PR #4950](https://github.com/alphagov/govuk_publishing_components/pull/4950))
* **BREAKING** Replace default layout_header menu with service navigation component ([PR #4934](https://github.com/alphagov/govuk_publishing_components/pull/4934))