### PR TITLE
Fix metadata title padding

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_metadata.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_metadata.scss
@@ -32,17 +32,17 @@
 }
 
 .gem-c-metadata--inverse-padded {
-  padding: govuk-spacing(2);
+  padding: govuk-spacing(2) govuk-spacing(4);
 
-  .gem-c-metadata__title {
-    padding: 0 govuk-spacing(3);
+  @include govuk-media-query($from: tablet) {
+    padding: govuk-spacing(2) govuk-spacing(5);
   }
 
   .gem-c-metadata__list {
-    margin: govuk-spacing(2);
+    margin: govuk-spacing(2) 0;
 
     @include govuk-media-query($from: tablet) {
-      margin: govuk-spacing(3);
+      margin: govuk-spacing(3) 0;
     }
   }
 }

--- a/app/views/govuk_publishing_components/components/_metadata.html.erb
+++ b/app/views/govuk_publishing_components/components/_metadata.html.erb
@@ -33,14 +33,12 @@
 %>
 <%= tag.div(**component_helper.all_attributes) do %>
   <% if title.present? %>
-    <%= content_tag :div, class: "gem-c-metadata__title" do %>
-      <%= render "govuk_publishing_components/components/heading", {
-        text: sanitize(title),
-        font_size: "m",
-        inverse:,
-        margin_bottom: 0,
-      } %>
-    <% end %>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: sanitize(title),
+      font_size: "m",
+      inverse:,
+      margin_bottom: 0,
+    } %>
   <% end %>
   <dl class="gem-c-metadata__list">
     <% if from.any? %>

--- a/spec/components/metadata_spec.rb
+++ b/spec/components/metadata_spec.rb
@@ -304,7 +304,7 @@ describe "Metadata", type: :view do
   it "renders the component with a title" do
     render_component(from: "<a href='/link'>Department</a>", title: "my title")
 
-    assert_select ".gem-c-metadata__title", text: "my title"
+    assert_select ".gem-c-heading", text: "my title"
   end
 
   def assert_truncation(length, limit)


### PR DESCRIPTION
## What
- removes the extra left spacing on the title element when on a dark background, aligning it with the rest of the text within the component
- simplify the CSS slightly by removing all the padding around the list element and moving it to the parent
- remove the wrapping element for the title as no longer necessary

## Why
Follows on from https://github.com/alphagov/govuk_publishing_components/pull/4965, noticed during unrelated work.

## Visual Changes
Issue occurs on mobile. Oddly Percy isn't picking this up as a visual diff at the moment.

Before | After
------ | ------
<img width="299" height="570" alt="Screenshot 2025-08-05 at 09 04 53" src="https://github.com/user-attachments/assets/50a1061a-d9c3-419a-b584-af06b746898b" /> | <img width="297" height="572" alt="Screenshot 2025-08-05 at 09 05 03" src="https://github.com/user-attachments/assets/56250891-eb35-481c-b713-0bdb68e7e9f9" />

