### PR TITLE
Use full width preview for `layout_for_public`

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
@@ -3,6 +3,7 @@ description: A layout to be used by public-facing applications
 body: |
   Because it is an entire HTML document, this component can only be [previewed on a separate page](/public).
 
+capture_full_width_screenshot: true
 display_preview: false
 display_html: true
 accessibility_criteria: |


### PR DESCRIPTION
## What
Use full width preview for `layout_for_public`

## Why
<!-- What are the reasons behind this change being made? -->

## Visual Changes
There are no actual changes to the `layout_for_public` template layout or styles
