### PR TITLE
Version 60.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 60.0.1
 
 * Remove conditional comments and styles for Internet Explorer ([PR #4966](https://github.com/alphagov/govuk_publishing_components/pull/4966))
 * Make H3's on the feedback component into H2's to avoid them appearing subordinate to unrelated headings ([PR #4958](https://github.com/alphagov/govuk_publishing_components/pull/4958))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (60.0.0)
+    govuk_publishing_components (60.0.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "60.0.0".freeze
+  VERSION = "60.0.1".freeze
 end


### PR DESCRIPTION
## 60.0.1

* Remove conditional comments and styles for Internet Explorer ([PR #4966](https://github.com/alphagov/govuk_publishing_components/pull/4966))
* Make H3's on the feedback component into H2's to avoid them appearing subordinate to unrelated headings ([PR #4958](https://github.com/alphagov/govuk_publishing_components/pull/4958))