### PR TITLE
Add content block styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Remove unneeded Sass mixins ([PR #4969](https://github.com/alphagov/govuk_publishing_components/pull/4969))
 * Upgrade to LUX version 4.3.2 ([PR #5018](https://github.com/alphagov/govuk_publishing_components/pull/5018))
+* Add content block styles ([PR #4973](https://github.com/alphagov/govuk_publishing_components/pull/4973))
 
 ## 60.2.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_govspeak.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_govspeak.scss
@@ -5,6 +5,7 @@
 @import "govspeak/call-to-action";
 @import "govspeak/charts";
 @import "govspeak/contact";
+@import "govspeak/content-block";
 @import "govspeak/example";
 @import "govspeak/footnotes";
 @import "govspeak/form-download";

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_content-block.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_content-block.scss
@@ -1,0 +1,27 @@
+@import "govuk/core/lists";
+@import "govuk/core/typography";
+
+.content-block,
+.content-block__contact-key,
+.content-block__contact-value,
+.content-block__contact-list {
+  margin: 0;
+  padding: 0;
+}
+
+.content-block__contact-list {
+  .content-block__contact-key {
+    @extend %govuk-heading-m;
+  }
+}
+
+.content-block__contact-list--nested {
+  .content-block__contact-key {
+    @extend %govuk-heading-s;
+  }
+}
+
+.content-block .content-block__list {
+  @extend %govuk-list;
+  margin-left: 0;
+}

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -544,6 +544,75 @@ examples:
             </div>
           </div>
         </div>
+  contact_content_block:
+    data:
+      block: |
+        <div class="content-block content-block--contact">
+          <dl class="vcard content-block__contact-list">
+            <dt class="content-block__contact-key fn org">Get help with your application</dt>
+            <dd class="content-block__contact-value">
+              <dl class="content-block__contact-list--nested">
+                <dt class="content-block__contact-key">Address</dt>
+                <dd class="content-block__contact-value">
+                  <p class="adr">
+                    <span class="street-address"> 49 to 53 Cherry Street</span>,<br><span class="locality">London</span>,<br><span class="postal-code"> AB1 2DC </span>
+                  </p>
+                </dd>
+                <dt class="content-block__contact-key">Email</dt>
+                <dd class="content-block__contact-value">
+                  <ul class="content-block__list">
+                    <li>
+                      <a href="mailto:name@example.com" class="email">
+                        name@example.com
+                      </a>
+                    </li>
+                    <li>
+                      <p>We aim to respond within 2 working days</p>
+                    </li>
+                  </ul>
+                </dd>
+                <dt class="content-block__contact-key">Phone</dt>
+                <dd class="content-block__contact-value">
+                  <p>If you have a unique reference number, have it with you when you call.</p>
+                  <ul class="content-block__list">
+                    <li>
+                      <span>Phone: </span>
+                      <span class="tel">020 7946 0101</span>
+                    </li>
+                    <li>
+                      <span>Textphone: </span>
+                      <span class="tel">020 7946 0102</span>
+                    </li>
+                    <li>
+                      <span>Welsh language: </span>
+                      <span class="tel">020 7946 0103</span>
+                    </li>
+                  </ul>
+                  <p>Monday to Friday, 8am to 6pm<br>
+                    Saturday and Sunday, 10am to 4pm</p>
+                  <p>
+                    <a href="https://gov.uk/call-charges">
+                      Find out about call charges
+                    </a>
+                  </p>
+                </dd>
+                <dt class="content-block__contact-key">Webchat</dt>
+                <dd class="content-block__contact-value">
+                  <ul class="content-block__list">
+                    <li>
+                      <a href="http://example.com" class="url">
+                        Speak to an adviser now
+                      </a>
+                    </li>
+                    <li>
+                      <p>Current waiting time is 17 minutes</p>
+                    </li>
+                  </ul>
+                </dd>
+              </dl>
+            </dd>
+          </dl>
+        </div>
   charts:
     description: |
       The Government Statistical Service (GSS) guidance recommends [a limit of four categories as best practice for basic data visualisations](https://gss.civilservice.gov.uk/policy-store/data-visualisation-colours-in-charts/#section-5).


### PR DESCRIPTION
This adds some rudimentary styling to to the Govspeak component for the Contact Content Block generated via the Content Block Manager. We originally intended for these styles to be delivered via the [content_block_tools gem](https://github.com/alphagov/content_block_tools).

However, this resulted in a more weighty CSS output and also meant we had to pull in a dependency on `govuk-frontend` in another place, which meant there was a risk of dependencies getting out of whack (see
https://github.com/alphagov/frontend/pull/4943).

After some discussion with @maxgds and @richardTowers, we decided that the least worse option would be to distribute these styles in the Components gem. This is a minor misuse of tools, as content blocks are not _strictly_ a component, but this is already repeating a pattern that we’ve already established with the packaging of `govspeak` as a
“component but not a component”.

Thoughts welcome!

## Screenshot

<img width="2054" height="1720" alt="image" src="https://github.com/user-attachments/assets/73f32760-f376-43a9-8b85-fd2510b1825f" />
