### PR TITLE
Remove aria-expanded from feedback component Cancel buttons 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 ## Unreleased
 
 * Remove unused imports in layout-header.scss ([PR #4985](https://github.com/alphagov/govuk_publishing_components/pull/4985))
+* Remove aria-expanded from feedback component Cancel buttons ([PR #4974](https://github.com/alphagov/govuk_publishing_components/pull/4974))
+
 
 ## 60.0.1
 

--- a/app/views/govuk_publishing_components/components/feedback/_problem_form.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_problem_form.html.erb
@@ -58,8 +58,7 @@
 
       <button
         class="govuk-button govuk-button--secondary gem-c-feedback__close gem-c-feedback__js-show js-close-form"
-        aria-controls="something-is-wrong"
-        aria-expanded="true">
+        aria-controls="something-is-wrong">
         <%= t("components.feedback.close") %>
       </button>
     </div>

--- a/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
@@ -11,7 +11,6 @@
       <button
         class="govuk-button govuk-button--secondary js-close-form"
         aria-controls="page-is-not-useful"
-        aria-expanded="true"
         hidden>
         <%= t("components.feedback.close") %>
       </button>


### PR DESCRIPTION
## What
Remove the `aria-expanded` attribute from the feedback component "Cancel" buttons as per the recommendation and subsequent testing by our accessibility specialist.

This change does not result any visual changes.

## Why
DAC have reported an issue where the two "Cancel" buttons on the feedback component aren't using `aria-expanded` as expected. The buttons do collapse the region, but behave more like a 'Close' button than an expandable control. 

### Further information
We also sought feedback from our content designer on whether the button text needs changing to help screen reader users to understand the button's purpose but a decision was made to keep the current button text which was already revised some time ago; the user has clicked on a button to start an action so 'cancel' fits with that action to  'cancel' the journey.

Note the button also has an `aria-controls` attribute which the JS uses to identify the region to collapse. Our accessibility specialist advised keeping it as it won't break anything if unsupported. DAC didn't comment on it either. 

Fixes https://trello.com/c/1iE7T2ZB/3618-dacnamerolevalue02-feedback-component