### PR TITLE
Update govspeak documentation

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -7,6 +7,8 @@ body: |
 
   It applies styling to standard Markdown content, eg; paragraphs, headings and lists. It also applies styling to Govspeak specific markup, like [callouts](https://github.com/alphagov/govspeak#callouts), [contacts](https://github.com/alphagov/govspeak#points-of-contact) and [highlights](https://github.com/alphagov/govspeak#highlights).
 
+  Govspeak includes classes such as `fn` and `org` on some elements that are part of the [microformats](https://developers.google.com/custom-search/docs/structured_data#using-microformats) specification for representing commonly published items.
+
   Some JavaScript behaviours are applied to this component:
 
   - Progressively enhanced, accessible charts (using [Magna Charta](https://github.com/alphagov/magna-charta), derived from tabular data (see [example](./govspeak/charts))


### PR DESCRIPTION
## What
Add text to the govspeak component doc page to attribute the use of some classes in the govspeak examples to the microformat specification.

## Why
I just learned that's what these classes are for, and there's no documentation that explains this.

## Visual Changes
None.

