### PR TITLE
Remove unused imports in layout-header.scss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Remove unused imports in layout-header.scss ([PR #4985](https://github.com/alphagov/govuk_publishing_components/pull/4985))
+
 ## 60.0.1
 
 * Remove conditional comments and styles for Internet Explorer ([PR #4966](https://github.com/alphagov/govuk_publishing_components/pull/4966))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
@@ -1,6 +1,4 @@
 @import "govuk_publishing_components/individual_component_support";
-@import "govuk_publishing_components/components/search";
-@import "govuk_publishing_components/components/skip-link";
 @import "govuk/components/header/header";
 
 .gem-c-layout-header.gem-c-layout-header--no-bottom-border,


### PR DESCRIPTION
## What
Remove unused imports in `layout-header.scss`

Fixes: https://github.com/alphagov/govuk_publishing_components/issues/4967

## Why
The layout header component does not use the components below:
- skip-link component - imported separately, [example in whitehall](https://github.com/alphagov/whitehall/blob/6229ac511a0d454dbe0154b7781bb91a0725c07e/app/views/layouts/design_system.html.erb#L26C54-L26C63)
- search component - removed in https://github.com/alphagov/govuk_publishing_components/pull/4687

### Further info
Removing the imports could break in applications that are not aware that by importing layout-header, search and skip-link are rendered correctly without importing the required stylesheets separately.

From using the component auditing tools, this will not impact the publishing apps below as they use [_all_components.scss](https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/stylesheets/govuk_publishing_components/_all_components.scss) to import all component styles.

- collections-publisher (1)
- content-data-admin (1)
- content-publisher (1)
- local-links-manager (1)
- manuals-publisher (1)
- places-manager (1)
- publisher (1)
- release (1)
- search-admin (1)
- search-v2-evaluator (1)
- signon (1)
- specialist-publisher (1)
- support (1)
- transition (1)
- travel-advice-publisher (1)
- whitehall (2)

The app below will need to import the `skip-link` stylesheet to ensure it is rendered correctly:
- govspeak-preview (1) - related PR - https://github.com/alphagov/govspeak-preview/pull/732