### PR TITLE
Style govspeak footnote targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Style govspeak footnote targets ([PR #4992](https://github.com/alphagov/govuk_publishing_components/pull/4992))
 * Add Kurdish Sorani and Tigrinyan translations ([PR #4987](https://github.com/alphagov/govuk_publishing_components/pull/4987))
 * Remove unused imports in layout-header.scss ([PR #4985](https://github.com/alphagov/govuk_publishing_components/pull/4985))
 * Remove aria-expanded from feedback component Cancel buttons ([PR #4974](https://github.com/alphagov/govuk_publishing_components/pull/4974))

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_footnotes.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_footnotes.scss
@@ -30,6 +30,11 @@
       margin-left: 22px;
     }
 
+    li:target {
+      background: govuk-colour("light-grey");
+      border-bottom: solid 3px $govuk-border-colour;
+    }
+
     @include govuk-media-query($media-type: print) {
       border-top: 1px solid $govuk-text-colour;
 

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -679,16 +679,20 @@ examples:
   footnotes:
     data:
       block: |
-        <p>This is a text with a footnote<sup id="fnref:1a"><a href="#fn:1a" class="footnote">1</a></sup>.</p>
+        <p>This is a text with a footnote<sup id="fnref:1a"><a href="#fn:1a" class="footnote">1</a></sup>. This is some more text with another footnote<sup id="fnref:2a"><a href="#fn:2a" class="footnote">2</a></sup>.</p>
+        <p>This is a whole new paragraph with yet another footnote<sup id="fnref:3a"><a href="#fn:3a" class="footnote">3</a></sup>.</p>
 
         <div class="footnotes">
           <ol>
             <li id="fn:1a">
               <p>And here is the definition. <a href="#fnref:1a" class="reversefootnote">&#8617;</a></p>
             </li>
-            <li id="fn:2">
+            <li id="fn:2a">
               <a href="https://www.ons.gov.uk/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/datasets/weeklyprovisionalfiguresondeathsregisteredinenglandandwales" class="govuk-link">https://www.ons.gov.uk/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/datasets/weeklyprovisionalfiguresondeathsregisteredinenglandandwales</a>
-              <a href="#fnref:2" class="govuk-link">↩</a>
+              <a href="#fnref:2a" class="govuk-link">↩</a>
+            </li>
+            <li id="fn:3a">
+              <p>And here is another definition. <a href="#fnref:3a" class="reversefootnote">&#8617;</a></p>
             </li>
           </ol>
         </div>


### PR DESCRIPTION
## What
Make the chosen footnote visually different from the others.

- add styling using the [target](https://developer.mozilla.org/en-US/docs/Web/CSS/:target) pseudo class to govspeak footnotes, so that the currently selected footnote is visually distinct from any others
- this should distinguish the chosen footnote particularly in situations where it is not at the top of the scrolled viewport
- considered using the govuk-frontend focussed state for this but can't because footnotes may contain links already, so could result in a focus state within a focus state

I've also slightly expanded the govspeak footnote documentation just to make it clearer.

Preview app link: https://components-gem-pr-4992.herokuapp.com/component-guide/govspeak/footnotes

Example of a page with footnotes for testing: https://www.gov.uk/government/consultations/environmental-assessment-levels-eals-used-in-air-emissions-risk-assessments/public-feedback/appendix-c-summary-of-toxicological-evidence-for-mea-and-ndma

Checked with @nnagewad on the design of this.

## Why
Going to blame Jake Archibald for making a [really strong case against footnotes](https://jakearchibald.com/2025/give-footnotes-the-boot/) where I learned of the target pseudo class. We can't get rid of footnotes overnight, but maybe we can make them a bit better.

## Visual Changes
Highlighted footnote:

<img width="1068" height="365" alt="Screenshot 2025-08-19 at 13 19 54" src="https://github.com/user-attachments/assets/0ec28703-598b-4e58-b8dc-9b54bb35381e" />


Highlighted footnote containing a focussed link:

<img width="1072" height="372" alt="Screenshot 2025-08-19 at 13 20 04" src="https://github.com/user-attachments/assets/057e624b-ebf4-4266-bab9-50662f858ae2" />
