### PR TITLE
Adjustments to how `Ga4FormTracker` sets `text` on `submit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+* Adjustments to how Ga4FormTracker sets text on submit ([PR #4994](https://github.com/alphagov/govuk_publishing_components/pull/4994))
+
 ## 61.1.0
 
 * Revert GA4 phone number PII changes ([PR #5039](https://github.com/alphagov/govuk_publishing_components/pull/5039))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
@@ -135,7 +135,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         }
       } else if (inputNodename === 'SELECT' && elem.querySelectorAll('option:checked')) {
         var selectedOptions = Array.from(elem.querySelectorAll('option:checked')).map(function (element) { return element.text })
-        input.answer = this.useSelectCount ? selectedOptions.length : selectedOptions.join(',')
+        input.answer = this.useSelectCount && selectedOptions.length > 1 ? selectedOptions.length : selectedOptions.join(',')
       } else if (isTextField && elem.value) {
         if (this.includeTextInputValues || elem.hasAttribute('data-ga4-form-include-input')) {
           if (this.useTextCount && !isDateField) {

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
@@ -110,16 +110,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
       var isTextField = inputTypes.indexOf(inputType) !== -1 || inputNodename === 'TEXTAREA'
       var conditionalField = elem.closest('.govuk-checkboxes__conditional')
-      var conditionalCheckbox = conditionalField && conditionalField.querySelector('[aria-controls="' + conditionalField.id + '"]')
+      var conditionalCheckbox = conditionalField && this.module.querySelector('[aria-controls="' + conditionalField.id + '"]')
       var conditionalCheckboxChecked = conditionalCheckbox && conditionalCheckbox.checked
-
-      if (conditionalField && conditionalCheckboxChecked) {
-        var conditionalCheckboxLabel = conditionalField.querySelector('[for="' + conditionalCheckbox.id + '"]')
-
-        if (conditionalCheckboxLabel) {
-          input.parentSection = conditionalCheckboxLabel.innerText
-        }
-      }
 
       if (conditionalCheckbox && !conditionalCheckboxChecked) {
         // don't include conditional field if condition not checked
@@ -163,6 +155,15 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         // remove the input from those gathered as it has no value
         inputs.splice(i, 1)
       }
+
+      if (conditionalField && conditionalCheckboxChecked) {
+        var parentFieldset = conditionalField.closest('fieldset')
+        var parentLegend = parentFieldset && parentFieldset.querySelector('legend')
+
+        if (parentLegend) {
+          input.section = parentLegend.innerText + ' - ' + input.section
+        }
+      }
     }
     return inputs
   }
@@ -176,17 +177,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       if (answer) {
         if (this.recordJson) {
           var fieldSection = data[i].section
-          var parentFieldSection = data[i].parentSection
 
           if (fieldSection) {
-            if (parentFieldSection) {
-              answers[parentFieldSection] = answers[parentFieldSection] || {}
-              answers[parentFieldSection][fieldSection] = answers[parentFieldSection][fieldSection] || ''
-              answers[parentFieldSection][fieldSection] += ((answers[parentFieldSection][fieldSection] ? ',' : '') + answer)
-            } else {
-              answers[fieldSection] = answers[fieldSection] || ''
-              answers[fieldSection] += ((answers[fieldSection] ? ',' : '') + answer)
-            }
+            answers[fieldSection] = answers[fieldSection] ? (answers[fieldSection] + ',') : ''
+            answers[fieldSection] += answer
           }
         } else {
           answers.push(answer)

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
@@ -135,7 +135,13 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         }
       } else if (inputNodename === 'SELECT' && elem.querySelectorAll('option:checked')) {
         var selectedOptions = Array.from(elem.querySelectorAll('option:checked')).map(function (element) { return element.text })
-        input.answer = this.useSelectCount && selectedOptions.length > 1 ? selectedOptions.length : selectedOptions.join(',')
+
+        if (selectedOptions.length === 1 && !elem.value.length) {
+          // if placeholder value in select, do not include as not filled in
+          inputs.splice(i, 1)
+        } else {
+          input.answer = this.useSelectCount && selectedOptions.length > 1 ? selectedOptions.length : selectedOptions.join(',')
+        }
       } else if (isTextField && elem.value) {
         if (this.includeTextInputValues || elem.hasAttribute('data-ga4-form-include-input')) {
           if (this.useTextCount && !isDateField) {

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
@@ -113,6 +113,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       var conditionalCheckbox = conditionalField && this.module.querySelector('[aria-controls="' + conditionalField.id + '"]')
       var conditionalCheckboxChecked = conditionalCheckbox && conditionalCheckbox.checked
 
+      var isDateField = elem.closest('.govuk-date-input')
+
       if (conditionalCheckbox && !conditionalCheckboxChecked) {
         // don't include conditional field if condition not checked
         inputs.splice(i, 1)
@@ -136,7 +138,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         input.answer = this.useSelectCount ? selectedOptions.length : selectedOptions.join(',')
       } else if (isTextField && elem.value) {
         if (this.includeTextInputValues || elem.hasAttribute('data-ga4-form-include-input')) {
-          if (this.useTextCount) {
+          if (this.useTextCount && !isDateField) {
             input.answer = elem.value.length
           } else {
             var PIIRemover = new window.GOVUK.analyticsGa4.PIIRemover()
@@ -156,11 +158,28 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         inputs.splice(i, 1)
       }
 
+      var parentFieldset
+      var parentLegend
+
       if (conditionalField && conditionalCheckboxChecked) {
-        var parentFieldset = conditionalField.closest('fieldset')
-        var parentLegend = parentFieldset && parentFieldset.querySelector('legend')
+        parentFieldset = conditionalField.closest('fieldset')
+        parentLegend = parentFieldset && parentFieldset.querySelector('legend')
 
         if (parentLegend) {
+          input.section = parentLegend.innerText + ' - ' + input.section
+        }
+      } else if (isDateField) {
+        var dateFieldset = elem.closest('.govuk-date-input').closest('fieldset')
+        var dateLegend = dateFieldset && dateFieldset.querySelector('legend')
+
+        parentFieldset = dateFieldset.parentNode.closest('fieldset')
+
+        if (dateLegend) {
+          input.section = dateLegend.innerText + ' - ' + input.section
+        }
+
+        if (parentFieldset) {
+          parentLegend = parentFieldset.querySelector('legend')
           input.section = parentLegend.innerText + ' - ' + input.section
         }
       }

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
@@ -214,6 +214,22 @@ describe('Google Analytics form tracking', function () {
       expect(window.dataLayer[0]).toEqual(expected)
     })
 
+    it('does not collect data from select elements with placeholder', function () {
+      element.innerHTML =
+        '<label for="s1">Label</label>' +
+        '<select name="select" id="s1">' +
+          '<option selected value>Placeholder</option>' +
+          '<option value="option1">Option 1</option>' +
+          '<option value="option2">Option 2</option>' +
+        '</select>'
+      var select = document.getElementById('s1')
+      window.GOVUK.triggerEvent(select, 'change')
+      expected.event_data.text = 'No answer given'
+
+      window.GOVUK.triggerEvent(element, 'submit')
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+
     it('collects data from select[multiple] elements', function () {
       element.innerHTML =
         '<label for="s1">Label</label>' +

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
@@ -715,5 +715,20 @@ describe('Google Analytics form tracking', function () {
       window.GOVUK.triggerEvent(element, 'submit')
       expect(window.dataLayer[0]).toEqual(expected)
     })
+
+    it('collects single selected option from a select', function () {
+      element.innerHTML =
+        '<label for="s1">Label</label>' +
+        '<select multiple name="select" id="s1">' +
+          '<option selected value="option1">Option 1</option>' +
+          '<option value="option2">Option 2</option>' +
+          '<option value="option3">Option 3</option>' +
+        '</select>'
+
+      expected.event_data.text = 'Option 1'
+
+      window.GOVUK.triggerEvent(element, 'submit')
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
   })
 })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
@@ -396,6 +396,70 @@ describe('Google Analytics form tracking', function () {
       window.GOVUK.triggerEvent(element, 'submit')
       expect(window.dataLayer[0]).toEqual(expected)
     })
+
+    it('collects data from date inputs', function () {
+      element.innerHTML =
+      '<fieldset class="govuk-date-input">' +
+      '<legend>Date</legend>' +
+      '<div class="govuk-date-input__item">' +
+      '  <div class="govuk-form-group">' +
+      '    <label for="date_1i" class="gem-c-label govuk-label">Day</label>' +
+      '    <input data-ga4-form-include-input class="gem-c-input govuk-input govuk-input--width-4" name="day" id="date_1i" type="text" value="19">' +
+      '  </div>' +
+      '</div>' +
+      '<div class="govuk-date-input__item">' +
+      '  <div class="govuk-form-group">' +
+      '    <label for="date_2i" class="gem-c-label govuk-label">Month</label>' +
+      '    <input data-ga4-form-include-input class="gem-c-input govuk-input govuk-input--width-4" name="month" id="date_2i" type="text" value="08">' +
+      '  </div>' +
+      '</div>' +
+      '<div class="govuk-date-input__item">' +
+      '  <div class="govuk-form-group">' +
+      '    <label for="date_3i" class="gem-c-label govuk-label">Year</label>' +
+      '    <input data-ga4-form-include-input class="gem-c-input govuk-input govuk-input--width-4" name="year" id="date_3i" type="text" value="2025">' +
+      '   </div>' +
+      '</div>' +
+      '</fieldset>'
+
+      expected.event_data.text = JSON.stringify({ 'Date - Day': '19', 'Date - Month': '08', 'Date - Year': '2025' })
+      window.GOVUK.triggerEvent(element, 'submit')
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+
+    it('uses conditonal fieldset legend when collecting data from date inputs', function () {
+      element.innerHTML =
+        '<fieldset id="conditional-field" class="govuk-checkboxes__conditional">' +
+          '<legend>Parent legend</legend>' +
+          '<input type="checkbox" aria-controls="conditional-field" id="c1" name="checkbox[]" value="checkbox1"/>' +
+          '<label for="c1">checkbox1</label>' +
+          '<fieldset class="govuk-date-input">' +
+          '<legend>Date</legend>' +
+          '<div class="govuk-date-input__item">' +
+          '  <div class="govuk-form-group">' +
+          '    <label for="date_1i" class="gem-c-label govuk-label">Day</label>' +
+          '    <input data-ga4-form-include-input class="gem-c-input govuk-input govuk-input--width-4" name="day" id="date_1i" type="text" value="19">' +
+          '  </div>' +
+          '</div>' +
+          '<div class="govuk-date-input__item">' +
+          '  <div class="govuk-form-group">' +
+          '    <label for="date_2i" class="gem-c-label govuk-label">Month</label>' +
+          '    <input data-ga4-form-include-input class="gem-c-input govuk-input govuk-input--width-4" name="month" id="date_2i" type="text" value="08">' +
+          '  </div>' +
+          '</div>' +
+          '<div class="govuk-date-input__item">' +
+          '  <div class="govuk-form-group">' +
+          '    <label for="date_3i" class="gem-c-label govuk-label">Year</label>' +
+          '    <input data-ga4-form-include-input class="gem-c-input govuk-input govuk-input--width-4" name="year" id="date_3i" type="text" value="2025">' +
+          '   </div>' +
+          '</div>' +
+          '</fieldset>' +
+        '</fieldset>'
+
+      document.getElementById('c1').checked = true
+      expected.event_data.text = JSON.stringify({ 'Parent legend - Day': '19', 'Parent legend - Month': '08', 'Parent legend - Year': '2025' })
+      window.GOVUK.triggerEvent(element, 'submit')
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
   })
 
   describe('when tracking a form with text splitting enabled', function () {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
@@ -136,17 +136,19 @@ describe('Google Analytics form tracking', function () {
 
     it('collects data from checked conditional fields', function () {
       element.innerHTML =
+        '<div>' +
+        '<label for="c1">checkbox1</label>' +
+        '<input type="checkbox" aria-controls="conditional-field" id="c1" name="checkbox[]" value="checkbox1"/>' +
         '<div id="conditional-field" class="govuk-checkboxes__conditional">' +
-          '<label for="c1">checkbox1</label>' +
-          '<input type="checkbox" aria-controls="conditional-field" id="c1" name="checkbox[]" value="checkbox1"/>' +
           '<label for="c3">checkbox3</label>' +
           '<input type="checkbox" id="c3" name="checkbox[]" value="checkbox3"/>' +
+        '</div>' +
         '</div>'
 
       document.getElementById('c1').checked = true
       document.getElementById('c3').checked = true
 
-      expected.event_data.text = 'checkbox3'
+      expected.event_data.text = 'checkbox1,checkbox3'
 
       window.GOVUK.triggerEvent(element, 'submit')
       expect(window.dataLayer[0]).toEqual(expected)
@@ -154,11 +156,13 @@ describe('Google Analytics form tracking', function () {
 
     it('does not collect data from unchecked conditional fields', function () {
       element.innerHTML =
+        '<div>' +
+        '<label for="c1">checkbox1</label>' +
+        '<input type="checkbox" aria-controls="conditional-field" id="c1" name="checkbox[]" value="checkbox1"/>' +
         '<div id="conditional-field" class="govuk-checkboxes__conditional">' +
-          '<label for="c1">checkbox1</label>' +
-          '<input type="checkbox" aria-controls="conditional-field" id="c1" name="checkbox[]" value="checkbox1"/>' +
-          '<label for="text">Label</label>' +
-          '<input type="text" id="text" name="test-text" value="Some text"/>' +
+          '<label for="c3">checkbox3</label>' +
+          '<input type="checkbox" id="c3" name="checkbox[]" value="checkbox3"/>' +
+        '</div>' +
         '</div>'
 
       expected.event_data.text = 'No answer given'
@@ -287,20 +291,21 @@ describe('Google Analytics form tracking', function () {
 
     it('collects data from checked conditional checkboxes', function () {
       element.innerHTML =
-        '<div id="conditional-field" class="govuk-checkboxes__conditional">' +
+        '<fieldset id="conditional-field" class="govuk-checkboxes__conditional">' +
+          '<legend>Parent legend</legend>' +
+          '<input type="checkbox" aria-controls="conditional-field" id="c1" name="checkbox[]" value="checkbox1"/>' +
+          '<label for="c1">checkbox1</label>' +
           '<fieldset>' +
           '<legend>Checkbox legend</legend>' +
           '<label for="c3">checkbox3</label>' +
           '<input type="checkbox" id="c3" name="checkbox[]" value="checkbox3"/>' +
           '</fieldset>' +
-          '<input type="checkbox" aria-controls="conditional-field" id="c1" name="checkbox[]" value="checkbox1"/>' +
-          '<label for="c1">checkbox1</label>' +
-        '</div>'
+        '</fieldset>'
 
       document.getElementById('c1').checked = true
       document.getElementById('c3').checked = true
 
-      expected.event_data.text = JSON.stringify({ checkbox1: { 'Checkbox legend': 'checkbox3' } })
+      expected.event_data.text = JSON.stringify({ 'Parent legend - Checkbox legend': 'checkbox3' })
 
       window.GOVUK.triggerEvent(element, 'submit')
       expect(window.dataLayer[0]).toEqual(expected)
@@ -308,16 +313,19 @@ describe('Google Analytics form tracking', function () {
 
     it('collects data from checked conditional input', function () {
       element.innerHTML =
-        '<div id="conditional-field" class="govuk-checkboxes__conditional">' +
-          '<label for="c1">checkbox1</label>' +
+        '<fieldset id="conditional-field" class="govuk-checkboxes__conditional">' +
+          '<legend>Parent legend</legend>' +
           '<input type="checkbox" aria-controls="conditional-field" id="c1" name="checkbox[]" value="checkbox1"/>' +
+          '<label for="c1">checkbox1</label>' +
+          '<fieldset>' +
           '<label for="text">Text label</label>' +
           '<input type="text" id="text" name="test-text" value="Some text"/>' +
-        '</div>'
+          '</fieldset>' +
+        '</fieldset>'
 
       document.getElementById('c1').checked = true
 
-      expected.event_data.text = JSON.stringify({ checkbox1: { 'Text label': '[REDACTED]' } })
+      expected.event_data.text = JSON.stringify({ 'Parent legend - Text label': '[REDACTED]' })
 
       window.GOVUK.triggerEvent(element, 'submit')
       expect(window.dataLayer[0]).toEqual(expected)


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

- `Ga4FormTracker` conditional field adjustments
- `Ga4FormTracker` improve date component handling
- `Ga4FormTracker` report single selected option
- `Ga4FormTracker` stop including placeholders

## Why
<!-- What are the reasons behind this change being made? -->

### `Ga4FormTracker` conditional field adjustments

The fields within a conditional checkbox were always being included even if the checkbox was not checked. This was because the query for the conditional checkbox input was being executed from the wrong node. Moving the query to `this.module` has fixed this. This was not identified before as the markup within the tests was not accurate to how conditional checkboxes are rendered. In addition, the structure of conditional fields within the JSON assigned to `text` (if JSON recording enabled) has been flattened.

###  `Ga4FormTracker` improve date component handling

Improve how dates are represented within `text`. Given a form with a date component of values:

<img width="811" height="404" alt="Screenshot 2025-08-19 at 12 24 40" src="https://github.com/user-attachments/assets/b36e9f88-8b99-4a32-8714-5f4adda791ef" />

with `data-ga4-form-use-text-count` this would be the response:

```
{
  "Day": "2,
  "Month": "2",
  "Year": "4"
}
```

which would make it difficult to identify specific fields if a form had more than one date. Additionally, as the date fields are `input[type=text]` the character count of these fields would be returned instead of the date values. The adjustments introduced in this PR mean the date component is now represented as the following:
 
```
{
  "First published date - Day": "23",
  "First published date - Month": "08",
  "First published date - Year": "2025"
}
```

For a date component that isn't within a conditional fieldset such as:

<img width="294" height="172" alt="Screenshot 2025-08-19 at 12 26 26" src="https://github.com/user-attachments/assets/a5ce2c8e-0385-4b04-b1c9-14ca6cb18991" />

it will be represented as the following:

```
{
  "Date (required) - Day": "23",
  "Date (required) - Month": "08",
  "Date (required) - Year": "2025"
}
```

If the Date is within another legend (for selecting the date and time for instance) then it will be represented as the following:

<img width="440" height="422" alt="Screenshot 2025-09-24 at 12 10 46" src="https://github.com/user-attachments/assets/c5c93625-d12b-4c5a-885a-4975c415f9a7" />

```
{
  "Opening Date - Date (required) - Day": "23",
  "Opening Date - Date (required) - Month": "08",
  "Opening Date - Date (required) - Year": "2025"
}
```

### `Ga4FormTracker` report single selected option

Instead of reporting `1` for the value of a `select` with a single selected `option` with `useSelectCount` enabled, the text of the selected `option` will be used instead.

### `Ga4FormTracker` stop including placeholders

For `select` elements that have a blank placeholder option (that will be selected so that it acts as a placeholder), `Ga4FormTracker` will no longer include the text of that blank placeholder `option` in the reported submit event.