### PR TITLE
Version 60.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## 60.0.2
+## 60.1.0
 
 * Style govspeak footnote targets ([PR #4992](https://github.com/alphagov/govuk_publishing_components/pull/4992))
+* Upgrade to version 5.11.1 of govuk-frontend ([PR #4933](https://github.com/alphagov/govuk_publishing_components/pull/4933))
+
+## 60.0.2
+
 * Add Kurdish Sorani and Tigrinyan translations ([PR #4987](https://github.com/alphagov/govuk_publishing_components/pull/4987))
 * Remove unused imports in layout-header.scss ([PR #4985](https://github.com/alphagov/govuk_publishing_components/pull/4985))
 * Remove aria-expanded from feedback component Cancel buttons ([PR #4974](https://github.com/alphagov/govuk_publishing_components/pull/4974))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (60.0.2)
+    govuk_publishing_components (60.1.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -141,7 +141,7 @@ GEM
       rake (>= 13)
     googleapis-common-protos-types (1.20.0)
       google-protobuf (>= 3.18, < 5.a)
-    govuk_app_config (9.19.1)
+    govuk_app_config (9.19.2)
       logstasher (~> 2.1)
       opentelemetry-exporter-otlp (>= 0.25, < 0.31)
       opentelemetry-instrumentation-all (>= 0.39.1, < 0.79.0)
@@ -234,7 +234,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     null_logger (0.0.1)
-    opentelemetry-api (1.5.0)
+    opentelemetry-api (1.6.0)
     opentelemetry-common (0.22.0)
       opentelemetry-api (~> 1.0)
     opentelemetry-exporter-otlp (0.30.0)
@@ -443,7 +443,7 @@ GEM
       opentelemetry-semantic_conventions (>= 1.8.0)
     opentelemetry-registry (0.4.0)
       opentelemetry-api (~> 1.1)
-    opentelemetry-sdk (1.8.0)
+    opentelemetry-sdk (1.8.1)
       opentelemetry-api (~> 1.1)
       opentelemetry-common (~> 0.20)
       opentelemetry-registry (~> 0.2)
@@ -462,7 +462,7 @@ GEM
       prettyprint
     prettyprint (0.2.0)
     prism (1.4.0)
-    prometheus_exporter (2.2.0)
+    prometheus_exporter (2.3.0)
       webrick
     pry (0.15.2)
       coderay (~> 1.1)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "60.0.2".freeze
+  VERSION = "60.1.0".freeze
 end


### PR DESCRIPTION
## 60.1.0

* Style govspeak footnote targets ([PR #4992](https://github.com/alphagov/govuk_publishing_components/pull/4992))
* Upgrade to version 5.11.1 of govuk-frontend ([PR #4933](https://github.com/alphagov/govuk_publishing_components/pull/4933))