### PR TITLE
(NAV-2611) Remove `aria-expanded` attribute from feedback component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Remove focusable attribute from the close icon on the super nav search menu ([PR #5005](https://github.com/alphagov/govuk_publishing_components/pull/5005))
 * Remove date PII from GA4 page view tracking ([PR #5004](https://github.com/alphagov/govuk_publishing_components/pull/5004))
 * Introduce erb_lint linter ([PR #5003](https://github.com/alphagov/govuk_publishing_components/pull/5003))
+* Remove aria-expanded attribute from feedback component ([PR #4996](https://github.com/alphagov/govuk_publishing_components/pull/4996))
 
 ## 60.1.0
 

--- a/app/assets/javascripts/govuk_publishing_components/components/feedback.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/feedback.js
@@ -13,7 +13,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.closeForms = this.$module.querySelectorAll('.js-close-form')
     this.activeForm = false
     this.pageIsUsefulButton = this.$module.querySelector('.js-page-is-useful')
-    this.pageIsNotUsefulButton = this.$module.querySelector('.js-page-is-not-useful')
     this.somethingIsWrongButton = this.$module.querySelector('.js-something-is-wrong')
     this.promptQuestions = this.$module.querySelectorAll('.js-prompt-questions')
     this.promptSuccessMessage = this.$module.querySelector('.js-prompt-success')
@@ -24,7 +23,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   }
 
   Feedback.prototype.init = function () {
-    this.setInitialAriaAttributes()
     this.setHiddenValues()
     this.setSurveyPath()
     this.prompt.hidden = false
@@ -38,7 +36,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         e.preventDefault()
         var el = e.target.closest('button')
         this.toggleForm(el.getAttribute('aria-controls'))
-        this.updateAriaAttributes(el)
       }.bind(this))
     }
 
@@ -49,7 +46,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         var el = e.target
         var formToToggle = el.getAttribute('aria-controls')
         this.toggleForm(formToToggle)
-        this.setInitialAriaAttributes()
         this.revealInitialPrompt()
         var refocusClass = '.js-' + formToToggle
         this.$module.querySelector(refocusClass).focus()
@@ -82,7 +78,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
           if (xhr.status === 200) {
             this.showFormSuccess(xhr.message)
             this.revealInitialPrompt()
-            this.setInitialAriaAttributes()
             this.activeForm.hidden = true
             clearInterval(this.timerInterval)
           } else {
@@ -109,11 +104,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   Feedback.prototype.enableSubmitFormButton = function ($form) {
     var formButton = $form.querySelector('[type="submit"]')
     formButton.removeAttribute('disabled')
-  }
-
-  Feedback.prototype.setInitialAriaAttributes = function () {
-    this.pageIsNotUsefulButton.setAttribute('aria-expanded', false)
-    this.somethingIsWrongButton.setAttribute('aria-expanded', false)
   }
 
   Feedback.prototype.setHiddenValues = function () {
@@ -155,10 +145,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       var encodedPath = encodeURI(pathWithoutEmailPII)
       surveyLink.setAttribute('href', 'https://www.smartsurvey.co.uk/s/gov-uk-banner/?c=' + encodedPath)
     }
-  }
-
-  Feedback.prototype.updateAriaAttributes = function (linkClicked) {
-    linkClicked.setAttribute('aria-expanded', true)
   }
 
   Feedback.prototype.toggleForm = function (formId) {

--- a/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
@@ -59,7 +59,6 @@
               class: "govuk-button gem-c-feedback__prompt-link js-toggle-form js-page-is-not-useful",
               aria: {
                 controls: "page-is-not-useful",
-                expanded: "false",
               },
               data: {
                 ga4_event: ga4_no_button_event,
@@ -79,7 +78,6 @@
       <%= tag.button(
         class: "govuk-button gem-c-feedback__prompt-link js-toggle-form js-something-is-wrong",
         aria: {
-          expanded: "false",
           controls: "something-is-wrong",
         },
         data: {

--- a/spec/javascripts/components/feedback-spec.js
+++ b/spec/javascripts/components/feedback-spec.js
@@ -25,7 +25,7 @@ describe('Feedback component', function () {
                 </li>
                 <li class="gem-c-feedback__option-list-item">
                   <button class="govuk-button gem-c-feedback__prompt-link js-toggle-form js-page-is-not-useful"
-                    aria-controls="page-is-not-useful" aria-expanded="false"
+                    aria-controls="page-is-not-useful"
                     data-ga4-event="{'event_name':'form_submit','type':'feedback','text':'No','section':'Is this page useful?','tool_name':'Is this page useful?'}">
                     No <span class="govuk-visually-hidden">this page is not useful</span>
                   </button>
@@ -41,7 +41,7 @@ describe('Feedback component', function () {
             class="gem-c-feedback__prompt-questions gem-c-feedback__prompt-questions--something-is-wrong js-prompt-questions"
             hidden>
             <button class="govuk-button gem-c-feedback__prompt-link js-toggle-form js-something-is-wrong"
-              aria-expanded="false" aria-controls="something-is-wrong"
+              aria-controls="something-is-wrong"
               data-ga4-event="{'event_name':'form_submit','type':'feedback','text':'Report a problem with this page','section':'Is this page useful?','tool_name':'Is this page useful?'}">
               Report a problem with this page
             </button>
@@ -130,13 +130,6 @@ describe('Feedback component', function () {
     expect($('.gem-c-feedback .js-prompt-questions').prop('hidden')).toBe(false)
   })
 
-  it('conveys that the form is not expanded', function () {
-    loadFeedbackComponent()
-
-    expect($('.js-toggle-form[aria-controls="page-is-not-useful"]').attr('aria-expanded')).toBe('false')
-    expect($('.js-toggle-form[aria-controls="something-is-wrong"]').attr('aria-expanded')).toBe('false')
-  })
-
   // note that this test will fail in the browser 'run tests in random order' is disabled
   // or any link in the jasmine window is clicked e.g. a specific test suite
   // because the referrer will be localhost, not 'unknown'
@@ -180,14 +173,6 @@ describe('Feedback component', function () {
       expect($('.gem-c-feedback .js-prompt').prop('hidden')).toBe(true)
     })
 
-    it('conveys that the form is now expanded', function () {
-      loadFeedbackComponent()
-      $('.js-page-is-not-useful')[0].click()
-
-      expect($('.js-page-is-not-useful').attr('aria-expanded')).toBe('true')
-      expect($('.js-something-is-wrong').attr('aria-expanded')).toBe('false')
-    })
-
     it('has the page path in the survey', function () {
       var testPath = '/government/organisations/government-digital-service'
       var expectedUrl = 'https://www.smartsurvey.co.uk/s/gov-uk-banner/?c=' + testPath
@@ -228,14 +213,6 @@ describe('Feedback component', function () {
       expect($('.gem-c-feedback .js-prompt').prop('hidden')).toBe(true)
     })
 
-    it('conveys that the form is now expanded', function () {
-      loadFeedbackComponent()
-      $('.js-something-is-wrong')[0].click()
-
-      expect($('.js-page-is-not-useful').attr('aria-expanded')).toBe('false')
-      expect($('.js-something-is-wrong').attr('aria-expanded')).toBe('true')
-    })
-
     it('focusses the first field in the form', function () {
       loadFeedbackComponent()
       var $input = $('#something-is-wrong .govuk-textarea')[0]
@@ -261,13 +238,6 @@ describe('Feedback component', function () {
       expect($('.gem-c-feedback .js-prompt').prop('hidden')).toBe(false)
       expect(document.activeElement).toBe($('.js-something-is-wrong').get(0))
     })
-
-    it('conveys that the form is not expanded', function () {
-      loadFeedbackComponent()
-
-      expect($('.js-page-is-not-useful').attr('aria-expanded')).toBe('false')
-      expect($('.js-something-is-wrong').attr('aria-expanded')).toBe('false')
-    })
   })
 
   describe('Clicking the close link in the "not useful" form', function () {
@@ -284,13 +254,6 @@ describe('Feedback component', function () {
     it('shows the prompt', function () {
       expect($('.gem-c-feedback .js-prompt').prop('hidden')).toBe(false)
       expect(document.activeElement).toBe($('.js-page-is-not-useful').get(0))
-    })
-
-    it('conveys that the form is not expanded', function () {
-      loadFeedbackComponent()
-
-      expect($('.js-page-is-not-useful').attr('aria-expanded')).toBe('false')
-      expect($('.js-something-is-wrong').attr('aria-expanded')).toBe('false')
     })
   })
 


### PR DESCRIPTION
## What

- Remove the `aria-expanded` attribute from the yes/no buttons in the feedback component view template and JavaScript file
- Updated the tests for the feedback component
  - Update the fixture to reflect the latest version of the feedback component HTML
  - Remove tests relating to `aria-expanded` on the yes/no buttons as this attribute was removed from the HTML

## Why

DAC have reported an issue where the two "Cancel" buttons on the feedback component aren't using aria-expanded as expected. The buttons do collapse the region, but behave more like a 'Close' button than an expandable control.

This change ensures the aria-expanded attribute is not set in the view template or via JavaScript for the feedback component.

### Further info

- Jira: https://gov-uk.atlassian.net/browse/NAV-2611
- Relates to https://github.com/alphagov/govuk_publishing_components/pull/4974
