### PR TITLE
Remove date PII from GA4 page view tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 * Address string literal deprecation ([PR #4999](https://github.com/alphagov/govuk_publishing_components/pull/4999))
 * Remove focusable attribute from the close icon on the super nav search menu ([PR #5005](https://github.com/alphagov/govuk_publishing_components/pull/5005))
-
+* Remove date PII from GA4 page view tracking ([PR #5004](https://github.com/alphagov/govuk_publishing_components/pull/5004))
 
 ## 60.1.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
@@ -159,7 +159,7 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
     },
 
     getTitle: function () {
-      return this.PIIRemover.stripPIIWithOverride(document.title, true, true)
+      return this.PIIRemover.stripPIIWithOverride(document.title, false, true)
     },
 
     // window.httpStatusCode is set in the source of the error page in static

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
@@ -355,10 +355,21 @@ describe('Google Tag Manager page view tracking', function () {
     expect(window.dataLayer[0]).toEqual(expected)
   })
 
-  it('removes email, postcode, date, and phone number pii from the title, location and referrer', function () {
-    document.title = 'example@gov.uk - SW12AA - 2020-01-01 - 0123456789'
-    expected.page_view.title = '[email] - [postcode] - [date] - [phone number]'
+  it('removes email, postcode, and phone number pii from the page title', function () {
+    document.title = 'example@gov.uk - SW12AA - 0123456789'
+    expected.page_view.title = '[email] - [postcode] - [phone number]'
+    GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
+    expect(window.dataLayer[0]).toEqual(expected)
+  })
 
+  it('doesn\'t remove dates from the page title', function () {
+    document.title = '01-01-2026'
+    expected.page_view.title = '01-01-2026'
+    GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
+    expect(window.dataLayer[0]).toEqual(expected)
+  })
+
+  it('removes email, postcode, date, and phone number pii from the page location and referrer', function () {
     spyOnProperty(document, 'referrer', 'get').and.returnValue('https://gov.uk/example@gov.uk/SW12AA/2020-01-01/0123456789')
     expected.page_view.referrer = 'https://gov.uk/[email]/[postcode]/[date]/[phone number]'
 


### PR DESCRIPTION
## What / Why
- Remove date PII (Personally Identifiable Information) redaction from page titles in our GA4 page view tracking
- This was needed when a smart answer included PII in the page title, but it no longer does this so the stripping of dates can be removed here.
- Trello card: https://trello.com/c/PJdyFZGF

## Visual Changes

None.