### PR TITLE
Add fallback for missing GA4 canonical URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Remove date PII from GA4 page view tracking ([PR #5004](https://github.com/alphagov/govuk_publishing_components/pull/5004))
 * Introduce erb_lint linter ([PR #5003](https://github.com/alphagov/govuk_publishing_components/pull/5003))
 * Remove aria-expanded attribute from feedback component ([PR #4996](https://github.com/alphagov/govuk_publishing_components/pull/4996))
+* Add fallback for missing GA4 canonical URL ([PR #5009](https://github.com/alphagov/govuk_publishing_components/pull/5009))
 
 ## 60.1.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
@@ -85,11 +85,21 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
       }
     },
 
+    getBasePath: function () {
+      return this.getMetaContent('ga4-base-path')
+    },
+
     getCanonicalHref: function () {
       var link = document.querySelector('link[rel=canonical]')
 
       if (link) {
         return link.href
+      }
+
+      var basePath = this.getBasePath()
+
+      if (basePath) {
+        return window.location.origin + basePath // e.g. https://www.gov.uk + /browse
       }
     },
 

--- a/lib/govuk_publishing_components/presenters/meta_tags.rb
+++ b/lib/govuk_publishing_components/presenters/meta_tags.rb
@@ -43,6 +43,7 @@ module GovukPublishingComponents
         meta_tags["govuk:content-has-history"] = "true" if has_content_history?
         meta_tags["govuk:ga4-strip-dates"] = "true" if should_strip_dates_pii?(content_item, local_assigns)
         meta_tags["govuk:ga4-strip-postcodes"] = "true" if should_strip_postcode_pii?(content_item, local_assigns)
+        meta_tags["govuk:ga4-base-path"] = content_item[:base_path] if content_item[:base_path]
         meta_tags["govuk:first-published-at"] = content_item[:first_published_at] if content_item[:first_published_at]
         meta_tags["govuk:updated-at"] = content_item[:updated_at] if content_item[:updated_at]
         meta_tags["govuk:public-updated-at"] = content_item[:public_updated_at] if content_item[:public_updated_at]

--- a/spec/components/meta_tags_spec.rb
+++ b/spec/components/meta_tags_spec.rb
@@ -509,6 +509,19 @@ describe "Meta tags", type: :view do
     assert_no_meta_tag("govuk:ga4-political-status")
   end
 
+  it "renders govuk:ga4-base-path by grabbing the content item's base path" do
+    render_component(content_item: example_document_for("transaction", "transaction"))
+    assert_meta_tag("govuk:ga4-base-path", "/council-tax-bands")
+  end
+
+  it "doesn't render govuk:ga4-base-path if there's no base path in the content item" do
+    content_item = example_document_for("html_publication", "published_with_history_mode")
+    content_item.delete("base_path")
+
+    render_component(content_item:)
+    assert_no_meta_tag("govuk:ga4-base-path")
+  end
+
   def assert_political_status_for(political, current, expected_political_status)
     render_component(content_item: { details: { political:, government: { current:, slug: "government" } } })
     assert_meta_tag("govuk:political-status", expected_political_status)

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
@@ -739,7 +739,7 @@ describe('Google Tag Manager page view tracking', function () {
     })
   })
 
-  it('returns a canonical_url', function () {
+  it('returns a canonical_url if the link element exists', function () {
     var link = document.createElement('link')
     var head = document.getElementsByTagName('head')[0]
 
@@ -753,5 +753,20 @@ describe('Google Tag Manager page view tracking', function () {
     expect(window.dataLayer[0]).toEqual(expected)
 
     head.removeChild(link)
+  })
+
+  it('falls back to constructing a canonical_url if the link element doesn\'t exist', function () {
+    var meta = document.createElement('meta')
+    meta.setAttribute('name', 'govuk:ga4-base-path')
+    meta.setAttribute('content', '/browse/example')
+    var head = document.getElementsByTagName('head')[0]
+
+    head.appendChild(meta)
+
+    expected.page_view.canonical_url = window.location.origin + '/browse/example'
+    GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
+    expect(window.dataLayer[0]).toEqual(expected)
+
+    head.removeChild(meta)
   })
 })


### PR DESCRIPTION
## What/Why
- Some pages on GOV.UK have a `<link rel="canonical` tag which contains the canonical url of the page. We grab this value for GA4 tracking purposes.
- The pages that have the canonical url are ones that render the `machine_readable_metadata` component.
- Not all pages are rendering this component though, so we need an alternative way to get the canonical URL.
- Looking at the code, the canonical_url is usually a combination of the domain name and the base_path.:
https://github.com/alphagov/govuk_publishing_components/blob/63cfc71c53293949b584963556a5f21e598d9b68/lib/govuk_publishing_components/presenters/machine_readable/page.rb#L14-L16
- This only seems to be overruled in [one case by travel advice](https://github.com/search?q=org%3Aalphagov+govuk_publishing_components%2Fcomponents%2Fmachine_readable_metadata+AND+canonical_url&type=code), so I think we can be confident most canonical urls are domain + base_path. 
- Therefore, we can recreate this code in our GA4 tracking where the `<link rel="canonical"` tag doesn't exist in the DOM.
- Trello card: https://trello.com/c/LbnGWY6Y
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

None.
