### PR TITLE
Version 60.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 60.2.0
 
 * Upgrade to LUX 4.2.1 ([PR #5007](https://github.com/alphagov/govuk_publishing_components/pull/5007))
 * Address string literal deprecation ([PR #4999](https://github.com/alphagov/govuk_publishing_components/pull/4999))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (60.1.0)
+    govuk_publishing_components (60.2.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "60.1.0".freeze
+  VERSION = "60.2.0".freeze
 end


### PR DESCRIPTION
## 60.2.0

* Upgrade to LUX 4.2.1 ([PR #5007](https://github.com/alphagov/govuk_publishing_components/pull/5007))
* Address string literal deprecation ([PR #4999](https://github.com/alphagov/govuk_publishing_components/pull/4999))
* Remove focusable attribute from the close icon on the super nav search menu ([PR #5005](https://github.com/alphagov/govuk_publishing_components/pull/5005))
* Remove date PII from GA4 page view tracking ([PR #5004](https://github.com/alphagov/govuk_publishing_components/pull/5004))
* Introduce erb_lint linter ([PR #5003](https://github.com/alphagov/govuk_publishing_components/pull/5003))
* Remove aria-expanded attribute from feedback component ([PR #4996](https://github.com/alphagov/govuk_publishing_components/pull/4996))
* Add fallback for missing GA4 canonical URL ([PR #5009](https://github.com/alphagov/govuk_publishing_components/pull/5009))