### PR TITLE
Remove the `blue_bar` option from `layout_for_public` template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Set `row_classes` in the Summary Card component to be an array ([PR #5011](https://github.com/alphagov/govuk_publishing_components/pull/5011))
 * Update cookie banner component hide button text ([PR #5012](https://github.com/alphagov/govuk_publishing_components/pull/5012))
+* Remove the blue_bar option from layout_for_public template ([PR #5016](https://github.com/alphagov/govuk_publishing_components/pull/5016))
 * Add govuk_chat_onboarding_complete cookie to cookie categories ([PR #5014](https://github.com/alphagov/govuk_publishing_components/pull/5014))
 
 ## 60.2.0

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-for-public.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-for-public.scss
@@ -4,10 +4,6 @@
   font-family: $govuk-font-family;
 }
 
-.gem-c-layout-for-public__blue-bar-wrapper--browse {
-  background-color: #263135;
-}
-
 .gem-c-layout-for-public-account-menu {
   margin: 0 0 govuk-spacing(6) 0;
   padding: 0;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-for-public.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-for-public.scss
@@ -4,19 +4,8 @@
   font-family: $govuk-font-family;
 }
 
-.gem-c-layout-for-public__blue-bar {
-  background: $govuk-brand-colour;
-  height: govuk-spacing(2);
-}
-
 .gem-c-layout-for-public__blue-bar-wrapper--browse {
   background-color: #263135;
-}
-
-.govuk-frontend-supported .gem-c-layout-for-public__global-banner-wrapper {
-  margin-top: - govuk-spacing(2);
-  min-height: govuk-spacing(2);
-  position: relative;
 }
 
 .gem-c-layout-for-public-account-menu {

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -4,7 +4,6 @@
   for_static ||= false
   emergency_banner ||= nil
   full_width ||= false
-  blue_bar = false
   global_banner ||= nil
   html_lang ||= "en"
   homepage ||= false
@@ -28,25 +27,6 @@
   omit_account_navigation ||= false
   omit_account_phase_banner ||= false
 
-# This is a hack - but it's the only way I can find to not have two blue bars on
-# constrained width layouts.
-#
-# The full width layout hides the blue bar underneath the black header bar - so
-# full width pages won't see the blue bar unless it's added by another component
-# - and for most pages that component is the global banner.
-#
-# The constrained width layout doesn't hide the blue bar - so having the global
-# banner on a constrained width layout means there are two blue bars.
-#
-# The global banner is shown with JavaScript, so users without JavaScript won't
-# see it. So the constrained width blue bar can't be turned off as then it'll be
-# off for everyone.
-#
-# This booleon adds a CSS class that shifts the banners up by the blue bar's
-# height, making the two blue bars overlap and appear as one. The class is added
-# when a) there's content for the emergency or global banner *and* b) when using
-# the contrained width layout.
-  blue_bar_dedupe = false
   body_css_classes = %w(gem-c-layout-for-public govuk-template__body)
   body_css_classes << "draft" if draft_watermark
   body_css_classes << "global-banner-present" if global_banner.present?
@@ -115,18 +95,8 @@
 
     <%= raw(emergency_banner) %>
 
-    <% if (blue_bar && !global_banner.present? && !homepage) || (blue_bar_dedupe) %>
-      <%= content_tag(:div, class: blue_bar_wrapper_classes) do %>
-        <div class="gem-c-layout-for-public__blue-bar govuk-width-container"></div>
-      <% end %>
-    <% end %>
-
     <% if global_banner.present? %>
-      <%= content_tag("div", {
-        class: blue_bar_dedupe ? "gem-c-layout-for-public__global-banner-wrapper" : nil,
-      }) do %>
-        <%= raw(global_banner) %>
-      <% end %>
+      <%= raw(global_banner) %>
     <% end %>
 
     <% if show_account_layout %>

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -8,7 +8,6 @@
   html_lang ||= "en"
   homepage ||= false
   layout_helper = GovukPublishingComponents::Presenters::PublicLayoutHelper.new(local_assigns)
-  blue_bar_background_colour = layout_helper.blue_bar_background_colours.include?(blue_bar_background_colour) ? blue_bar_background_colour : nil
   logo_link ||= "/"
   navigation_items ||= []
   one_login_navigation_items ||= {}
@@ -30,9 +29,6 @@
   body_css_classes = %w(gem-c-layout-for-public govuk-template__body)
   body_css_classes << "draft" if draft_watermark
   body_css_classes << "global-banner-present" if global_banner.present?
-
-  blue_bar_wrapper_classes = %w()
-  blue_bar_wrapper_classes << "gem-c-layout-for-public__blue-bar-wrapper--#{blue_bar_background_colour}" if blue_bar_background_colour
 -%>
 <!DOCTYPE html>
 <html class="govuk-template govuk-template--rebranded" lang="<%= html_lang %>">

--- a/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
@@ -38,13 +38,6 @@ examples:
     description: This allows the header to be omitted which is currently used when rendering CSV previews from Whitehall
     data:
       omit_header: true
-  blue_bar_background:
-    description: For use when a page has a heading component with a background colour.
-    data:
-      for_static: true
-      full_width: true
-      blue_bar: true
-      blue_bar_background_colour: "no"
   omit_feedback:
     description: This allows the feedback form to be omitted
     data:

--- a/lib/govuk_publishing_components/presenters/public_layout_helper.rb
+++ b/lib/govuk_publishing_components/presenters/public_layout_helper.rb
@@ -1,7 +1,6 @@
 module GovukPublishingComponents
   module Presenters
     class PublicLayoutHelper
-      BLUE_BAR_BACKGROUND_COLOURS = %w[browse].freeze
       FOOTER_NAVIGATION_COLUMNS = [2, 1].freeze
       FOOTER_META = {
         items: [
@@ -63,10 +62,6 @@ module GovukPublishingComponents
 
       def footer_navigation_columns
         FOOTER_NAVIGATION_COLUMNS
-      end
-
-      def blue_bar_background_colours
-        BLUE_BAR_BACKGROUND_COLOURS
       end
     end
   end

--- a/spec/components/layout_for_public_spec.rb
+++ b/spec/components/layout_for_public_spec.rb
@@ -105,42 +105,6 @@ describe "Layout for public", :capybara, type: :view do
     assert_select "#test-global-banner", text: "This is a global banner test"
   end
 
-  it "has no blue bar by default" do
-    render_component({})
-
-    assert_select ".gem-c-layout-for-public__blue-bar", false
-  end
-
-  it "has no blue bar when using the full width layout" do
-    render_component(full_width: true)
-
-    assert_select ".gem-c-layout-for-public__blue-bar", false
-  end
-
-  it "does not render the blue bar even if `blue_bar` is `true`" do
-    render_component(blue_bar: true)
-
-    assert_select ".gem-c-layout-for-public__blue-bar", false
-  end
-
-  it "does not render the blue bar even if `full_width` is true and `blue_bar` is true" do
-    render_component(full_width: true, blue_bar: true)
-
-    assert_select ".gem-c-layout-for-public__blue-bar", false
-  end
-
-  it "does not render the blue bar with a background even if valid background specified" do
-    render_component(blue_bar: true, full_width: true, blue_bar_background_colour: "browse")
-
-    assert_select ".gem-c-layout-for-public__blue-bar-wrapper--browse .gem-c-layout-for-public__blue-bar", false
-  end
-
-  it "does not render the blue bar with a background if an invalid background specified" do
-    render_component(blue_bar: true, full_width: true, blue_bar_background_colour: "invalid")
-
-    expect(page).not_to have_selector(".gem-c-layout-for-public__blue-bar-wrapper--invalid")
-  end
-
   it "has the default logo link when no logo_link is specified" do
     render_component({})
 


### PR DESCRIPTION
## What
Remove the `blue_bar` option from `layout_for_public` view template

## Why
The `blue_bar` option was used prior to the brand update to display a 10px blue border at the bottom of the super navigation menu across GOV.UK

This option can safely be removed as the `blue_bar` option no longer exists

Jira: https://gov-uk.atlassian.net/browse/NAV-18190

## Visual Changes
The visual changes shown are expected following the removal of the `blue_bar_background` option