### PR TITLE
Upgrade to LUX version 4.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Upgrade to LUX version 4.3.2 ([PR #5018](https://github.com/alphagov/govuk_publishing_components/pull/5018))
+
 ## 60.2.1
 
 * Set `row_classes` in the Summary Card component to be an array ([PR #5011](https://github.com/alphagov/govuk_publishing_components/pull/5011))

--- a/app/assets/javascripts/govuk_publishing_components/vendor/lux/lux-reporter.js
+++ b/app/assets/javascripts/govuk_publishing_components/vendor/lux/lux-reporter.js
@@ -22,9 +22,9 @@
 (function () {
   'use strict';
 
-  const max = Math.max;
-  const floor = Math.floor;
-  const round = Math.round;
+  var max = Math.max;
+  var floor = Math.floor;
+  var round = Math.round;
   /**
   * Clamp a number so that it is never less than 0
   */
@@ -41,15 +41,16 @@
 
   var scriptStartTime = now();
 
+  var _a;
   // If the various performance APIs aren't available, we export an empty object to
   // prevent having to make regular typeof checks.
-  const performance = window.performance || {};
-  const timing = performance.timing || {
+  var performance = window.performance || {};
+  var timing = performance.timing || {
     activationStart: 0,
     // If performance.timing isn't available, we attempt to polyfill the navigationStart value.
     // Our first attempt is from LUX.ns, which is the time that the snippet execution began. If this
     // is not available, we fall back to the time that the current script execution began.
-    navigationStart: window.LUX?.ns || scriptStartTime,
+    navigationStart: ((_a = window.LUX) === null || _a === void 0 ? void 0 : _a.ns) || scriptStartTime,
   };
   function navigationType() {
     if (performance.navigation && typeof performance.navigation.type !== "undefined") {
@@ -66,34 +67,34 @@
   * @see https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-deliverytype
   */
   function deliveryType() {
-    const navEntry = getNavigationEntry();
+    var navEntry = getNavigationEntry();
     if ("deliveryType" in navEntry) {
       return navEntry.deliveryType || "(empty string)";
     }
     return undefined;
   }
   function getNavigationEntry() {
-    const navEntries = getEntriesByType("navigation");
+    var navEntries = getEntriesByType("navigation");
     if (navEntries.length) {
-      const nativeEntry = navEntries[0];
-      const entry = {
+      var nativeEntry = navEntries[0];
+      var entry_1 = {
         navigationStart: 0,
         activationStart: 0,
       };
-      for (const key in nativeEntry) {
-        entry[key] = nativeEntry[key];
+      for (var key in nativeEntry) {
+        entry_1[key] = nativeEntry[key];
       }
-      return entry;
+      return entry_1;
     }
-    const navType = navigationType();
-    const entry = {
+    var navType = navigationType();
+    var entry = {
       navigationStart: 0,
       activationStart: 0,
       startTime: 0,
       type: navType == 2 ? "back_forward" : navType === 1 ? "reload" : "navigate",
     };
-    if (true) {
-      for (const key in timing) {
+    {
+      for (var key in timing) {
         if (typeof timing[key] === "number" && key !== "navigationStart") {
           entry[key] = floor(timing[key] - timing.navigationStart);
         }
@@ -108,7 +109,7 @@
   */
   function getEntriesByType(type) {
     if (typeof performance.getEntriesByType === "function") {
-      const entries = performance.getEntriesByType(type);
+      var entries = performance.getEntriesByType(type);
       if (entries && entries.length) {
         return entries;
       }
@@ -122,7 +123,7 @@
   */
   function getEntriesByName(type) {
     if (typeof performance.getEntriesByName === "function") {
-      const entries = performance.getEntriesByName(type);
+      var entries = performance.getEntriesByName(type);
       if (entries && entries.length) {
         return entries;
       }
@@ -138,18 +139,18 @@
     return true;
   }
   function onVisible(cb) {
-    afterPrerender(() => {
+    afterPrerender(function () {
       if (isVisible()) {
         cb();
       }
       else {
-        const onVisibleCallback = () => {
+        var onVisibleCallback_1 = function () {
           if (isVisible()) {
             cb();
-            removeEventListener("visibilitychange", onVisibleCallback);
+            removeEventListener("visibilitychange", onVisibleCallback_1);
           }
         };
-        addEventListener("visibilitychange", onVisibleCallback, true);
+        addEventListener("visibilitychange", onVisibleCallback_1, true);
       }
     });
   }
@@ -168,13 +169,34 @@
     return getNavigationEntry().redirectCount > 0 || timing.redirectEnd > 0;
   }
 
+  var subscribers = {};
+  var eventData = {};
+  function subscribe(event, callback) {
+    if (!subscribers[event]) {
+      subscribers[event] = [];
+    }
+    subscribers[event].push(callback);
+    // Ensure previous event data is available to new subscribers
+    if (eventData[event] !== undefined) {
+      callback(eventData[event]);
+    }
+  }
+  function emit(event, data) {
+    eventData[event] = data;
+    if (!subscribers[event]) {
+      return;
+    }
+    subscribers[event].forEach(function (callback) { return callback(data); });
+  }
+
   function addFlag(flags, flag) {
     return flags | flag;
   }
 
   // Wrapper to support older browsers (<= IE8)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  function addListener(type, callback, useCapture = false) {
+  function addListener(type, callback, useCapture) {
+    if (useCapture === void 0) { useCapture = false; }
     if (addEventListener) {
       addEventListener(type, callback, useCapture);
     }
@@ -184,7 +206,8 @@
   }
   // Wrapper to support older browsers (<= IE8)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  function removeListener(type, callback, useCapture = false) {
+  function removeListener(type, callback, useCapture) {
+    if (useCapture === void 0) { useCapture = false; }
     if (removeEventListener) {
       removeEventListener(type, callback, useCapture);
     }
@@ -193,14 +216,14 @@
     }
   }
 
-  const START_MARK = "LUX_start";
-  const END_MARK = "LUX_end";
-  const BOOLEAN_TRUE = "true";
+  var START_MARK = "LUX_start";
+  var END_MARK = "LUX_end";
+  var BOOLEAN_TRUE = "true";
 
   /**
   * Milliseconds since navigationStart representing when the page was restored from the bfcache
   */
-  let pageRestoreTime;
+  var pageRestoreTime;
   function setPageRestoreTime(time) {
     pageRestoreTime = time;
   }
@@ -213,7 +236,8 @@
   * is the page restore time. On all other pages this value will be zero.
   */
   function getZeroTime() {
-    return max(getPageRestoreTime() || 0, getNavigationEntry().activationStart, getEntriesByName(START_MARK).pop()?.startTime || 0);
+    var _a;
+    return max(getPageRestoreTime() || 0, getNavigationEntry().activationStart, ((_a = getEntriesByName(START_MARK).pop()) === null || _a === void 0 ? void 0 : _a.startTime) || 0);
   }
   /**
   * Most time-based metrics that LUX reports should be relative to the "zero" marker, rounded down
@@ -236,13 +260,15 @@
   * time since the last LUX.init() call.
   */
   function msSincePageInit() {
-    const sinceNavigationStart = msSinceNavigationStart();
-    const startMark = getEntriesByName(START_MARK).pop();
+    var sinceNavigationStart = msSinceNavigationStart();
+    var startMark = getEntriesByName(START_MARK).pop();
     if (startMark) {
       return floor(sinceNavigationStart - startMark.startTime);
     }
     return sinceNavigationStart;
   }
+
+  var version = "4.3.0";
 
   function padStart(str, length, char) {
     while (str.length < length) {
@@ -251,24 +277,25 @@
     return str;
   }
 
-  const VERSION = "4.2.1";
+  var VERSION = version;
   /**
   * Returns the version of the script as a float to be stored in legacy systems that do not support
   * string versions.
   */
-  function versionAsFloat(ver = VERSION) {
-    const parts = ver.split(".");
+  function versionAsFloat(ver) {
+    if (ver === void 0) { ver = VERSION; }
+    var parts = ver.split(".");
     return parseFloat(parts[0] + "." + padStart(parts[1], 2, "0") + padStart(parts[2], 2, "0"));
   }
 
-  const sendBeaconFallback = (url, data) => {
-    const xhr = new XMLHttpRequest();
+  var sendBeaconFallback = function (url, data) {
+    var xhr = new XMLHttpRequest();
     xhr.open("POST", url, true);
     xhr.setRequestHeader("content-type", "application/json");
     xhr.send(String(data));
     return true;
   };
-  const sendBeacon = "sendBeacon" in navigator ? navigator.sendBeacon.bind(navigator) : sendBeaconFallback;
+  var sendBeacon = "sendBeacon" in navigator ? navigator.sendBeacon.bind(navigator) : sendBeaconFallback;
   /**
   * Some values should only be reported if they are non-zero. The exception to this is when the page
   * was prerendered or restored from BF cache
@@ -285,8 +312,8 @@
   */
   function fitUserTimingEntries(utValues, config, url) {
     // Start with the maximum allowed UT entries per beacon
-    const beaconUtValues = utValues.slice(0, config.maxBeaconUTEntries);
-    const remainingUtValues = utValues.slice(config.maxBeaconUTEntries);
+    var beaconUtValues = utValues.slice(0, config.maxBeaconUTEntries);
+    var remainingUtValues = utValues.slice(config.maxBeaconUTEntries);
     // Trim UT entries until they fit within the maximum URL length, ensuring at least one UT entry
     // is included.
     while ((url + "&UT=" + beaconUtValues.join(",")).length > config.maxBeaconUrlLength &&
@@ -295,93 +322,92 @@
     }
     return [beaconUtValues, remainingUtValues];
   }
-  class Beacon {
-    config;
-    logger;
-    isRecording = true;
-    isSent = false;
-    sendRetries = 0;
-    maxMeasureTimeout = 0;
-    customerId;
-    pageId;
-    sessionId;
-    flags = 0;
-    startTime;
-    metricCollectors = {};
-    onBeforeSendCbs = [];
-    constructor(opts) {
+  var Beacon = /** @class */ (function () {
+    function Beacon(opts) {
+      var _this = this;
+      this.isRecording = true;
+      this.isSent = false;
+      this.sendRetries = 0;
+      this.maxMeasureTimeout = 0;
+      this.flags = 0;
+      this.metricCollectors = {};
+      this.onBeforeSendCbs = [];
       this.startTime = opts.startTime || getZeroTime();
       this.config = opts.config;
       this.logger = opts.logger;
       this.customerId = opts.customerId;
       this.sessionId = opts.sessionId;
       this.pageId = opts.pageId;
-      this.maxMeasureTimeout = window.setTimeout(() => {
-        this.logger.logEvent(82 /* LogEvent.PostBeaconTimeoutReached */);
-        this.stopRecording();
-        this.send();
+      this.maxMeasureTimeout = window.setTimeout(function () {
+        _this.logger.logEvent(82 /* LogEvent.PostBeaconTimeoutReached */);
+        _this.stopRecording();
+        _this.send();
       }, this.config.maxMeasureTime - msSincePageInit());
-      addListener("securitypolicyviolation", (e) => {
-        if (e.disposition !== "report" && e.blockedURI === this.config.beaconUrlV2 && "URL" in self) {
+      addListener("securitypolicyviolation", function (e) {
+        if (e.disposition !== "report" && e.blockedURI === _this.config.beaconUrlV2 && "URL" in self) {
           // Some websites might have CSP rules that allow the GET beacon, but not the POST beacon.
           // We can detect this here and attempt to send the beacon to a fallback endpoint.
           //
           // If the fallback endpoint has not been provided in the config, we will fall back to using
           // the POST beacon pathname on the GET beacon origin.
-          if (!this.config.beaconUrlFallback) {
-            const getOrigin = new URL(this.config.beaconUrl).origin;
-            const postPathname = new URL(this.config.beaconUrlV2).pathname;
-            this.config.beaconUrlFallback = getOrigin + postPathname;
+          if (!_this.config.beaconUrlFallback) {
+            var getOrigin = new URL(_this.config.beaconUrl).origin;
+            var postPathname = new URL(_this.config.beaconUrlV2).pathname;
+            _this.config.beaconUrlFallback = getOrigin + postPathname;
           }
           // Update the V2 beacon URL
-          this.config.beaconUrlV2 = this.config.beaconUrlFallback;
-          this.logger.logEvent(90 /* LogEvent.PostBeaconCSPViolation */, [this.config.beaconUrlV2]);
-          this.addFlag(4096 /* Flags.BeaconBlockedByCsp */);
+          _this.config.beaconUrlV2 = _this.config.beaconUrlFallback;
+          _this.logger.logEvent(90 /* LogEvent.PostBeaconCSPViolation */, [_this.config.beaconUrlV2]);
+          _this.addFlag(4096 /* Flags.BeaconBlockedByCsp */);
           // Not all browsers return false if sendBeacon fails. In this case, `this.isSent` will be
           // true, even though the beacon wasn't sent. We need to reset this flag to ensure we can
           // retry sending the beacon.
-          this.isSent = false;
+          _this.isSent = false;
           // Try to send the beacon again
-          if (this.sendRetries < 1) {
-            this.sendRetries++;
-            this.send();
+          if (_this.sendRetries < 1) {
+            _this.sendRetries++;
+            _this.send();
           }
         }
       });
       this.logger.logEvent(80 /* LogEvent.PostBeaconInitialised */);
     }
-    isBeingSampled() {
-      const bucket = parseInt(String(this.sessionId).slice(-2));
+    Beacon.prototype.isBeingSampled = function () {
+      var bucket = parseInt(String(this.sessionId).slice(-2));
       return bucket < this.config.samplerate;
-    }
-    stopRecording() {
+    };
+    Beacon.prototype.stopRecording = function () {
       this.isRecording = false;
       this.logger.logEvent(86 /* LogEvent.PostBeaconStopRecording */);
-    }
-    addCollector(metric, collector) {
+    };
+    Beacon.prototype.addCollector = function (metric, collector) {
       this.metricCollectors[metric] = collector;
-    }
-    addFlag(flag) {
+    };
+    Beacon.prototype.addFlag = function (flag) {
       this.flags = addFlag(this.flags, flag);
-    }
-    beaconUrl() {
+    };
+    Beacon.prototype.beaconUrl = function () {
       return this.config.beaconUrlV2;
-    }
-    onBeforeSend(cb) {
+    };
+    Beacon.prototype.onBeforeSend = function (cb) {
       this.onBeforeSendCbs.push(cb);
-    }
-    send() {
+    };
+    Beacon.prototype.send = function () {
+      if (this.isSent) {
+        return;
+      }
       this.logger.logEvent(81 /* LogEvent.PostBeaconSendCalled */);
-      for (const cb of this.onBeforeSendCbs) {
+      for (var _i = 0, _a = this.onBeforeSendCbs; _i < _a.length; _i++) {
+        var cb = _a[_i];
         cb();
       }
       if (!this.isBeingSampled()) {
         return;
       }
-      const collectionStart = now();
-      const metricData = {};
-      for (const metric in this.metricCollectors) {
-        const data = this.metricCollectors[metric](this.config);
+      var collectionStart = now();
+      var metricData = {};
+      for (var metric in this.metricCollectors) {
+        var data = this.metricCollectors[metric](this.config);
         this.logger.logEvent(91 /* LogEvent.PostBeaconCollector */, [metric, !!data]);
         if (data) {
           metricData[metric] = data;
@@ -393,20 +419,17 @@
         this.logger.logEvent(85 /* LogEvent.PostBeaconCancelled */);
         return;
       }
-      if (this.isSent) {
-        this.logger.logEvent(84 /* LogEvent.PostBeaconAlreadySent */);
-        return;
-      }
       // Only clear the max measure timeout if there's data to send.
       clearTimeout(this.maxMeasureTimeout);
-      const beaconUrl = this.beaconUrl();
-      const payload = Object.assign({
+      var beaconUrl = this.beaconUrl();
+      var payload = Object.assign({
         customerId: this.customerId,
         flags: this.flags,
         measureDuration: msSincePageInit(),
         collectionDuration: now() - collectionStart,
         pageId: this.pageId,
         scriptVersion: VERSION,
+        snippetVersion: this.config.snippetVersion,
         sessionId: this.sessionId,
         startTime: this.startTime,
       }, metricData);
@@ -414,6 +437,7 @@
         if (sendBeacon(beaconUrl, JSON.stringify(payload))) {
           this.isSent = true;
           this.logger.logEvent(83 /* LogEvent.PostBeaconSent */, [beaconUrl, payload]);
+          emit("beacon", payload);
         }
       }
       catch (e) {
@@ -422,8 +446,9 @@
       if (!this.isSent) {
         this.logger.logEvent(89 /* LogEvent.PostBeaconSendFailed */, [beaconUrl, payload]);
       }
-    }
-  }
+    };
+    return Beacon;
+  }());
   var BeaconMetricKey;
   (function (BeaconMetricKey) {
     BeaconMetricKey["CLS"] = "cls";
@@ -440,15 +465,16 @@
     }
     else {
       // Listen for the onload event and run the callback after a short delay
-      addListener("load", () => {
+      addListener("load", function () {
         setTimeout(callback, 200);
       });
     }
   }
 
-  const luxOrigin = "https://lux.speedcurve.com";
+  var luxOrigin = "https://lux.speedcurve.com";
   function fromObject(obj) {
-    const autoMode = getProperty(obj, "auto", true);
+    var spaMode = getProperty(obj, "spaMode", false);
+    var autoMode = spaMode ? false : getProperty(obj, "auto", true);
     return {
       allowEmptyPostBeacon: getProperty(obj, "allowEmptyPostBeacon", false),
       auto: autoMode,
@@ -466,14 +492,15 @@
       maxBeaconUrlLength: getProperty(obj, "maxBeaconUrlLength", 8190),
       maxBeaconUTEntries: getProperty(obj, "maxBeaconUTEntries", 20),
       maxErrors: getProperty(obj, "maxErrors", 5),
-      maxMeasureTime: getProperty(obj, "maxMeasureTime", 60_000),
-      measureUntil: getProperty(obj, "measureUntil", "onload"),
+      maxMeasureTime: getProperty(obj, "maxMeasureTime", 60000),
+      measureUntil: getProperty(obj, "measureUntil", spaMode ? "pagehidden" : "onload"),
       minMeasureTime: getProperty(obj, "minMeasureTime", 0),
       newBeaconOnPageShow: getProperty(obj, "newBeaconOnPageShow", false),
       pagegroups: getProperty(obj, "pagegroups"),
       samplerate: getProperty(obj, "samplerate", 100),
-      sendBeaconOnPageHidden: getProperty(obj, "sendBeaconOnPageHidden", autoMode),
+      sendBeaconOnPageHidden: getProperty(obj, "sendBeaconOnPageHidden", spaMode || autoMode),
       serverTiming: getProperty(obj, "serverTiming"),
+      spaMode: spaMode,
       trackErrors: getProperty(obj, "trackErrors", true),
       trackHiddenPages: getProperty(obj, "trackHiddenPages", false),
     };
@@ -485,13 +512,13 @@
     return defaultValue;
   }
 
-  const SESSION_COOKIE_NAME = "lux_uid";
+  var SESSION_COOKIE_NAME = "lux_uid";
 
-  const customDataValues = {};
-  let updatedCustomData = {};
+  var customDataValues = {};
+  var updatedCustomData = {};
   function addCustomDataValue(name, value) {
-    const typeV = typeof value;
-    const valueIsEmpty = typeV === "undefined" || value === null;
+    var typeV = typeof value;
+    var valueIsEmpty = typeV === "undefined" || value === null;
     if (!valueIsEmpty && customDataValues[name] !== value) {
       // If the value is new or different to the previous value, record it so that later we can send
       // only the values that have changed.
@@ -517,10 +544,10 @@
   * Convert a set of custom data values to the string format expected by the backend.
   */
   function valuesToString(values) {
-    const strings = [];
-    for (let key in values) {
+    var strings = [];
+    for (var key in values) {
       // Convert all values to strings
-      let value = "" + values[key];
+      var value = "" + values[key];
       // Strip out reserved characters (, and | are used as delimiters)
       key = key.replace(/,/g, "").replace(/\|/g, "");
       value = value.replace(/,/g, "").replace(/\|/g, "");
@@ -530,8 +557,9 @@
   }
 
   function getClosestScTrackAttribute(el) {
+    var _a;
     if (el.hasAttribute("data-sctrack")) {
-      const trackId = el.getAttribute("data-sctrack")?.trim();
+      var trackId = (_a = el.getAttribute("data-sctrack")) === null || _a === void 0 ? void 0 : _a.trim();
       if (trackId) {
         return trackId;
       }
@@ -548,20 +576,22 @@
     }
     return false;
   }
-  const MAX_SELECTOR_LENGTH = 100;
-  function getNodeSelector(node, selector = "") {
+  var MAX_SELECTOR_LENGTH = 100;
+  function getNodeSelector(node, selector) {
+    if (selector === void 0) { selector = ""; }
     return _getNodeSelector(node, selector).slice(0, MAX_SELECTOR_LENGTH);
   }
-  function _getNodeSelector(node, selector = "") {
+  function _getNodeSelector(node, selector) {
+    if (selector === void 0) { selector = ""; }
     try {
       if (selector &&
         (node.nodeType === 9 || selector.length > MAX_SELECTOR_LENGTH || !node.parentNode)) {
-        // Final selector.
-        return selector;
+          // Final selector.
+          return selector;
       }
-      const el = node;
+      var el = node;
       // Our first preference is to use the data-sctrack attribute from anywhere in the tree
-      const trackId = getClosestScTrackAttribute(el);
+      var trackId = getClosestScTrackAttribute(el);
       if (trackId) {
         return trackId;
       }
@@ -571,15 +601,15 @@
       }
       else if (el) {
         // Otherwise attempt to get parent elements recursively
-        const name = el.nodeType === 1 ? el.nodeName.toLowerCase() : el.nodeName.toUpperCase();
-        let classes = el.className ? "." + el.className.replace(/\s+/g, ".") : "";
+        var name_1 = el.nodeType === 1 ? el.nodeName.toLowerCase() : el.nodeName.toUpperCase();
+        var classes = el.className ? "." + el.className.replace(/\s+/g, ".") : "";
         // Remove classes until the selector is short enough
-        while ((name + classes).length > MAX_SELECTOR_LENGTH) {
+        while ((name_1 + classes).length > MAX_SELECTOR_LENGTH) {
           classes = classes.split(".").slice(0, -1).join(".");
         }
-        const currentSelector = name + classes + (selector ? ">" + selector : "");
+        var currentSelector = name_1 + classes + (selector ? ">" + selector : "");
         if (el.parentNode) {
-          const selectorWithParent = getNodeSelector(el.parentNode, currentSelector);
+          var selectorWithParent = getNodeSelector(el.parentNode, currentSelector);
           if (selectorWithParent.length < MAX_SELECTOR_LENGTH) {
             return selectorWithParent;
           }
@@ -593,27 +623,7 @@
     return selector;
   }
 
-  const subscribers = {};
-  const eventData = {};
-  function subscribe(event, callback) {
-    if (!subscribers[event]) {
-      subscribers[event] = [];
-    }
-    subscribers[event].push(callback);
-    // Ensure previous event data is available to new subscribers
-    if (eventData[event] !== undefined) {
-      callback(eventData[event]);
-    }
-  }
-  function emit(event, data) {
-    eventData[event] = data;
-    if (!subscribers[event]) {
-      return;
-    }
-    subscribers[event].forEach((callback) => callback(data));
-  }
-
-  const KNOWN_TRACKING_PARAMS = [
+  var KNOWN_TRACKING_PARAMS = [
     "utm_source",
     "utm_campaign",
     "utm_medium",
@@ -624,11 +634,12 @@
   * Add known tracking parameters to the custom data storage.
   */
   function getTrackingParams() {
-    const trackingParams = {};
+    var trackingParams = {};
     if (location.search && typeof URLSearchParams === "function") {
-      const p = new URLSearchParams(location.search);
-      for (const key of KNOWN_TRACKING_PARAMS) {
-        const value = p.get(key);
+      var p = new URLSearchParams(location.search);
+      for (var _i = 0, KNOWN_TRACKING_PARAMS_1 = KNOWN_TRACKING_PARAMS; _i < KNOWN_TRACKING_PARAMS_1.length; _i++) {
+        var key = KNOWN_TRACKING_PARAMS_1[_i];
+        var value = p.get(key);
         if (value) {
           trackingParams[key] = value;
         }
@@ -637,42 +648,46 @@
     return trackingParams;
   }
 
-  class Logger {
-    events = [];
-    logEvent(event, args = []) {
+  var Logger = /** @class */ (function () {
+    function Logger() {
+      this.events = [];
+    }
+    Logger.prototype.logEvent = function (event, args) {
+      if (args === void 0) { args = []; }
       this.events.push([now(), event, args]);
-    }
-    getEvents() {
+    };
+    Logger.prototype.getEvents = function () {
       return this.events;
-    }
-  }
+    };
+    return Logger;
+  }());
 
-  let sessionValue = 0;
-  let sessionEntries = [];
-  let sessionAttributions = [];
-  let largestEntry;
-  let maximumSessionValue = 0;
+  var sessionValue = 0;
+  var sessionEntries = [];
+  var sessionAttributions = [];
+  var largestEntry;
+  var maximumSessionValue = 0;
   function processEntry$3(entry) {
     if (!entry.hadRecentInput) {
-      const firstEntry = sessionEntries[0];
-      const latestEntry = sessionEntries[sessionEntries.length - 1];
-      const sources = entry.sources
+      var firstEntry = sessionEntries[0];
+      var latestEntry = sessionEntries[sessionEntries.length - 1];
+      var sources = entry.sources
       ? entry.sources
-      .filter((source) => source.node)
-      .map((source) => ({
+      .filter(function (source) { return source.node; })
+      .map(function (source) { return ({
         value: entry.value,
         startTime: processTimeMetric(entry.startTime),
         elementSelector: getNodeSelector(source.node),
         elementType: source.node.nodeName,
-      }))
+      }); })
       : [];
       if (sessionEntries.length &&
         (entry.startTime - latestEntry.startTime >= 1000 ||
           entry.startTime - firstEntry.startTime >= 5000)) {
-        sessionValue = entry.value;
-        sessionEntries = [entry];
-        sessionAttributions = sources;
-        largestEntry = entry;
+          sessionValue = entry.value;
+          sessionEntries = [entry];
+          sessionAttributions = sources;
+          largestEntry = entry;
       }
       else {
         sessionValue += entry.value;
@@ -710,7 +725,40 @@
     };
   }
 
-  let entries = [];
+  /******************************************************************************
+  Copyright (c) Microsoft Corporation.
+
+  Permission to use, copy, modify, and/or distribute this software for any
+  purpose with or without fee is hereby granted.
+
+  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+  REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+  AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+  INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+  LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+  OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+  PERFORMANCE OF THIS SOFTWARE.
+  ***************************************************************************** */
+  /* global Reflect, Promise, SuppressedError, Symbol, Iterator */
+
+
+  var __assign = function() {
+    __assign = Object.assign || function __assign(t) {
+      for (var s, i = 1, n = arguments.length; i < n; i++) {
+        s = arguments[i];
+        for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+      }
+      return t;
+    };
+    return __assign.apply(this, arguments);
+  };
+
+  typeof SuppressedError === "function" ? SuppressedError : function (error, suppressed, message) {
+    var e = new Error(message);
+    return e.name = "SuppressedError", e.error = error, e.suppressed = suppressed, e;
+  };
+
+  var entries = [];
   function processEntry$2(entry) {
     entries.push(entry);
   }
@@ -721,13 +769,13 @@
     return entries;
   }
   function getData$2(config) {
-    const summarizedEntries = [];
-    let totalDuration = 0;
-    let totalBlockingDuration = 0;
-    let totalStyleAndLayoutDuration = 0;
-    let totalWorkDuration = 0;
-    entries.forEach((entry) => {
-      const { startTime, blockingDuration, duration, renderStart, styleAndLayoutStart } = entry;
+    var summarizedEntries = [];
+    var totalDuration = 0;
+    var totalBlockingDuration = 0;
+    var totalStyleAndLayoutDuration = 0;
+    var totalWorkDuration = 0;
+    entries.forEach(function (entry) {
+      var startTime = entry.startTime, blockingDuration = entry.blockingDuration, duration = entry.duration, renderStart = entry.renderStart, styleAndLayoutStart = entry.styleAndLayoutStart;
       totalDuration += duration;
       totalBlockingDuration += blockingDuration;
       totalStyleAndLayoutDuration += styleAndLayoutStart
@@ -748,18 +796,18 @@
       totalEntries: entries.length,
       totalStyleAndLayoutDuration: floor(totalStyleAndLayoutDuration),
       totalWorkDuration: floor(totalWorkDuration),
-      scripts: summarizeLoAFScripts(entries.flatMap((entry) => entry.scripts), config),
+      scripts: summarizeLoAFScripts(entries.flatMap(function (entry) { return entry.scripts; }), config),
       // Only keep the slowest LoAF entries
       entries: summarizedEntries
-      .sort((a, b) => b.duration - a.duration)
+      .sort(function (a, b) { return b.duration - a.duration; })
       .slice(0, config.maxAttributionEntries)
-      .sort((a, b) => a.startTime - b.startTime),
+      .sort(function (a, b) { return a.startTime - b.startTime; }),
     };
   }
   function summarizeLoAFScripts(scripts, config) {
-    const summary = {};
-    scripts.forEach((script) => {
-      const key = script.sourceURL;
+    var summary = {};
+    scripts.forEach(function (script) {
+      var key = script.sourceURL;
       if (!summary[key]) {
         summary[key] = {
           sourceUrl: script.sourceURL,
@@ -782,13 +830,8 @@
       summary[key].timings.push([floor(script.startTime), floor(script.duration)]);
     });
     return Object.values(summary)
-    .map((script) => ({
-      ...script,
-      totalDuration: floor(script.totalDuration),
-      totalPauseDuration: floor(script.totalPauseDuration),
-      totalForcedStyleAndLayoutDuration: floor(script.totalForcedStyleAndLayoutDuration),
-    }))
-    .sort((a, b) => b.totalDuration - a.totalDuration)
+    .map(function (script) { return (__assign(__assign({}, script), { totalDuration: floor(script.totalDuration), totalPauseDuration: floor(script.totalPauseDuration), totalForcedStyleAndLayoutDuration: floor(script.totalForcedStyleAndLayoutDuration) })); })
+    .sort(function (a, b) { return b.totalDuration - a.totalDuration; })
     .slice(0, config.maxAttributionEntries);
   }
 
@@ -797,7 +840,7 @@
   * bare minimum required to measure just the INP value and does not store the actual event entries.
   */
   // The maximum number of interactions to store
-  const MAX_INTERACTIONS = 10;
+  var MAX_INTERACTIONS = 10;
   var INPPhase;
   (function (INPPhase) {
     INPPhase["InputDelay"] = "ID";
@@ -805,11 +848,11 @@
     INPPhase["PresentationDelay"] = "PD";
   })(INPPhase || (INPPhase = {}));
   // A list of the slowest interactions
-  let slowestEntries = [];
+  var slowestEntries = [];
   // A map of the slowest interactions by ID
-  let slowestEntriesMap = {};
+  var slowestEntriesMap = {};
   // The total number of interactions recorded on the page
-  let interactionCountEstimate = 0;
+  var interactionCountEstimate = 0;
   function reset$1() {
     interactionCountEstimate = 0;
     slowestEntries = [];
@@ -817,22 +860,22 @@
   }
   function processEntry$1(entry) {
     if (entry.interactionId || (entry.entryType === "first-input" && !entryExists(entry))) {
-      const { duration, startTime, interactionId, name, processingStart, processingEnd, target } = entry;
+      var duration = entry.duration, startTime = entry.startTime, interactionId = entry.interactionId, name_1 = entry.name, processingStart = entry.processingStart, processingEnd = entry.processingEnd, target = entry.target;
       if (duration < 0) {
         return;
       }
-      const processingTime = processingEnd - processingStart;
-      const existingEntry = slowestEntriesMap[interactionId];
-      const selector = target ? getNodeSelector(target) : null;
+      var processingTime = processingEnd - processingStart;
+      var existingEntry = slowestEntriesMap[interactionId];
+      var selector = target ? getNodeSelector(target) : null;
       if (existingEntry) {
-        const longerDuration = duration > existingEntry.duration;
-        const sameWithLongerProcessingTime = duration === existingEntry.duration && processingTime > existingEntry.processingTime;
+        var longerDuration = duration > existingEntry.duration;
+        var sameWithLongerProcessingTime = duration === existingEntry.duration && processingTime > existingEntry.processingTime;
         if (longerDuration || sameWithLongerProcessingTime) {
           // Only replace an existing interation if the duration is longer, or if the duration is the
           // same but the processing time is longer. The logic around this is that the interaction with
           // longer processing time is likely to be the event that actually had a handler.
           existingEntry.duration = duration;
-          existingEntry.name = name;
+          existingEntry.name = name_1;
           existingEntry.processingEnd = processingEnd;
           existingEntry.processingStart = processingStart;
           existingEntry.processingTime = processingTime;
@@ -844,54 +887,57 @@
       else {
         interactionCountEstimate++;
         slowestEntriesMap[interactionId] = {
-          duration,
-          interactionId,
-          name,
-          processingEnd,
-          processingStart,
-          processingTime,
-          selector,
-          startTime,
-          target,
+          duration: duration,
+          interactionId: interactionId,
+          name: name_1,
+          processingEnd: processingEnd,
+          processingStart: processingStart,
+          processingTime: processingTime,
+          selector: selector,
+          startTime: startTime,
+          target: target,
         };
         slowestEntries.push(slowestEntriesMap[interactionId]);
       }
       // Only store the longest <MAX_INTERACTIONS> interactions
-      slowestEntries.sort((a, b) => b.duration - a.duration);
-      slowestEntries.splice(MAX_INTERACTIONS).forEach((entry) => {
+      slowestEntries.sort(function (a, b) { return b.duration - a.duration; });
+      slowestEntries.splice(MAX_INTERACTIONS).forEach(function (entry) {
         delete slowestEntriesMap[entry.interactionId];
       });
     }
   }
   function entryExists(e1) {
-    return slowestEntries.some((e2) => e1.startTime === e2.startTime && e1.duration === e2.duration);
+    return slowestEntries.some(function (e2) { return e1.startTime === e2.startTime && e1.duration === e2.duration; });
   }
   /**
   * Returns an estimated high percentile INP value based on the total number of interactions on the
   * current page.
   */
   function getHighPercentileInteraction() {
-    const index = Math.min(slowestEntries.length - 1, Math.floor(getInteractionCount() / 50));
+    var index = Math.min(slowestEntries.length - 1, Math.floor(getInteractionCount() / 50));
     return slowestEntries[index];
   }
   function getData$1(config) {
-    const interaction = getHighPercentileInteraction();
+    var _a;
+    var interaction = getHighPercentileInteraction();
     if (!interaction) {
       return undefined;
     }
-    const { duration, startTime, processingStart } = interaction;
-    const inpScripts = getEntries$1()
-    .flatMap((entry) => entry.scripts)
+    var duration = interaction.duration, startTime = interaction.startTime, processingStart = interaction.processingStart;
+    var inpScripts = getEntries$1()
+    .flatMap(function (entry) { return entry.scripts; })
     // Only include scripts that started during the interaction
-    .filter((script) => script.startTime + script.duration >= startTime && script.startTime <= startTime + duration)
-    .map((_script) => {
-      const script = JSON.parse(JSON.stringify(_script));
+    .filter(function (script) {
+      return script.startTime + script.duration >= startTime && script.startTime <= startTime + duration;
+    })
+    .map(function (_script) {
+      var script = JSON.parse(JSON.stringify(_script));
       // Clamp the script duration to the time of the interaction
       script.duration = script.startTime + script.duration - max(startTime, script.startTime);
       script.inpPhase = getINPPhase(script, interaction);
       return script;
     });
-    const loafScripts = summarizeLoAFScripts(inpScripts, config);
+    var loafScripts = summarizeLoAFScripts(inpScripts, config);
     return {
       value: interaction.duration,
       startTime: processTimeMetric(startTime),
@@ -906,14 +952,14 @@
       attribution: {
         eventType: interaction.name,
         elementSelector: interaction.selector || null,
-        elementType: interaction.target?.nodeName || null,
-        loafScripts,
+        elementType: ((_a = interaction.target) === null || _a === void 0 ? void 0 : _a.nodeName) || null,
+        loafScripts: loafScripts,
       },
     };
   }
   function getINPPhase(script, interaction) {
-    const { processingStart, processingTime, startTime } = interaction;
-    const inputDelay = processingStart - startTime;
+    var processingStart = interaction.processingStart, processingTime = interaction.processingTime, startTime = interaction.startTime;
+    var inputDelay = processingStart - startTime;
     if (script.startTime < startTime + inputDelay) {
       return INPPhase.InputDelay;
     }
@@ -929,7 +975,7 @@
     return interactionCountEstimate;
   }
 
-  let lcpEntry;
+  var lcpEntry;
   function processEntry(entry) {
     if (!lcpEntry || entry.startTime > lcpEntry.startTime) {
       lcpEntry = entry;
@@ -942,18 +988,18 @@
     if (!lcpEntry) {
       return undefined;
     }
-    let subParts = null;
+    var subParts = null;
     if (lcpEntry.url) {
-      const lcpResource = getEntriesByType("resource").find((resource) => resource.name === lcpEntry.url);
+      var lcpResource = getEntriesByType("resource").find(function (resource) { return resource.name === lcpEntry.url; });
       if (lcpResource) {
-        const navEntry = getNavigationEntry();
-        const responseStart = navEntry.responseStart || timing.responseStart;
-        const activationStart = navEntry.activationStart;
-        const ttfb = max(0, responseStart - activationStart);
-        const lcpStartTime = lcpResource.startTime;
-        const lcpRequestStart = (lcpResource.requestStart || lcpStartTime) - activationStart;
-        const lcpResponseEnd = max(lcpRequestStart, lcpResource.responseEnd - activationStart);
-        const lcpRenderTime = max(lcpResponseEnd, lcpStartTime - activationStart);
+        var navEntry = getNavigationEntry();
+        var responseStart = navEntry.responseStart || timing.responseStart;
+        var activationStart = navEntry.activationStart;
+        var ttfb = max(0, responseStart - activationStart);
+        var lcpStartTime = lcpResource.startTime;
+        var lcpRequestStart = (lcpResource.requestStart || lcpStartTime) - activationStart;
+        var lcpResponseEnd = max(lcpRequestStart, lcpResource.responseEnd - activationStart);
+        var lcpRenderTime = max(lcpResponseEnd, lcpStartTime - activationStart);
         subParts = {
           resourceLoadDelay: clamp(floor(lcpRequestStart - ttfb)),
           resourceLoadTime: clamp(floor(lcpResponseEnd - lcpRequestStart)),
@@ -961,7 +1007,7 @@
         };
       }
     }
-    const value = lcpEntry.startTime;
+    var value = lcpEntry.startTime;
     if (!shouldReportValue(value)) {
       // It's possible the LCP entry we have occurred before the current page was initialised. In
       // this case, we don't want to report the LCP value.
@@ -969,7 +1015,7 @@
     }
     return {
       value: processTimeMetric(value),
-      subParts,
+      subParts: subParts,
       attribution: lcpEntry.element
       ? {
         elementSelector: getNodeSelector(lcpEntry.element),
@@ -979,20 +1025,20 @@
     };
   }
 
-  const ALL_ENTRIES = [];
+  var ALL_ENTRIES = [];
   function observe(type, callback, options) {
     if (typeof PerformanceObserver === "function" &&
       PerformanceObserver.supportedEntryTypes.includes(type)) {
-      const po = new PerformanceObserver((list) => {
-        list.getEntries().forEach((entry) => callback(entry));
+      var po = new PerformanceObserver(function (list) {
+        list.getEntries().forEach(function (entry) { return callback(entry); });
       });
-      po.observe(Object.assign({ type, buffered: true }, { options }));
+      po.observe(Object.assign({ type: type, buffered: true }, { options: options }));
       return po;
     }
     return undefined;
   }
   function getEntries(type) {
-    return ALL_ENTRIES.filter((entry) => entry.entryType === type);
+    return ALL_ENTRIES.filter(function (entry) { return entry.entryType === type; });
   }
   function addEntry(entry) {
     ALL_ENTRIES.push(entry);
@@ -1001,24 +1047,24 @@
   /**
   * A server timing metric that has its value set to the duration field
   */
-  const TYPE_DURATION = "r";
+  var TYPE_DURATION = "r";
   /**
   * When a description metric has no value, we consider it to be a boolean and set it to this value.
   */
-  const BOOLEAN_TRUE_VALUE = "true";
+  var BOOLEAN_TRUE_VALUE = "true";
   function getKeyValuePairs(config, serverTiming) {
-    const pairs = {};
-    serverTiming.forEach((stEntry) => {
-      const name = stEntry.name;
-      const description = stEntry.description;
+    var pairs = {};
+    serverTiming.forEach(function (stEntry) {
+      var name = stEntry.name;
+      var description = stEntry.description;
       if (name in config) {
-        const spec = config[name];
-        const multiplier = spec[1];
+        var spec = config[name];
+        var multiplier = spec[1];
         if (spec[0] === TYPE_DURATION) {
           pairs[name] = stEntry.duration * (multiplier || 1);
         }
         else if (description && multiplier) {
-          const numericValue = parseFloat(description);
+          var numericValue = parseFloat(description);
           if (!isNaN(numericValue)) {
             pairs[name] = numericValue * multiplier;
           }
@@ -1032,12 +1078,12 @@
   }
 
   function getMatchesFromPatternMap(patternMap, hostname, pathname, firstOnly) {
-    const matches = [];
-    for (const key in patternMap) {
-      const patterns = patternMap[key];
+    var matches = [];
+    for (var key in patternMap) {
+      var patterns = patternMap[key];
       if (Array.isArray(patterns)) {
-        for (const i in patterns) {
-          const pattern = patterns[i];
+        for (var i in patterns) {
+          var pattern = patterns[i];
           if (typeof pattern === "string" && patternMatchesUrl(pattern, hostname, pathname)) {
             if (firstOnly) {
               return key;
@@ -1053,7 +1099,7 @@
     return matches;
   }
   function patternMatchesUrl(pattern, hostname, pathname) {
-    const regex = createRegExpFromPattern(pattern);
+    var regex = createRegExpFromPattern(pattern);
     if (pattern.charAt(0) === "/") {
       // Rule is a pathname only
       return regex.test(pathname);
@@ -1069,8 +1115,8 @@
     return str.replace(/[-/\\^$+?.()|[\]{}]/g, "\\$&");
   }
 
-  let LUX = window.LUX || {};
-  let scriptEndTime = scriptStartTime;
+  var LUX = window.LUX || {};
+  var scriptEndTime = scriptStartTime;
   LUX = (function () {
     // -------------------------------------------------------------------------
     // Settings
@@ -1084,19 +1130,19 @@
     // -------------------------------------------------------------------------
     /// End
     // -------------------------------------------------------------------------
-    const logger = new Logger();
-    const globalConfig = fromObject(LUX);
+    var logger = new Logger();
+    var globalConfig = fromObject(LUX);
     logger.logEvent(1 /* LogEvent.EvaluationStart */, [VERSION, JSON.stringify(globalConfig)]);
     // Variable aliases that allow the minifier to reduce file size.
-    const document = window.document;
-    const addEventListener = window.addEventListener;
-    const removeEventListener = window.removeEventListener;
-    const setTimeout = window.setTimeout;
-    const clearTimeout = window.clearTimeout;
-    const encodeURIComponent = window.encodeURIComponent;
-    const thisScript = document.currentScript || {};
+    var document = window.document;
+    var addEventListener = window.addEventListener;
+    var removeEventListener = window.removeEventListener;
+    var setTimeout = window.setTimeout;
+    var clearTimeout = window.clearTimeout;
+    var encodeURIComponent = window.encodeURIComponent;
+    var thisScript = document.currentScript || {};
     // Log JS errors.
-    let nErrors = 0;
+    var nErrors = 0;
     function errorHandler(e) {
       if (!globalConfig.trackErrors) {
         return;
@@ -1104,7 +1150,7 @@
       nErrors++;
       if (e && typeof e.filename !== "undefined" && typeof e.message !== "undefined") {
         // Always send LUX errors
-        const isLuxError = e.filename.indexOf("/lux.js?") > -1 || e.message.indexOf("LUX") > -1;
+        var isLuxError = e.filename.indexOf("/lux.js?") > -1 || e.message.indexOf("LUX") > -1;
         if (isLuxError || (nErrors <= globalConfig.maxErrors && _sample())) {
           // Sample & limit other errors.
           // Send the error beacon.
@@ -1134,28 +1180,28 @@
     }
     addEventListener("error", errorHandler);
     // Bitmask of flags for this session & page
-    let gFlags = 0;
-    const gaMarks = [];
-    const gaMeasures = [];
-    let ghIx = {}; // hash for Interaction Metrics (scroll, click, keyboard)
-    let gbLuxSent = 0; // have we sent the LUX data? (avoid sending twice in unload)
-    let gbNavSent = 0; // have we sent the Nav Timing beacon yet? (avoid sending twice for SPA)
-    let gbIxSent = 0; // have we sent the IX data? (avoid sending twice for SPA)
-    let gbFirstPV = 1; // this is the first page view (vs. a SPA "soft nav")
-    const gSessionTimeout = 30 * 60; // number of seconds after which we consider a session to have "timed out" (used for calculating bouncerate)
-    let gSyncId = createSyncId(); // if we send multiple beacons, use this to sync them (eg, LUX & IX) (also called "luxid")
-    let gUid = refreshUniqueId(gSyncId); // cookie for this session ("Unique ID")
-    let gCustomDataTimeout; // setTimeout timer for sending a Custom data beacon after onload
-    let gMaxMeasureTimeout; // setTimeout timer for sending the beacon after a maximum measurement time
+    var gFlags = 0;
+    var gaMarks = [];
+    var gaMeasures = [];
+    var ghIx = {}; // hash for Interaction Metrics (scroll, click, keyboard)
+    var gbLuxSent = 0; // have we sent the LUX data? (avoid sending twice in unload)
+    var gbNavSent = 0; // have we sent the Nav Timing beacon yet? (avoid sending twice for SPA)
+    var gbIxSent = 0; // have we sent the IX data? (avoid sending twice for SPA)
+    var gbFirstPV = 1; // this is the first page view (vs. a SPA "soft nav")
+    var gSessionTimeout = 30 * 60; // number of seconds after which we consider a session to have "timed out" (used for calculating bouncerate)
+    var gSyncId = createSyncId(); // if we send multiple beacons, use this to sync them (eg, LUX & IX) (also called "luxid")
+    var gUid = refreshUniqueId(gSyncId); // cookie for this session ("Unique ID")
+    var gCustomDataTimeout; // setTimeout timer for sending a Custom data beacon after onload
+    var gMaxMeasureTimeout; // setTimeout timer for sending the beacon after a maximum measurement time
     // Storing the customer ID in a local variable makes it possible to run multiple instances of lux.js
     // on the same page.
-    let _thisCustomerId = LUX.customerid;
-    const beaconCollectors = [];
-    const logEntry = (entry) => {
+    var _thisCustomerId = LUX.customerid;
+    var beaconCollectors = [];
+    var logEntry = function (entry) {
       logger.logEvent(42 /* LogEvent.PerformanceEntryReceived */, [entry]);
     };
     // Most PerformanceEntry types we log an event for and add it to the global entry store.
-    const processAndLogEntry = (entry) => {
+    var processAndLogEntry = function (entry) {
       addEntry(entry);
       logEntry(entry);
     };
@@ -1163,7 +1209,7 @@
       observe("longtask", processAndLogEntry);
       observe("element", processAndLogEntry);
       observe("paint", processAndLogEntry);
-      if (observe("largest-contentful-paint", (entry) => {
+      if (observe("largest-contentful-paint", function (entry) {
         // Process the LCP entry for the legacy beacon
         processAndLogEntry(entry);
         // Process the LCP entry for the new beacon
@@ -1171,36 +1217,36 @@
       })) {
         beaconCollectors.push([BeaconMetricKey.LCP, getData]);
       }
-      if (observe("layout-shift", (entry) => {
+      if (observe("layout-shift", function (entry) {
         processEntry$3(entry);
         logEntry(entry);
       })) {
         beaconCollectors.push([BeaconMetricKey.CLS, getData$3]);
       }
-      if (observe("long-animation-frame", (entry) => {
+      if (observe("long-animation-frame", function (entry) {
         processEntry$2(entry);
         logEntry(entry);
       })) {
         beaconCollectors.push([BeaconMetricKey.LoAF, getData$2]);
       }
-      const handleINPEntry = (entry) => {
+      var handleINPEntry_1 = function (entry) {
         processEntry$1(entry);
         logEntry(entry);
       };
-      observe("first-input", (entry) => {
+      observe("first-input", function (entry) {
         logEntry(entry);
-        const entryTime = entry.processingStart - entry.startTime;
+        var entryTime = entry.processingStart - entry.startTime;
         if (!gFirstInputDelay || gFirstInputDelay < entryTime) {
           gFirstInputDelay = floor(entryTime);
         }
         // Allow first-input events to be considered for INP
-        handleINPEntry(entry);
+        handleINPEntry_1(entry);
       });
       // TODO: Set durationThreshold to 40 once performance.interactionCount is widely supported.
       // Right now we have to count every event to get the total interaction count so that we can
       // estimate a high percentile value for INP.
-      if (observe("event", (entry) => {
-        handleINPEntry(entry);
+      if (observe("event", function (entry) {
+        handleINPEntry_1(entry);
         // It's useful to log the interactionId, but it is not serialised by default. Annoyingly, we
         // need to manually serialize our own object with the keys we want.
         logEntry({
@@ -1219,27 +1265,28 @@
     catch (e) {
       logger.logEvent(51 /* LogEvent.PerformanceObserverError */, [e]);
     }
-    const initPostBeacon = () => {
-      const b = new Beacon({
+    var initPostBeacon = function () {
+      var b = new Beacon({
         config: globalConfig,
-        logger,
+        logger: logger,
         customerId: getCustomerId(),
         sessionId: gUid,
         pageId: gSyncId,
       });
-      beaconCollectors.forEach(([metric, collector]) => {
+      beaconCollectors.forEach(function (_a) {
+        var metric = _a[0], collector = _a[1];
         b.addCollector(metric, collector);
       });
       return b;
     };
-    let beacon = initPostBeacon();
+    var beacon = initPostBeacon();
     if (_sample()) {
       logger.logEvent(21 /* LogEvent.SessionIsSampled */, [globalConfig.samplerate]);
     }
     else {
       logger.logEvent(22 /* LogEvent.SessionIsNotSampled */, [globalConfig.samplerate]);
     }
-    const gLuxSnippetStart = LUX.ns ? LUX.ns - timing.navigationStart : 0;
+    var gLuxSnippetStart = LUX.ns ? LUX.ns - timing.navigationStart : 0;
     if (!performance.timing) {
       logger.logEvent(71 /* LogEvent.NavTimingNotSupported */);
       gFlags = addFlag(gFlags, 2 /* Flags.NavTimingNotSupported */);
@@ -1250,9 +1297,9 @@
     // FIRST INPUT DELAY (FID)
     // The basic idea behind FID is to attach various input event listeners and measure the time
     // between when the event happens and when the handler executes. That is FID.
-    let gFirstInputDelay;
-    const gaEventTypes = ["click", "mousedown", "keydown", "touchstart", "pointerdown"]; // NOTE: does NOT include scroll!
-    const ghListenerOptions = { passive: true, capture: true };
+    var gFirstInputDelay;
+    var gaEventTypes = ["click", "mousedown", "keydown", "touchstart", "pointerdown"]; // NOTE: does NOT include scroll!
+    var ghListenerOptions = { passive: true, capture: true };
     // Record the FIRST input delay.
     function recordDelay(delay) {
       if (!gFirstInputDelay) {
@@ -1284,7 +1331,7 @@
     // Record FID as the delta between when the event happened and when the
     // listener was able to execute.
     function onInput(evt) {
-      let bCancelable = false;
+      var bCancelable = false;
       try {
         // Seeing "Permission denied" errors, so do a simple try-catch.
         bCancelable = evt.cancelable;
@@ -1295,19 +1342,19 @@
         return;
       }
       if (bCancelable) {
-        let now = msSinceNavigationStart();
-        const eventTimeStamp = evt.timeStamp;
+        var now_1 = msSinceNavigationStart();
+        var eventTimeStamp = evt.timeStamp;
         if (eventTimeStamp > 1520000000) {
           // If the event timeStamp is an epoch time instead of a time relative to NavigationStart,
           // then compare it to Date.now() instead of performance.now().
-          now = Number(new Date());
+          now_1 = Number(new Date());
         }
-        if (eventTimeStamp > now) {
+        if (eventTimeStamp > now_1) {
           // If there is a race condition and eventTimeStamp happened after
           // this code was executed, something is wrong. Bail.
           return;
         }
-        const delay = now - eventTimeStamp;
+        var delay = now_1 - eventTimeStamp;
         if (evt.type === "pointerdown") {
           // special case
           onPointerDown(delay);
@@ -1324,23 +1371,28 @@
     ////////////////////// FID END
     // This is a wrapper around performance.mark that falls back to a polyfill when the User Timing
     // API isn't supported.
-    function _mark(...args) {
+    function _mark() {
+      var _a, _b;
+      var args = [];
+      for (var _i = 0; _i < arguments.length; _i++) {
+        args[_i] = arguments[_i];
+      }
       logger.logEvent(4 /* LogEvent.MarkCalled */, args);
       if (performance.mark) {
         // Use the native performance.mark where possible...
-        return performance.mark(...args);
+        return performance.mark.apply(performance, args);
       }
       // ...Otherwise provide a polyfill
-      if (true) {
-        const name = args[0];
-        const detail = args[1]?.detail || null;
-        const startTime = args[1]?.startTime || msSincePageInit();
-        const entry = {
+      {
+        var name_1 = args[0];
+        var detail = ((_a = args[1]) === null || _a === void 0 ? void 0 : _a.detail) || null;
+        var startTime = ((_b = args[1]) === null || _b === void 0 ? void 0 : _b.startTime) || msSincePageInit();
+        var entry = {
           entryType: "mark",
           duration: 0,
-          name,
-          detail,
-          startTime,
+          name: name_1,
+          detail: detail,
+          startTime: startTime,
         };
         gaMarks.push(entry);
         gFlags = addFlag(gFlags, 4 /* Flags.UserTimingNotSupported */);
@@ -1350,12 +1402,16 @@
     }
     // This is a wrapper around performance.measure that falls back to a polyfill when the User Timing
     // API isn't supported.
-    function _measure(...args) {
+    function _measure() {
+      var args = [];
+      for (var _i = 0; _i < arguments.length; _i++) {
+        args[_i] = arguments[_i];
+      }
       logger.logEvent(5 /* LogEvent.MeasureCalled */, args);
-      const name = args[0];
-      let startMarkName = args[1];
-      let endMarkName = args[2];
-      let options;
+      var name = args[0];
+      var startMarkName = args[1];
+      var endMarkName = args[2];
+      var options;
       if (typeof startMarkName === "object") {
         options = args[1];
         startMarkName = options.start;
@@ -1388,20 +1444,20 @@
       }
       if (performance.measure) {
         // Use the native performance.measure where possible...
-        return performance.measure(...args);
+        return performance.measure.apply(performance, args);
       }
       // ...Otherwise provide a polyfill
-      if (true) {
-        const navEntry = getNavigationEntry();
-        let startTime = typeof startMarkName === "number" ? startMarkName : 0;
-        let endTime = typeof endMarkName === "number" ? endMarkName : msSincePageInit();
-        const throwError = (missingMark) => {
+      {
+        var navEntry = getNavigationEntry();
+        var startTime = typeof startMarkName === "number" ? startMarkName : 0;
+        var endTime = typeof endMarkName === "number" ? endMarkName : msSincePageInit();
+        var throwError = function (missingMark) {
           throw new DOMException("Failed to execute 'measure' on 'Performance': The mark '" +
             missingMark +
             "' does not exist");
         };
         if (typeof startMarkName === "string") {
-          const startMark = _getMark(startMarkName);
+          var startMark = _getMark(startMarkName);
           if (startMark) {
             startTime = startMark.startTime;
           }
@@ -1414,7 +1470,7 @@
           }
         }
         if (typeof endMarkName === "string") {
-          const endMark = _getMark(endMarkName);
+          var endMark = _getMark(endMarkName);
           if (endMark) {
             endTime = endMark.startTime;
           }
@@ -1426,20 +1482,20 @@
             throwError(endMarkName);
           }
         }
-        let duration = endTime - startTime;
-        let detail = null;
+        var duration = endTime - startTime;
+        var detail = null;
         if (options) {
           if (options.duration) {
             duration = options.duration;
           }
           detail = options.detail;
         }
-        const entry = {
+        var entry = {
           entryType: "measure",
-          name,
-          detail,
-          startTime,
-          duration,
+          name: name,
+          detail: detail,
+          startTime: startTime,
+          duration: duration,
         };
         gaMeasures.push(entry);
         gFlags = addFlag(gFlags, 4 /* Flags.UserTimingNotSupported */);
@@ -1453,8 +1509,8 @@
     }
     function _getM(name, aItems) {
       if (aItems) {
-        for (let i = aItems.length - 1; i >= 0; i--) {
-          const m = aItems[i];
+        for (var i = aItems.length - 1; i >= 0; i--) {
+          var m = aItems[i];
           if (name === m.name) {
             return m;
           }
@@ -1464,7 +1520,7 @@
     }
     // Return an array of marks.
     function _getMarks() {
-      const marks = getEntriesByType("mark");
+      var marks = getEntriesByType("mark");
       if (marks.length) {
         return marks;
       }
@@ -1472,7 +1528,7 @@
     }
     // Return an array of measures.
     function _getMeasures() {
-      const measures = getEntriesByType("measure");
+      var measures = getEntriesByType("measure");
       if (measures.length) {
         return measures;
       }
@@ -1483,49 +1539,49 @@
       // The User Timing spec allows for there to be multiple marks with the same name,
       // and multiple measures with the same name. But we can only send back one value
       // for a name, so we always take the maximum value.
-      const hUT = {};
-      const startMark = _getMark(START_MARK);
+      var hUT = {};
+      var startMark = _getMark(START_MARK);
       // For user timing values taken in a SPA page load, we need to adjust them
       // so that they're zeroed against the last LUX.init() call.
-      const tZero = getZeroTime();
+      var tZero = getZeroTime();
       // marks
-      _getMarks().forEach((mark) => {
-        const name = mark.name;
+      _getMarks().forEach(function (mark) {
+        var name = mark.name;
         if (name === START_MARK || name === END_MARK) {
           // Don't include the internal marks in the beacon
           return;
         }
-        const startTime = floor(mark.startTime - tZero);
+        var startTime = floor(mark.startTime - tZero);
         if (startTime < 0) {
           // Exclude marks that were taken before the current SPA page view
           return;
         }
         if (typeof hUT[name] === "undefined") {
-          hUT[name] = { startTime };
+          hUT[name] = { startTime: startTime };
         }
         else {
           hUT[name].startTime = max(startTime, hUT[name].startTime);
         }
       });
       // measures
-      _getMeasures().forEach((measure) => {
+      _getMeasures().forEach(function (measure) {
         if (startMark && measure.startTime < startMark.startTime) {
           // Exclude measures that were taken before the current SPA page view
           return;
         }
-        const name = measure.name;
-        const startTime = floor(measure.startTime - tZero);
-        const duration = floor(measure.duration);
+        var name = measure.name;
+        var startTime = floor(measure.startTime - tZero);
+        var duration = floor(measure.duration);
         if (typeof hUT[name] === "undefined" || startTime > hUT[name].startTime) {
-          hUT[name] = { startTime, duration };
+          hUT[name] = { startTime: startTime, duration: duration };
         }
       });
       // Convert the user timing values into a delimited string. This string takes the format
       // markName|startTime,measureName|startTime|duration,[markName...]
-      const aUT = [];
-      for (const utName in hUT) {
-        const { startTime, duration } = hUT[utName];
-        const utParts = [utName, startTime];
+      var aUT = [];
+      for (var utName in hUT) {
+        var _a = hUT[utName], startTime = _a.startTime, duration = _a.duration;
+        var utParts = [utName, startTime];
         if (typeof duration !== "undefined") {
           utParts.push(duration);
         }
@@ -1535,10 +1591,10 @@
     }
     // Return a string of Element Timing Metrics formatted for beacon querystring.
     function elementTimingValues() {
-      const aET = [];
-      getEntries("element").forEach((entry) => {
+      var aET = [];
+      getEntries("element").forEach(function (entry) {
         if (entry.identifier && entry.startTime) {
-          const value = processTimeMetric(entry.startTime);
+          var value = processTimeMetric(entry.startTime);
           if (shouldReportValue(value)) {
             logger.logEvent(43 /* LogEvent.PerformanceEntryProcessed */, [entry]);
             aET.push(entry.identifier + "|" + value);
@@ -1553,24 +1609,24 @@
         // Do not return any CPU metrics if Long Tasks API is not supported.
         return "";
       }
-      let sCPU = "";
-      const hCPU = {};
-      const hCPUDetails = {}; // TODO - Could remove this later after large totals go away.
-      const longTaskEntries = getEntries("longtask");
+      var sCPU = "";
+      var hCPU = {};
+      var hCPUDetails = {}; // TODO - Could remove this later after large totals go away.
+      var longTaskEntries = getEntries("longtask");
       // Add up totals for each "type" of long task
       if (longTaskEntries.length) {
-        const tZero = getZeroTime();
-        longTaskEntries.forEach((entry) => {
-          let dur = floor(entry.duration);
-          if (entry.startTime < tZero) {
+        var tZero_1 = getZeroTime();
+        longTaskEntries.forEach(function (entry) {
+          var dur = floor(entry.duration);
+          if (entry.startTime < tZero_1) {
             // In a SPA it is possible that we were in the middle of a Long Task when
             // LUX.init() was called. If so, only include the duration after tZero.
-            dur -= tZero - entry.startTime;
+            dur -= tZero_1 - entry.startTime;
           }
           // Only process entries that we calculated to have a valid duration
           if (dur > 0) {
             logger.logEvent(43 /* LogEvent.PerformanceEntryProcessed */, [entry]);
-            const type = entry.attribution[0].name;
+            var type = entry.attribution[0].name;
             if (!hCPU[type]) {
               hCPU[type] = 0;
               hCPUDetails[type] = "";
@@ -1582,14 +1638,14 @@
         });
       }
       // TODO - Add more types if/when they become available.
-      const jsType = typeof hCPU["script"] !== "undefined" ? "script" : "unknown"; // spec changed from "script" to "unknown" Nov 2018
+      var jsType = typeof hCPU["script"] !== "undefined" ? "script" : "unknown"; // spec changed from "script" to "unknown" Nov 2018
       if (typeof hCPU[jsType] === "undefined") {
         // Initialize default values for pages that have *no Long Tasks*.
         hCPU[jsType] = 0;
         hCPUDetails[jsType] = "";
       }
-      const hStats = cpuStats(hCPUDetails[jsType]);
-      const sStats = ",n|" +
+      var hStats = cpuStats(hCPUDetails[jsType]);
+      var sStats = ",n|" +
       hStats.count +
       ",d|" +
       hStats.median +
@@ -1602,19 +1658,19 @@
     // Return a hash of "stats" about the CPU details incl. count, max, and median.
     function cpuStats(sDetails) {
       // tuples of starttime|duration, eg: ,456|250,789|250,1012|250
-      let max = 0;
+      var max = 0;
       // FCI is beginning of 5 second window of no Long Tasks _after_ first contentful paint
-      const fcp = getFcp();
-      let fci = fcp || 0;
+      var fcp = getFcp();
+      var fci = fcp || 0;
       // If FCP is not supported, we can't calculate a valid FCI.
-      let bFoundFci = typeof fcp === "undefined";
-      const aValues = [];
-      const aTuples = sDetails.split(",");
-      for (let i = 0; i < aTuples.length; i++) {
-        const aTuple = aTuples[i].split("|");
+      var bFoundFci = typeof fcp === "undefined";
+      var aValues = [];
+      var aTuples = sDetails.split(",");
+      for (var i = 0; i < aTuples.length; i++) {
+        var aTuple = aTuples[i].split("|");
         if (aTuple.length === 2) {
-          const start = parseInt(aTuple[0]);
-          const dur = parseInt(aTuple[1]);
+          var start = parseInt(aTuple[0]);
+          var dur = parseInt(aTuple[1]);
           aValues.push(dur);
           max = dur > max ? dur : max;
           // FCI
@@ -1627,7 +1683,7 @@
             }
             else {
               // Less than 5 seconds of inactivity
-              const val = processTimeMetric(start + dur);
+              var val = processTimeMetric(start + dur);
               if (shouldReportValue(val)) {
                 fci = val; // FCI is now the end of this Long Task
               }
@@ -1635,16 +1691,16 @@
           }
         }
       }
-      const count = aValues.length;
-      const median = arrayMedian(aValues);
-      return { count, median, max, fci };
+      var count = aValues.length;
+      var median = arrayMedian(aValues);
+      return { count: count, median: median, max: max, fci: fci };
     }
     // Return the median value from an array of integers.
     function arrayMedian(aValues) {
       if (0 === aValues.length) {
         return 0;
       }
-      const half = floor(aValues.length / 2);
+      var half = floor(aValues.length / 2);
       aValues.sort(sortNumeric);
       if (aValues.length % 2) {
         // Return the middle value.
@@ -1657,21 +1713,21 @@
     }
     // Track how long it took lux.js to load via Resource Timing.
     function selfLoading() {
-      let sLuxjs = "";
+      var sLuxjs = "";
       if (gbFirstPV && performance.getEntriesByName) {
         // Get the lux script URL (including querystring params).
-        const aResources = performance.getEntriesByName(thisScript.src);
+        var aResources = performance.getEntriesByName(thisScript.src);
         if (aResources && aResources.length) {
-          const r = aResources[0];
+          var r = aResources[0];
           // DO NOT USE DURATION!!!!!
           // See https://www.stevesouders.com/blog/2014/11/25/serious-confusion-with-resource-timing/
-          const dns = floor(r.domainLookupEnd - r.domainLookupStart);
-          const tcp = floor(r.connectEnd - r.connectStart);
-          const fb = floor(r.responseStart - r.requestStart);
-          const content = floor(r.responseEnd - r.responseStart);
-          const networkDuration = dns + tcp + fb + content;
-          const parseEval = scriptEndTime - scriptStartTime;
-          const transferSize = r.encodedBodySize ? r.encodedBodySize : 0;
+          var dns = floor(r.domainLookupEnd - r.domainLookupStart);
+          var tcp = floor(r.connectEnd - r.connectStart);
+          var fb = floor(r.responseStart - r.requestStart);
+          var content = floor(r.responseEnd - r.responseStart);
+          var networkDuration = dns + tcp + fb + content;
+          var parseEval = scriptEndTime - scriptStartTime;
+          var transferSize = r.encodedBodySize ? r.encodedBodySize : 0;
           // Instead of a delimiter use a 1-letter abbreviation as a separator.
           sLuxjs =
           "d" +
@@ -1705,8 +1761,8 @@
     }
     // Return a string of Interaction Metrics formatted for beacon querystring.
     function ixValues() {
-      const aIx = [];
-      for (const key in ghIx) {
+      var aIx = [];
+      for (var key in ghIx) {
         aIx.push(key + "|" + encodeURIComponent(ghIx[key]));
       }
       return aIx.join(",");
@@ -1736,34 +1792,22 @@
       if (typeof gUid === "undefined" || typeof globalConfig.samplerate === "undefined") {
         return false; // bail
       }
-      const nThis = ("" + gUid).substr(-2); // number for THIS page - from 00 to 99
+      var nThis = ("" + gUid).substr(-2); // number for THIS page - from 00 to 99
       return parseInt(nThis) < globalConfig.samplerate;
     }
     /**
     * Re-initialize lux.js to start a new "page". This is typically called within a SPA at the
     * beginning of a page transition, but is also called internally when the BF cache is restored.
     */
-    function _init(startTime, clearFlags = true) {
-      // Some customers (incorrectly) call LUX.init on the very first page load of a SPA. This would
-      // cause some first-page-only data (like paint metrics) to be lost. To prevent this, we silently
-      // bail from this function when we detect an unnecessary LUX.init call.
-      const endMark = _getMark(END_MARK);
-      if (!endMark) {
-        return;
-      }
+    function _init(startTime, clearFlags) {
+      if (clearFlags === void 0) { clearFlags = true; }
       // Mark the "navigationStart" for this SPA page. A start time can be passed through, for example
       // to set a page's start time as an event timestamp.
       if (startTime) {
-        _mark(START_MARK, { startTime });
+        _mark(START_MARK, { startTime: startTime });
       }
       else {
         _mark(START_MARK);
-      }
-      logger.logEvent(3 /* LogEvent.InitCalled */);
-      // This is an edge case where LUX.auto = true but LUX.init() has been called. In this case, the
-      // POST beacon will not be sent automatically, so we need to send it here.
-      if (globalConfig.auto && !beacon.isSent) {
-        beacon.send();
       }
       // Clear all interactions from the previous "page".
       _clearIx();
@@ -1795,7 +1839,7 @@
     }
     // Return the number of blocking (synchronous) external scripts in the page.
     function blockingScripts() {
-      const lastViewportElem = lastViewportElement();
+      var lastViewportElem = lastViewportElement();
       if (!lastViewportElem) {
         // If we can not find the last DOM element in the viewport,
         // use the old technique of just counting sync scripts.
@@ -1803,10 +1847,10 @@
       }
       // Find all the synchronous scripts that are ABOVE the last DOM element in the
       // viewport. (If they are BELOW then they do not block rendering of initial viewport.)
-      const aElems = document.getElementsByTagName("script");
-      let num = 0;
-      for (let i = 0, len = aElems.length; i < len; i++) {
-        const e = aElems[i];
+      var aElems = document.getElementsByTagName("script");
+      var num = 0;
+      for (var i = 0, len = aElems.length; i < len; i++) {
+        var e = aElems[i];
         if (e.src &&
           !e.async &&
           !e.defer &&
@@ -1820,10 +1864,10 @@
     }
     // Return the number of blocking (synchronous) external scripts in the page.
     function blockingStylesheets() {
-      let nBlocking = 0;
-      const aElems = document.getElementsByTagName("link");
-      for (let i = 0, len = aElems.length; i < len; i++) {
-        const e = aElems[i];
+      var nBlocking = 0;
+      var aElems = document.getElementsByTagName("link");
+      for (var i = 0, len = aElems.length; i < len; i++) {
+        var e = aElems[i];
         if (e.href && "stylesheet" === e.rel && 0 !== e.href.indexOf("data:")) {
           if (
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1840,10 +1884,10 @@
     }
     // Return the number of synchronous external scripts in the page.
     function syncScripts() {
-      const aElems = document.getElementsByTagName("script");
-      let num = 0;
-      for (let i = 0, len = aElems.length; i < len; i++) {
-        const e = aElems[i];
+      var aElems = document.getElementsByTagName("script");
+      var num = 0;
+      for (var i = 0, len = aElems.length; i < len; i++) {
+        var e = aElems[i];
         if (e.src && !e.async && !e.defer) {
           // If the script has a SRC and async is false, then increment the counter.
           num++;
@@ -1853,10 +1897,10 @@
     }
     // Return the number of external scripts in the page.
     function numScripts() {
-      const aElems = document.getElementsByTagName("script");
-      let num = 0;
-      for (let i = 0, len = aElems.length; i < len; i++) {
-        const e = aElems[i];
+      var aElems = document.getElementsByTagName("script");
+      var num = 0;
+      for (var i = 0, len = aElems.length; i < len; i++) {
+        var e = aElems[i];
         if (e.src) {
           num++;
         }
@@ -1865,10 +1909,10 @@
     }
     // Return the number of stylesheets in the page.
     function numStylesheets() {
-      const aElems = document.getElementsByTagName("link");
-      let num = 0;
-      for (let i = 0, len = aElems.length; i < len; i++) {
-        const e = aElems[i];
+      var aElems = document.getElementsByTagName("link");
+      var num = 0;
+      for (var i = 0, len = aElems.length; i < len; i++) {
+        var e = aElems[i];
         if (e.href && "stylesheet" == e.rel) {
           num++;
         }
@@ -1876,10 +1920,10 @@
       return num;
     }
     function inlineTagSize(tagName) {
-      const aElems = document.getElementsByTagName(tagName);
-      let size = 0;
-      for (let i = 0, len = aElems.length; i < len; i++) {
-        const e = aElems[i];
+      var aElems = document.getElementsByTagName(tagName);
+      var size = 0;
+      for (var i = 0, len = aElems.length; i < len; i++) {
+        var e = aElems[i];
         try {
           size += e.innerHTML.length;
         }
@@ -1892,16 +1936,16 @@
       return size;
     }
     function getNavTiming() {
-      let s = "";
-      let ns = timing.navigationStart;
-      const startMark = _getMark(START_MARK);
-      const endMark = _getMark(END_MARK);
+      var s = "";
+      var ns = timing.navigationStart;
+      var startMark = _getMark(START_MARK);
+      var endMark = _getMark(END_MARK);
       if (startMark && endMark && !getPageRestoreTime()) {
         // This is a SPA page view, so send the SPA marks & measures instead of Nav Timing.
         // Note: getPageRestoreTime() indicates this was a bfcache restore, which we don't want to treat as a SPA.
-        const start = floor(startMark.startTime); // the start mark is "zero"
+        var start = floor(startMark.startTime); // the start mark is "zero"
         ns += start; // "navigationStart" for a SPA is the real navigationStart plus the start mark
-        const end = floor(endMark.startTime) - start; // delta from start mark
+        var end = floor(endMark.startTime) - start; // delta from start mark
         s =
         ns +
         // fetchStart and activationStart are the same as navigationStart for a SPA
@@ -1909,21 +1953,17 @@
         0 +
         "fs" +
         0 +
-        "ls" +
-        end +
-        "le" +
-        end +
-        "";
+        (end > 0 ? "ls" + end + "le" + end : "");
       }
       else if (performance.timing) {
         // Return the real Nav Timing metrics because this is the "main" page view (not a SPA)
-        const navEntry = getNavigationEntry();
-        const startRender = getStartRender();
-        const fcp = getFcp();
-        const lcp = getLcp();
-        const prefixNTValue = (key, prefix, ignoreZero) => {
-          if (typeof navEntry[key] === "number") {
-            const value = navEntry[key];
+        var navEntry_1 = getNavigationEntry();
+        var startRender = getStartRender();
+        var fcp = getFcp();
+        var lcp = getLcp();
+        var prefixNTValue = function (key, prefix, ignoreZero) {
+          if (typeof navEntry_1[key] === "number") {
+            var value = navEntry_1[key];
             // We allow zero values for most navigation timing metrics, but for some metrics we want
             // to ignore zeroes. The exceptions are that all metrics can be zero if the page was either
             // prerendered or restored from the BF cache.
@@ -1933,19 +1973,23 @@
           }
           return "";
         };
-        let loadEventStartStr = prefixNTValue("loadEventStart", "ls", true);
-        let loadEventEndStr = prefixNTValue("loadEventEnd", "le", true);
+        // loadEventStart always comes from navigation timing
+        var loadEventStartStr = prefixNTValue("loadEventStart", "ls", true);
+        // If LUX.markLoadTime() was called in SPA Mode, we allow the custom mark to override loadEventEnd
+        var loadEventEndStr = globalConfig.spaMode && endMark
+        ? "le" + processTimeMetric(endMark.startTime)
+        : prefixNTValue("loadEventEnd", "le", true);
         if (getPageRestoreTime() && startMark && endMark) {
           // For bfcache restores, we set the load time to the time it took for the page to be restored.
-          const loadTime = floor(endMark.startTime - startMark.startTime);
+          var loadTime = floor(endMark.startTime - startMark.startTime);
           loadEventStartStr = "ls" + loadTime;
           loadEventEndStr = "le" + loadTime;
         }
-        const redirect = wasRedirected();
-        const isSecure = document.location.protocol === "https:";
+        var redirect = wasRedirected();
+        var isSecure = document.location.protocol === "https:";
         s = [
           ns,
-          "as" + clamp(navEntry.activationStart),
+          "as" + clamp(navEntry_1.activationStart),
           redirect && !getPageRestoreTime() ? prefixNTValue("redirectStart", "rs") : "",
           redirect && !getPageRestoreTime() ? prefixNTValue("redirectEnd", "re") : "",
           prefixNTValue("fetchStart", "fs"),
@@ -1970,7 +2014,7 @@
       }
       else if (endMark) {
         // This is a "main" page view that does NOT support Navigation Timing - strange.
-        const end = floor(endMark.startTime);
+        var end = floor(endMark.startTime);
         s =
         ns +
         "fs" +
@@ -1985,11 +2029,11 @@
     }
     // Return First Contentful Paint or undefined if not supported.
     function getFcp() {
-      const paintEntries = getEntriesByType("paint");
-      for (let i = 0; i < paintEntries.length; i++) {
-        const entry = paintEntries[i];
+      var paintEntries = getEntriesByType("paint");
+      for (var i = 0; i < paintEntries.length; i++) {
+        var entry = paintEntries[i];
         if (entry.name === "first-contentful-paint") {
-          const value = processTimeMetric(entry.startTime);
+          var value = processTimeMetric(entry.startTime);
           if (shouldReportValue(value)) {
             return value;
           }
@@ -1999,10 +2043,10 @@
     }
     // Return Largest Contentful Paint or undefined if not supported.
     function getLcp() {
-      const lcpEntries = getEntries("largest-contentful-paint");
+      var lcpEntries = getEntries("largest-contentful-paint");
       if (lcpEntries.length) {
-        const lastEntry = lcpEntries[lcpEntries.length - 1];
-        const value = processTimeMetric(lastEntry.startTime);
+        var lastEntry = lcpEntries[lcpEntries.length - 1];
+        var value = processTimeMetric(lastEntry.startTime);
         if (shouldReportValue(value)) {
           logger.logEvent(43 /* LogEvent.PerformanceEntryProcessed */, [lastEntry]);
           return value;
@@ -2015,12 +2059,12 @@
     // Return undefined if not supported.
     function getStartRender() {
       if ("PerformancePaintTiming" in self) {
-        const paintEntries = getEntriesByType("paint");
+        var paintEntries = getEntriesByType("paint");
         if (paintEntries.length) {
-          const paintValues = paintEntries.map((entry) => entry.startTime).sort(sortNumeric);
+          var paintValues = paintEntries.map(function (entry) { return entry.startTime; }).sort(sortNumeric);
           // Use the earliest valid paint entry as the start render time.
-          for (let i = 0; i < paintValues.length; i++) {
-            const value = processTimeMetric(paintValues[i]);
+          for (var i = 0; i < paintValues.length; i++) {
+            var value = processTimeMetric(paintValues[i]);
             if (shouldReportValue(value)) {
               return value;
             }
@@ -2064,17 +2108,17 @@
       return String(_thisCustomerId);
     }
     function avgDomDepth() {
-      const aElems = document.getElementsByTagName("*");
-      let i = aElems.length;
-      let totalParents = 0;
+      var aElems = document.getElementsByTagName("*");
+      var i = aElems.length;
+      var totalParents = 0;
       while (i--) {
         totalParents += numParents(aElems[i]);
       }
-      const average = round(totalParents / aElems.length);
+      var average = round(totalParents / aElems.length);
       return average;
     }
     function numParents(elem) {
-      let n = 0;
+      var n = 0;
       if (elem.parentNode) {
         while ((elem = elem.parentNode)) {
           n++;
@@ -2083,13 +2127,13 @@
       return n;
     }
     function docHeight(doc) {
-      const body = doc.body, docelem = doc.documentElement;
-      const height = max(body ? body.scrollHeight : 0, body ? body.offsetHeight : 0, docelem ? docelem.clientHeight : 0, docelem ? docelem.scrollHeight : 0, docelem ? docelem.offsetHeight : 0);
+      var body = doc.body, docelem = doc.documentElement;
+      var height = max(body ? body.scrollHeight : 0, body ? body.offsetHeight : 0, docelem ? docelem.clientHeight : 0, docelem ? docelem.scrollHeight : 0, docelem ? docelem.offsetHeight : 0);
       return height;
     }
     function docWidth(doc) {
-      const body = doc.body, docelem = doc.documentElement;
-      const width = max(body ? body.scrollWidth : 0, body ? body.offsetWidth : 0, docelem ? docelem.clientWidth : 0, docelem ? docelem.scrollWidth : 0, docelem ? docelem.offsetWidth : 0);
+      var body = doc.body, docelem = doc.documentElement;
+      var width = max(body ? body.scrollWidth : 0, body ? body.offsetWidth : 0, docelem ? docelem.clientWidth : 0, docelem ? docelem.scrollWidth : 0, docelem ? docelem.offsetWidth : 0);
       return width;
     }
     // Return the main HTML document transfer size (in bytes).
@@ -2099,8 +2143,8 @@
     // Return the connection type based on Network Information API.
     // Note this API is in flux.
     function connectionType() {
-      const c = navigator.connection;
-      let connType = "";
+      var c = navigator.connection;
+      var connType = "";
       if (c && c.effectiveType) {
         connType = c.effectiveType;
         if ("slow-2g" === connType) {
@@ -2117,11 +2161,11 @@
     }
     // Return an array of image elements that are in the top viewport.
     function imagesATF() {
-      const aImages = document.getElementsByTagName("img");
-      const aImagesAtf = [];
+      var aImages = document.getElementsByTagName("img");
+      var aImagesAtf = [];
       if (aImages) {
-        for (let i = 0, len = aImages.length; i < len; i++) {
-          const image = aImages[i];
+        for (var i = 0, len = aImages.length; i < len; i++) {
+          var image = aImages[i];
           if (inViewport(image)) {
             aImagesAtf.push(image);
           }
@@ -2136,15 +2180,15 @@
         // but if no parent then start with BODY.
         parent = document.body;
       }
-      let lastChildInViewport;
+      var lastChildInViewport;
       if (parent) {
         // Got errors that parent was null so testing again here.
         // Find the last child that is in the viewport.
         // Elements are listed in DOM order.
-        const aChildren = parent.children;
+        var aChildren = parent.children;
         if (aChildren) {
-          for (let i = 0, len = aChildren.length; i < len; i++) {
-            const child = aChildren[i];
+          for (var i = 0, len = aChildren.length; i < len; i++) {
+            var child = aChildren[i];
             if (inViewport(child)) {
               // The children are in DOM order, so we just have to
               // save the LAST child that was in the viewport.
@@ -2165,10 +2209,10 @@
     }
     // Return true if the element is in the viewport.
     function inViewport(e) {
-      const vh = document.documentElement.clientHeight;
-      const vw = document.documentElement.clientWidth;
+      var vh = document.documentElement.clientHeight;
+      var vw = document.documentElement.clientWidth;
       // Return true if the top-left corner is in the viewport and it has width & height.
-      const lt = findPos(e);
+      var lt = findPos(e);
       return (lt[0] >= 0 &&
         lt[1] >= 0 &&
         lt[0] < vw &&
@@ -2179,8 +2223,8 @@
     // Return an array containing the top & left coordinates of the element.
     // from http://www.quirksmode.org/js/findpos.html
     function findPos(el) {
-      let curleft = 0;
-      let curtop = 0;
+      var curleft = 0;
+      var curtop = 0;
       while (el) {
         try {
           curleft += el.offsetLeft;
@@ -2194,8 +2238,10 @@
       }
       return [curleft, curtop];
     }
-    // Mark the load time of the current page. Intended to be used in SPAs where it is not desirable to
-    // send the beacon as soon as the page has finished loading.
+    /**
+    * Mark the load time of the current page. Intended to be used in SPAs where it is not desirable
+    * to send the beacon as soon as the page has finished loading.
+    */
     function _markLoadTime(time) {
       logger.logEvent(12 /* LogEvent.MarkLoadTimeCalled */, [time]);
       if (time) {
@@ -2207,7 +2253,7 @@
     }
     function createMaxMeasureTimeout() {
       clearMaxMeasureTimeout();
-      gMaxMeasureTimeout = setTimeout(() => {
+      gMaxMeasureTimeout = setTimeout(function () {
         gFlags = addFlag(gFlags, 32 /* Flags.BeaconSentAfterTimeout */);
         beacon.addFlag(32 /* Flags.BeaconSentAfterTimeout */);
         _sendLux();
@@ -2219,7 +2265,7 @@
       }
     }
     function _getBeaconUrl(customData) {
-      const queryParams = [
+      var queryParams = [
         "v=" + versionAsFloat(),
         "id=" + getCustomerId(),
         "sid=" + gSyncId,
@@ -2231,7 +2277,10 @@
       if (gFlags) {
         queryParams.push("fl=" + gFlags);
       }
-      const customDataValues = valuesToString(customData);
+      if (globalLux.snippetVersion) {
+        queryParams.push("sv=" + globalLux.snippetVersion);
+      }
+      var customDataValues = valuesToString(customData);
       if (customDataValues) {
         queryParams.push("CD=" + customDataValues);
         clearUpdateCustomData();
@@ -2239,13 +2288,15 @@
       return globalConfig.beaconUrl + "?" + queryParams.join("&");
     }
     // Beacon back the LUX data.
-    function _sendLux(fromUnload = false) {
+    function _sendLux(fromUnload) {
+      var _a;
+      if (fromUnload === void 0) { fromUnload = false; }
       if (!isVisible() && !globalConfig.trackHiddenPages && !fromUnload) {
         logger.logEvent(13 /* LogEvent.SendCancelledPageHidden */);
         return;
       }
       clearMaxMeasureTimeout();
-      const customerid = getCustomerId();
+      var customerid = getCustomerId();
       if (!customerid ||
         !gSyncId ||
         !_sample() || // OUTSIDE the sampled range
@@ -2254,21 +2305,32 @@
         return;
       }
       logger.logEvent(9 /* LogEvent.DataCollectionStart */);
-      const startMark = _getMark(START_MARK);
-      const endMark = _getMark(END_MARK);
-      if (!startMark || (endMark && endMark.startTime < startMark.startTime)) {
-        // Record the synthetic loadEventStart time for this page, unless it was already recorded
-        // with LUX.markLoadTime()
-        _markLoadTime();
+      var startMark = _getMark(START_MARK);
+      var endMark = _getMark(END_MARK);
+      if (!startMark) {
+        // For hard navigations set the synthetic load time when the beacon is being sent, unless
+        // one has already been set.
+        if (!endMark) {
+          _markLoadTime();
+        }
+      }
+      else {
+        // For soft navigations, only set the synthetic load time if SPA mode is not enabled, and...
+        if (!globalConfig.spaMode) {
+          // ...there is no existing end mark, or the end mark is from a previous SPA page.
+          if (!endMark || endMark.startTime < startMark.startTime) {
+            _markLoadTime();
+          }
+        }
       }
       // Store any tracking parameters as custom data
-      const trackingParams = getTrackingParams();
-      for (const key in trackingParams) {
+      var trackingParams = getTrackingParams();
+      for (var key in trackingParams) {
         logger.logEvent(44 /* LogEvent.TrackingParamAdded */, [key, trackingParams[key]]);
         addCustomDataValue("_" + key, trackingParams[key]);
       }
-      let sIx = "";
-      let INP = getINPDetails();
+      var sIx = "";
+      var INP = getINPDetails();
       // If we haven't already sent an interaction beacon, check for interaction metrics and include
       // them in the main beacon.
       if (!gbIxSent) {
@@ -2279,10 +2341,10 @@
           INP = undefined;
         }
       }
-      const sET = elementTimingValues(); // Element Timing data
-      const sCPU = cpuTimes();
-      const clsData = getData$3(globalConfig);
-      const sLuxjs = selfLoading();
+      var sET = elementTimingValues(); // Element Timing data
+      var sCPU = cpuTimes();
+      var clsData = getData$3(globalConfig);
+      var sLuxjs = selfLoading();
       if (!isVisible()) {
         gFlags = addFlag(gFlags, 8 /* Flags.VisibilityStateNotVisible */);
         beacon.addFlag(8 /* Flags.VisibilityStateNotVisible */);
@@ -2292,31 +2354,31 @@
         beacon.addFlag(1024 /* Flags.PageWasPrerendered */);
       }
       if (globalConfig.serverTiming) {
-        const navEntry = getNavigationEntry();
+        var navEntry = getNavigationEntry();
         if (navEntry.serverTiming) {
-          const stPairs = getKeyValuePairs(globalConfig.serverTiming, navEntry.serverTiming);
-          for (const name in stPairs) {
-            _addData(name, stPairs[name]);
+          var stPairs = getKeyValuePairs(globalConfig.serverTiming, navEntry.serverTiming);
+          for (var name_2 in stPairs) {
+            _addData(name_2, stPairs[name_2]);
           }
         }
       }
       if (LUX.conversions) {
-        getMatchesFromPatternMap(LUX.conversions, location.hostname, location.pathname).forEach((conversion) => {
+        getMatchesFromPatternMap(LUX.conversions, location.hostname, location.pathname).forEach(function (conversion) {
           LUX.addData(conversion, BOOLEAN_TRUE);
         });
       }
       // We want ALL beacons to have ALL the data used for query filters (geo, pagelabel, browser, & custom data).
       // So we create a base URL that has all the necessary information:
-      const baseUrl = _getBeaconUrl(getAllCustomData());
-      const is = inlineTagSize("script");
-      const ic = inlineTagSize("style");
-      const ds = docSize();
-      const ct = connectionType();
-      const dt = deliveryType();
+      var baseUrl = _getBeaconUrl(getAllCustomData());
+      var is = inlineTagSize("script");
+      var ic = inlineTagSize("style");
+      var ds = docSize();
+      var ct = connectionType();
+      var dt = deliveryType();
       // Note some page stat values (the `PS` query string) are non-numeric. To make extracting these
       // values easier, we append an underscore "_" to the value. Values this is used for include
       // connection type (ct) and delivery type (dt).
-      const metricsQueryString =
+      var metricsQueryString =
       // only send Nav Timing and lux.js metrics on initial pageload (not for SPA page views)
       (gbNavSent ? "" : "&NT=" + getNavTiming()) +
       "&LJS=" +
@@ -2364,10 +2426,10 @@
       // INP and sub-parts
       (INP ? getINPString(INP) : "");
       // We add the user timing entries last so that we can split them to reduce the URL size if necessary.
-      const utValues = userTimingValues();
-      let [beaconUtValues, remainingUtValues] = fitUserTimingEntries(utValues, globalConfig, baseUrl + metricsQueryString);
+      var utValues = userTimingValues();
+      var _b = fitUserTimingEntries(utValues, globalConfig, baseUrl + metricsQueryString), beaconUtValues = _b[0], remainingUtValues = _b[1];
       // Send the MAIN LUX beacon.
-      const mainBeaconUrl = baseUrl +
+      var mainBeaconUrl = baseUrl +
       metricsQueryString +
       (beaconUtValues.length > 0 ? "&UT=" + beaconUtValues.join(",") : "");
       logger.logEvent(23 /* LogEvent.MainBeaconSent */, [mainBeaconUrl]);
@@ -2378,20 +2440,20 @@
       gbIxSent = sIx ? 1 : 0;
       // Send other beacons for JUST User Timing.
       while (remainingUtValues.length) {
-        [beaconUtValues, remainingUtValues] = fitUserTimingEntries(remainingUtValues, globalConfig, baseUrl);
-        const utBeaconUrl = baseUrl + "&UT=" + beaconUtValues.join(",");
+        _a = fitUserTimingEntries(remainingUtValues, globalConfig, baseUrl), beaconUtValues = _a[0], remainingUtValues = _a[1];
+        var utBeaconUrl = baseUrl + "&UT=" + beaconUtValues.join(",");
         logger.logEvent(24 /* LogEvent.UserTimingBeaconSent */, [utBeaconUrl]);
         _sendBeacon(utBeaconUrl);
       }
     }
-    let ixTimerId;
+    var ixTimerId;
     function _sendIxAfterDelay() {
       clearTimeout(ixTimerId);
       ixTimerId = setTimeout(_sendIx, globalConfig.interactionBeaconDelay);
     }
     // Beacon back the IX data separately (need to sync with LUX beacon on the backend).
     function _sendIx() {
-      const customerid = getCustomerId();
+      var customerid = getCustomerId();
       if (!customerid ||
         !gSyncId ||
         !_sample() || // OUTSIDE the sampled range
@@ -2400,10 +2462,10 @@
       ) {
         return;
       }
-      const sIx = ixValues(); // Interaction Metrics
-      const INP = getINPDetails();
+      var sIx = ixValues(); // Interaction Metrics
+      var INP = getINPDetails();
       if (sIx) {
-        const beaconUrl = _getBeaconUrl(getUpdatedCustomData()) +
+        var beaconUrl = _getBeaconUrl(getUpdatedCustomData()) +
         "&IX=" +
         sIx +
         (typeof gFirstInputDelay !== "undefined" ? "&FID=" + gFirstInputDelay : "") +
@@ -2416,7 +2478,7 @@
     // Beacon back custom data that is recorded _after_ the main beacon was sent
     // (i.e., custom data after window.onload).
     function _sendCustomData() {
-      const customerid = getCustomerId();
+      var customerid = getCustomerId();
       if (!customerid ||
         !gSyncId ||
         !_sample() || // OUTSIDE the sampled range
@@ -2424,9 +2486,9 @@
       ) {
         return;
       }
-      const customDataValues = valuesToString(getUpdatedCustomData());
+      var customDataValues = valuesToString(getUpdatedCustomData());
       if (customDataValues) {
-        const beaconUrl = _getBeaconUrl(getUpdatedCustomData());
+        var beaconUrl = _getBeaconUrl(getUpdatedCustomData());
         logger.logEvent(26 /* LogEvent.CustomDataBeaconSent */, [beaconUrl]);
         _sendBeacon(beaconUrl);
       }
@@ -2450,7 +2512,7 @@
       }
     }
     function _keyHandler(e) {
-      const { keyCode } = e;
+      var keyCode = e.keyCode;
       /**
       * Ignore modifier keys
       *
@@ -2466,7 +2528,7 @@
       if (typeof ghIx["k"] === "undefined") {
         ghIx["k"] = msSincePageInit();
         if (e && e.target instanceof Element) {
-          const trackId = getNodeSelector(e.target);
+          var trackId = getNodeSelector(e.target);
           if (trackId) {
             ghIx["ki"] = trackId;
           }
@@ -2484,7 +2546,7 @@
         // Only one interaction type is recorded. Scrolls are considered less important, so delete
         // any scroll times if they exist.
         delete ghIx["s"];
-        let target;
+        var target = void 0;
         try {
           // Seeing "Permission denied" errors, so do a simple try-catch.
           if (e && e.target instanceof Element) {
@@ -2500,7 +2562,7 @@
             ghIx["cx"] = e.clientX;
             ghIx["cy"] = e.clientY;
           }
-          const trackId = getNodeSelector(target);
+          var trackId = getNodeSelector(target);
           if (trackId) {
             ghIx["ci"] = trackId;
           }
@@ -2510,7 +2572,7 @@
       _removeIxHandlers();
     }
     function _addUnloadHandlers() {
-      const onunload = () => {
+      var onunload = function () {
         gFlags = addFlag(gFlags, 16 /* Flags.BeaconSentFromUnloadHandler */);
         beacon.addFlag(16 /* Flags.BeaconSentFromUnloadHandler */);
         logger.logEvent(10 /* LogEvent.UnloadHandlerTriggered */);
@@ -2528,7 +2590,7 @@
         addListener("unload", onunload, true);
         addListener("beforeunload", onunload, true);
       }
-      addListener("visibilitychange", () => {
+      addListener("visibilitychange", function () {
         if (document.visibilityState === "hidden") {
           onunload();
         }
@@ -2547,8 +2609,9 @@
     // This is a big number (epoch ms . random) that is used to matchup a LUX beacon with a separate IX beacon
     // (because they get sent at different times). Each "page view" (including SPA) should have a
     // unique gSyncId.
-    function createSyncId(inSampleBucket = false) {
-      let syncId;
+    function createSyncId(inSampleBucket) {
+      if (inSampleBucket === void 0) { inSampleBucket = false; }
+      var syncId;
       if (inSampleBucket) {
         // "00" matches all sample rates
         syncId = Number(new Date()) + "00000";
@@ -2564,16 +2627,16 @@
     // If there is NOT a UID then set it to the new value (which is the same as the "sync ID" for this page).
     // Refresh its expiration date and return its value.
     function refreshUniqueId(newValue) {
-      let uid = _getCookie(SESSION_COOKIE_NAME);
+      var uid = _getCookie(SESSION_COOKIE_NAME);
       if (!uid || uid.length < 11) {
         uid = newValue;
       }
       else {
         // Prevent sessions lasting more than 24 hours.
         // The first 10 characters of uid is the epoch time when the session started.
-        const uidStart = parseInt(uid.substring(0, 10));
-        const now = Number(new Date()) / 1000; // in seconds
-        if (now - uidStart > 24 * 60 * 60) {
+        var uidStart = parseInt(uid.substring(0, 10));
+        var now_2 = Number(new Date()) / 1000; // in seconds
+        if (now_2 - uidStart > 24 * 60 * 60) {
           // older than 24 hours - reset to new value
           uid = newValue;
         }
@@ -2598,7 +2661,7 @@
         return LUX.label;
       }
       if (typeof LUX.pagegroups !== "undefined") {
-        const label = getMatchesFromPatternMap(LUX.pagegroups, location.hostname, location.pathname, true);
+        var label = getMatchesFromPatternMap(LUX.pagegroups, location.hostname, location.pathname, true);
         if (label) {
           gFlags = addFlag(gFlags, 512 /* Flags.PageLabelFromUrlPattern */);
           beacon.addFlag(512 /* Flags.PageLabelFromUrlPattern */);
@@ -2606,9 +2669,9 @@
         }
       }
       if (typeof LUX.jspagelabel !== "undefined") {
-        const evaluateJsPageLabel = Function('"use strict"; return ' + LUX.jspagelabel);
+        var evaluateJsPageLabel = Function('"use strict"; return ' + LUX.jspagelabel);
         try {
-          const label = evaluateJsPageLabel();
+          var label = evaluateJsPageLabel();
           if (label) {
             gFlags = addFlag(gFlags, 256 /* Flags.PageLabelFromGlobalVariable */);
             beacon.addFlag(256 /* Flags.PageLabelFromGlobalVariable */);
@@ -2627,9 +2690,9 @@
     function _getCookie(name) {
       try {
         // Seeing "Permission denied" errors, so do a simple try-catch.
-        const aTuples = document.cookie.split(";");
-        for (let i = 0; i < aTuples.length; i++) {
-          const aTuple = aTuples[i].split("=");
+        var aTuples = document.cookie.split(";");
+        for (var i = 0; i < aTuples.length; i++) {
+          var aTuple = aTuples[i].split("=");
           if (name === aTuple[0].trim()) {
             // cookie name starts with " " if not first
             return unescape(aTuple[1]);
@@ -2658,7 +2721,7 @@
     // Set "LUX.auto=false" to disable send results automatically and
     // instead you must call LUX.send() explicitly.
     if (globalConfig.auto) {
-      const sendBeaconWhenVisible = () => {
+      var sendBeaconWhenVisible_1 = function () {
         if (globalConfig.trackHiddenPages) {
           _sendLux();
         }
@@ -2666,30 +2729,30 @@
           onVisible(_sendLux);
         }
       };
-      const sendBeaconAfterMinimumMeasureTime = () => {
-        const elapsedTime = msSincePageInit();
-        const timeRemaining = globalConfig.minMeasureTime - elapsedTime;
+      var sendBeaconAfterMinimumMeasureTime_1 = function () {
+        var elapsedTime = msSincePageInit();
+        var timeRemaining = globalConfig.minMeasureTime - elapsedTime;
         if (timeRemaining <= 0) {
           logger.logEvent(11 /* LogEvent.OnloadHandlerTriggered */, [
             elapsedTime,
             globalConfig.minMeasureTime,
           ]);
           if (globalConfig.measureUntil === "onload") {
-            onPageLoad(sendBeaconWhenVisible);
+            onPageLoad(sendBeaconWhenVisible_1);
           }
         }
         else {
           // Try again after the minimum measurement time has elapsed
-          setTimeout(sendBeaconAfterMinimumMeasureTime, timeRemaining);
+          setTimeout(sendBeaconAfterMinimumMeasureTime_1, timeRemaining);
         }
       };
-      sendBeaconAfterMinimumMeasureTime();
+      sendBeaconAfterMinimumMeasureTime_1();
     }
     // When newBeaconOnPageShow = true, we initiate a new page view whenever a page is restored from
     // bfcache. Since we have no "onload" event to hook into after a bfcache restore, we rely on the
     // unload and maxMeasureTime handlers to send the beacon.
     if (globalConfig.newBeaconOnPageShow) {
-      addEventListener("pageshow", (event) => {
+      addEventListener("pageshow", function (event) {
         if (event.persisted) {
           // Record the timestamp of the bfcache restore
           setPageRestoreTime(event.timeStamp);
@@ -2697,8 +2760,9 @@
           // restore. Wrapping this in a setTimeout ensures the browser has enough time to update the
           // visibility.
           // See https://bugs.chromium.org/p/chromium/issues/detail?id=1133363
-          setTimeout(() => {
+          setTimeout(function () {
             if (gbLuxSent) {
+              logger.logEvent(17 /* LogEvent.BfCacheRestore */);
               // If the beacon was already sent for this page, we start a new page view and mark the
               // load time as the time it took to restore the page.
               _init(getPageRestoreTime(), false);
@@ -2723,38 +2787,85 @@
     * LUX functions and properties must be attached to the existing global object to ensure that
     * changes made to the global object are reflected in the "internal" LUX object, and vice versa.
     */
-    const globalLux = globalConfig;
+    var globalLux = globalConfig;
     // Functions
+    globalLux.addData = _addData;
+    globalLux.cmd = _runCommand;
+    globalLux.getSessionId = _getUniqueId;
     globalLux.mark = _mark;
-    globalLux.measure = _measure;
-    globalLux.init = _init;
     globalLux.markLoadTime = _markLoadTime;
+    globalLux.measure = _measure;
     globalLux.on = subscribe;
-    globalLux.send = () => {
-      logger.logEvent(7 /* LogEvent.SendCalled */);
+    globalLux.snippetVersion = LUX.snippetVersion;
+    globalLux.version = VERSION;
+    globalLux.init = function (time) {
+      logger.logEvent(3 /* LogEvent.InitCalled */);
+      // Some customers (incorrectly) call LUX.init on the very first page load of a SPA. This would
+      // cause some first-page-only data (like paint metrics) to be lost. To prevent this, we silently
+      // bail from this function when we detect an unnecessary LUX.init call.
+      //
+      // Some notes about how this is compatible with SPA mode:
+      //  - For "new" implementations where SPA mode has always been enabled, we expect
+      //    LUX.startSoftNavigation() to be called instead of LUX.init(), so this code path should
+      //    never be reached.
+      //
+      //  - For "old" implementations, we expect LUX.send() is still being called. So we can rely on
+      //    there being an end mark from the previous LUX.send() call.
+      //
+      var endMark = _getMark(END_MARK);
+      if (!endMark) {
+        logger.logEvent(18 /* LogEvent.InitCallIgnored */);
+        return;
+      }
+      // In SPA mode, ensure the previous page's beacon has been sent
+      if (globalConfig.spaMode) {
+        beacon.send();
+        _sendLux();
+      }
+      _init(time);
+    };
+    globalLux.startSoftNavigation = function (time) {
+      logger.logEvent(14 /* LogEvent.StartSoftNavigationCalled */);
       beacon.send();
       _sendLux();
+      _init(time);
     };
-    globalLux.addData = _addData;
-    globalLux.getSessionId = _getUniqueId; // so customers can do their own sampling
-    globalLux.getDebug = () => {
+    globalLux.send = function (force) {
+      if (globalConfig.spaMode && !force) {
+        // In SPA mode, sending the beacon manually is not necessary, and is ignored unless the `force`
+        // parameter has been specified.
+        logger.logEvent(16 /* LogEvent.SendCancelledSpaMode */);
+        // If markLoadTime() has not already been called, we assume this send() call corresponds to a
+        // "loaded" state and mark it as the load time. This mark is important as it is used to
+        // decide whether an init() call can be ignored or not.
+        var startMark = _getMark(START_MARK);
+        var endMark = _getMark(END_MARK);
+        if (!endMark || (startMark && endMark.startTime < startMark.startTime)) {
+          _markLoadTime();
+        }
+      }
+      else {
+        logger.logEvent(7 /* LogEvent.SendCalled */);
+        beacon.send();
+        _sendLux();
+      }
+    };
+    globalLux.getDebug = function () {
       console.log("SpeedCurve RUM debugging documentation: https://support.speedcurve.com/docs/rum-js-api#luxgetdebug");
       return logger.getEvents();
     };
-    globalLux.forceSample = () => {
+    globalLux.forceSample = function () {
       logger.logEvent(8 /* LogEvent.ForceSampleCalled */);
       setUniqueId(createSyncId(true));
     };
-    globalLux.doUpdate = () => {
+    globalLux.doUpdate = function () {
       // Deprecated, intentionally empty.
     };
-    globalLux.cmd = _runCommand;
-    // Public properties
-    globalLux.version = VERSION;
     /**
     * Run a command from the command queue
     */
-    function _runCommand([fn, ...args]) {
+    function _runCommand(_a) {
+      var fn = _a[0], args = _a.slice(1);
       if (typeof globalLux[fn] === "function") {
         // eslint-disable-next-line @typescript-eslint/ban-types
         globalLux[fn].apply(globalLux, args);

--- a/app/assets/javascripts/govuk_publishing_components/vendor/lux/lux-reporter.js
+++ b/app/assets/javascripts/govuk_publishing_components/vendor/lux/lux-reporter.js
@@ -268,7 +268,7 @@
     return sinceNavigationStart;
   }
 
-  var version = "4.3.0";
+  var version = "4.3.2";
 
   function padStart(str, length, char) {
     while (str.length < length) {
@@ -586,8 +586,8 @@
     try {
       if (selector &&
         (node.nodeType === 9 || selector.length > MAX_SELECTOR_LENGTH || !node.parentNode)) {
-          // Final selector.
-          return selector;
+        // Final selector.
+        return selector;
       }
       var el = node;
       // Our first preference is to use the data-sctrack attribute from anywhere in the tree
@@ -684,10 +684,10 @@
       if (sessionEntries.length &&
         (entry.startTime - latestEntry.startTime >= 1000 ||
           entry.startTime - firstEntry.startTime >= 5000)) {
-          sessionValue = entry.value;
-          sessionEntries = [entry];
-          sessionAttributions = sources;
-          largestEntry = entry;
+        sessionValue = entry.value;
+        sessionEntries = [entry];
+        sessionAttributions = sources;
+        largestEntry = entry;
       }
       else {
         sessionValue += entry.value;
@@ -1714,7 +1714,7 @@
     // Track how long it took lux.js to load via Resource Timing.
     function selfLoading() {
       var sLuxjs = "";
-      if (gbFirstPV && performance.getEntriesByName) {
+      if (gbFirstPV && performance.getEntriesByName && thisScript.src) {
         // Get the lux script URL (including querystring params).
         var aResources = performance.getEntriesByName(thisScript.src);
         if (aResources && aResources.length) {
@@ -2277,8 +2277,8 @@
       if (gFlags) {
         queryParams.push("fl=" + gFlags);
       }
-      if (globalLux.snippetVersion) {
-        queryParams.push("sv=" + globalLux.snippetVersion);
+      if (LUX.snippetVersion) {
+        queryParams.push("sv=" + LUX.snippetVersion);
       }
       var customDataValues = valuesToString(customData);
       if (customDataValues) {
@@ -2900,4 +2900,3 @@
   // End of more settings
   // ---------------------------------------------------------------------------
 })();
-//# sourceMappingURL=lux.js.map


### PR DESCRIPTION
## What / why
Update to latest version of LUX, according to https://github.com/alphagov/govuk_publishing_components/blob/main/docs/real-user-metrics.md#getting-the-new-code

Slightly oddly this update seems to undo a lot of the changes from the [previous version](https://github.com/alphagov/govuk_publishing_components/pull/5007), namely that most instances of `var` were replaced with `const` or `let` - they've now been changed back to `var`, oddly.

While I was writing this PR to update to 4.3.0, 4.3.2 was released, so have included that as a separate commit to show the differences.

## Visual Changes
None.
