### PR TITLE
Version 60.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 60.2.1
 
 * Set `row_classes` in the Summary Card component to be an array ([PR #5011](https://github.com/alphagov/govuk_publishing_components/pull/5011))
 * Update cookie banner component hide button text ([PR #5012](https://github.com/alphagov/govuk_publishing_components/pull/5012))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (60.2.0)
+    govuk_publishing_components (60.2.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "60.2.0".freeze
+  VERSION = "60.2.1".freeze
 end


### PR DESCRIPTION
## 60.2.1
* Set `row_classes` in the Summary Card component to be an array ([PR #5011](https://github.com/alphagov/govuk_publishing_components/pull/5011))
* Update cookie banner component hide button text ([PR #5012](https://github.com/alphagov/govuk_publishing_components/pull/5012))
* Remove the blue_bar option from layout_for_public template ([PR #5016](https://github.com/alphagov/govuk_publishing_components/pull/5016))
* Add govuk_chat_onboarding_complete cookie to cookie categories ([PR #5014](https://github.com/alphagov/govuk_publishing_components/pull/5014))
