### PR TITLE
GOV.UK Frontend v5.11.0 and v5.11.1 updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* GOV.UK Frontend v5.11.0 and v5.11.1 updates ([PR #5023](https://github.com/alphagov/govuk_publishing_components/pull/5023))
+
 ## 61.0.0
 
 * Remove unneeded Sass mixins ([PR #4969](https://github.com/alphagov/govuk_publishing_components/pull/4969))

--- a/app/assets/stylesheets/govuk_publishing_components/govuk_frontend_support.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/govuk_frontend_support.scss
@@ -19,13 +19,10 @@ $gem-quiet-button-hover-colour: darken($gem-quiet-button-colour, 5%);
 
 $gem-hover-dark-background: #dddcdb;
 
-// Dart Sass 1.79.0 introduced support for CSS Color Level 4 color spaces.
-// Consequently, the `govuk-tint` mixin now outputs rgb values with floating-point precision,
-// leading to unsupported property value warnings in some browsers, such as Safari 11.1.1.
-// To maintain compatibility, we're defining equivalent hex color values as variables.
+// Brand refresh
 
-$govuk-blue-tint-95: #f4f8fb; // govuk-tint(govuk-colour("blue"), 95%)
-$govuk-blue-tint-80: #d2e2f1; // govuk-tint(govuk-colour("blue"), 80%)
-$govuk-blue-tint-50: #8eb8dc; // govuk-tint(govuk-colour("blue"), 50%)
+$govuk-blue-tint-95: govuk-tint($govuk-brand-colour, 95%);
+$govuk-blue-tint-80: govuk-tint(govuk-colour("blue"), 80%);
+$govuk-blue-tint-50: govuk-tint(govuk-colour("blue"), 50%);
 
 $govuk-rebrand-template-background-colour: $govuk-blue-tint-95;

--- a/app/views/govuk_publishing_components/components/_service_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_service_navigation.html.erb
@@ -5,6 +5,7 @@
   service_name_url ||= nil
   navigation_items ||= []
   navigation_aria_label ||= t("components.layout_header.menu")
+  collapse_navigation_on_mobile = local_assigns.fetch(:collapse_navigation_on_mobile, navigation_items.length > 1)
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-service-navigation govuk-service-navigation")
@@ -29,9 +30,11 @@
 
         <% if navigation_items.present? %>
           <nav aria-label="<%= navigation_aria_label %>" class="govuk-service-navigation__wrapper">
-            <button type="button" class="govuk-service-navigation__toggle govuk-js-service-navigation-toggle" aria-controls="navigation" hidden>
-              Menu
-            </button>
+            <% if collapse_navigation_on_mobile %>
+              <button type="button" class="govuk-service-navigation__toggle govuk-js-service-navigation-toggle" aria-controls="navigation" hidden>
+                Menu
+              </button>
+            <% end %>
             <ul class="govuk-service-navigation__list" id="navigation">
               <% navigation_items.each do |nav| %>
                 <%

--- a/app/views/govuk_publishing_components/components/_service_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_service_navigation.html.erb
@@ -5,10 +5,12 @@
   service_name_url ||= nil
   navigation_items ||= []
   navigation_aria_label ||= t("components.layout_header.menu")
+  inverse ||= false
   collapse_navigation_on_mobile = local_assigns.fetch(:collapse_navigation_on_mobile, navigation_items.length > 1)
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-service-navigation govuk-service-navigation")
+  component_helper.add_class("govuk-service-navigation--inverse") if inverse
   component_helper.add_aria_attribute({ label: "Service information" }) if service_name.present?
   component_helper.add_data_attribute({ module: "govuk-service-navigation" })
 

--- a/app/views/govuk_publishing_components/components/docs/service_navigation.yml
+++ b/app/views/govuk_publishing_components/components/docs/service_navigation.yml
@@ -74,3 +74,23 @@ examples:
       - text: Navigation item 2
         href: "#"
       full_width: true
+  with_navigation_links_and_collapse_navigation_on_mobile_set_to_false:
+    data:
+      navigation_items:
+      - text: Navigation item 1
+        href: "#"
+        active: true
+      - text: Navigation item 2
+        href: "#"
+      collapse_navigation_on_mobile: false
+  with_a_single_navigation_item:
+    data:
+      navigation_items:
+      - text: Navigation item 1
+        href: "#"
+  with_a_single_navigation_item_and_collapse_navigation_on_mobile:
+    data:
+      navigation_items:
+      - text: Navigation item 1
+        href: "#"
+      collapse_navigation_on_mobile: true

--- a/app/views/govuk_publishing_components/components/docs/service_navigation.yml
+++ b/app/views/govuk_publishing_components/components/docs/service_navigation.yml
@@ -74,6 +74,15 @@ examples:
       - text: Navigation item 2
         href: "#"
       full_width: true
+  inverse:
+    data:
+      navigation_items:
+      - text: Navigation item 1
+        href: "#"
+        active: true
+      - text: Navigation item 2
+        href: "#"
+      inverse: true
   with_navigation_links_and_collapse_navigation_on_mobile_set_to_false:
     data:
       navigation_items:

--- a/spec/components/service_navigation_spec.rb
+++ b/spec/components/service_navigation_spec.rb
@@ -98,6 +98,11 @@ describe "Service navigation", type: :view do
     assert_select("span.govuk-service-navigation__service-name .govuk-service-navigation__link", text: "My service name")
   end
 
+  it "renders with inverse styles" do
+    render_component({ navigation_items:, inverse: true })
+    assert_select(".gem-c-service-navigation.govuk-service-navigation--inverse")
+  end
+
   it "renders without toggle if collapse_navigation_on_mobile is `false`" do
     render_component({ navigation_items:, collapse_navigation_on_mobile: false })
     assert_select(".govuk-service-navigation__toggle", false)

--- a/spec/components/service_navigation_spec.rb
+++ b/spec/components/service_navigation_spec.rb
@@ -34,11 +34,11 @@ describe "Service navigation", type: :view do
     assert_empty render_component({})
   end
 
-  it "renders with navigation items" do
+  it "renders with multiple navigation items and toggle" do
     render_component({ navigation_items: })
 
     assert_select("div.gem-c-service-navigation")
-
+    assert_select(".govuk-service-navigation__toggle", text: "Menu")
     assert_select(".govuk-service-navigation__item:nth-child(1) .govuk-service-navigation__link", text: "Navigation item 1")
     assert_select(".govuk-service-navigation__item:nth-child(2) .govuk-service-navigation__link", text: "Navigation item 2")
     assert_select(".govuk-service-navigation__item:nth-child(3) .govuk-service-navigation__link", text: "Navigation item 3")
@@ -96,5 +96,40 @@ describe "Service navigation", type: :view do
     assert_select("section.gem-c-service-navigation")
 
     assert_select("span.govuk-service-navigation__service-name .govuk-service-navigation__link", text: "My service name")
+  end
+
+  it "renders without toggle if collapse_navigation_on_mobile is `false`" do
+    render_component({ navigation_items:, collapse_navigation_on_mobile: false })
+    assert_select(".govuk-service-navigation__toggle", false)
+  end
+
+  it "renders without toggle if the navigation only has one item" do
+    render_component({ navigation_items: [
+                         {
+                           text: "Navigation item 1",
+                           href: "#",
+                           data: {
+                             hello: "world",
+                             another: "test",
+                           },
+                         },
+                       ],
+                       inverse: true })
+    assert_select(".govuk-service-navigation__toggle", false)
+  end
+
+  it "renders with toggle if the navigation only has one item but `collapse_navigation_on_mobile` is true'" do
+    render_component({ navigation_items: [
+                         {
+                           text: "Navigation item 1",
+                           href: "#",
+                           data: {
+                             hello: "world",
+                             another: "test",
+                           },
+                         },
+                       ],
+                       collapse_navigation_on_mobile: true })
+    assert_select(".govuk-service-navigation__toggle", text: "Menu")
   end
 end


### PR DESCRIPTION
## What

https://gov-uk.atlassian.net/browse/NAV-18205

GOV.UK Frontend v5.11.0 and v5.11.1 updates
- The Service navigation component no longer uses a menu on mobile for a single link
- Add inverse styling to Service navigation
- Reapply colour mixins instead of hex values (used for the brand refresh)

**Review URL**: https://components-gem-pr-5023.herokuapp.com/component-guide/service_navigation

## Why

Although GOV.UK Publishing Components was previously updated to versions GOV.UK Frontend 5.11.0 - 5.11.2, not all fixes and improvements from those releases were applied. This pull request ensures that the remaining updates are now implemented.

## Anything else

If testing from the 'preview all' page in the component guide, only the first service navigation menu toggle responds. This happens because each toggle is tied to a unique navigation container id `id="navigation"`. This matches the https://design-system.service.gov.uk/components/service-navigation/ examples.