### PR TITLE
Version 61.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 61.0.0
 
 * Remove unneeded Sass mixins ([PR #4969](https://github.com/alphagov/govuk_publishing_components/pull/4969))
 * Upgrade to LUX version 4.3.2 ([PR #5018](https://github.com/alphagov/govuk_publishing_components/pull/5018))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (60.2.1)
+    govuk_publishing_components (61.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "60.2.1".freeze
+  VERSION = "61.0.0".freeze
 end


### PR DESCRIPTION
## 61.0.0

* **BREAKING:** Remove unneeded Sass mixins ([PR #4969](https://github.com/alphagov/govuk_publishing_components/pull/4969))
* Upgrade to LUX version 4.3.2 ([PR #5018](https://github.com/alphagov/govuk_publishing_components/pull/5018))
* Add content block styles ([PR #4973](https://github.com/alphagov/govuk_publishing_components/pull/4973))
* Restructure HTML and use flexbox in super navigation component ([PR #4997](https://github.com/alphagov/govuk_publishing_components/pull/4997))