### PR TITLE
Fix heading component margin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Fix heading component margin ([PR #5026](https://github.com/alphagov/govuk_publishing_components/pull/5026))
 * GOV.UK Frontend v5.11.0 and v5.11.1 updates ([PR #5023](https://github.com/alphagov/govuk_publishing_components/pull/5023))
 
 ## 61.0.0

--- a/app/assets/stylesheets/govuk_publishing_components/components/_heading.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_heading.scss
@@ -1,8 +1,10 @@
 @import "govuk_publishing_components/individual_component_support";
 
-.gem-c-heading,
-.gem-c-heading__text {
-  margin: 0;
+.gem-c-heading {
+  // needs to be this specific to override govuk-heading
+  .gem-c-heading__text {
+    margin: 0;
+  }
 }
 
 .gem-c-heading--padding {


### PR DESCRIPTION
## What
- govuk-heading class inside the heading component in some circumstances overrode the heading component, giving the heading inside a bottom margin
- heading inside the component should always have a margin bottom of zero, allowing the wrapping element to set the margin, controlled by the component

## Why
Recently noticed on https://www.gov.uk/cma-cases/veterinary-services-market-for-pets-review

## Visual Changes
Before | After
------ | -----
<img width="710" height="354" alt="Screenshot 2025-09-16 at 15 38 48" src="https://github.com/user-attachments/assets/af6ba508-33bf-4cb8-8fc2-a80ba01bda82" /> | <img width="705" height="321" alt="Screenshot 2025-09-16 at 15 38 58" src="https://github.com/user-attachments/assets/5d117b8c-5dba-4851-91f1-1cd27709dbe0" />
