### PR TITLE
Version 61.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 61.0.1
 
 * Fix heading component margin ([PR #5026](https://github.com/alphagov/govuk_publishing_components/pull/5026))
 * GOV.UK Frontend v5.11.0 and v5.11.1 updates ([PR #5023](https://github.com/alphagov/govuk_publishing_components/pull/5023))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (61.0.0)
+    govuk_publishing_components (61.0.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "61.0.0".freeze
+  VERSION = "61.0.1".freeze
 end


### PR DESCRIPTION
## 61.0.1

* Fix heading component margin ([PR #5026](https://github.com/alphagov/govuk_publishing_components/pull/5026))
* GOV.UK Frontend v5.11.0 and v5.11.1 updates ([PR #5023](https://github.com/alphagov/govuk_publishing_components/pull/5023))
