### PR TITLE
Fix specificity issue with single page notification button

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_single-page-notification-button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_single-page-notification-button.scss
@@ -7,6 +7,7 @@
   color: $govuk-link-colour;
   cursor: pointer;
   background: none;
+  @include govuk-font(16);
 
   &:focus {
     border-color: transparent;

--- a/app/views/govuk_publishing_components/components/_single_page_notification_button.html.erb
+++ b/app/views/govuk_publishing_components/components/_single_page_notification_button.html.erb
@@ -31,7 +31,7 @@
       <input type="hidden" name="link" value="<%= spnb_helper.base_path %>">
     <% end %>
     <%= content_tag(:button, button_text, {
-      class: "govuk-body-s gem-c-single-page-notification-button__submit",
+      class: "gem-c-single-page-notification-button__submit",
       type: "submit",
       data: {
         ga4_link: ga4_link_data_attributes,


### PR DESCRIPTION
## What
- text inside the button was rendering black and not blue as intended in some circumstances
- this was because the wrapping element has a class of govuk-body-s, which sets the black font colour
- if govuk-frontend styles are loaded first, button text is blue, if they load second, button text is black
- fixing by removing the govuk-body-s class and replacing with specific govuk-font setting on the text element itself

## Why
Noticed on https://www.gov.uk/government/publications/budget-2016-documents during testing of an unrelated issue.

## Visual Changes
Note that 'before' only happens if the styles are loaded in an unexpected order. However this is a brittleness in our Sass, and should be corrected even if the styles are loaded as expected.

Before | After
------ | -----
<img width="305" height="92" alt="Screenshot 2025-09-17 at 10 50 44" src="https://github.com/user-attachments/assets/ccb3699f-6e9f-4a28-b7ed-9d31bfa3107d" /> | <img width="297" height="97" alt="Screenshot 2025-09-17 at 11 03 49" src="https://github.com/user-attachments/assets/8fec914f-3f41-4241-a7ab-0a6cda6eb4c1" />
