### PR TITLE
Fix print link button styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix print link button styles ([PR #5036](https://github.com/alphagov/govuk_publishing_components/pull/5036))
+
 ## 61.0.2
 
 * Fix incorrect colour on summary banner heading ([PR #5030](https://github.com/alphagov/govuk_publishing_components/pull/5030))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_print-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_print-link.scss
@@ -47,6 +47,7 @@ $gem-c-print-link-background-height: 18px;
   color: $govuk-link-colour;
   cursor: pointer;
   margin: govuk-spacing(0);
+  @include govuk-font(16);
 
   &:focus {
     background-color: $govuk-focus-colour;

--- a/app/views/govuk_publishing_components/components/_print_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_print_link.html.erb
@@ -10,7 +10,7 @@
   ((child_data_attributes[:module] ||= "") << " " << (require_js ? "print-link" : "button")).strip!
 
   child_classes = %w[govuk-link]
-  child_classes << "govuk-body-s gem-c-print-link__button" if href.nil?
+  child_classes << "gem-c-print-link__button" if href.nil?
   child_classes << "gem-c-print-link__link govuk-link--no-visited-state" if href.present?
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)


### PR DESCRIPTION
## What
- govuk-body-s was overriding the colour on the print link button text, despite it being overridden by the components own styles
- this is due to a change in govspeak, which will be addressed separately, but this change makes the component less brittle by not relying on govuk-body-s anymore

## Why
Spotted by @AshGDS as being the wrong colour on this page: https://www.gov.uk/guidance/download-the-govuk-app

## Visual Changes
Note that this only occurs where the print link component appears on a page with the govspeak component.

Before | After
------ | ------
<img width="175" height="59" alt="Screenshot 2025-09-19 at 14 41 02" src="https://github.com/user-attachments/assets/1e7efe7f-b99f-4da9-b325-63742ff86a43" /> | <img width="176" height="58" alt="Screenshot 2025-09-19 at 14 41 21" src="https://github.com/user-attachments/assets/e35542d5-ab51-4c5f-9d45-cb1d803c98a9" />

Relates to https://github.com/alphagov/govuk_publishing_components/issues/5035
