### PR TITLE
Fix govspeak styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Fix govspeak styles ([PR #5037](https://github.com/alphagov/govuk_publishing_components/pull/5037))
 * Fix print link button styles ([PR #5036](https://github.com/alphagov/govuk_publishing_components/pull/5036))
 
 ## 61.0.2

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_content-block.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_content-block.scss
@@ -1,6 +1,3 @@
-@import "govuk/core/lists";
-@import "govuk/core/typography";
-
 .content-block,
 .content-block__contact-key,
 .content-block__contact-value,
@@ -11,17 +8,19 @@
 
 .content-block__contact-list {
   .content-block__contact-key {
-    @extend %govuk-heading-m;
+    margin-bottom: govuk-spacing(4);
+    @include govuk-font(24, $weight: "bold");
   }
 }
 
 .content-block__contact-list--nested {
   .content-block__contact-key {
-    @extend %govuk-heading-s;
+    margin-bottom: govuk-spacing(4);
+    @include govuk-font(19, $weight: "bold");
   }
 }
 
 .content-block .content-block__list {
-  @extend %govuk-list;
   margin-left: 0;
+  list-style: none;
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_content-block.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_content-block.scss
@@ -6,16 +6,13 @@
   padding: 0;
 }
 
-.content-block__contact-list {
-  .content-block__contact-key {
-    margin-bottom: govuk-spacing(4);
-    @include govuk-font(24, $weight: "bold");
-  }
+.content-block__contact-key {
+  @include govuk-responsive-margin(4, "bottom");
+  @include govuk-font(24, $weight: "bold");
 }
 
 .content-block__contact-list--nested {
   .content-block__contact-key {
-    margin-bottom: govuk-spacing(4);
     @include govuk-font(19, $weight: "bold");
   }
 }


### PR DESCRIPTION
## What
Stop importing the GOVUK Frontend typography styles in the govspeak styles.

## Why
This was causing this issue: https://github.com/alphagov/govuk_publishing_components/issues/5035

## Visual Changes
There's a very small change in the spacing between list items, because they are no longer based on the GOVUK Frontend list classes. I've left them like this because they are now consistent with the rest of govspeak, which means we can iterate them more easily in one place further down the road if we want.

Before | After
------ | ------
<img width="620" height="466" alt="Screenshot 2025-09-19 at 15 34 16" src="https://github.com/user-attachments/assets/8dd590c3-b072-4036-8328-6acaee3b2f16" /> | <img width="629" height="451" alt="Screenshot 2025-09-19 at 15 34 03" src="https://github.com/user-attachments/assets/825021a2-f338-4f65-a895-76b5f835242d" /> 

(it's a very small change, easier to see full size if you want to compare it with https://components.publishing.service.gov.uk/component-guide/govspeak/contact_content_block/preview)