### PR TITLE
Version 61.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 61.0.3
 
 * Fix govspeak styles ([PR #5037](https://github.com/alphagov/govuk_publishing_components/pull/5037))
 * Fix print link button styles ([PR #5036](https://github.com/alphagov/govuk_publishing_components/pull/5036))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (61.0.2)
+    govuk_publishing_components (61.0.3)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "61.0.2".freeze
+  VERSION = "61.0.3".freeze
 end


### PR DESCRIPTION
## 61.0.3

* Fix govspeak styles ([PR #5037](https://github.com/alphagov/govuk_publishing_components/pull/5037))
* Fix print link button styles ([PR #5036](https://github.com/alphagov/govuk_publishing_components/pull/5036))
* Rename `gem-c-print-force-` classes to `gem-print-force-` ([PR #5034](https://github.com/alphagov/govuk_publishing_components/pull/5034))
