### PR TITLE
Adjust action link arrow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Revert GA4 phone number PII changes ([PR #5039](https://github.com/alphagov/govuk_publishing_components/pull/5039))
+* Adjust action link arrow ([PR #5040](https://github.com/alphagov/govuk_publishing_components/pull/5040))
 
 ## 61.0.3
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
@@ -14,39 +14,35 @@
   width: 36px;
   vertical-align: middle;
 
-  svg {
-    height: 28px;
-    vertical-align: middle;
-    width: 28px;
+  @include govuk-media-query($from: tablet) {
+    width: 45px;
+  }
+}
 
-    .gem-c-action-link__icon__circle {
-      fill: #eeefef;
+.gem-c-action-link__svg {
+  height: 28px;
+  vertical-align: middle;
+  width: 28px;
 
-      // stylelint-disable max-nesting-depth
-      @media (forced-colors: active) {
-        fill: LinkText;
-      }
-      // stylelint-enable max-nesting-depth
+  .gem-c-action-link__icon__circle {
+    fill: #eeefef;
+
+    @media (forced-colors: active) {
+      fill: LinkText;
     }
+  }
 
-    .gem-c-action-link__icon__arrow {
-      fill: #000000;
+  .gem-c-action-link__icon__arrow {
+    fill: #000000;
 
-      // stylelint-disable max-nesting-depth
-      @media (forced-colors: active) {
-        fill: Canvas;
-      }
-      // stylelint-enable max-nesting-depth
+    @media (forced-colors: active) {
+      fill: Canvas;
     }
   }
 
   @include govuk-media-query($from: tablet) {
-    width: 45px;
-
-    svg {
-      height: 35px;
-      width: 35px;
-    }
+    height: 35px;
+    width: 35px;
   }
 }
 
@@ -54,18 +50,16 @@
   padding-top: 2px;
   width: 30px;
 
-  svg {
+  .gem-c-action-link__svg {
     height: 25px;
     width: 25px;
+  }
 
-    .gem-c-action-link__icon__arrow {
-      fill: #272828;
+  .gem-c-action-link__icon__arrow {
+    fill: #272828;
 
-      // stylelint-disable max-nesting-depth
-      @media (forced-colors: active) {
-        fill: currentcolor;
-      }
-      // stylelint-enable max-nesting-depth
+    @media (forced-colors: active) {
+      fill: currentcolor;
     }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
@@ -12,6 +12,7 @@
   display: table-cell;
   line-height: 1;
   width: 36px;
+  vertical-align: middle;
 
   svg {
     height: 28px;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
@@ -76,6 +76,18 @@
   @include govuk-font(19, $weight: bold, $line-height: 1.3);
 }
 
+.gem-c-action-link--large {
+  .gem-c-action-link__icon {
+    height: 40px;
+    width: 56px;
+  }
+
+  .gem-c-action-link__svg {
+    height: 40px;
+    width: 40px;
+  }
+}
+
 @include govuk-media-query($media-type: print) {
   .gem-c-action-link {
     * {

--- a/app/views/govuk_publishing_components/components/_action_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_action_link.html.erb
@@ -7,6 +7,7 @@
   inverse ||= false
   simple ||= false
   simple_light ||= false
+  large ||= false
 
   link_classes = %w(govuk-link gem-c-action-link__link gem-print-force-link-styles)
   link_classes << "govuk-link--inverse" if inverse
@@ -15,12 +16,13 @@
   component_helper.add_class("gem-c-action-link")
   component_helper.add_class("gem-c-action-link--inverse") if inverse
   component_helper.add_class("gem-c-action-link--simple") if simple
+  component_helper.add_class("gem-c-action-link--large") if large
 %>
 <% if text.present? %>
   <%= tag.div(**component_helper.all_attributes) do %>
     <% if simple || simple_light %>
       <span class="gem-c-action-link__icon gem-c-action-link__icon--simple" hidden>
-        <svg xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true" viewBox="0 0 23 23">
+        <svg xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true" viewBox="0 0 23 23" class="gem-c-action-link__svg">
           <g class="gem-c-action-link__icon__arrow">
             <path d="M14.943 11.795 10.44 7.292 11.733 6l5.795 5.795-5.795 5.795-1.293-1.292 4.503-4.503Z" />
             <path d="M3.956 10.881h11.485v1.828H3.956v-1.828Z" />
@@ -29,7 +31,7 @@
       </span>
     <% elsif %>
       <span class="gem-c-action-link__icon" hidden>
-        <svg xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true" viewBox="0 0 27 27">
+        <svg xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true" viewBox="0 0 27 27" class="gem-c-action-link__svg">
           <circle class="gem-c-action-link__icon__circle" cx="13.5" cy="13.5" r="13.5" />
           <g class="gem-c-action-link__icon__arrow">
             <path d="m17.701 13.526-3.827-3.828L14.973 8.6l4.926 4.926-4.926 4.926-1.099-1.099 3.827-3.827Z" />

--- a/app/views/govuk_publishing_components/components/docs/action_link.yml
+++ b/app/views/govuk_publishing_components/components/docs/action_link.yml
@@ -25,3 +25,10 @@ examples:
       text: Getting financial help and keeping your business safe
       href: "/financial-help"
       simple: true
+  large:
+    description: For use on the GOV.UK homepage popular links.
+    data:
+      text: This way for cookies
+      href: "/cookies"
+      large: true
+

--- a/spec/components/action_link_spec.rb
+++ b/spec/components/action_link_spec.rb
@@ -43,4 +43,13 @@ describe "Action link", type: :view do
     )
     assert_select ".gem-c-action-link--inverse"
   end
+
+  it "renders large version" do
+    render_component(
+      text: "Get more info",
+      href: "/coronavirus",
+      large: true,
+    )
+    assert_select ".gem-c-action-link.gem-c-action-link--large"
+  end
 end


### PR DESCRIPTION
## What
Change the vertical alignment of the action link arrow to be in the middle, not the top.

- arrow previously aligned to the top (default) whereas text is vertically aligned to the middle
- not noticeable most of the time but on the homepage, where several action links with differing text are next to each other, and an override is in place to make this change
- still not noticeable unless text size is increased (can do zoom text only in Firefox)
- therefore moving this positioning change to the component itself as the default, as it seems like a sensible option
- action link only used on homepage, browse pages, coronavirus page

Also add a new option `large` for display on the homepage, and refactoring the stylesheet a bit following these changes.

## Why
Noticed during the work on https://github.com/alphagov/frontend/pull/4928 that this behaviour is happening in frontend, but only because of a style override on a component, which breaks our rule of component isolation, so moving this to the component itself.

Done as the default behaviour rather than an option on the component because this seems like a sensible default for how we're currently using the action link component.

## Visual Changes
Demonstrating the new arrow position: showing a forced example from the component guide, the homepage (what it would look like if the override wasn't in place) and browse page.

Before | After
------- | ------
<img width="438" height="297" alt="Screenshot 2025-09-24 at 14 48 48" src="https://github.com/user-attachments/assets/6995c7e7-7ef5-473d-8131-f6bb82a17f7b" /> | <img width="428" height="288" alt="Screenshot 2025-09-24 at 14 48 56" src="https://github.com/user-attachments/assets/7559541b-0ce4-4721-b67c-38f8046e35c9" />
<img width="1000" height="573" alt="Screenshot 2025-09-24 at 14 51 33" src="https://github.com/user-attachments/assets/5af533db-8a13-4504-8fe5-de9cd264452e" /> | <img width="987" height="513" alt="Screenshot 2025-09-24 at 14 50 12" src="https://github.com/user-attachments/assets/a56e39b6-2142-4154-b828-e747fde4557a" /> 
<img width="989" height="855" alt="Screenshot 2025-09-24 at 14 59 50" src="https://github.com/user-attachments/assets/39302ee4-94c4-40c2-ba07-cd30bf76c79e" /> | <img width="999" height="852" alt="Screenshot 2025-09-24 at 14 59 57" src="https://github.com/user-attachments/assets/9d96171c-d6d3-4059-aae9-52f69308400d" />

New large option (alongside the default for comparison)

<img width="346" height="294" alt="Screenshot 2025-09-26 at 11 35 17" src="https://github.com/user-attachments/assets/779103db-17b1-4321-861d-9bacdce5b49a" />

