### PR TITLE
Release Version 61.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 61.1.2
 
 * Move draft watermark from static to layout_for_public ([PR #5062](https://github.com/alphagov/govuk_publishing_components/pull/5062))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (61.1.1)
+    govuk_publishing_components (61.1.2)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "61.1.1".freeze
+  VERSION = "61.1.2".freeze
 end


### PR DESCRIPTION
## 61.1.2

* Move draft watermark from static to layout_for_public ([PR #5062](https://github.com/alphagov/govuk_publishing_components/pull/5062))