### PR TITLE
Release version 61.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 61.1.3
 
 * Fix accessibility failures on the select with search component ([PR #5064](https://github.com/alphagov/govuk_publishing_components/pull/5064))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (61.1.2)
+    govuk_publishing_components (61.1.3)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "61.1.2".freeze
+  VERSION = "61.1.3".freeze
 end


### PR DESCRIPTION
* Fix accessibility failures on the select with search component ([PR #5064](https://github.com/alphagov/govuk_publishing_components/pull/5064))