### PR TITLE
Update heading component docs

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/heading.yml
+++ b/app/views/govuk_publishing_components/components/docs/heading.yml
@@ -26,7 +26,7 @@ examples:
       heading_level: 3
   different_font_sizes:
     description: |
-      Set a different font size for the heading. Uses the [GOV.UK Frontend heading sizes](https://design-system.service.gov.uk/styles/headings/) but defaults to 27px for legacy reasons. Valid options are `xl`, `l`, `m` and `s`.
+      Set a different font size for the heading. Uses the [GOV.UK Frontend heading sizes](https://design-system.service.gov.uk/styles/headings/). Valid options are `xl`, `l`, `m` and `s`.
 
       This option is not tied to the `heading_level` option in order to give flexibility.
     data:


### PR DESCRIPTION
## What

Remove reference to the default 27px font-size, the default size is now 24px and follows the design system type scale.

## Why

To ensure the component guide documentation is up-to-date and accurate.