### PR TITLE
Update auditing list of apps using static

### DIFF
--- a/app/models/govuk_publishing_components/audit_comparer.rb
+++ b/app/models/govuk_publishing_components/audit_comparer.rb
@@ -7,7 +7,6 @@ module GovukPublishingComponents
         @applications_using_static = %w[
           collections
           finder-frontend
-          frontend
           government-frontend
           service-manual-frontend
           smart-answers


### PR DESCRIPTION
## What / why
- remove frontend from the list of applications using static, that is used by the component auditing tools
- this changes how the auditing handles the application in terms of raising warnings about assets that aren't being included when they should
- more relevant now that frontend is both not using static and not using the per-page component asset model, this is a good way of checking that frontend has the right assets (even though it's still throwing a few irrelevant warnings about the service navigation component)

## Visual Changes
Without this change the auditing throws up 29 warnings, and incorrectly states that frontend uses static. With this change the warnings go down to 5.

Before | After
----- | ------
<img width="1000" height="548" alt="Screenshot 2025-10-15 at 14 48 56" src="https://github.com/user-attachments/assets/e2f5ef6b-0081-44a3-abb0-6a7dd293843d" /> | <img width="938" height="425" alt="Screenshot 2025-10-15 at 14 48 29" src="https://github.com/user-attachments/assets/7460ad3e-5977-4564-9374-eefd55db942f" />
