### PR TITLE
Version 61.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 61.3.0
 
 * Allow every component's CSS files to render on a component's preview page ([PR #5055](https://github.com/alphagov/govuk_publishing_components/pull/5055))
 * Add missing languages to component wrapper helper ([PR #5081](https://github.com/alphagov/govuk_publishing_components/pull/5081))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (61.2.0)
+    govuk_publishing_components (61.3.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "61.2.0".freeze
+  VERSION = "61.3.0".freeze
 end


### PR DESCRIPTION
## 61.3.0

* Allow every component's CSS files to render on a component's preview page ([PR #5055](https://github.com/alphagov/govuk_publishing_components/pull/5055))
* Add missing languages to component wrapper helper ([PR #5081](https://github.com/alphagov/govuk_publishing_components/pull/5081))