### PR TITLE
Add `Ga4FormChangeTracker`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fix component guide for applications without individual css loading ([PR #5087](https://github.com/alphagov/govuk_publishing_components/pull/5087))
 * Standardise success alert text size ([PR #5098](https://github.com/alphagov/govuk_publishing_components/pull/5098))
 * Revert #5055 'Allow every component's CSS files to render on a component's preview page' ([PR #5096](https://github.com/alphagov/govuk_publishing_components/pull/5096))
+* Add `Ga4FormChangeTracker` ([PR #5084](https://github.com/alphagov/govuk_publishing_components/pull/5084))
 
 ## 61.3.1
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4-publishing.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4-publishing.js
@@ -1,0 +1,1 @@
+//= require ./analytics-ga4/ga4-form-change-tracker

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-change-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-change-tracker.js
@@ -1,0 +1,147 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+// This does not meet Grade C browser support for Edge
+// as `CSS.escape` is not supported in Edge 12-18.
+//
+// Running this will cause an error in Edge 12-18
+// but will not impact other JS being run.
+
+(function (Modules) {
+  'use strict'
+
+  function Ga4FormChangeTracker (module) {
+    this.module = module
+  }
+
+  Ga4FormChangeTracker.prototype.init = function () {
+    var consentCookie = window.GOVUK.getConsentCookie()
+
+    if (consentCookie && consentCookie.usage) {
+      this.startModule()
+    } else {
+      this.start = this.startModule.bind(this)
+      window.addEventListener('cookie-consent', this.start)
+    }
+  }
+
+  // triggered by cookie-consent event, which happens when users consent to cookies
+  Ga4FormChangeTracker.prototype.startModule = function () {
+    if (window.dataLayer) {
+      window.removeEventListener('cookie-consent', this.start)
+      this.module.addEventListener('change', this.trackFormChange.bind(this))
+    }
+  }
+
+  Ga4FormChangeTracker.prototype.getSection = function (target, checkableValue) {
+    const { id } = target
+
+    const fieldset = target.closest('fieldset')
+    const legend = fieldset && fieldset.querySelector('legend')
+    const sectionContainer = this.module.closest('[data-ga4-section]')
+    const label = this.module.querySelector(`label[for='${window.CSS.escape(id)}']`)
+
+    const ga4FormSectionContainer = target.closest('[data-ga4-form-section]')
+
+    // by default use the nearest `data-ga4-section` (if present)
+    let section = sectionContainer && sectionContainer.dataset.ga4Section
+
+    // unless there is a nearest `data-ga4-form-section`
+    if (ga4FormSectionContainer) {
+      section = ga4FormSectionContainer.dataset.ga4FormSection
+    } else {
+      // otherwise use the label of input (if it is a text field)
+      section = label ? label.innerText : section
+      // or use the legend of the input (if it is checkable field)
+      section = legend && checkableValue ? legend.innerText : section
+    }
+
+    return section
+  }
+
+  Ga4FormChangeTracker.prototype.handleDateComponent = function (target) {
+    const isDateComponent = target.closest('.govuk-date-input')
+    const value = target.value
+
+    if (!isDateComponent) { return value.length }
+
+    // only track if completely filled in
+    const inputs = [
+      ...target.closest('.govuk-date-input').querySelectorAll('input')
+    ]
+    const allInputsSet = inputs.every((input) => input.value)
+
+    if (allInputsSet) {
+      return inputs.map((input) => input.value).join('/')
+    }
+  }
+
+  Ga4FormChangeTracker.prototype.trackFormChange = function (event) {
+    const target = event.target
+    const { type, id } = target
+
+    if (type === 'search') return
+
+    const indexContainer =
+      window.GOVUK.analyticsGa4.core.trackFunctions.findTrackingAttributes(
+        target,
+        'data-ga4-index'
+      )
+
+    let index = {}
+
+    if (indexContainer) {
+      try {
+        index = JSON.parse(indexContainer.getAttribute('data-ga4-index'))
+      } catch (e) {
+        console.warn('GA4 configuration error: ' + e.message, window.location)
+      }
+    }
+
+    const value = (event.detail && event.detail.value) || target.value
+
+    // a radio or check input with a `name` and `value`
+    // or an option of `value` within a `select` with `name`
+    const checkableValue = this.module.querySelector(
+      `#${window.CSS.escape(id)}[value="${window.CSS.escape(value)}"], #${window.CSS.escape(id)} [value="${window.CSS.escape(value)}"]`
+    )
+
+    let action = 'select'
+    let text
+
+    if (checkableValue) {
+      // radio, check, option can have `:checked` pseudo-class
+      if (!checkableValue.matches(':checked')) {
+        action = 'remove'
+      }
+
+      text = checkableValue.innerText ||
+        this.module.querySelector(`label[for='${window.CSS.escape(id)}']`).innerText
+
+      if (text) {
+        text = text.replace(/\r?\n|\r/g, ' ')
+      }
+    } else if (!text) {
+      // it's a free form text field
+      text = this.handleDateComponent(target)
+
+      if (!text) return
+    }
+
+    window.GOVUK.analyticsGa4.core.applySchemaAndSendData(
+      {
+        ...index,
+        section: this.getSection(
+          target,
+          checkableValue && checkableValue.matches(':not(option)')
+        ),
+        event_name: 'select_content',
+        action,
+        text
+      },
+      'event_data'
+    )
+  }
+
+  Modules.Ga4FormChangeTracker = Ga4FormChangeTracker
+})(window.GOVUK.Modules)

--- a/docs/analytics-ga4/trackers/ga4-form-change-tracker.md
+++ b/docs/analytics-ga4/trackers/ga4-form-change-tracker.md
@@ -1,0 +1,120 @@
+# Google Analytics 4 form change tracker
+
+This script is intended for adding GA4 tracking to form changes. It is triggered on the 'change' event of the form. It depends upon the main GA4 analytics code to function.
+
+## Basic use
+
+For the following form:
+
+```html
+<form
+  data-module="ga4-form-change-tracker"
+>
+  <fieldset>
+    <label for="text-input">What is your favourite pudding?</label>
+    <input id="text-input" name="text-input" type="text">
+  </fieldset>
+  <fieldset>
+    <label for="select">Choose your favourite ice cream flavour(s)</label>
+    <select multiple id="select" name="select">
+      <option value="chocolate">Chocolate</option>
+      <option value="banana">Banana</option>
+      <option value="strawberry">Strawberry</option>
+    </select>
+  </fieldset>
+  <fieldset>
+    <legend>What is your favourite cake?</label>
+    <div>
+      <label for="checkbox-1">Victoria</label>
+      <input id="checkbox-1" type="checkbox" name="favourite-cake" value="victoria">
+    </div>
+    <div>
+      <label for="checkbox-2">Carrot</label>
+      <input id="checkbox-2" type="checkbox" name="favourite-cake" value="carrot">
+    </div>
+    <div>
+      <label for="checkbox-3">Battenburg</label>
+      <input id="checkbox-3" type="checkbox" name="favourite-cake" value="battenburg">
+    </div>
+  </fieldset>
+</form>
+```
+
+If a field is changed then an event will fire in the following format:
+
+```json
+{
+  "event": "event_data",
+  "event_data": {
+    "event_name": "select_content",
+    "section": "SECTION OF INPUT",
+    "text": "VALUE OF INPUT"
+    "action": "select|remove"
+  }
+}
+```
+
+When an input is changed or a selection from a group is chosen:
+
+| Target | Section | Change | Text | Action |
+| ------ | ------- | ------ | ---- | ------ |
+| `input[type=text]` | What is your favourite pudding? | `value="Pie"` | 3 | select
+| `select` | Choose your favourite ice cream flavour(s) | `<option value="chocolate" selected>` | Chocolate | select
+| `input[type=checkbox]/input[type=radio]` | What is your favourite cake? | `<input id="checkbox-1" selected>` | Victoria | select
+
+For `input[type=text]`, the character count is returned instead of the value. This is to prevent inclusion of PII and the size of the event being too large for GA4 to record (if the `text` is too large).
+
+When a previously selected choice from a group is deselected:
+
+| Target | Section | Change | Text | Action |
+| ------ | ------- | ------ | ---- | ------ |
+| `select` | Choose your favourite ice cream flavour(s) | `<option value="chocolate">` | Chocolate | remove
+| `input[type=checkbox]` | What is your favourite cake? | `<input id="checkbox-1">` | Victoria | remove
+
+If the changed element has a `data-ga4-index-section` or is a descendent of an element with a `data-ga4-index-section` attribute in the format:
+
+```html
+<fieldset data-ga4-index-section="{'index_section': 1, 'index_section_count': 1}">
+```
+this will be included in the event:
+
+```json
+{
+  "event": "event_data",
+  "event_data": {
+    "index": {
+      "index_section": 1,
+      "index_section_count": 1
+    },
+    "event_name": "select_content",
+    "section": "SECTION OF INPUT",
+    "text": "VALUE OF INPUT"
+    "action": "select|remove"
+  }
+}
+```
+
+By default `section` is determined by the label of the field or the legend of the fieldset that the field is within. This can be overridden by using `ga4-form-section` on a parent node:
+
+```html
+  <fieldset ga4-form-section="When was the last time you had desert?"></fieldset>
+```
+
+which will result in the following event:
+
+```json
+{
+  "event": "event_data",
+  "event_data": {
+    "event_name": "select_content",
+    "section": "When was the last time you had desert?",
+    "text": "VALUE OF INPUT"
+    "action": "select|remove"
+  }
+}
+```
+
+This is useful for forms that have groupings of `fieldset` with multiple `input` within (such specifying a date and time ).
+
+For the date component, an event will only be fired when all the fields of the date component have been filled in.
+

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-change-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-change-tracker.spec.js
@@ -1,0 +1,243 @@
+/* eslint-env jasmine */
+
+describe('Ga4 Form Change Tracker', function () {
+  const GOVUK = window.GOVUK
+
+  let trackedInputs, mockGa4SendData, form, container
+
+  const Form = window.GOVUK.Modules.JasmineHelpers.Form
+
+  const expectedAttributes = {
+    event_name: 'select_content',
+    section: Form.formDefaultOptions.label,
+    text: Form.formDefaultOptions.value
+  }
+
+  beforeEach(function () {
+    window.dataLayer = []
+    this.agreeToCookies()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    container.remove()
+  })
+
+  describe('should fire correct event from a tracked form', () => {
+    const createFormAndSetup = (container, ...fields) => {
+      form = new Form(fields)
+
+      form.appendToParent(container)
+      form.setAttribute('data-ga4-form-change-tracker', true)
+      const tracker = new GOVUK.Modules.Ga4FormChangeTracker(form.form)
+      tracker.init()
+    }
+
+    beforeAll(() => {
+      mockGa4SendData = spyOn(
+        window.GOVUK.analyticsGa4.core,
+        'applySchemaAndSendData'
+      )
+    })
+
+    beforeEach(() => {
+      document.body.appendChild(container)
+      mockGa4SendData.calls.reset()
+    })
+
+    it('when a standard input or select is selected and changed', () => {
+      trackedInputs = ['radio', 'checkbox', 'text', 'textarea', 'select']
+
+      createFormAndSetup(container, ...trackedInputs)
+
+      trackedInputs.forEach((field, index) => {
+        mockGa4SendData.calls.reset()
+
+        const dataIndex = {
+          index_section: index,
+          index_section_count: trackedInputs.length
+        }
+
+        const trackedInput = form
+          .querySelector(`input[type="${field}"], ${field}`)
+
+        trackedInput.setAttribute('data-ga4-index', JSON.stringify(dataIndex))
+
+        form.triggerChange(`input[type="${field}"], ${field}`)
+
+        expect(mockGa4SendData).toHaveBeenCalledWith(
+          {
+            ...expectedAttributes,
+            ...(field.match('text') ? { text: expectedAttributes.text.length } : {}),
+            ...dataIndex,
+            action: 'select'
+          },
+          'event_data'
+        )
+      })
+    })
+
+    it('when a labelled field within a fieldset is changed', () => {
+      createFormAndSetup(container, 'addAnotherFieldSet')
+
+      const index = {
+        index_section: 0,
+        index_section_count: 1
+      }
+
+      mockGa4SendData.calls.reset()
+
+      const text = container.querySelector('input[type="text"]')
+      text.setAttribute('data-ga4-index', JSON.stringify(index))
+
+      form.triggerChange('input')
+
+      expect(mockGa4SendData).toHaveBeenCalledWith(
+        {
+          ...expectedAttributes,
+          text: expectedAttributes.text.length,
+          section: `${Form.formDefaultOptions.label}`,
+          ...index,
+          action: 'select'
+        },
+        'event_data'
+      )
+    })
+
+    it('should track input with a value containing newlines', () => {
+      createFormAndSetup(container, 'radio')
+
+      mockGa4SendData.calls.reset()
+
+      const input = container.querySelector('input')
+      const label = container.querySelector('label')
+
+      label.innerHTML = `this is a value
+
+        with a new line
+      `
+
+      input.click()
+
+      expect(mockGa4SendData).toHaveBeenCalledWith(
+        {
+          ...expectedAttributes,
+          text: 'this is a value with a new line',
+          action: 'select'
+        },
+        'event_data'
+      )
+    })
+
+    it('when a checkbox is deselected', () => {
+      createFormAndSetup(container, 'checkbox')
+
+      const index = {
+        index_section: 0,
+        index_section_count: 1
+      }
+
+      const checkbox = container.querySelector('input[type="checkbox"]')
+      checkbox.setAttribute('data-ga4-index', JSON.stringify(index))
+
+      form.triggerChange('input[type="checkbox"]')
+
+      mockGa4SendData.calls.reset()
+
+      form.triggerChange('input[type="checkbox"]')
+
+      expect(mockGa4SendData).toHaveBeenCalledWith(
+        {
+          ...expectedAttributes,
+          ...index,
+          action: 'remove'
+        },
+        'event_data'
+      )
+    })
+
+    describe('when the date component', () => {
+      let inputs
+      const index = {
+        index_section: 0,
+        index_section_count: 1
+      }
+
+      beforeEach(() => {
+        createFormAndSetup(container, 'date')
+
+        inputs = form.querySelectorAll('input')
+
+        inputs.forEach((input) => {
+          input.setAttribute('data-ga4-index', JSON.stringify(index))
+          form.triggerChange(`input[name="${input.name}"]`)
+        })
+      })
+
+      it('is entirely filled in', () => {
+        expect(mockGa4SendData).toHaveBeenCalledWith(
+          {
+            ...expectedAttributes,
+            ...index,
+            action: 'select',
+            text: Array(3).fill(expectedAttributes.text).join('/')
+          },
+          'event_data'
+        )
+      })
+
+      it('is not entirely filled in', () => {
+        mockGa4SendData.calls.reset()
+
+        inputs[0].value = ''
+
+        expect(mockGa4SendData).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when multiple select', () => {
+      const index = {
+        index_section: 0,
+        index_section_count: 1
+      }
+      let select, options
+
+      beforeEach(() => {
+        createFormAndSetup(container, 'select-multiple')
+
+        select = form.querySelector('select')
+
+        select.setAttribute('data-ga4-index', JSON.stringify(index))
+
+        options = form.querySelectorAll('option')
+        options[0].selected = true
+        options[1].selected = true
+
+        mockGa4SendData.calls.reset()
+      })
+
+      it('has an option deselected', () => {
+        options[1].selected = false
+
+        mockGa4SendData.calls.reset()
+
+        select.dispatchEvent(
+          new window.CustomEvent('change', {
+            bubbles: true,
+            detail: { value: options[1].value }
+          })
+        )
+
+        expect(mockGa4SendData).toHaveBeenCalledWith(
+          {
+            ...expectedAttributes,
+            ...index,
+            action: 'remove'
+          },
+          'event_data'
+        )
+      })
+    })
+  })
+})

--- a/spec/javascripts/helpers/form-helper.js
+++ b/spec/javascripts/helpers/form-helper.js
@@ -1,0 +1,212 @@
+'use strict'
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {}
+;(function (Modules) {
+  const addAnotherFieldSet = (options) => {
+    const { legend, label } = options
+    const el = document.createElement('div')
+    el.innerHTML = `
+      <fieldset>
+      <legend>${legend}</legend>
+      <label for="text-input">${label}</label>
+      <input id="text-input" name="text-input" type="text">
+      </fieldset>
+    `
+    return el
+  }
+
+  const date = (options) => {
+    const { legend } = options
+    const el = document.createElement('div')
+    el.innerHTML = `
+      <fieldset data-ga4-form-section="${legend}" class="govuk-date-input">
+      <legend>${legend}</legend>
+      <div class="govuk-date-input__item">
+        <div class="govuk-form-group">
+          <label for="date_1i" class="gem-c-label govuk-label">Day</label>
+          <input class="gem-c-input govuk-input govuk-input--width-4" name="date(1i)" id="date_1i" type="text">
+        </div>
+      </div>
+      <div class="govuk-date-input__item">
+        <div class="govuk-form-group">
+          <label for="date_2i" class="gem-c-label govuk-label">Month</label>
+          <input class="gem-c-input govuk-input govuk-input--width-4" name="date(2i)" id="date_2i" type="text">
+        </div>
+      </div>
+      <div class="govuk-date-input__item">
+        <div class="govuk-form-group">
+          <label for="date_3i" class="gem-c-label govuk-label">Year</label>
+          <input class="gem-c-input govuk-input govuk-input--width-4" name="date(3i)" id="date_3i" type="text">
+        </div>
+      </div>
+      </fieldset>
+    `
+    return el
+  }
+
+  const checkbox = (options) => {
+    const { legend, value } = options
+    const el = document.createElement('div')
+    el.innerHTML = `
+      <fieldset>
+        <legend>${legend}</legend>
+        <div>
+          <div>
+            <input type="checkbox" name="favourite_colour[]" id="checkboxes" value="1" class="govuk-checkboxes__input">
+            <label for="checkboxes" class="govuk-label govuk-checkboxes__label">${value}</label>
+          </div>
+        </div>
+      </fieldset>
+    `
+    return el
+  }
+
+  const text = (options) => {
+    const { label } = options
+    const el = document.createElement('div')
+    el.innerHTML = `
+      <label for="text-input">${label}</label>
+      <input id="text-input" name="text-input" type="text">
+    `
+    return el
+  }
+
+  const textarea = (options) => {
+    const { label } = options
+    const el = document.createElement('div')
+    el.innerHTML = `
+      <label for="text-area">${label}</label>
+      <textarea id="text-area" name="text-area">
+    `
+    return el
+  }
+
+  const radio = (options) => {
+    const { legend, value } = options
+    const el = document.createElement('div')
+    el.innerHTML = `
+      <fieldset class="govuk-fieldset">
+        <legend>${legend}</legend>
+        <div class="govuk-radios">
+            <input type="radio" name="radio(1i)" id="radio_1i" value="1">
+            <label for="radio_1i">${value}</label>
+        </div>
+        <div class="govuk-radios">
+            <input type="radio" name="radio(2i)" id="radio_2i" value="2">
+            <label for="radio_2i">${value} 2</label>
+        </div>
+      </fieldset>
+    `
+    return el
+  }
+
+  const select = (options, name = 'select') => {
+    const { label, option } = options
+    const el = document.createElement('div')
+    el.innerHTML = `
+      <label class="govuk-label" for="${name}">${label}</label>
+      <select name="${name}" id="${name}">
+        <option value="1">Red</option>
+        <option value="2">${option}</option>
+      </select>
+    `
+    return el
+  }
+
+  const selectMultiple = (options) => {
+    const el = select(options, 'select-multiple')
+    el.querySelector('select').setAttribute('multiple', true)
+    return el
+  }
+
+  const formInputs = {
+    date,
+    checkbox,
+    text,
+    textarea,
+    radio,
+    select,
+    'select-multiple': selectMultiple,
+    addAnotherFieldSet
+  }
+
+  class Form {
+    form
+
+    static formDefaultOptions = {
+      label: 'What is your favourite colour?',
+      option: 'Blue',
+      legend: 'What is your favourite colour?',
+      value: 'Blue'
+    }
+
+    // generate a `form` with inputs specified in `inputs`
+    // where an input is defined in `formInputs` and return
+    // a proxy which passes calls to `form` to `this.form`
+    // and otherwise calls function within `Form` (if defined)
+    constructor(inputs, options = Form.formDefaultOptions) {
+      this.options = options
+      this.inputs = inputs || Object.keys(formInputs)
+      this.form = this.createForm(...this.inputs)
+
+      return new Proxy(this, {
+        get(target, prop) {
+          if (Reflect.has(...arguments)) return Reflect.get(...arguments)
+
+          if (typeof target.form[prop] === 'function')
+            return (...args) => target.form[prop](...args)
+
+          return target.form[prop]
+        }
+      })
+    }
+
+    createForm = (...inputs) => {
+      const form = document.createElement('form')
+
+      document.createElement('div')
+      ;(inputs.length ? inputs : Object.keys(formInputs)).forEach((input) => {
+        const newInput = document.createElement('div')
+
+        newInput.innerHTML = formInputs[input](this.options).innerHTML
+        form.appendChild(newInput)
+      })
+
+      const submitButton = document.createElement('button')
+      submitButton.type = 'submit'
+      submitButton.innerHTML = 'Save'
+
+      form.appendChild(submitButton)
+
+      return form
+    }
+
+    appendToParent = (el) => el.appendChild(this.form)
+
+    submit = (element) => {
+      element && element.focus()
+
+      this.form.dispatchEvent(new Event('submit'))
+    }
+
+    triggerChange = (selector) => {
+      const field = this.form.querySelector(selector)
+
+      if (field.tagName === 'SELECT') {
+        field.querySelectorAll('option')[1].selected = true
+        field.dispatchEvent(new Event('change', { bubbles: true }))
+      } else {
+        field.click()
+
+        if (field.tagName === 'TEXTAREA' || field.type === 'text') {
+          field.value = this.options.value
+        }
+        field.dispatchEvent(new Event('change', { bubbles: true }))
+      }
+    }
+  }
+
+  Modules.JasmineHelpers = {
+    Form
+  }
+})(window.GOVUK.Modules)

--- a/spec/support/jasmine-browser.json
+++ b/spec/support/jasmine-browser.json
@@ -22,6 +22,7 @@
     "helpers/jquery-1.12.4.js",
     "helpers/jasmine-jquery-2.0.5.js",
     "helpers/SpecHelper.js",
+    "helpers/form-helper.js",
     "vendor/*.js"
   ],
   "browser": "headlessChrome"


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

Add `Ga4FormChangeTracker` along with associated tests and documentation.

## Why
<!-- What are the reasons behind this change being made? -->

`Ga4FormChangeTracker` adds tracking for form `change`. `Ga4FormTracker` was intended for forms with a single input (Smart Answer forms) and so only tracks on form `submit`. This is not sufficient tracking to determine how users interact with the more complex forms in publishing applications. 

This was originally written as an extension of `Ga4FormTracker` within Whitehall (see https://github.com/alphagov/whitehall/pull/10201, https://github.com/alphagov/whitehall/pull/10781). More publishing applications (https://gov-uk.atlassian.net/browse/CM-569, https://gov-uk.atlassian.net/browse/MAIN-2075) are now being updated to use GA4 and require the same form `change` tracking functionality. 
