### PR TITLE
Standardise success alert text size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Standardise success alert text size ([PR #5098](https://github.com/alphagov/govuk_publishing_components/pull/5098))
 * Revert #5055 "Allow every component's CSS files to render on a component's preview page" ([PR #5096](https://github.com/alphagov/govuk_publishing_components/pull/5096))
 
 ## 61.3.1

--- a/app/assets/stylesheets/govuk_publishing_components/components/_success-alert.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_success-alert.scss
@@ -1,10 +1,6 @@
 @import "govuk_publishing_components/individual_component_support";
 @import "govuk/components/notification-banner/notification-banner";
 
-.gem-c-success-alert__message {
-  @include govuk-font(19, $weight: bold);
-}
-
 // stylelint-disable declaration-no-important
 @include govuk-media-query($media-type: print) {
   .gem-c-success-alert {

--- a/app/views/govuk_publishing_components/components/_success_alert.html.erb
+++ b/app/views/govuk_publishing_components/components/_success_alert.html.erb
@@ -21,7 +21,7 @@
       <%= tag.h3 message, class: "govuk-notification-banner__heading" %>
       <%= description %>
     <% else %>
-      <%= tag.p message, class: "govuk-body gem-c-success-alert__message" %>
+      <%= tag.p message, class: "govuk-notification-banner__heading" %>
     <% end %>
   </div>
 <% end %>

--- a/spec/components/success_alert_spec.rb
+++ b/spec/components/success_alert_spec.rb
@@ -7,7 +7,7 @@ describe "Success Alert", type: :view do
 
   it "shows the message" do
     render_component(message: "Foo")
-    assert_select ".gem-c-success-alert__message", text: "Foo"
+    assert_select ".govuk-notification-banner__heading", text: "Foo"
   end
 
   it "allows a block to be given for description" do


### PR DESCRIPTION
## What / why
Change the text size in the success alert component.

- size of the initial text in the component (bold) varied from 19px if no description provided to 24px if it was
- can't see any reason for this behaviour and not consistent with the original [Design System component](https://design-system.service.gov.uk/components/notification-banner/), so making them the same size

## Visual Changes
With this change the bold text is always 24px, regardless of whether a description is included or not.

Before | After
------ | ------
<img width="1087" height="1078" alt="Screenshot 2025-10-24 at 16 06 06" src="https://github.com/user-attachments/assets/7435fa50-bc19-4928-930c-61fb19134ff5" /> | <img width="1083" height="1142" alt="Screenshot 2025-10-24 at 16 06 14" src="https://github.com/user-attachments/assets/aba21ef8-7759-438d-87e4-3b6ea27b3d51" />
