### PR TITLE
`Ga4FormTracker` `id` selector fix

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
@@ -85,7 +85,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       var labelFor = label.getAttribute('for')
       var input = false
       if (labelFor) {
-        input = this.module.querySelector('[id=' + labelFor + ']')
+        input = this.module.querySelector('[id="' + labelFor + '"]')
       } else {
         input = label.querySelector('input')
       }


### PR DESCRIPTION
## What

Add double quotes to `id` selector in `Ga4FormTracker`.

## Why

Prevent "invalid selector" error occurring when submitting a form (which would prevent form being tracked).