### PR TITLE
Update asset_helper_spec.rb

### DIFF
--- a/spec/features/asset_helper_spec.rb
+++ b/spec/features/asset_helper_spec.rb
@@ -40,6 +40,21 @@ describe "When the asset helper is configured", :capybara do
     end
   end
 
+  scenario "request all stylesheets when exclude_css_from_static is set to true" do
+    GovukPublishingComponents.configure do |config|
+      config.exclude_css_from_static = true
+    end
+
+    visit "/asset_helper"
+
+    within(:xpath, "//head", visible: :hidden) do
+      expect(page).to have_selector('link[href^="/assets/application-"][rel="stylesheet"]', visible: :hidden)
+      expect(page).to have_selector('link[href^="/assets/govuk_publishing_components/components/_notice-"][rel="stylesheet"]', visible: :hidden)
+      expect(page).to have_selector('link[href^="/assets/govuk_publishing_components/components/_details-"][rel="stylesheet"]', visible: :hidden)
+      expect(page).not_to have_selector('link[href^="/assets/govuk_publishing_components/components/_heading-"][rel="stylesheet"]', visible: :hidden)
+    end
+  end
+
   scenario "request all stylesheets when exclude_css_from_static is set to false" do
     GovukPublishingComponents.configure do |config|
       config.exclude_css_from_static = false


### PR DESCRIPTION
## What

Add test to check all stylesheets are loaded when exclude_css_from_static is set to true and visiting the `asset_helper` page.

## Why

Puts back a similar test was removed in https://github.com/alphagov/govuk_publishing_components/pull/5087
