### PR TITLE
Release 61.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 61.4.0
 
 * Fix component guide for applications without individual css loading ([PR #5087](https://github.com/alphagov/govuk_publishing_components/pull/5087))
 * Standardise success alert text size ([PR #5098](https://github.com/alphagov/govuk_publishing_components/pull/5098))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (61.3.1)
+    govuk_publishing_components (61.4.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "61.3.1".freeze
+  VERSION = "61.4.0".freeze
 end


### PR DESCRIPTION
## 61.4.0

* Fix component guide for applications without individual css loading ([PR #5087](https://github.com/alphagov/govuk_publishing_components/pull/5087))
* Standardise success alert text size ([PR #5098](https://github.com/alphagov/govuk_publishing_components/pull/5098))
* Revert #5055 'Allow every component's CSS files to render on a component's preview page' ([PR #5096](https://github.com/alphagov/govuk_publishing_components/pull/5096))
* Add `Ga4FormChangeTracker` ([PR #5084](https://github.com/alphagov/govuk_publishing_components/pull/5084))