### PR TITLE
Restore option select tests

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/components/option-select.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/option-select.js
@@ -296,12 +296,12 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     var isComponentParentHidden = this.isComponentParentHidden()
 
     if (isComponentParentHidden) {
-      initialOptionContainerHeight = 200
-      height = 200
+      initialOptionContainerHeight = 180
+      height = 180
     }
 
     // Resize if the list is only slightly bigger than its container
-    // If isComponentParentHidden is true, then 200 < 250
+    // If isComponentParentHidden is true, then 180 < 250
     // And the container height is always set to 201px
     if (height < initialOptionContainerHeight + 50) {
       this.setContainerHeight(height + 1)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_option-select.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_option-select.scss
@@ -85,7 +85,7 @@
 
 .gem-c-option-select__container {
   position: relative;
-  max-height: 200px;
+  max-height: 180px;
   overflow-y: auto;
   overflow-x: hidden;
   background-color: govuk-colour("white");
@@ -144,7 +144,7 @@
   }
 
   .gem-c-option-select__container {
-    height: 200px;
+    height: 180px;
   }
 
   .gem-c-option-select__container--large {

--- a/spec/javascripts/components/option-select-spec.js
+++ b/spec/javascripts/components/option-select-spec.js
@@ -290,7 +290,7 @@ describe('An option select component', function () {
       // Set some visual properties which are done in the CSS IRL
       $checkboxList = $element.find('.js-options-container')
       $checkboxList.css({
-        height: 200,
+        height: 180,
         position: 'relative',
         overflow: 'scroll'
       })
@@ -303,17 +303,17 @@ describe('An option select component', function () {
     })
 
     it('expands the checkbox-container to fit checkbox list if the list is < 50px larger than the container', function () {
-      $checkboxListInner.height(201)
+      $checkboxListInner.height(181)
       optionSelect.setupHeight()
 
       // Wrapping HTML should adjust to fit inner height
       expect($checkboxList.height()).toBeGreaterThan($checkboxListInner.height())
-      expect($checkboxListInner.height()).toBeLessThan(250)
+      expect($checkboxListInner.height()).toBeLessThan(230)
     })
 
     it('expands the checkbox-container just enough to cut the last visible item in half horizontally, if there are many items', function () {
       $checkboxList.css({
-        'max-height': 200,
+        'max-height': 180,
         width: 600
       })
       optionSelect.setupHeight()
@@ -339,7 +339,7 @@ describe('An option select component', function () {
 
     it('sets the height of the container sensibly', function () {
       var containerHeight = $('body').find('.js-options-container').height()
-      expect(containerHeight).toBe(201)
+      expect(containerHeight).toBe(181)
     })
   })
 
@@ -362,7 +362,7 @@ describe('An option select component', function () {
       $($element).find('button').click()
 
       var containerHeight = $('.js-options-container').height()
-      expect(containerHeight).toBeGreaterThan(200)
+      expect(containerHeight).toBeGreaterThan(180)
       expect(containerHeight).toBeLessThan(550)
     })
   })


### PR DESCRIPTION
## What
- restores tests that were disabled as part of a recent change that caused them to break
- also fixes a small issue where max-height was overriding height for the component calculation

## Why
Relates to issue https://github.com/alphagov/govuk_publishing_components/issues/5099

## Visual changes
Should make the automatic calculation of the option select component to always show that there are more checkboxes if you scroll down more reliable.
