### PR TITLE
Hide the Magna Charta toggle button from screen-reader users [WHIT-2594]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Hide the Magna Charta toggle button from screen-reader users ([PR #5118](https://github.com/alphagov/govuk_publishing_components/pull/5118))
+
 ## 61.4.1
 
 * Add more languages to our component wrapper helper validation ([PR #5119](https://github.com/alphagov/govuk_publishing_components/pull/5119))

--- a/app/assets/javascripts/govuk_publishing_components/lib/govspeak/magna-charta.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/govspeak/magna-charta.js
@@ -120,7 +120,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         this.addClassesToHeader()
         this.applyWidths()
         this.insert()
-        this.$table.classList.add('mc-hidden')
+        this.$table.classList.add('govuk-visually-hidden')
         this.applyOutdent()
       } catch (error) {
         console.error('MagnaCharta error:', error)
@@ -200,6 +200,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     toggleStatus.setAttribute('role', 'alert')
 
     link.classList.add('govuk-body-s', 'mc-toggle-button')
+    link.setAttribute('aria-hidden', 'true')
     link.appendChild(toggleText)
     link.appendChild(toggleStatus)
 
@@ -217,7 +218,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       var toggleStatus = that.toggleLink.querySelector('.mc-toggle-status')
 
       that.$graphContainer.classList.toggle('mc-hidden')
-      that.$table.classList.toggle('mc-hidden')
+      that.$table.classList.toggle('govuk-visually-hidden')
 
       toggleText.innerHTML = toggleText.innerHTML === tableVisible ? chartVisible : tableVisible
       toggleStatus.innerHTML = toggleStatus.innerHTML === tableAlert ? chartAlert : tableAlert

--- a/spec/javascripts/govuk_publishing_components/lib/govspeak/magna-charta-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/govspeak/magna-charta-spec.js
@@ -151,12 +151,12 @@ describe('Magna charta', function () {
 
     it('running toggle switches between chart and table', function () {
       toggle[0].click()
-      expect(table).not.toHaveClass('mc-hidden')
+      expect(table).not.toHaveClass('govuk-visually-hidden')
       expect(graphContainer).toHaveClass('mc-hidden')
 
       // toggle it back
       toggle[0].click()
-      expect(table).toHaveClass('mc-hidden')
+      expect(table).toHaveClass('govuk-visually-hidden')
       expect(graphContainer).not.toHaveClass('mc-hidden')
     })
 
@@ -326,13 +326,13 @@ describe('Magna charta', function () {
     })
 
     it('doesnt show the chart initially', function () {
-      expect(table).not.toHaveClass('mc-hidden')
+      expect(table).not.toHaveClass('govuk-visually-hidden')
       expect(graphContainer).toHaveClass('mc-hidden')
     })
 
     it('graph is shown when toggle is called', function () {
       element.find('.mc-toggle-button')[0].click()
-      expect(table).toHaveClass('mc-hidden')
+      expect(table).toHaveClass('govuk-visually-hidden')
       expect(graphContainer).not.toHaveClass('mc-hidden')
     })
   })


### PR DESCRIPTION
## What

Hide the  Magna Charta toggle button from screen-reader users.

Stacked bar charts use a button to toggle between stacked bar chart view and an accessible table view. However, there is a problem with the way this is presented to screen-reader users and so the button must be hidden from those users.

## Why

The last DAC report highlighted an issue with the label of the button that's used to toggle a stacked bar chart between its chart and table view. The suggested fix was to include context about the table in the button label itself. The original request can be viewed here: [Trello card](https://trello.com/c/qnP1hpo3/76-dacheadingsandlabels02)

During the attempted fix, I considered that the premise of the fix was flawed: the button doesn't need a better label, because screen-reader users _don't need the button_. As the chart is already hidden from those users with the `aria-hidden` attribute, the button has no effect because the bar chart is never rendered for them. So the button is redundant for screen-reader users. More reasoning is available in the [Jira Ticket](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-2594).

The fix is therefore to hide the button from screen-reader users and modify the table so that it's visually hidden, and not completely hidden by default. This means screen-reader users will experience the accessible table as intended, while other users can use the toggle if they want to switch between the two views.

## Testing

For testing, go to the preview app on Heroku (the deployed branch), and select the Govspeak component from the list. Then select the Chart options to view some stacked charts. You can now use the toggle button to test the new behaviour. _Note: this needs to be tested in screen-readers._

## Visual Changes
No visual changes.
