### PR TITLE
Add more languages to our component wrapper helper validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add more languages to our component wrapper helper validation ([PR #5119](https://github.com/alphagov/govuk_publishing_components/pull/5119))
+
 ## 61.4.0
 
 * Fix component guide for applications without individual css loading ([PR #5087](https://github.com/alphagov/govuk_publishing_components/pull/5087))

--- a/lib/govuk_publishing_components/presenters/component_wrapper_helper.rb
+++ b/lib/govuk_publishing_components/presenters/component_wrapper_helper.rb
@@ -183,7 +183,7 @@ module GovukPublishingComponents
       def check_lang_is_valid(lang)
         return if lang.blank?
 
-        langs = %w[ab aa af ak sq am ar an hy as av ae ay az bm ba eu be bn bh bi bs br bg my ca ch ce ny zh zh-Hans zh-Hant zh-tw cv kw co cr hr cs da dv nl dz en eo et ee fo fj fi fr ff gl gd gv ka de el kl gn gu ht ha he hz hi ho hu is io ig id in ia ie iu ik ga it ja jv kl kn kr ks kk km ki rw rn ky kv kg ko ku kj lo la lv li ln lt lu lg lb gv mk mg ms ml mt mi mr mh mo mn na nv ng nd ne no nb nn ii oc oj cu or om os pi ps fa pl pt pa pa-pk qu rm ro ru se sm sg sa sr sh st tn sn ii sd si ss sk sl so nr es su sw ss sv tl ty tg ta tt te th bo ti to ts tr tk tw ug uk ur uz ve vi vo wa cy wo fy xh yi ji yo za zu]
+        langs = %w[ab aa af ak sq am ar an hy as av ae ay az bm ba eu be bn bh bi bs br bg my ca ch ce ny zh zh-Hans zh-Hant zh-hk zh-tw cv kw co cr hr cs da dv nl dz dr en eo et ee fo fj fi fr ff gl gd gv ka de el kl gn gu ht ha he hz hi ho hu is io ig id in ia ie iu ik ga it ja jv kl kn kr ks kk km ki rw rn ky kv kg ko ku kj lo la lv li ln lt lu lg lb gv mk mg ms ml mt mi mr mh mo mn na nv ng nd ne no nb nn ii oc oj cu or om os pi ps fa pl pt pa pa-pk qu rm ro ru se sm sg sa sr sh st tn sn ii sd si ss sk sl so nr es es-419 su sw ss sv tl ty tg ta tt te th bo ti to ts tr tk tw ug uk ur uz ve vi vo wa cy wo fy xh yi ji yo za zu]
         unless langs.include? lang
           raise(ArgumentError, "lang attribute (#{lang}) is not recognised")
         end


### PR DESCRIPTION
## What / Why
<!-- What are the reasons behind this change being made? -->
- Add `zh-hk`, `es-419`, and `dr` to the component wrapper helper language validation
- I noticed this page is crashing on production as the locale isn't supported in the component wrapper helper: 
  - https://www.gov.uk/government/publications/cervical-screening-invitations.zh-hk
  - https://www.gov.uk/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do.zh-hk - this page seems to have no styles, I think it's because its a `gone` route technically but because it's crashing it's not loading the `gone` view and instead is showing a broken GOVUK mirror page.
- I added `es-419` as it's a locale I know is on GOVUK but wasn't represented in the component wrapper helper. 
- I've also added `dr` which has a file in our repo (`dr.yml`) - haven't found any crashing pages for it but pages for it exist on GOVUK e.g. https://www.gov.uk/government/publications/covid-19-rapid-lateral-flow-test-kit-instructions-getein-biotech.dr

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
