### PR TITLE
[DO NOT MERGE] Add options details to component wrapper helper

### DIFF
--- a/app/views/govuk_publishing_components/components/_breadcrumbs.html.erb
+++ b/app/views/govuk_publishing_components/components/_breadcrumbs.html.erb
@@ -13,6 +13,7 @@
   classes << "govuk-breadcrumbs--inverse" if inverse
   classes << "gem-c-breadcrumbs--border-bottom" if border == "bottom"
 
+  local_assigns[:suppress_output] = true
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class(classes.join(" "))
   component_helper.add_aria_attribute({ label: "Breadcrumb" })

--- a/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
@@ -24,6 +24,7 @@
                                 )))
   services_cookies ||= nil
 
+  local_assigns[:suppress_output] = true
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.set_id(id)
   component_helper.add_class("gem-c-cookie-banner govuk-clearfix govuk-cookie-banner js-banner-wrapper")

--- a/app/views/govuk_publishing_components/components/_emergency_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_emergency_banner.html.erb
@@ -25,6 +25,7 @@
   description_classes = %w[gem-c-emergency-banner__description]
   description_classes << "gem-c-emergency-banner__description--homepage" if homepage
 
+  local_assigns[:suppress_output] = true
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-emergency-banner gem-c-emergency-banner--#{campaign_class}")
   component_helper.add_class("gem-c-emergency-banner--homepage") if homepage

--- a/app/views/govuk_publishing_components/components/_feedback.html.erb
+++ b/app/views/govuk_publishing_components/components/_feedback.html.erb
@@ -8,6 +8,7 @@
 
   disable_ga4 ||= false
 
+  local_assigns[:suppress_output] = true
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-feedback govuk-!-display-none-print")
   component_helper.add_data_attribute({ module: "feedback" })

--- a/app/views/govuk_publishing_components/components/_fieldset.html.erb
+++ b/app/views/govuk_publishing_components/components/_fieldset.html.erb
@@ -16,6 +16,7 @@
     describedby = error_id
   end
 
+  local_assigns[:suppress_output] = true
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-fieldset govuk-form-group")
   component_helper.add_class("govuk-form-group--error") if error_message

--- a/app/views/govuk_publishing_components/components/_global_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_global_banner.html.erb
@@ -7,6 +7,7 @@
   banner_version ||= nil
   always_visible ||= false # if true banner is always visible & does not disappear automatically after 3 pageviews
 
+  local_assigns[:suppress_output] = true
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-global-banner govuk-!-display-none-print")
   component_helper.set_id("global-banner")

--- a/app/views/govuk_publishing_components/components/_govspeak.html.erb
+++ b/app/views/govuk_publishing_components/components/_govspeak.html.erb
@@ -9,6 +9,7 @@
   direction_class = "gem-c-govspeak--direction-#{direction}" if local_assigns.include?(:direction)
   disable_youtube_expansions = local_assigns.fetch(:disable_youtube_expansions) if local_assigns.include?(:disable_youtube_expansions)
 
+  local_assigns[:suppress_output] = true
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-govspeak govuk-govspeak")
   component_helper.add_class(direction_class) if direction_class

--- a/app/views/govuk_publishing_components/components/_layout_footer.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_footer.html.erb
@@ -6,6 +6,7 @@
   hide_licence ||= false
   layout_footer_helper = GovukPublishingComponents::Presenters::LayoutFooterHelper.new(navigation, meta)
 
+  local_assigns[:suppress_output] = true
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-layout-footer govuk-footer")
   component_helper.add_data_attribute({ module: "ga4-link-tracker" })

--- a/app/views/govuk_publishing_components/components/_layout_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_header.html.erb
@@ -11,6 +11,7 @@
   width_class = full_width ? "govuk-header__container--full-width" : "govuk-width-container"
   logo_link ||= "/"
 
+  local_assigns[:suppress_output] = true
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-layout-header govuk-header")
   component_helper.add_class("gem-c-layout-header--no-bottom-border") if remove_bottom_border || navigation_items

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -35,6 +35,7 @@
 
   dropdown_menu_classes = %w(gem-c-layout-super-navigation-header__navigation-dropdown-menu)
 
+  local_assigns[:suppress_output] = true
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-layout-super-navigation-header")
   component_helper.add_data_attribute({ module: "ga4-event-tracker ga4-link-tracker", ga4_expandable: "" })

--- a/app/views/govuk_publishing_components/components/_secondary_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_secondary_navigation.html.erb
@@ -4,6 +4,7 @@
   id ||= nil
   items ||= []
 
+  local_assigns[:suppress_output] = true
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_aria_attribute({label: aria_label})
   component_helper.add_class("gem-c-secondary-navigation")

--- a/app/views/govuk_publishing_components/components/_service_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_service_navigation.html.erb
@@ -8,6 +8,7 @@
   inverse ||= false
   collapse_navigation_on_mobile = local_assigns.fetch(:collapse_navigation_on_mobile, navigation_items.length > 1)
 
+  local_assigns[:suppress_output] = true
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-service-navigation govuk-service-navigation")
   component_helper.add_class("govuk-service-navigation--inverse") if inverse

--- a/lib/govuk_publishing_components/presenters/component_wrapper_helper.rb
+++ b/lib/govuk_publishing_components/presenters/component_wrapper_helper.rb
@@ -1,6 +1,8 @@
 module GovukPublishingComponents
   module Presenters
     class ComponentWrapperHelper
+      include ActionView::Helpers::SanitizeHelper
+
       def initialize(options)
         @options = options
 
@@ -19,7 +21,7 @@ module GovukPublishingComponents
         check_rel_is_valid(@options[:rel]) if @options.include?(:rel)
         check_target_is_valid(@options[:target]) if @options.include?(:target)
         check_margin_bottom_is_valid(@options[:margin_bottom]) if @options.include?(:margin_bottom)
-        add_data_attribute({ options: @options.keys.join(",") }) unless @options.include?(:suppress_output)
+        add_data_attribute({ options: options_passed }) unless in_production? || @options.include?(:suppress_output)
       end
 
       def all_attributes
@@ -45,6 +47,15 @@ module GovukPublishingComponents
         attributes[:title] = @options[:title] if @options[:title].present?
 
         attributes
+      end
+
+      def options_passed
+        @options.transform_values { |v| v.is_a?(Hash) ? v : strip_tags(v.to_s)[0, 50] }.to_h.to_json
+      end
+
+      def in_production?
+        # https://github.com/alphagov/govuk_app_config?tab=readme-ov-file#environment
+        %w[production staging].include? GovukEnvironment.current
       end
 
       def set_id(id)

--- a/lib/govuk_publishing_components/presenters/component_wrapper_helper.rb
+++ b/lib/govuk_publishing_components/presenters/component_wrapper_helper.rb
@@ -19,6 +19,7 @@ module GovukPublishingComponents
         check_rel_is_valid(@options[:rel]) if @options.include?(:rel)
         check_target_is_valid(@options[:target]) if @options.include?(:target)
         check_margin_bottom_is_valid(@options[:margin_bottom]) if @options.include?(:margin_bottom)
+        add_data_attribute({ options: @options.keys.join(",") }) unless @options.include?(:suppress_output)
       end
 
       def all_attributes

--- a/spec/lib/govuk_publishing_components/presenters/component_wrapper_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/component_wrapper_helper_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe GovukPublishingComponents::Presenters::ComponentWrapperHelper do
         type: "submit",
         draggable: "true",
         title: "Hello",
+        suppress_output: true,
       }
       component_helper = described_class.new(args)
       expected = {
@@ -56,6 +57,7 @@ RSpec.describe GovukPublishingComponents::Presenters::ComponentWrapperHelper do
         type: nil,
         draggable: nil,
         title: nil,
+        suppress_output: true,
       )
       expect(component_helper.all_attributes).to eql({})
     end
@@ -74,13 +76,40 @@ RSpec.describe GovukPublishingComponents::Presenters::ComponentWrapperHelper do
         type: "",
         draggable: "",
         title: "",
+        suppress_output: true,
       )
       expect(component_helper.all_attributes).to eql({})
     end
 
+    it "outputs component options details" do
+      args = {
+        id: "this-is-my-id",
+        data_attributes: {
+          module: "this-is-my-module",
+        },
+        aria: {
+          labelledby: "element",
+        },
+        title: "Hello",
+      }
+      component_helper = described_class.new(args)
+      expected = {
+        id: "this-is-my-id",
+        data: {
+          options: "id,data_attributes,aria,title",
+          module: "this-is-my-module",
+        },
+        aria: {
+          labelledby: "element",
+        },
+        title: "Hello",
+      }
+      expect(component_helper.all_attributes).to eql(expected)
+    end
+
     describe "classes" do
       it "accepts valid class names" do
-        component_helper = described_class.new(classes: "gem-c-component govuk-component app-c-component brand--thing brand__thing direction-rtl gem-print-force-link-styles")
+        component_helper = described_class.new(classes: "gem-c-component govuk-component app-c-component brand--thing brand__thing direction-rtl gem-print-force-link-styles", suppress_output: true)
         expected = {
           class: "gem-c-component govuk-component app-c-component brand--thing brand__thing direction-rtl gem-print-force-link-styles",
         }
@@ -159,7 +188,7 @@ RSpec.describe GovukPublishingComponents::Presenters::ComponentWrapperHelper do
       end
 
       it "can add data attributes to already passed data attributes" do
-        helper = described_class.new(data_attributes: { module: "original-module", other: "other" })
+        helper = described_class.new(data_attributes: { module: "original-module", other: "other" }, suppress_output: true)
         helper.add_data_attribute({ module: "extra-module", another: "another" })
         expect(helper.all_attributes[:data]).to eql({ module: "original-module extra-module", other: "other", another: "another" })
       end


### PR DESCRIPTION
## What
Improve debugging for components using the component wrapper helper.

- adds a data attribute to components using the component wrapper helper that contains a JSON string of all of the options passed to that component, and their (truncated to 50 characters) values
- includes a suppress option (so we can disable it in components that don't need this, and so we don't have to rewrite all of the existing tests to include the new data)
- won't be included on staging or production, as adds a bit to the page weight

## Why
It would be good to have better transparency around which options are being passed to instances of components. Sometimes it's easy to see (they're written in the .erb) but sometimes they're passed an object from a presenter method, and it's a bit trickier to follow the code and see what the component is actually being passed.

With this addition, all of the options passed to the component are recorded as a data attribute on the parent element of the component. We can add something into the GOV.UK browser extension to run a bit of JS (something like the below) to read this information and append it to the page.

```JS
const components = document.querySelectorAll('[data-options]')
for (var i = 0; i < components.length; i++) {
  const thisel = components[i]
  const data = JSON.parse(thisel.getAttribute('data-options'))

  const match_name = /\bgem-c-[a-z0-9]+(?:-[a-z0-9]+)*(?=\s|$)/;
  let name = thisel.getAttribute('class')
  name = name.match(match_name)[0].replace('gem-c-', '').replaceAll('-', ' ')

  let formatted_data = `<strong>${name} component options</strong>`
  for (var key in data) {
    let value = data[key]
    if (value.length == 50) {
      value = `${value}..`
    }
    formatted_data = `${formatted_data}<br/>${key}: ${value}`
  }

  const div = document.createElement('div')
  div.style.border = 'solid 1px black'
  div.style.padding = '5px'
  div.innerHTML = formatted_data

  const parent = thisel.parentNode
  parent.insertBefore(div, thisel)
}
```

## Visual Changes
No visual change, but once we've hooked up the browser extension it could look something like the below.

<img width="1106" height="572" alt="Screenshot 2025-11-14 at 15 33 25" src="https://github.com/user-attachments/assets/1448a9fe-bc1d-4714-8678-10cc1d0cb9db" />
