### PR TITLE
(CM-644) Remove headings from contact blocks 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Remove headings from contact blocks ([PR #5133](https://github.com/alphagov/govuk_publishing_components/pull/5133))
 * LUX v4.4.2 ([PR #5127](https://github.com/alphagov/govuk_publishing_components/pull/5127))
 * Upgrade to version 5.13.0 of govuk-frontend ([PR #5071](https://github.com/alphagov/govuk_publishing_components/pull/5071))
 * Do not add crest classes for organisation logos with no visual identity or a custom logo ([PR #5131](https://github.com/alphagov/govuk_publishing_components/pull/5131))

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_content-block.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_content-block.scss
@@ -7,14 +7,8 @@
 }
 
 .content-block__contact-key {
+  @include govuk-font(19, $weight: "bold");
   @include govuk-responsive-margin(4, "bottom");
-  @include govuk-font(24, $weight: "bold");
-}
-
-.content-block__contact-list--nested {
-  .content-block__contact-key {
-    @include govuk-font(19, $weight: "bold");
-  }
 }
 
 .content-block .content-block__list {

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -547,69 +547,64 @@ examples:
   contact_content_block:
     data:
       block: |
-        <div class="content-block content-block--contact">
-          <dl class="vcard content-block__contact-list">
-            <dt class="content-block__contact-key fn org">Get help with your application</dt>
+        <div class="vcard">
+          <dl class="content-block__contact-list">
+            <dt class="content-block__contact-key">Address</dt>
             <dd class="content-block__contact-value">
-              <dl class="content-block__contact-list--nested">
-                <dt class="content-block__contact-key">Address</dt>
-                <dd class="content-block__contact-value">
-                  <p class="adr">
-                    <span class="street-address"> 49 to 53 Cherry Street</span>,<br><span class="locality">London</span>,<br><span class="postal-code"> AB1 2DC </span>
-                  </p>
-                </dd>
-                <dt class="content-block__contact-key">Email</dt>
-                <dd class="content-block__contact-value">
-                  <ul class="content-block__list">
-                    <li>
-                      <a href="mailto:name@example.com" class="email">
-                        name@example.com
-                      </a>
-                    </li>
-                    <li>
-                      <p>We aim to respond within 2 working days</p>
-                    </li>
-                  </ul>
-                </dd>
-                <dt class="content-block__contact-key">Phone</dt>
-                <dd class="content-block__contact-value">
-                  <p>If you have a unique reference number, have it with you when you call.</p>
-                  <ul class="content-block__list">
-                    <li>
-                      <span>Phone: </span>
-                      <span class="tel">020 7946 0101</span>
-                    </li>
-                    <li>
-                      <span>Textphone: </span>
-                      <span class="tel">020 7946 0102</span>
-                    </li>
-                    <li>
-                      <span>Welsh language: </span>
-                      <span class="tel">020 7946 0103</span>
-                    </li>
-                  </ul>
-                  <p>Monday to Friday, 8am to 6pm<br>
-                    Saturday and Sunday, 10am to 4pm</p>
-                  <p>
-                    <a href="https://gov.uk/call-charges">
-                      Find out about call charges
-                    </a>
-                  </p>
-                </dd>
-                <dt class="content-block__contact-key">Webchat</dt>
-                <dd class="content-block__contact-value">
-                  <ul class="content-block__list">
-                    <li>
-                      <a href="http://example.com" class="url">
-                        Speak to an adviser now
-                      </a>
-                    </li>
-                    <li>
-                      <p>Current waiting time is 17 minutes</p>
-                    </li>
-                  </ul>
-                </dd>
-              </dl>
+              <p class="adr">
+                <span class="street-address"> 49 to 53 Cherry Street</span>,<br><span class="locality">London</span>,<br><span class="postal-code"> AB1 2DC </span>
+              </p>
+            </dd>
+            <dt class="content-block__contact-key">Email</dt>
+            <dd class="content-block__contact-value">
+              <ul class="content-block__list">
+                <li>
+                  <a href="mailto:name@example.com" class="email">
+                    name@example.com
+                  </a>
+                </li>
+                <li>
+                  <p>We aim to respond within 2 working days</p>
+                </li>
+              </ul>
+            </dd>
+            <dt class="content-block__contact-key">Phone</dt>
+            <dd class="content-block__contact-value">
+              <p>If you have a unique reference number, have it with you when you call.</p>
+              <ul class="content-block__list">
+                <li>
+                  <span>Phone: </span>
+                  <span class="tel">020 7946 0101</span>
+                </li>
+                <li>
+                  <span>Textphone: </span>
+                  <span class="tel">020 7946 0102</span>
+                </li>
+                <li>
+                  <span>Welsh language: </span>
+                  <span class="tel">020 7946 0103</span>
+                </li>
+              </ul>
+              <p>Monday to Friday, 8am to 6pm<br>
+                Saturday and Sunday, 10am to 4pm</p>
+              <p>
+                <a href="https://gov.uk/call-charges">
+                  Find out about call charges
+                </a>
+              </p>
+            </dd>
+            <dt class="content-block__contact-key">Webchat</dt>
+            <dd class="content-block__contact-value">
+              <ul class="content-block__list">
+                <li>
+                  <a href="http://example.com" class="url">
+                    Speak to an adviser now
+                  </a>
+                </li>
+                <li>
+                  <p>Current waiting time is 17 minutes</p>
+                </li>
+              </ul>
             </dd>
           </dl>
         </div>


### PR DESCRIPTION
When we first put contact blocks together, we made the decision to mirror the contacts in the [Contact a department or service team][] design. We hit a problem when trying to use `h2`s in the blocks, as wec ould not guarantee where a block would be added, and this had accessibility issues.

To get around this, we decided to render contacts within nested definition lists, reset the margins, padding etc and style the `dt` elements like `h2` and `h3`s.

HOWEVER, when testing this with users, we found that they expected the `dt` “headings” for blocks to appear in page navigation, as this is how headings behave elsewhere.

To get around this issue, we’ve decided to not show the heading of a block at all, and let the user put in their own headings when embedding contact blocks.

The change to the code is in the Tools gem [here](https://github.com/alphagov/govuk_content_block_tools/pull/114), but this updates the styling slightly to be lighter, as we are now no longer nesting `dl` attributes.

## Screeshots

### Before

<img width="960" height="822" alt="image" src="https://github.com/user-attachments/assets/c90e9094-753f-4cc9-b83f-aadf3809e2b7" />

### After

<img width="960" height="772" alt="image" src="https://github.com/user-attachments/assets/e0c24510-3434-4a72-b9ad-ba049dc3db61" />

[Contact a department or service team]: https://design-system.service.gov.uk/patterns/contact-a-department-or-service-team/
