### PR TITLE
Fix gap in Ukraine sidebar CTA

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_contextual-sidebar.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_contextual-sidebar.scss
@@ -34,16 +34,11 @@
   text-decoration: none;
 }
 
-.gem-c-contextual-sidebar__cta--ukraine {
-  border-top: 7px solid #fed700;
-  position: relative;
+.gem-c-contextual-sidebar__cta-ukraine {
+  margin-top: -7px;
+  border-top: 7px solid #4b7ec1;
 
-  &::before {
-    content: "";
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: -14px;
-    border-top: 7px solid #4b7ec1;
+  .gem-c-contextual-sidebar__cta {
+    border-top: 7px solid #fed700;
   }
 }

--- a/app/views/govuk_publishing_components/components/contextual_sidebar/_ukraine_cta.html.erb
+++ b/app/views/govuk_publishing_components/components/contextual_sidebar/_ukraine_cta.html.erb
@@ -4,31 +4,33 @@
   lang = shared_helper.t_locale("components.related_navigation.ukraine.title")
   data_module = "ga4-link-tracker" unless disable_ga4
 %>
-<%= tag.div class: "gem-c-contextual-sidebar__cta gem-c-contextual-sidebar__cta--ukraine", data: { module: data_module } do %>
-  <%= tag.h2 title, class: "gem-c-contextual-sidebar__heading govuk-heading-s" %>
-  <%= tag.ul class: "gem-c-contextual-sidebar__list" do %>
-    <% index_total = t("components.related_navigation.ukraine.links").length %>
-    <% t("components.related_navigation.ukraine.links").each_with_index do |link, index| %>
-      <%= tag.li class: "gem-c-contextual-sidebar__text govuk-body" do %>
-        <%
-          ga4_attributes = {
-            event_name: "navigation",
-            type: "related content",
-            index_section: "#{ga4_tracking_counts.index_section_count}",
-            index_link: "#{index + 1}",
-            index_section_count: "#{ga4_tracking_counts.index_section_count}",
-            index_total: "#{index_total}",
-            section: title,
-          } unless disable_ga4
-        %>
-        <%= link_to link[:label],
-          link[:href],
-          class: "govuk-link",
-          data: {
-            ga4_link: ga4_attributes,
-          },
-          lang: lang %>
+<div class="gem-c-contextual-sidebar__cta-ukraine">
+  <%= tag.div class: "gem-c-contextual-sidebar__cta", data: { module: data_module } do %>
+    <%= tag.h2 title, class: "gem-c-contextual-sidebar__heading govuk-heading-s" %>
+    <%= tag.ul class: "gem-c-contextual-sidebar__list" do %>
+      <% index_total = t("components.related_navigation.ukraine.links").length %>
+      <% t("components.related_navigation.ukraine.links").each_with_index do |link, index| %>
+        <%= tag.li class: "gem-c-contextual-sidebar__text govuk-body" do %>
+          <%
+            ga4_attributes = {
+              event_name: "navigation",
+              type: "related content",
+              index_section: "#{ga4_tracking_counts.index_section_count}",
+              index_link: "#{index + 1}",
+              index_section_count: "#{ga4_tracking_counts.index_section_count}",
+              index_total: "#{index_total}",
+              section: title,
+            } unless disable_ga4
+          %>
+          <%= link_to link[:label],
+            link[:href],
+            class: "govuk-link",
+            data: {
+              ga4_link: ga4_attributes,
+            },
+            lang: lang %>
+        <% end %>
       <% end %>
     <% end %>
   <% end %>
-<% end %>
+</div>

--- a/spec/components/contextual_sidebar_spec.rb
+++ b/spec/components/contextual_sidebar_spec.rb
@@ -42,9 +42,9 @@ describe "Contextual sidebar", type: :view do
       content_item:,
     )
     index_total = 4 # have to hard code this here but if ukraine links change this number may change, and test will fail
-    assert_select ".gem-c-contextual-sidebar .gem-c-contextual-sidebar__cta--ukraine[data-module='ga4-link-tracker']"
-    assert_select ".gem-c-contextual-sidebar .gem-c-contextual-sidebar__cta--ukraine .govuk-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"related content\",\"index_section\":\"1\",\"index_link\":\"1\",\"index_section_count\":\"1\",\"index_total\":\"#{index_total}\",\"section\":\"Invasion of Ukraine\"}']"
-    assert_select ".gem-c-contextual-sidebar .gem-c-contextual-sidebar__cta--ukraine .govuk-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"related content\",\"index_section\":\"1\",\"index_link\":\"2\",\"index_section_count\":\"1\",\"index_total\":\"#{index_total}\",\"section\":\"Invasion of Ukraine\"}']"
+    assert_select ".gem-c-contextual-sidebar__cta-ukraine .gem-c-contextual-sidebar__cta[data-module='ga4-link-tracker']"
+    assert_select ".gem-c-contextual-sidebar__cta-ukraine .gem-c-contextual-sidebar__cta .govuk-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"related content\",\"index_section\":\"1\",\"index_link\":\"1\",\"index_section_count\":\"1\",\"index_total\":\"#{index_total}\",\"section\":\"Invasion of Ukraine\"}']"
+    assert_select ".gem-c-contextual-sidebar__cta-ukraine .gem-c-contextual-sidebar__cta .govuk-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"related content\",\"index_section\":\"1\",\"index_link\":\"2\",\"index_section_count\":\"1\",\"index_total\":\"#{index_total}\",\"section\":\"Invasion of Ukraine\"}']"
   end
 
   it "allows GA4 tracking to be disabled" do


### PR DESCRIPTION
## What / why

- on some zoom levels a 1px gap appeared between the colours of the Ukraine flag in the contextual sidebar
- example page: https://www.gov.uk/government/speeches/russias-narrative-of-inevitable-victory-is-contradicted-by-its-military-and-economic-failures-uk-statement-to-the-osce
- not sure what the cause was but the CSS used an absolutely positioned before pseudo element, relying on specific positioning
- solution is a bit less elegant but far simpler: wrap the Ukraine CTA in a new wrapping DIV and style that with the blue border top, style the inner with the yellow border top

## Visual Changes

 Before | After
--------|--------
<img width="445" height="447" alt="Screenshot 2025-11-21 at 10 58 44" src="https://github.com/user-attachments/assets/1dcaf563-3c30-4dc7-88f9-ff13d343f84f" /> | <img width="449" height="432" alt="Screenshot 2025-11-21 at 10 58 55" src="https://github.com/user-attachments/assets/c79ff3dd-aacd-4fc1-81ae-345cac9d06b3" />

