### PR TITLE
Fix title of applications consistency page

### DIFF
--- a/app/views/govuk_publishing_components/applications_page/show.html.erb
+++ b/app/views/govuk_publishing_components/applications_page/show.html.erb
@@ -1,5 +1,9 @@
-<% content_for :title, "Component audit" %>
+<% content_for :title, "Applications consistency" %>
 <% add_gem_component_stylesheet("table") %>
+
+<%= render "govuk_publishing_components/components/back_link", {
+  href: "/component-guide",
+} %>
 
 <%= render "govuk_publishing_components/components/heading", {
   text: "Applications",

--- a/app/views/govuk_publishing_components/audit/show.html.erb
+++ b/app/views/govuk_publishing_components/audit/show.html.erb
@@ -2,9 +2,13 @@
   add_gem_component_stylesheet("table")
   add_gem_component_stylesheet("select")
   add_gem_component_stylesheet("summary-list")
+  content_for :title, "Component audit"
 %>
 
-<% content_for :title, "Component audit" %>
+<%= render "govuk_publishing_components/components/back_link", {
+  href: "/component-guide",
+} %>
+
 <%= render "govuk_publishing_components/components/heading", {
     text: "Components audit",
     heading_level: 1,


### PR DESCRIPTION
## What / why
Fix the title of the applications consistency page, as it was previously copied from another template.

Also add back links to this and the audit page, to improve navigation.

## Visual Changes

<img width="749" height="417" alt="Screenshot 2025-11-21 at 13 14 40" src="https://github.com/user-attachments/assets/9b3f692d-ae9c-40da-ad8c-d7f9f2a16446" />
