### PR TITLE
Refactor image card CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Refactor image card CSS ([PR #5147](https://github.com/alphagov/govuk_publishing_components/pull/5147))
 * Decrease inverse header mobile/tablet padding ([PR #5149](https://github.com/alphagov/govuk_publishing_components/pull/5149))
 * Add option to inverse header for HMRC manuals ([PR #5148](https://github.com/alphagov/govuk_publishing_components/pull/5148))
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -6,70 +6,30 @@
   display: flex;
   display: -ms-flexbox;
   flex-direction: column-reverse;
-  -ms-flex-direction: column-reverse;
+  -ms-flex-direction: row-reverse;
+  gap: govuk-spacing(2);
+  justify-content: space-between;
+  align-items: stretch;
   @include govuk-text-colour;
-  @include govuk-clearfix;
 
-  @include govuk-media-query($from: mobile, $until: tablet) {
-    display: block;
-
-    .gem-c-image-card__text-wrapper {
-      float: right;
-      padding-left: 0;
-    }
+  @include govuk-media-query($until: tablet) {
+    flex-direction: row-reverse;
+    gap: govuk-spacing(3);
   }
 }
 
-.gem-c-image-card__header-and-context-wrapper {
-  display: flex;
-  flex-direction: column-reverse;
-  -ms-flex-direction: column-reverse;
+.gem-c-image-card__text-wrapper {
+  flex-grow: 1;
+  flex-basis: 50%;
 }
 
 .gem-c-image-card__image-wrapper {
+  flex-grow: 1;
+  flex-basis: 50%;
   margin: 0;
 
   @include govuk-media-query($from: tablet) {
-    margin-bottom: govuk-spacing(2);
     height: 100%;
-  }
-
-  + .gem-c-image-card__text-wrapper {
-    @include govuk-media-query($until: tablet) {
-      padding-left: 0;
-    }
-  }
-}
-
-@include govuk-media-query($from: mobile, $until: tablet) {
-  .gem-c-image-card {
-    margin: 0 (- govuk-spacing(3)) govuk-spacing(6) (- govuk-spacing(3));
-  }
-
-  .gem-c-image-card__image-wrapper {
-    @include govuk-grid-column($width: one-half, $at: mobile);
-  }
-
-  .gem-c-image-card__text-wrapper {
-    @include govuk-grid-column($width: one-half, $at: mobile);
-  }
-
-  .gem-c-image-card__image-wrapper.gem-c-image-card__image-wrapper--one-third {
-    @include govuk-grid-column($width: one-third, $float: right, $at: mobile);
-  }
-
-  .gem-c-image-card__text-wrapper.gem-c-image-card__text-wrapper--two-thirds {
-    @include govuk-grid-column($width: two-thirds, $float: right, $at: mobile);
-  }
-}
-
-@include govuk-media-query($from: tablet) {
-  .gem-c-image-card__image-wrapper.gem-c-image-card__image-wrapper--one-third {
-    @include govuk-grid-column($width: one-third, $float: right, $at: tablet);
-  }
-
-  .gem-c-image-card__text-wrapper.gem-c-image-card__text-wrapper--two-thirds {
-    @include govuk-grid-column($width: two-thirds, $float: right, $at: tablet);
   }
 }
 
@@ -77,68 +37,8 @@
   display: block;
   height: auto;
   width: 100%;
+  border: 0;
   border-top: 1px solid $govuk-border-colour;
-  border-left: none;
-  border-right: none;
-  border-bottom: none;
-}
-
-.gem-c-image-card.gem-c-image-card--two-thirds {
-  // Change default flex-direction from column-reverse
-  // so that the image and text appear in the same row,
-  // with the image to the left
-  flex-direction: row-reverse;
-  -ms-flex-direction: row-reverse;
-  // Wrap flex items onto a new line and ensure
-  // that items are aligned correctly
-  flex-wrap: wrap-reverse;
-  -ms-flex-wrap: wrap-reverse;
-  justify-content: flex-end;
-  align-items: flex-end;
-}
-
-.gem-c-image-card--two-thirds {
-  .gem-c-image-card__image {
-    border-top: none;
-  }
-
-  // TODO: Temporary fixes to ensure the layout
-  // renders correctly on screen sizes less than 320px wide
-  @include govuk-media-query($until: "mobile") {
-    padding: 0 govuk-spacing(3);
-  }
-
-  .gem-c-image-card__image-wrapper {
-    @include govuk-media-query($until: "mobile") {
-      margin-bottom: govuk-spacing(2);
-    }
-  }
-
-  // Ensures the font-size is 19px on all screen sizes
-  .gem-c-image-card__title-link--large-font-size-mobile,
-  .gem-c-image-card__description--large-font-size-mobile {
-    @include govuk-media-query($until: "tablet") {
-      font-size: 19px;
-      font-size: govuk-px-to-rem(19);
-    }
-  }
-}
-
-.gem-c-image-card__image-wrapper.gem-c-image-card__image-wrapper--one-third {
-  // The first two values set flex-grow and flex-basis to 0
-  // This ensures that the flex item does not grow or shrink
-  // The the last value, sets flex-basis to 95px
-  // padding-left is set to 15px and the image used is 80px wide
-  flex: 0 0 95px;
-  padding-right: 0;
-}
-
-.gem-c-image-card__text-wrapper.gem-c-image-card__text-wrapper--two-thirds {
-  // The first two values set flex-grow and flex-basis to 1
-  // This allows the flex item contain the image card text to grow or shrink
-  // The last value, sets flex-basis to 70%
-  // If the width of the flex-item shrinks below 70%, it will wrap onto a new line
-  flex: 1 1 70%;
 }
 
 .gem-c-image-card__title {
@@ -155,22 +55,13 @@
   // position relative and a higher z-index to put them above the after element
   &::after {
     content: "";
+    display: block;
     position: absolute;
     z-index: 1;
     top: 0;
     left: 0;
     right: 0;
     height: 100%;
-    $ie-background: rgba(255, 255, 255, 0);
-    background: $ie-background; // because internet explorer
-    -ms-high-contrast-adjust: none;
-  }
-
-  @include govuk-media-query($from: mobile, $until: tablet) {
-    &::after {
-      left: govuk-spacing(3);
-      right: govuk-spacing(3);
-    }
   }
 }
 
@@ -235,47 +126,34 @@
   }
 }
 
-.gem-c-image-card--large.gem-c-image-card {
-  display: flex;
-  margin: 0 0 govuk-spacing(6) 0;
-  @include govuk-media-query($from: tablet) {
-    display: block;
+.gem-c-image-card--two-thirds {
+  flex-direction: row-reverse;
+  gap: govuk-spacing(3);
+
+  .gem-c-image-card__text-wrapper {
+    flex: 1 1 70%;
+  }
+
+  .gem-c-image-card__image-wrapper {
+    flex: 0 0 80px;
+  }
+
+  .gem-c-image-card__image {
+    border-top: none;
+  }
+
+  @include govuk-media-query($until: "mobile") {
+    flex-direction: column-reverse;
   }
 }
 
 .gem-c-image-card--large {
-  .gem-c-image-card__image-wrapper {
-    margin-bottom: govuk-spacing(2);
-    float: none;
-    width: auto;
-    max-width: 100%;
-    @include govuk-grid-column($width: one-half, $at: tablet);
+  flex-direction: column-reverse;
+  gap: govuk-spacing(2);
 
-    & { // stylelint-disable-line no-duplicate-selectors
-      // overriding the padding from govuk-grid-column mixin
-      padding: 0;
-    }
-
-    @include govuk-media-query($from: tablet) {
-      padding: 0 govuk-spacing(2) 0 0;
-      margin-bottom: 0;
-    }
-  }
-
-  .gem-c-image-card__text-wrapper {
-    overflow: hidden;
-    @include govuk-grid-column($width: one-half, $at: tablet);
-
-    & { // stylelint-disable-line no-duplicate-selectors
-      // overriding the padding from govuk-grid-column mixin
-      padding: 0;
-    }
-
-    @include govuk-media-query($from: tablet) {
-      float: right;
-      padding: 0 govuk-spacing(3);
-      margin-bottom: 0;
-    }
+  @include govuk-media-query($from: tablet) {
+    flex-direction: row-reverse;
+    gap: govuk-spacing(5);
   }
 
   .gem-c-image-card__title {
@@ -337,15 +215,6 @@
 
 .gem-c-image-card__youtube-thumbnail-container:focus .gem-c-image-card__youtube-thumbnail-container-text {
   @include govuk-focused-text;
-}
-
-.gem-c-image-card--no-image {
-  .gem-c-image-card__text-wrapper {
-    @include govuk-media-query($from: mobile, $until: tablet) {
-      float: left;
-      padding: 0 govuk-spacing(3);
-    }
-  }
 }
 
 // stylelint-disable declaration-no-important

--- a/app/views/govuk_publishing_components/components/_image_card.html.erb
+++ b/app/views/govuk_publishing_components/components/_image_card.html.erb
@@ -9,14 +9,11 @@
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-image-card")
-  component_helper.add_class("govuk-grid-row") if card_helper.two_thirds
   component_helper.add_class("gem-c-image-card--large") if card_helper.large
   component_helper.add_class("gem-c-image-card--two-thirds") if card_helper.two_thirds
-  component_helper.add_class("gem-c-image-card--no-image") unless (card_helper.image_src || card_helper.youtube_video_id)
   component_helper.add_class(brand_helper.brand_class) if brand_helper.brand_class
 
   text_wrapper_classes = %w[gem-c-image-card__text-wrapper]
-  text_wrapper_classes << "gem-c-image-card__text-wrapper--two-thirds" if card_helper.two_thirds
 
   font_size ||= card_helper.large ? "m" : "s"
   heading_class = %w[gem-c-image-card__title]
@@ -42,19 +39,20 @@
 <% if card_helper.href || card_helper.extra_details.any? %>
   <%= tag.div(**component_helper.all_attributes) do %>
     <%= content_tag(:div, class: text_wrapper_classes) do %>
-      <div class="gem-c-image-card__header-and-context-wrapper">
-        <% if card_helper.heading_text %>
-          <%= content_tag(shared_helper.get_heading_level, class: heading_class) do %>
-            <% if card_helper.href %>
-              <%= link_to card_helper.heading_text, card_helper.href, class: heading_link_classes %>
-            <% else %>
-              <%= card_helper.heading_text %>
-            <% end %>
+      <%= card_helper.context %>
+
+      <% if card_helper.heading_text %>
+        <%= content_tag(shared_helper.get_heading_level, class: heading_class) do %>
+          <% if card_helper.href %>
+            <%= link_to card_helper.heading_text, card_helper.href, class: heading_link_classes %>
+          <% else %>
+            <%= card_helper.heading_text %>
           <% end %>
         <% end %>
-        <%= card_helper.context %>
-      </div>
+      <% end %>
+
       <%= card_helper.description %>
+
       <% if card_helper.extra_details.any? %>
         <ul class="gem-c-image-card__list <%= "gem-c-image-card__list--indented" if not card_helper.extra_details_no_indent %>">
           <% card_helper.extra_details.each do |link| %>

--- a/lib/govuk_publishing_components/presenters/image_card_helper.rb
+++ b/lib/govuk_publishing_components/presenters/image_card_helper.rb
@@ -58,7 +58,6 @@ module GovukPublishingComponents
 
       def image
         classes = %w[gem-c-image-card__image-wrapper]
-        classes << "gem-c-image-card__image-wrapper--one-third" if @two_thirds
         height = 200
         width = 300
         height = 90 if @two_thirds

--- a/spec/components/image_card_spec.rb
+++ b/spec/components/image_card_spec.rb
@@ -100,7 +100,7 @@ describe "ImageCard", type: :view do
 
   it "labels a no-image version" do
     render_component(href: "#", heading_text: "test", extra_details: [{ href: "/1", text: "link1" }], brand: "attorney-generals-office")
-    assert_select ".gem-c-image-card--no-image"
+    assert_select ".gem-c-image-card__image-wrapper", false
   end
 
   it "renders a large version" do
@@ -111,8 +111,6 @@ describe "ImageCard", type: :view do
   it "renders two thirds variant with correct image width and height attributes" do
     render_component(href: "#", image_src: "/moo.jpg", image_alt: "some meaningful alt text", heading_text: "test", two_thirds: true)
     assert_select ".gem-c-image-card.gem-c-image-card--two-thirds"
-    assert_select ".gem-c-image-card__text-wrapper.gem-c-image-card__text-wrapper--two-thirds"
-    assert_select ".gem-c-image-card__image-wrapper.gem-c-image-card__image-wrapper--one-third"
     assert_select ".gem-c-image-card__image[width='90']"
     assert_select ".gem-c-image-card__image[height='90']"
   end


### PR DESCRIPTION
## What
Refactor the image card component CSS.

- fully embrace flexbox, by removing all floats and spacing and replacing with flex and gaps
- remove reliance on govuk-grid for layout on two thirds variant, use flexbox
- fix layout of two thirds variant below 320px
- reorder classes a little more logically
- clean up large variant
- remove need for custom classes when no image present, rely instead on flexbox, variant now expands the text to fill the space on mobile
- remove context wrapper element for heading text and context, seemed to only exist to reverse the order of its contents, instead reorder its contents in the template
- there's also some custom CSS in `frontend` to change the image card styles, those should now be removed, this change takes those into account

## Why
We're looking at potential changes to this component and this reduction in code will help to simplify those later improvements.

https://gov-uk.atlassian.net/jira/software/c/projects/PNP/boards/1356?selectedIssue=PNP-9712

## Visual Changes
Shouldn't really be any...

- desktop should look exactly the same
- mobile might look fractionally different, I think the image is a little wider but this is because the spacing is now more evenly distributed between text and image
- no image variant now allows the text to fill the full width of its parent
- two thirds variant below 320px now allows the image to fill the full width of its parent
