### PR TITLE
Decrease inverse header mobile/tablet padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Unreleased
 
+* Decrease inverse header mobile/tablet padding ([PR #5149](https://github.com/alphagov/govuk_publishing_components/pull/5149))
+
 ## 62.1.0
 
 * Adjust govspeak imports of component styles ([PR #5142](https://github.com/alphagov/govuk_publishing_components/pull/5142))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_inverse-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_inverse-header.scss
@@ -6,6 +6,11 @@
   margin-bottom: govuk-spacing(6);
   padding: govuk-spacing(3) govuk-spacing(6) govuk-spacing(6) govuk-spacing(6);
   box-sizing: border-box;
+
+  @include govuk-media-query($until: desktop) {
+    padding-left: govuk-spacing(3);
+    padding-right: govuk-spacing(3);
+  }
 }
 
 .gem-c-inverse-header__subtext {


### PR DESCRIPTION
## What / why
- reduce the left/right padding for the inverse header to 15px on mobile and tablet
- makes better use of space, looks better on mobile

## Visual Changes
Desktop remains the same.

Mobile:

Before | After
--------|--------
<img width="307" height="240" alt="Screenshot 2025-12-01 at 09 30 23" src="https://github.com/user-attachments/assets/0539584a-8afb-40ba-86d6-ce06705e39ce" /> | <img width="308" height="207" alt="Screenshot 2025-12-01 at 09 30 32" src="https://github.com/user-attachments/assets/34ae438d-835e-472b-984f-b5b0a5e063a6" />

Tablet:

Before | After
--------|--------
<img width="516" height="170" alt="Screenshot 2025-12-01 at 09 31 30" src="https://github.com/user-attachments/assets/c53216b8-6d21-45f1-ad79-a788af3bc520" /> | <img width="516" height="172" alt="Screenshot 2025-12-01 at 09 31 35" src="https://github.com/user-attachments/assets/ba0f2e23-5bee-4cae-a6fa-802cbde3ad02" />

On a HTML publication (mobile). I've set it to match the intervention banner beneath it, which also maintains 15px left/right padding until desktop, to try to make the page consistent (however the step by step nav header behaves differently, maybe an optimisation for another time).

Before | After
--------|--------
<img width="341" height="929" alt="Screenshot 2025-12-01 at 09 32 44" src="https://github.com/user-attachments/assets/7fef1a53-41d9-4757-877a-d6d307b35380" /> | <img width="340" height="936" alt="Screenshot 2025-12-01 at 09 35 13" src="https://github.com/user-attachments/assets/57f16ee9-3b97-4394-887d-428db51f19da" />
