### PR TITLE
Make govspeak chart's turquoise colour AAA compliant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Update related navigation toggle texts for improved accessibility ([PR #5145](https://github.com/alphagov/govuk_publishing_components/pull/5145))
+* Make govspeak chart's turquoise colour AAA compliant ([PR #5153](https://github.com/alphagov/govuk_publishing_components/pull/5153))
 
 ## 62.2.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_charts.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_charts.scss
@@ -31,7 +31,7 @@
   // https://gss.civilservice.gov.uk/policy-store/data-visualisation-colours-in-charts/#section-5
 
   $gss-colour-dark-blue: #12436d;
-  $gss-colour-turquoise: #28a197;
+  $gss-colour-turquoise: #1bbbaf;
   $gss-colour-dark-pink: #801650;
   $gss-colour-orange: #f46a25;
   $gss-colour-dark-grey: #3d3d3d;
@@ -42,7 +42,7 @@
   $chart-border: govuk-colour("white"); // Chart border colour
   $key-border: govuk-colour("white"); // Key border colour
   $bar-colours: $gss-colour-dark-blue, $gss-colour-turquoise, $gss-colour-dark-pink, $gss-colour-orange, $gss-colour-dark-grey, $gss-colour-plum;
-  $bar-text-colours: govuk-colour("white"), govuk-colour("white"), govuk-colour("white"), govuk-colour("black"), govuk-colour("white"), govuk-colour("black");
+  $bar-text-colours: govuk-colour("white"), govuk-colour("black"), govuk-colour("white"), govuk-colour("black"), govuk-colour("white"), govuk-colour("black");
   $bar-cell-colour: govuk-colour("black");
   $bar-outdented-colour: govuk-colour("black");
 


### PR DESCRIPTION
## What / Why
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Change the turquoise colour in the govspeak chart component to a lighter shade with black text so that it meets AAA compliance
- The old turquoise failed to meet the 4.5:1 contrast ratio against white text, so we needed to fix this 
- Initially we were going to update the shade to just be AA compliant, but we decided to go with AAA compliance instead as it's more inclusive as shown by https://www.whocanuse.com/?bg=1bbbaf&fg=000000&fs=16&fw=
- This change has been approved by our accessibility specialist
- This colour also keeps the contrast against the adjacent colours higher than 3:1 (thanks @jon-kirwan for spotting this initially so I could fix it)
- Preview app link: https://components-gem-pr-5153.herokuapp.com/component-guide/govspeak/chart_with_colours/preview
- Jira card: https://gov-uk.atlassian.net/browse/NAV-18538

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

| Before | After |
|--------|--------|
| <img width="622" height="433" alt="image" src="https://github.com/user-attachments/assets/97f0c8ff-fad5-4584-89c5-0cabff1d2dba" /> | <img width="622" height="433" alt="image" src="https://github.com/user-attachments/assets/46e5d832-8d60-45cc-8e1c-9acf1ec85d41" /> |
