### PR TITLE
Reset `window.LUX` when user rejects cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Remove reliance on CGI.parse ([PR #5424](https://github.com/alphagov/govuk_publishing_components/pull/5424))
+* Reset `window.LUX` when user rejects cookies ([PR #5344](https://github.com/alphagov/govuk_publishing_components/pull/5344))
 
 ## 66.0.0
 

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-settings.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-settings.js
@@ -54,7 +54,7 @@
 
         if (name === 'usage' && !value) {
           window.GOVUK.stopSendingAnalytics = true
-          window.GOVUK.LUX = {}
+          window.LUX = {}
         }
       }
     }

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-settings.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-settings.js
@@ -54,7 +54,7 @@
 
         if (name === 'usage' && !value) {
           window.GOVUK.stopSendingAnalytics = true
-          window.LUX = {}
+          window.LUX.auto = false
         }
       }
     }

--- a/spec/javascripts/govuk_publishing_components/lib/cookie-settings-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/cookie-settings-spec.js
@@ -1,4 +1,6 @@
 /* eslint-env jasmine */
+/* global LUX */
+
 var GOVUK = window.GOVUK || {}
 
 describe('cookieSettings', function () {
@@ -96,6 +98,10 @@ describe('cookieSettings', function () {
   })
 
   describe('submitSettingsForm', function () {
+    it('confirms that LUX object exists and contains data before running dependent tests', function () {
+      expect(Object.keys(LUX).length).toBeGreaterThan(0)
+    })
+
     it('updates consent cookie with any changes', function () {
       spyOn(window.GOVUK, 'setConsentCookie').and.callThrough()
 
@@ -111,6 +117,9 @@ describe('cookieSettings', function () {
 
       expect(window.GOVUK.setConsentCookie).toHaveBeenCalledWith({ settings: false, usage: false, campaigns: false })
       expect(cookie.settings).toBeFalsy()
+      expect(LUX.auto).toBeFalsy()
+
+      LUX.auto = true // Reset LUX.auto to true for other tests
     })
 
     it('sets cookies_preferences_set cookie on form submit', function () {


### PR DESCRIPTION
## What

When usage tracking is disabled or withdrawn for cookies, we should not only stop sending analytics data but also clear any data stored in the LUX object. The implementation currently assumes that LUX is available at `window.GOVUK.LUX`, but this property does not exist. It's possible that something in our implementation or the API has changed.

 Reset `window.LUX` instead to attempt to fix the issue. However, this is a preliminary attempt at fixing this as it doesn't appear to be documented in [the RUM API](https://support.speedcurve.com/docs/rum-js-api#lux-properties) as a way to reset the usage data, and we're still gathering information on how to best handle this.

## Why

Jira card: https://gov-uk.atlassian.net/jira/software/c/projects/NAV/boards/1422?selectedIssue=NAV-18727