### PR TITLE
Fix signup link having data='false' attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
 
 ## Unreleased
 
-* Remove unused 'services_cookies' option from cookie banner
- ([PR #5488](https://github.com/alphagov/govuk_publishing_components/pull/5488))
+* Remove unused 'services_cookies' option from cookie banner ([PR #5488](https://github.com/alphagov/govuk_publishing_components/pull/5488))
+* Fix signup link having data='false' attribute ([PR #5356](https://github.com/alphagov/govuk_publishing_components/pull/5356))
 
 ## 66.4.2
 

--- a/app/views/govuk_publishing_components/components/_signup_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_signup_link.html.erb
@@ -5,7 +5,7 @@
   link_href ||= false
   heading ||= false
   background ||= false
-  data ||= false
+  data ||= nil
 
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)

--- a/app/views/govuk_publishing_components/components/docs/signup_link.yml
+++ b/app/views/govuk_publishing_components/components/docs/signup_link.yml
@@ -31,3 +31,11 @@ examples:
       link_text: 'Click right here to sign up!!'
       link_href: '/this-signs-you-up'
       heading_level: 1
+  with_data_attributes_on_the_link:
+    data:
+      heading: 'Sign up for email notifications'
+      link_text: 'Click right here to sign up!!'
+      link_href: '/this-signs-you-up'
+      data:
+        hello: world
+


### PR DESCRIPTION
## What/Why
<!-- What are the reasons behind this change being made? -->
- This component had `data ||= false` for setting data attributes. This meant that when no data attributes existed it would add `data='false'` to the HTML. Changing the value from `false` to `nil` should fix this.

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

A new example added to the signup link component.
