### PR TITLE
Change GTM config for dev docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Change GTM config for dev docs ([PR #5380](https://github.com/alphagov/govuk_publishing_components/pull/5380))
+
 ## 65.2.0
 
 * Add black and white colour variants to details component ([PR #5364](https://github.com/alphagov/govuk_publishing_components/pull/5364))

--- a/app/assets/javascripts/govuk_publishing_components/domain-config.js
+++ b/app/assets/javascripts/govuk_publishing_components/domain-config.js
@@ -55,6 +55,6 @@ window.GOVUK.vars.domains = [
       'docs.publishing.service.gov.uk'
     ],
     initialiseGA4: true,
-    id: 'GTM-TNKCK97'
+    id: 'GTM-NQTG3X8K'
   }
 ]


### PR DESCRIPTION
## What / why
- the analysts are moving some of the containers around ahead of the aggregate changes, so the container ID for docs.publishing.service is changing
- https://gov-uk.atlassian.net/browse/IA-2641?issueKey=IA-2641&subProduct=jira-software

## Visual Changes
None.
