### PR TITLE
Version 65.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 65.2.1
 
 * Change GTM config for dev docs ([PR #5380](https://github.com/alphagov/govuk_publishing_components/pull/5380))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (65.2.0)
+    govuk_publishing_components (65.2.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "65.2.0".freeze
+  VERSION = "65.2.1".freeze
 end


### PR DESCRIPTION
## 65.2.1

* Change GTM config for dev docs ([PR #5380](https://github.com/alphagov/govuk_publishing_components/pull/5380))
