### PR TITLE
Change feedback component styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Change feedback component styles ([PR #5382](https://github.com/alphagov/govuk_publishing_components/pull/5382))
+
 ## 65.2.2
 
 * Add missing Welsh translations for devolved nations content types ([PR #5371](https://github.com/alphagov/govuk_publishing_components/pull/5371))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -4,6 +4,9 @@ $feedback-prompt-border-top-colour: $govuk-blue-tint-50;
 .gem-c-feedback {
   background: govuk-colour("white");
   margin-top: govuk-spacing(6);
+  background-color: $feedback-prompt-background-colour;
+  color: govuk-colour("black");
+  border-top: 1px solid $feedback-prompt-border-top-colour;
 
   @include govuk-media-query($from: desktop) {
     margin-top: govuk-spacing(9);
@@ -27,9 +30,7 @@ $feedback-prompt-border-top-colour: $govuk-blue-tint-50;
 }
 
 .gem-c-feedback__prompt {
-  background-color: $feedback-prompt-background-colour;
   color: govuk-colour("black");
-  border-top: 1px solid $feedback-prompt-border-top-colour;
   outline: 0;
 }
 
@@ -201,10 +202,10 @@ $feedback-prompt-border-top-colour: $govuk-blue-tint-50;
 
 .gem-c-feedback__form {
   padding: govuk-spacing(3);
-  border-top: 1px solid $govuk-border-colour;
 
   @include govuk-media-query($from: tablet) {
     padding: govuk-spacing(6);
+    padding-bottom: 0;
   }
 }
 
@@ -230,6 +231,15 @@ $feedback-prompt-border-top-colour: $govuk-blue-tint-50;
   margin: 0 govuk-spacing(2);
   @include govuk-media-query($until: tablet) {
     margin: govuk-spacing(4) 0 0;
+  }
+}
+
+.gem-c-feedback__button-wrapper {
+  @include govuk-media-query($from: tablet) {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+    gap: govuk-spacing(2);
   }
 }
 

--- a/app/views/govuk_publishing_components/components/feedback/_problem_form.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_problem_form.html.erb
@@ -49,18 +49,23 @@
         end
       %>
 
-      <%= render "govuk_publishing_components/components/button", {
-        text: t("components.feedback.send"),
-        data_attributes: {
-          ga4_event: ga4_submit_button_event,
-        },
-      } %>
+      <div class="gem-c-feedback__button-wrapper">
+        <%= render "govuk_publishing_components/components/button", {
+          text: t("components.feedback.send"),
+          data_attributes: {
+            ga4_event: ga4_submit_button_event,
+          },
+          margin_bottom: 6,
+        } %>
 
-      <button
-        class="govuk-button govuk-button--secondary gem-c-feedback__close gem-c-feedback__js-show js-close-form"
-        aria-controls="something-is-wrong">
-        <%= t("components.feedback.close") %>
-      </button>
+        <%= render "govuk_publishing_components/components/button", {
+          text: t("components.feedback.close"),
+          classes: "js-close-form",
+          aria_controls: "something-is-wrong",
+          secondary_quiet: true,
+          margin_bottom: 0,
+        } %>
+      </div>
     </div>
   </div>
 </form>

--- a/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
@@ -8,12 +8,14 @@
         <%= t("components.feedback.more_about_visit") %>
         <a href="https://www.smartsurvey.co.uk/s/gov-uk-banner/?c=no-js" class="govuk-link" target="_blank" rel="noopener noreferrer external">Please fill in this survey (opens in a new tab<noscript> and requires JavaScript</noscript>)</a>.
       </p>
-      <button
-        class="govuk-button govuk-button--secondary js-close-form"
-        aria-controls="page-is-not-useful"
-        hidden>
-        <%= t("components.feedback.close") %>
-      </button>
+
+      <%= render "govuk_publishing_components/components/button", {
+        text: t("components.feedback.close"),
+        classes: "js-close-form",
+        aria_controls: "page-is-not-useful",
+        secondary_quiet: true,
+        margin_bottom: 6,
+      } %>
     </div>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -90,7 +90,7 @@ en:
         start: Wales
     feedback:
       close: Cancel
-      dont_include_personal_info: Don’t include personal or financial information like your National Insurance number or credit card details.
+      dont_include_personal_info: Do not include personal or financial information like your National Insurance number or credit card details.
       email_address: Email address
       help_us_improve_govuk: Help us improve GOV.UK
       is_not_useful: this page is not useful


### PR DESCRIPTION
## What
Restyle the feedback component. Specifically:

- adds the light blue background to the 'no' and 'report a problem with this page' forms (previously white) to make the whole component visually consistent (the unopened state and success state for 'yes' had the blue background already)
- use the button component for certain buttons, which removes the 'hidden' attribute from the 'cancel' button in the 'no' option, but this doesn't appear to do anything (?)
- use the secondary quiet style for the existing secondary buttons, as this improves their contrast against the new background
- adjust spacing around the component to fit in these changes, including removing margin bottom on the 'no' 'cancel' button, and setting margins on the 'send' and 'cancel' buttons to keep the spacing consistent with the current look

## Why
Better aligns with the rest of the page, and makes it more consistent with itself.

Been meaning to fix this for a while.

Also fixes https://gov-uk.atlassian.net/jira/software/c/projects/PNP/boards/1356?quickFilter=1456&selectedIssue=PNP-9898&useStoredSettings=true

## Visual Changes
Changes below shown for mobile and desktop. The only slight wrinkle is that the newly applied secondary quiet button style on 'cancel' lacks the bottom edge of the green button style, so side-by-side they're not the same height (on desktop). It's a very small difference though, and one that should probably be addressed separately on the button component rather than here.

Before | After
------ | -----
<img width="515" height="987" alt="Screenshot 2026-04-08 at 17 13 26" src="https://github.com/user-attachments/assets/6ea97cf9-d55c-4222-8aa8-af0f819e247a" /> | <img width="516" height="976" alt="Screenshot 2026-04-08 at 17 13 39" src="https://github.com/user-attachments/assets/d24ea9cb-e4f2-4eb3-b32d-9aa5d69b994f" />
<img width="1107" height="1133" alt="Screenshot 2026-04-08 at 17 13 51" src="https://github.com/user-attachments/assets/b3b9b02d-c254-4349-b222-4db5f4d2a358" /> | <img width="1106" height="1111" alt="Screenshot 2026-04-08 at 17 14 02" src="https://github.com/user-attachments/assets/5f0d0bbe-949e-4646-a781-899c51ae4541" />

For context here it is on an actual GOV.UK page. First showing the 'report a problem' form:

<img width="1018" height="1044" alt="Screenshot 2026-04-08 at 17 19 37" src="https://github.com/user-attachments/assets/1ef86c0b-d622-4580-af13-bc07db14fd03" />

And now showing the 'no' form:

<img width="1014" height="764" alt="Screenshot 2026-04-08 at 17 19 47" src="https://github.com/user-attachments/assets/0f26cb25-48b1-401f-baf6-0c1ef0fa4e3e" />
