### PR TITLE
Expand audit table

### DIFF
--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -477,6 +477,57 @@ $code-delete-bg: #fadddd;
   }
 }
 
+.table-container {
+  container-type: inline-size;
+  container-name: page;
+}
+
+@container page (width > 1040px) {
+  $w: 960px;
+
+  .table-wrapper {
+    position: relative;
+    z-index: 0;
+    box-sizing: border-box;
+    margin-left: calc(((-100cqw + $w) / 2) - 1px);
+    margin-right: calc(((-100cqw + $w) / 2) - 1px);
+    background: #ffffff;
+    padding: 15px;
+  }
+}
+
+.govuk-tabs {
+  $w: 920px;
+
+  @container page (width > 1040px) {
+    .table-wrapper {
+      margin-left: calc(((-100cqw + $w) / 2) - 1px);
+      margin-right: calc(((-100cqw + $w) / 2) - 1px);
+
+      &::before,
+      &::after {
+        content: "";
+        z-index: -1;
+        position: absolute;
+        top: -1px;
+        bottom: -1px;
+        width: calc((100cqw - 960px) / 2);
+        box-sizing: border-box;
+        border-top: solid 1px $govuk-border-colour;
+        border-bottom: solid 1px $govuk-border-colour;
+      }
+
+      &::before {
+        left: 0;
+      }
+
+      &::after {
+        right: 0;
+      }
+    }
+  }
+}
+
 // Note: This is a temporary override to ensure the background color on component preview
 // pages remains white, this can be removed once the --rebrand flag is removed from govuk-frontend
 .govuk-template--rebranded {

--- a/app/views/govuk_publishing_components/audit/_component_contents.html.erb
+++ b/app/views/govuk_publishing_components/audit/_component_contents.html.erb
@@ -1,153 +1,155 @@
 <p class="govuk-body">
   Numbers in table headers show column totals. Numbers in table cells show number of lines in files. Note that component test files cannot currently be detected in applications that use minitest instead of Rspec.</p>
 </p>
-<table class="govuk-table">
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row" <% if show_application_name %> data-audit-headings<% end %>>
-      <th scope="col" class="govuk-table__header sticky-table-header" data-component-type="total">Component</th>
-      <th scope="col" class="govuk-table__header sticky-table-header" data-component-type="template" title="Component has a template">
-        Template
-        <% unless show_application_name %>
-          <span class="component__count"><%= passed_components[:component_numbers][:template] %></span>
-        <% end %>
-      </th>
-      <th scope="col" class="govuk-table__header sticky-table-header" data-component-type="stylesheet" title="Component has a stylesheet">
-        CSS
-        <% unless show_application_name %>
-          <span class="component__count"><%= passed_components[:component_numbers][:stylesheet] %></span>
-        <% end %>
-      </th>
-      <th scope="col" class="govuk-table__header sticky-table-header" data-component-type="print_stylesheet" title="Component has print styles">
-        Print CSS
-        <% unless show_application_name %>
-          <span class="component__count"><%= passed_components[:component_numbers][:print_stylesheet] %></span>
-        <% end %>
-      </th>
-      <th scope="col" class="govuk-table__header sticky-table-header" data-component-type="javascript" title="Component has JavaScript">
-        JS
-        <% unless show_application_name %>
-          <span class="component__count"><%= passed_components[:component_numbers][:javascript] %></span>
-        <% end %>
-      </th>
-      <th scope="col" class="govuk-table__header sticky-table-header" data-component-type="javascript_test" title="Component has a JavaScript test file">
-        JS test
-        <% unless show_application_name %>
-          <span class="component__count"><%= passed_components[:component_numbers][:javascript_test] %></span>
-        <% end %>
-      </th>
-      <th scope="col" class="govuk-table__header sticky-table-header" data-component-type="uses-govuk-frontend-css" title="Component includes styles imported from govuk-frontend">
-        GF CSS
-        <% unless show_application_name %>
-          <span class="component__count"><%= passed_components[:component_numbers][:uses_govuk_frontend_css] %></span>
-        <% end %>
-      </th>
-      <th scope="col" class="govuk-table__header sticky-table-header" data-component-type="uses-govuk-frontend-js" title="Component includes JavaScript imported from govuk-frontend">
-        GF JS
-        <% unless show_application_name %>
-          <span class="component__count"><%= passed_components[:component_numbers][:uses_govuk_frontend_js] %></span>
-        <% end %>
-      </th>
-      <th scope="col" class="govuk-table__header sticky-table-header" data-component-type="test" title="Component has a test file">
-        Test
-        <% unless show_application_name %>
-          <span class="component__count"><%= passed_components[:component_numbers][:test] %></span>
-        <% end %>
-      </th>
-      <th scope="col" class="govuk-table__header sticky-table-header" data-component-type="helper" title="Component has a helper file">
-        Helper
-        <% unless show_application_name %>
-          <span class="component__count"><%= passed_components[:component_numbers][:helper] %></span>
-        <% end %>
-      </th>
-    </tr>
-  </thead>
-  <tbody class="govuk-table__body" <% if show_application_name %> data-audit-list<% end %>>
-    <% passed_components[:component_file_details].each do |component| %>
-      <tr class="govuk-table__row" data-application="<%= component[:application] %>">
-        <th scope="row" class="govuk-table__header" data-component-type="total">
-          <% if component[:link] %>
-            <a href="<%= component[:link] %>" class="govuk-link">
-              <%= component[:name] %>
-            </a>
-          <% else %>
-            <%= component[:name] %>
-          <% end %>
-          <% if show_application_name %>
-            <span class="component__application-name">
-              <%= component[:application] %>
-            </span>
+<div class="table-wrapper">
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row" <% if show_application_name %> data-audit-headings<% end %>>
+        <th scope="col" class="govuk-table__header sticky-table-header" data-component-type="total">Component</th>
+        <th scope="col" class="govuk-table__header sticky-table-header" data-component-type="template" title="Component has a template">
+          Template
+          <% unless show_application_name %>
+            <span class="component__count"><%= passed_components[:component_numbers][:template] %></span>
           <% end %>
         </th>
-        <td class="govuk-table__cell" data-component-type="template">
-          <% if component[:template_exists] %>
-            <a href="<%= component[:template_link] %>" class="govuk-link" title="This file has <%= component[:template_lines] %> lines">
-              <%= component[:template_lines] %>
-              <span class="govuk-visually-hidden">lines of code in <%= component[:name] %> template</span>
-            </a>
+        <th scope="col" class="govuk-table__header sticky-table-header" data-component-type="stylesheet" title="Component has a stylesheet">
+          CSS
+          <% unless show_application_name %>
+            <span class="component__count"><%= passed_components[:component_numbers][:stylesheet] %></span>
           <% end %>
-        </td>
-        <td class="govuk-table__cell" data-component-type="stylesheet">
-          <% if component[:stylesheet_exists] %>
-            <a href="<%= component[:stylesheet_link] %>" class="govuk-link" title="This file has <%= component[:stylesheet_lines] %> lines">
-              <%= component[:stylesheet_lines] %>
-              <span class="govuk-visually-hidden">lines of code in <%= component[:name] %> stylesheet</span>
-            </a>
+        </th>
+        <th scope="col" class="govuk-table__header sticky-table-header" data-component-type="print_stylesheet" title="Component has print styles">
+          Print CSS
+          <% unless show_application_name %>
+            <span class="component__count"><%= passed_components[:component_numbers][:print_stylesheet] %></span>
           <% end %>
-        </td>
-        <td class="govuk-table__cell" data-component-type="print_stylesheet">
-          <% if component[:print_stylesheet_exists] %>
-            <span title="This component has a print stylesheet">
-              Yes
-            </span>
+        </th>
+        <th scope="col" class="govuk-table__header sticky-table-header" data-component-type="javascript" title="Component has JavaScript">
+          JS
+          <% unless show_application_name %>
+            <span class="component__count"><%= passed_components[:component_numbers][:javascript] %></span>
           <% end %>
-        </td>
-        <td class="govuk-table__cell" data-component-type="javascript">
-          <% if component[:javascript_exists] %>
-            <a href="<%= component[:javascript_link] %>" class="govuk-link" title="This file has <%= component[:javascript_lines] %> lines">
-              <%= component[:javascript_lines] %>
-              <span class="govuk-visually-hidden">lines of code in <%= component[:name] %> javascript</span>
-            </a>
+        </th>
+        <th scope="col" class="govuk-table__header sticky-table-header" data-component-type="javascript_test" title="Component has a JavaScript test file">
+          JS test
+          <% unless show_application_name %>
+            <span class="component__count"><%= passed_components[:component_numbers][:javascript_test] %></span>
           <% end %>
-        </td>
-        <td class="govuk-table__cell" data-component-type="javascript_test">
-          <% if component[:javascript_test_exists] %>
-            <a href="<%= component[:javascript_test_link] %>" class="govuk-link" title="This file has <%= component[:javascript_test_lines] %> lines">
-              <%= component[:javascript_test_lines] %>
-              <span class="govuk-visually-hidden">lines of code in <%= component[:name] %> javascript test</span>
-            </a>
+        </th>
+        <th scope="col" class="govuk-table__header sticky-table-header" data-component-type="uses-govuk-frontend-css" title="Component includes styles imported from govuk-frontend">
+          GF CSS
+          <% unless show_application_name %>
+            <span class="component__count"><%= passed_components[:component_numbers][:uses_govuk_frontend_css] %></span>
           <% end %>
-        </td>
-        <td class="govuk-table__cell" data-component-type="uses-govuk-frontend-css">
-          <% if component[:uses_govuk_frontend_css] %>
-            <span title="Component includes styles imported from govuk-frontend">
-              Yes
-            </span>
+        </th>
+        <th scope="col" class="govuk-table__header sticky-table-header" data-component-type="uses-govuk-frontend-js" title="Component includes JavaScript imported from govuk-frontend">
+          GF JS
+          <% unless show_application_name %>
+            <span class="component__count"><%= passed_components[:component_numbers][:uses_govuk_frontend_js] %></span>
           <% end %>
-        </td>
-        <td class="govuk-table__cell" data-component-type="uses-govuk-frontend-js">
-          <% if component[:uses_govuk_frontend_js] %>
-            <span title="Component includes JavaScript imported from govuk-frontend">
-              Yes
-            </span>
+        </th>
+        <th scope="col" class="govuk-table__header sticky-table-header" data-component-type="test" title="Component has a test file">
+          Test
+          <% unless show_application_name %>
+            <span class="component__count"><%= passed_components[:component_numbers][:test] %></span>
           <% end %>
-        </td>
-        <td class="govuk-table__cell" data-component-type="test">
-          <% if component[:test_exists] %>
-            <a href="<%= component[:test_link] %>" class="govuk-link" title="This file has <%= component[:test_lines] %> lines">
-              <%= component[:test_lines] %>
-              <span class="govuk-visually-hidden">lines of code in <%= component[:name] %> test</span>
-            </a>
+        </th>
+        <th scope="col" class="govuk-table__header sticky-table-header" data-component-type="helper" title="Component has a helper file">
+          Helper
+          <% unless show_application_name %>
+            <span class="component__count"><%= passed_components[:component_numbers][:helper] %></span>
           <% end %>
-        </td>
-        <td class="govuk-table__cell" data-component-type="helper">
-          <% if component[:helper_exists] %>
-            <a href="<%= component[:helper_link] %>" class="govuk-link" title="This file has <%= component[:helper_lines] %> lines">
-              <%= component[:helper_lines] %>
-              <span class="govuk-visually-hidden">lines of code in <%= component[:name] %> helper</span>
-            </a>
-          <% end %>
-        </td>
+        </th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+    <tbody class="govuk-table__body" <% if show_application_name %> data-audit-list<% end %>>
+      <% passed_components[:component_file_details].each do |component| %>
+        <tr class="govuk-table__row" data-application="<%= component[:application] %>">
+          <th scope="row" class="govuk-table__header" data-component-type="total">
+            <% if component[:link] %>
+              <a href="<%= component[:link] %>" class="govuk-link">
+                <%= component[:name] %>
+              </a>
+            <% else %>
+              <%= component[:name] %>
+            <% end %>
+            <% if show_application_name %>
+              <span class="component__application-name">
+                <%= component[:application] %>
+              </span>
+            <% end %>
+          </th>
+          <td class="govuk-table__cell" data-component-type="template">
+            <% if component[:template_exists] %>
+              <a href="<%= component[:template_link] %>" class="govuk-link" title="This file has <%= component[:template_lines] %> lines">
+                <%= component[:template_lines] %>
+                <span class="govuk-visually-hidden">lines of code in <%= component[:name] %> template</span>
+              </a>
+            <% end %>
+          </td>
+          <td class="govuk-table__cell" data-component-type="stylesheet">
+            <% if component[:stylesheet_exists] %>
+              <a href="<%= component[:stylesheet_link] %>" class="govuk-link" title="This file has <%= component[:stylesheet_lines] %> lines">
+                <%= component[:stylesheet_lines] %>
+                <span class="govuk-visually-hidden">lines of code in <%= component[:name] %> stylesheet</span>
+              </a>
+            <% end %>
+          </td>
+          <td class="govuk-table__cell" data-component-type="print_stylesheet">
+            <% if component[:print_stylesheet_exists] %>
+              <span title="This component has a print stylesheet">
+                Yes
+              </span>
+            <% end %>
+          </td>
+          <td class="govuk-table__cell" data-component-type="javascript">
+            <% if component[:javascript_exists] %>
+              <a href="<%= component[:javascript_link] %>" class="govuk-link" title="This file has <%= component[:javascript_lines] %> lines">
+                <%= component[:javascript_lines] %>
+                <span class="govuk-visually-hidden">lines of code in <%= component[:name] %> javascript</span>
+              </a>
+            <% end %>
+          </td>
+          <td class="govuk-table__cell" data-component-type="javascript_test">
+            <% if component[:javascript_test_exists] %>
+              <a href="<%= component[:javascript_test_link] %>" class="govuk-link" title="This file has <%= component[:javascript_test_lines] %> lines">
+                <%= component[:javascript_test_lines] %>
+                <span class="govuk-visually-hidden">lines of code in <%= component[:name] %> javascript test</span>
+              </a>
+            <% end %>
+          </td>
+          <td class="govuk-table__cell" data-component-type="uses-govuk-frontend-css">
+            <% if component[:uses_govuk_frontend_css] %>
+              <span title="Component includes styles imported from govuk-frontend">
+                Yes
+              </span>
+            <% end %>
+          </td>
+          <td class="govuk-table__cell" data-component-type="uses-govuk-frontend-js">
+            <% if component[:uses_govuk_frontend_js] %>
+              <span title="Component includes JavaScript imported from govuk-frontend">
+                Yes
+              </span>
+            <% end %>
+          </td>
+          <td class="govuk-table__cell" data-component-type="test">
+            <% if component[:test_exists] %>
+              <a href="<%= component[:test_link] %>" class="govuk-link" title="This file has <%= component[:test_lines] %> lines">
+                <%= component[:test_lines] %>
+                <span class="govuk-visually-hidden">lines of code in <%= component[:name] %> test</span>
+              </a>
+            <% end %>
+          </td>
+          <td class="govuk-table__cell" data-component-type="helper">
+            <% if component[:helper_exists] %>
+              <a href="<%= component[:helper_link] %>" class="govuk-link" title="This file has <%= component[:helper_lines] %> lines">
+                <%= component[:helper_lines] %>
+                <span class="govuk-visually-hidden">lines of code in <%= component[:name] %> helper</span>
+              </a>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/govuk_publishing_components/audit/show.html.erb
+++ b/app/views/govuk_publishing_components/audit/show.html.erb
@@ -1,4 +1,5 @@
 <% content_for :title, "Component audit" %>
+<% content_for :body_classes, "table-container" %>
 
 <%= render "govuk_publishing_components/components/back_link", {
   href: "/component-guide",

--- a/app/views/layouts/govuk_publishing_components/application.html.erb
+++ b/app/views/layouts/govuk_publishing_components/application.html.erb
@@ -44,7 +44,7 @@
     <%= yield :application_stylesheet %>
     <%= yield :extra_headers %>
   </head>
-  <body class="gem-c-layout-for-admin govuk-template__body">
+  <body class="gem-c-layout-for-admin govuk-template__body <%= yield :body_classes %>">
     <%= javascript_tag nonce: true do -%>
       document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');
     <% end %>


### PR DESCRIPTION
## What
- use CSS container queries to allow the component files table in the auditing pages to expand to fill the page width, when the page is above 1040px wide

## Why
I wanted to use container queries to experiment with tables. This table has been quite cramped for a while and I wanted to see if something like this could be possible. I don't fully understand the maths (I've had to add an extra pixel to the calculation to get it exactly right) and below a screen size of 1040px it doesn't work properly, but overall it seems like an improvement.

On browsers that don't support container queries it should just look as it did before.

## Visual Changes
Table now expands outside of the width of the page wrapper to meet the edge of the browser viewport. I've added some pseudo elements to style a 'box' around the whole thing.

<img width="1468" height="939" alt="Screenshot 2026-04-13 at 13 39 36" src="https://github.com/user-attachments/assets/f89cb4db-0dab-4a6b-8dec-636dafed81be" />
