### PR TITLE
[DO NOT MERGE] Enhance govspeak tables

### DIFF
--- a/app/assets/javascripts/component_guide/application.js
+++ b/app/assets/javascripts/component_guide/application.js
@@ -4,5 +4,6 @@
 //= require ../govuk_publishing_components/dependencies
 //= require ../govuk_publishing_components/components/accordion
 //= require ../govuk_publishing_components/components/intervention
+//= require ../govuk_publishing_components/components/modal-dialogue
 //= require ../govuk_publishing_components/components/password-input
 //= require ../govuk_publishing_components/components/tabs

--- a/app/assets/javascripts/govuk_publishing_components/components/govspeak.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/govspeak.js
@@ -7,11 +7,13 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   }
 
   Govspeak.prototype.init = function () {
+    console.log('govspeak')
     if (this.$module.className.indexOf('js-disable-youtube') === -1) {
       this.embedYoutube()
     }
 
     this.createBarcharts()
+    this.enhanceTables()
   }
 
   Govspeak.prototype.embedYoutube = function () {
@@ -21,6 +23,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   Govspeak.prototype.createBarcharts = function () {
     var enhancement = new window.GOVUK.GovspeakBarchartEnhancement(this.$module)
+    enhancement.init()
+  }
+
+  Govspeak.prototype.enhanceTables = function () {
+    var enhancement = new window.GOVUK.GovspeakTableEnhancement(this.$module)
     enhancement.init()
   }
 

--- a/app/assets/javascripts/govuk_publishing_components/components/govspeak.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/govspeak.js
@@ -9,6 +9,7 @@
     }
 
     this.createBarcharts()
+    this.enhanceTables()
   }
 
   Govspeak.prototype.embedYoutube = function () {
@@ -18,6 +19,11 @@
 
   Govspeak.prototype.createBarcharts = function () {
     var enhancement = new window.GOVUK.GovspeakBarchartEnhancement(this.$module)
+    enhancement.init()
+  }
+
+  Govspeak.prototype.enhanceTables = function () {
+    var enhancement = new window.GOVUK.GovspeakTableEnhancement(this.$module)
     enhancement.init()
   }
 

--- a/app/assets/javascripts/govuk_publishing_components/components/modal-dialogue.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/modal-dialogue.js
@@ -42,11 +42,13 @@
   ModalDialogue.prototype.handleOpen = function (event) {
     if (event) {
       event.preventDefault()
+      this.$focusedElementBeforeOpen = event.target
+    } else {
+      this.$focusedElementBeforeOpen = document.activeElement
     }
 
     this.$html.classList.add('gem-o-template--modal')
     this.$body.classList.add('gem-o-template__body--modal')
-    this.$focusedElementBeforeOpen = document.activeElement
     this.$module.style.display = 'block'
     this.$dialogBox.focus()
 

--- a/app/assets/javascripts/govuk_publishing_components/lib/govspeak/table-enhancement.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/govspeak/table-enhancement.js
@@ -1,0 +1,76 @@
+window.GOVUK = window.GOVUK || {};
+
+(function (GOVUK) {
+  'use strict'
+
+  var TableEnhancement = function (element) {
+    this.element = element
+  }
+
+  TableEnhancement.prototype.init = function () {
+    console.log('init tables')
+    var allTables = this.element.querySelectorAll('table')
+
+    for (var j = 0; j < allTables.length; j++) {
+      const table = allTables[j]
+      // don't apply this functionality to tables already handled by charts
+      if (table.classList.contains('js-barchart-table')) {
+        continue
+      }
+      const parent = table.parentNode
+
+      // wrap the table in a div to make it easier to style
+      const wrapperId = `govspeak-table-${j}`
+      var tableWrapper = document.createElement('div')
+      tableWrapper.setAttribute('id', wrapperId)
+      tableWrapper.classList.add('js-container')
+      parent.insertBefore(tableWrapper, table)
+      tableWrapper.appendChild(table)
+
+      var tableControls = document.createElement('div')
+      tableControls.innerHTML = `
+        <button class="js-toggle-container govuk-button govuk-button--secondary" data-controls="${wrapperId}">Toggle table in popup</button>
+      `
+      parent.insertBefore(tableControls, tableWrapper)
+
+      tableControls.querySelector('.js-toggle-container').addEventListener('click', () => {
+        const target = document.getElementById(wrapperId)
+        target.classList.toggle('gem-c-govspeak-table--container')
+        if (target.classList.contains('gem-c-govspeak-table--container')) {
+          this.setMargins(target)
+        } else {
+          this.resetMargins(target)
+        }
+      })
+    }
+
+    this.resizeEvent = this.onResize.bind(this)
+    window.addEventListener('resize', this.resizeEvent)
+  }
+
+  TableEnhancement.prototype.onResize = function () {
+    clearTimeout(this.resizeTimeout)
+    this.resizeTimeout = setTimeout(function () {
+      var containers = document.querySelectorAll('.gem-c-govspeak-table--container')
+      for (var j = 0; j < containers.length; j++) {
+        this.resetMargins(containers[j])
+        this.setMargins(containers[j])
+      }
+    }.bind(this), 100)
+  }
+
+  TableEnhancement.prototype.setMargins = function (el) {
+    const bounds = el.getBoundingClientRect()
+    const docWidth = document.documentElement.clientWidth || document.body.clientWidth
+
+    el.style.marginLeft = `-${bounds.left - 1}px`
+    el.style.marginRight = `-${docWidth - bounds.left - bounds.width - 1}px`
+  }
+
+  TableEnhancement.prototype.resetMargins = function (el) {
+    el.style.marginLeft = 'auto'
+    el.style.marginRight = 'auto'
+  }
+
+  GOVUK.GovspeakTableEnhancement = TableEnhancement
+}(window.GOVUK))

--- a/app/assets/javascripts/govuk_publishing_components/lib/govspeak/table-enhancement.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/govspeak/table-enhancement.js
@@ -28,7 +28,7 @@ window.GOVUK = window.GOVUK || {};
 
       var tableControls = document.createElement('div')
       tableControls.innerHTML = `
-        <button class="js-toggle-modal govuk-button govuk-button--secondary gem-c-govspeak__table-button" data-toggle="modal" data-target="${this.modalId}" data-button="${j}">Open ${tableCaption} in a popup</button>
+        <button class="js-toggle-modal govuk-button govuk-button--secondary gem-c-govspeak__table-button" data-toggle="modal" data-button="${j}">Open ${tableCaption} in a popup</button>
       `
       const parent = table.parentNode
       parent.insertBefore(tableControls, table)

--- a/app/assets/javascripts/govuk_publishing_components/lib/govspeak/table-enhancement.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/govspeak/table-enhancement.js
@@ -1,0 +1,53 @@
+window.GOVUK = window.GOVUK || {};
+
+(function (GOVUK) {
+  'use strict'
+
+  var TableEnhancement = function (element) {
+    this.element = element
+    this.modalId = 'modal-for-tables'
+    this.modalComponent = document.getElementById(this.modalId)
+  }
+
+  TableEnhancement.prototype.init = function () {
+    window.GOVUK.vars = window.GOVUK.vars || {}
+    if (window.GOVUK.vars.govspeakTableEnhancement || !this.modalComponent || !window.GOVUK.Modules.ModalDialogue) {
+      return
+    }
+    this.allTables = document.querySelectorAll('.gem-c-govspeak table')
+    var triggerElements = []
+
+    for (var j = 0; j < this.allTables.length; j++) {
+      const table = this.allTables[j]
+      // don't apply this functionality to tables already handled by charts
+      if (table.classList.contains('js-barchart-table')) {
+        continue
+      }
+      const caption = table.querySelector('caption')
+      const tableCaption = caption ? caption.textContent : 'table'
+
+      var tableControls = document.createElement('div')
+      tableControls.innerHTML = `
+        <button class="js-toggle-modal govuk-button govuk-button--secondary gem-c-govspeak__table-button" data-toggle="modal" data-target="${this.modalId}" data-button="${j}">Open ${tableCaption} in a popup</button>
+      `
+      const parent = table.parentNode
+      parent.insertBefore(tableControls, table)
+      triggerElements.push(tableControls.querySelector('.js-toggle-modal'))
+    }
+
+    const modalContent = document.getElementById('modal-content')
+    var module = new GOVUK.Modules.ModalDialogue(this.modalComponent)
+    module.init()
+
+    triggerElements.forEach((button) => {
+      button.addEventListener('click', (e) => {
+        const table = this.allTables[button.getAttribute('data-button')]
+        modalContent.innerHTML = `<div class="gem-c-govspeak gem-c-govspeak__modal-table"><table>${table.innerHTML}</table></div>`
+        module.handleOpen(e)
+      })
+    })
+    window.GOVUK.vars.govspeakTableEnhancement = true
+  }
+
+  GOVUK.GovspeakTableEnhancement = TableEnhancement
+}(window.GOVUK))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_modal-dialogue.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_modal-dialogue.scss
@@ -14,6 +14,7 @@ $govuk-modal-wide-breakpoint: $govuk-page-width + $govuk-modal-margin * 2 + $gov
   overflow-x: hidden;
   overflow-y: scroll;
   outline: 0;
+  max-width: none !important; // stylelint-disable-line declaration-no-important
 }
 
 .gem-c-modal-dialogue__box {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_modal-dialogue.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_modal-dialogue.scss
@@ -61,6 +61,14 @@ $govuk-modal-wide-breakpoint: $govuk-page-width + $govuk-modal-margin * 2 + $gov
   }
 }
 
+.gem-c-modal-dialogue__box--full-width {
+  @include govuk-media-query($from: tablet) {
+    max-width: none;
+    margin-left: govuk-spacing(1);
+    margin-right: govuk-spacing(1);
+  }
+}
+
 .gem-c-modal-dialogue__overlay {
   position: fixed;
   top: 0;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_modal-dialogue.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_modal-dialogue.scss
@@ -141,3 +141,22 @@ $govuk-modal-wide-breakpoint: $govuk-page-width + $govuk-modal-margin * 2 + $gov
     @include govuk-focused-text;
   }
 }
+
+.gem-c-modal-dialogue--scroll-within {
+  .gem-c-modal-dialogue__box {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .gem-c-modal-dialogue__content {
+    overflow-y: scroll;
+  }
+
+  @include govuk-media-query($from: tablet) {
+    .gem-c-modal-dialogue__box {
+      max-height: 94vh;
+      margin-top: 3vh;
+      margin-bottom: 0;
+    }
+  }
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_tables.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_tables.scss
@@ -55,6 +55,23 @@
       text-align: right;
     }
   }
+
+  .gem-c-govspeak-table--container {
+    box-sizing: border-box;
+    padding: 20px;
+    padding-bottom: 0;
+    margin-bottom: 20px;
+    display: flex;
+    justify-content: center;
+    position: relative;
+    background: #ffffff;
+    box-shadow: 0 0 20px 10px rgba(0, 0, 0, 0.1);
+
+    table {
+      max-height: 75vh;
+      width: auto;
+    }
+  }
 }
 
 // Add rtl table styling when `direction: "rtl"` is set
@@ -103,6 +120,10 @@
   .gem-c-govspeak {
     table a::after {
       display: none !important; // stylelint-disable-line declaration-no-important
+    }
+
+    .gem-c-govspeak-table--container table {
+      max-height: none;
     }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_tables.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_tables.scss
@@ -55,6 +55,40 @@
       text-align: right;
     }
   }
+
+  .gem-c-govspeak-table--container {
+    box-sizing: border-box;
+    padding: 20px;
+    padding-bottom: 0;
+    margin-bottom: 20px;
+    display: flex;
+    justify-content: center;
+    position: relative;
+    background: #ffffff;
+    box-shadow: 0 0 20px 10px rgba(0, 0, 0, 0.1);
+
+    table {
+      max-height: 75vh;
+      width: auto;
+    }
+  }
+}
+
+.gem-c-govspeak__table-button {
+  display: none;
+
+  @include govuk-media-query($from: tablet) {
+    display: inline-block;
+  }
+}
+
+.gem-c-govspeak__modal-table {
+  table {
+    display: table;
+    width: auto;
+    margin-left: auto;
+    margin-right: auto;
+  }
 }
 
 // Add rtl table styling when `direction: "rtl"` is set
@@ -103,6 +137,10 @@
   .gem-c-govspeak {
     table a::after {
       display: none !important; // stylelint-disable-line declaration-no-important
+    }
+
+    .gem-c-govspeak-table--container table {
+      max-height: none;
     }
   }
 }

--- a/app/views/govuk_publishing_components/components/_govspeak.html.erb
+++ b/app/views/govuk_publishing_components/components/_govspeak.html.erb
@@ -10,6 +10,7 @@
   component_helper.add_class("js-disable-youtube") if disable_youtube_expansions
   component_helper.add_class("gem-c-govspeak--inverse") if inverse
   component_helper.add_data_attribute({ module: "govspeak" })
+  @include_modal ||= OpenStruct.new(modal_included: false)
 %>
 <%= tag.div(**component_helper.all_attributes) do %>
   <% if local_assigns.include?(:content) %>
@@ -32,4 +33,16 @@
   <% elsif block_given? %>
     <%= yield %>
   <% end %>
+<% end %>
+
+<% unless @include_modal[:modal_included] %>
+  <%= render "govuk_publishing_components/components/modal_dialogue", {
+    id: "modal-for-tables",
+    full_width: true,
+    scroll_within: true,
+    disable_module: true,
+  } do %>
+    <div id="modal-content"></div>
+  <% end %>
+  <% @include_modal[:modal_included] = true %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/_govspeak.html.erb
+++ b/app/views/govuk_publishing_components/components/_govspeak.html.erb
@@ -3,6 +3,7 @@
   local_assigns[:margin_bottom] ||= 0
   direction_class = "gem-c-govspeak--direction-#{direction}" if local_assigns.include?(:direction)
   disable_youtube_expansions = local_assigns.fetch(:disable_youtube_expansions) if local_assigns.include?(:disable_youtube_expansions)
+  omit_modal ||= false
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-govspeak govuk-govspeak")
@@ -35,7 +36,7 @@
   <% end %>
 <% end %>
 
-<% unless @include_modal[:modal_included] %>
+<% unless @include_modal[:modal_included] || omit_modal %>
   <%= render "govuk_publishing_components/components/modal_dialogue", {
     id: "modal-for-tables",
     full_width: true,

--- a/app/views/govuk_publishing_components/components/_modal_dialogue.html.erb
+++ b/app/views/govuk_publishing_components/components/_modal_dialogue.html.erb
@@ -4,6 +4,7 @@
   full_width ||= false
   scroll_within ||= false
   aria_label ||= nil
+  disable_module ||= false
   dialog_classes = ["gem-c-modal-dialogue__box"]
   dialog_classes << "gem-c-modal-dialogue__box--wide" if wide
   dialog_classes << "gem-c-modal-dialogue__box--full-width" if full_width
@@ -11,7 +12,7 @@
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-modal-dialogue")
   component_helper.add_class("gem-c-modal-dialogue--scroll-within") if scroll_within
-  component_helper.add_data_attribute({ module: "modal-dialogue" })
+  component_helper.add_data_attribute({ module: "modal-dialogue" }) unless disable_module
   component_helper.set_id(id)
 %>
 

--- a/app/views/govuk_publishing_components/components/_modal_dialogue.html.erb
+++ b/app/views/govuk_publishing_components/components/_modal_dialogue.html.erb
@@ -1,9 +1,11 @@
 <%
   id ||= "modal-dialogue-#{SecureRandom.hex(4)}"
   wide ||= false
+  full_width ||= false
   aria_label ||= nil
   dialog_classes = ["gem-c-modal-dialogue__box"]
   dialog_classes << "gem-c-modal-dialogue__box--wide" if wide
+  dialog_classes << "gem-c-modal-dialogue__box--full-width" if full_width
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-modal-dialogue")

--- a/app/views/govuk_publishing_components/components/_modal_dialogue.html.erb
+++ b/app/views/govuk_publishing_components/components/_modal_dialogue.html.erb
@@ -2,6 +2,7 @@
   id ||= "modal-dialogue-#{SecureRandom.hex(4)}"
   wide ||= false
   full_width ||= false
+  scroll_within ||= false
   aria_label ||= nil
   dialog_classes = ["gem-c-modal-dialogue__box"]
   dialog_classes << "gem-c-modal-dialogue__box--wide" if wide
@@ -9,6 +10,7 @@
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-modal-dialogue")
+  component_helper.add_class("gem-c-modal-dialogue--scroll-within") if scroll_within
   component_helper.add_data_attribute({ module: "modal-dialogue" })
   component_helper.set_id(id)
 %>

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -1065,6 +1065,7 @@ examples:
           </ol>
         </div>
   tables:
+    description: Govspeak includes the modal component, which is used with some JS in the component to display tables in a modal. The option `omit_modal` can be applied to prevent this from occurring, if required.
     data:
       block: |
         <table>

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -1068,6 +1068,28 @@ examples:
     data:
       block: |
         <table>
+          <caption>Examples of words</caption>
+          <thead>
+            <tr>
+              <th>Short</th>
+              <th>Medium</th>
+              <th>Long</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>of</td>
+              <td>basket</td>
+              <td>unintelligable</td>
+            </tr>
+            <tr>
+              <td>in</td>
+              <td>splendid</td>
+              <td>utterances</td>
+            </tr>
+          </tbody>
+        </table>
+        <table>
           <caption>A table with data</caption>
           <thead>
             <tr>

--- a/app/views/govuk_publishing_components/components/docs/modal_dialogue.yml
+++ b/app/views/govuk_publishing_components/components/docs/modal_dialogue.yml
@@ -119,3 +119,27 @@ examples:
           <p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet fringilla dictum. Morbi at vehicula augue. Pellentesque varius orci et augue pellentesque, sed elementum massa posuere. Curabitur egestas consectetur arcu, in porta lorem sagittis eu. Nulla facilisi. Sed scelerisque ligula lectus. Nulla et ligula a eros laoreet lacinia nec et ipsum. Ut sagittis sapien est, ut blandit risus laoreet at. Vestibulum vitae erat sed dolor ultricies efficitur.</p>
           <p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet fringilla dictum. Morbi at vehicula augue. Pellentesque varius orci et augue pellentesque, sed elementum massa posuere. Curabitur egestas consectetur arcu, in porta lorem sagittis eu. Nulla facilisi. Sed scelerisque ligula lectus. Nulla et ligula a eros laoreet lacinia nec et ipsum. Ut sagittis sapien est, ut blandit risus laoreet at. Vestibulum vitae erat sed dolor ultricies efficitur.</p>
           <p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet fringilla dictum. Morbi at vehicula augue. Pellentesque varius orci et augue pellentesque, sed elementum massa posuere. Curabitur egestas consectetur arcu, in porta lorem sagittis eu. Nulla facilisi. Sed scelerisque ligula lectus. Nulla et ligula a eros laoreet lacinia nec et ipsum. Ut sagittis sapien est, ut blandit risus laoreet at. Vestibulum vitae erat sed dolor ultricies efficitur.</p>
+
+  scroll_within_modal:
+    description: |
+      Keeps the modal header always visible at the top of the screen, by making the scroll within the modal instead of outside.
+    embed: |
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Open modal with scroll",
+        data_attributes: {
+          toggle: "modal",
+          target: "modal-with-scroll"
+          }
+        } %>
+      <%= component %>
+    data:
+      id: modal-with-scroll
+      scroll_within: true
+      block: |
+        <h1 class="govuk-heading-l">Modal title</h1>
+          <p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet fringilla dictum. Morbi at vehicula augue. Pellentesque varius orci et augue pellentesque, sed elementum massa posuere. Curabitur egestas consectetur arcu, in porta lorem sagittis eu. Nulla facilisi. Sed scelerisque ligula lectus. Nulla et ligula a eros laoreet lacinia nec et ipsum. Ut sagittis sapien est, ut blandit risus laoreet at. Vestibulum vitae erat sed dolor ultricies efficitur.</p>
+          <p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet fringilla dictum. Morbi at vehicula augue. Pellentesque varius orci et augue pellentesque, sed elementum massa posuere. Curabitur egestas consectetur arcu, in porta lorem sagittis eu. Nulla facilisi. Sed scelerisque ligula lectus. Nulla et ligula a eros laoreet lacinia nec et ipsum. Ut sagittis sapien est, ut blandit risus laoreet at. Vestibulum vitae erat sed dolor ultricies efficitur.</p>
+          <p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet fringilla dictum. Morbi at vehicula augue. Pellentesque varius orci et augue pellentesque, sed elementum massa posuere. Curabitur egestas consectetur arcu, in porta lorem sagittis eu. Nulla facilisi. Sed scelerisque ligula lectus. Nulla et ligula a eros laoreet lacinia nec et ipsum. Ut sagittis sapien est, ut blandit risus laoreet at. Vestibulum vitae erat sed dolor ultricies efficitur.</p>
+          <p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet fringilla dictum. Morbi at vehicula augue. Pellentesque varius orci et augue pellentesque, sed elementum massa posuere. Curabitur egestas consectetur arcu, in porta lorem sagittis eu. Nulla facilisi. Sed scelerisque ligula lectus. Nulla et ligula a eros laoreet lacinia nec et ipsum. Ut sagittis sapien est, ut blandit risus laoreet at. Vestibulum vitae erat sed dolor ultricies efficitur.</p>
+          <p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet fringilla dictum. Morbi at vehicula augue. Pellentesque varius orci et augue pellentesque, sed elementum massa posuere. Curabitur egestas consectetur arcu, in porta lorem sagittis eu. Nulla facilisi. Sed scelerisque ligula lectus. Nulla et ligula a eros laoreet lacinia nec et ipsum. Ut sagittis sapien est, ut blandit risus laoreet at. Vestibulum vitae erat sed dolor ultricies efficitur.</p>
+          <p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet fringilla dictum. Morbi at vehicula augue. Pellentesque varius orci et augue pellentesque, sed elementum massa posuere. Curabitur egestas consectetur arcu, in porta lorem sagittis eu. Nulla facilisi. Sed scelerisque ligula lectus. Nulla et ligula a eros laoreet lacinia nec et ipsum. Ut sagittis sapien est, ut blandit risus laoreet at. Vestibulum vitae erat sed dolor ultricies efficitur.</p>

--- a/app/views/govuk_publishing_components/components/docs/modal_dialogue.yml
+++ b/app/views/govuk_publishing_components/components/docs/modal_dialogue.yml
@@ -59,6 +59,24 @@ examples:
       block: |
         <h1 class="govuk-heading-l">Modal title</h1>
           <p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet fringilla dictum. Morbi at vehicula augue. Pellentesque varius orci et augue pellentesque, sed elementum massa posuere. Curabitur egestas consectetur arcu, in porta lorem sagittis eu. Nulla facilisi. Sed scelerisque ligula lectus. Nulla et ligula a eros laoreet lacinia nec et ipsum. Ut sagittis sapien est, ut blandit risus laoreet at. Vestibulum vitae erat sed dolor ultricies efficitur.</p>
+  full_width:
+    description: |
+      A full width version of the modal dialogue will (nearly) match the entire width of the screen.
+    embed: |
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Full width modal",
+        data_attributes: {
+          toggle: "modal",
+          target: "modal-full-width"
+        }
+      } %>
+      <%= component %>
+    data:
+      id: modal-full-width
+      full_width: true
+      block: |
+        <h1 class="govuk-heading-l">Modal title</h1>
+          <p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet fringilla dictum. Morbi at vehicula augue. Pellentesque varius orci et augue pellentesque, sed elementum massa posuere. Curabitur egestas consectetur arcu, in porta lorem sagittis eu. Nulla facilisi. Sed scelerisque ligula lectus. Nulla et ligula a eros laoreet lacinia nec et ipsum. Ut sagittis sapien est, ut blandit risus laoreet at. Vestibulum vitae erat sed dolor ultricies efficitur.</p>
   with_form:
     description: |
       Modal dialogue with form elements inside to show how it prevents tabbing to outside the dialogue when open while preserving the tabindex on focusable elements

--- a/app/views/govuk_publishing_components/components/docs/modal_dialogue.yml
+++ b/app/views/govuk_publishing_components/components/docs/modal_dialogue.yml
@@ -143,3 +143,20 @@ examples:
           <p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet fringilla dictum. Morbi at vehicula augue. Pellentesque varius orci et augue pellentesque, sed elementum massa posuere. Curabitur egestas consectetur arcu, in porta lorem sagittis eu. Nulla facilisi. Sed scelerisque ligula lectus. Nulla et ligula a eros laoreet lacinia nec et ipsum. Ut sagittis sapien est, ut blandit risus laoreet at. Vestibulum vitae erat sed dolor ultricies efficitur.</p>
           <p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet fringilla dictum. Morbi at vehicula augue. Pellentesque varius orci et augue pellentesque, sed elementum massa posuere. Curabitur egestas consectetur arcu, in porta lorem sagittis eu. Nulla facilisi. Sed scelerisque ligula lectus. Nulla et ligula a eros laoreet lacinia nec et ipsum. Ut sagittis sapien est, ut blandit risus laoreet at. Vestibulum vitae erat sed dolor ultricies efficitur.</p>
           <p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet fringilla dictum. Morbi at vehicula augue. Pellentesque varius orci et augue pellentesque, sed elementum massa posuere. Curabitur egestas consectetur arcu, in porta lorem sagittis eu. Nulla facilisi. Sed scelerisque ligula lectus. Nulla et ligula a eros laoreet lacinia nec et ipsum. Ut sagittis sapien est, ut blandit risus laoreet at. Vestibulum vitae erat sed dolor ultricies efficitur.</p>
+  disable_module:
+    description: Prevents the component JavaScript from initialising on page load, allowing other JavaScript to do this manually. Needed for when modals are used to display the contents of govspeak tables.
+    embed: |
+      <%= render "govuk_publishing_components/components/button", {
+        text: "This shouldn't do anything",
+        data_attributes: {
+          toggle: "modal",
+          target: "modal-disabled"
+        }
+      } %>
+      <%= component %>
+    data:
+      id: modal-disabled
+      disable_module: true
+      block: |
+        <h1 class="govuk-heading-l">Modal title</h1>
+        <p class="govuk-body">Lorem.</p>

--- a/spec/component_guide/component_index_spec.rb
+++ b/spec/component_guide/component_index_spec.rb
@@ -67,6 +67,7 @@ describe "Component guide index", :capybara do
 @import 'govuk_publishing_components/components/layout-for-public';
 @import 'govuk_publishing_components/components/layout-header';
 @import 'govuk_publishing_components/components/layout-super-navigation-header';
+@import 'govuk_publishing_components/components/modal-dialogue';
 @import 'govuk_publishing_components/components/phase-banner';
 @import 'govuk_publishing_components/components/print-link';
 @import 'govuk_publishing_components/components/related-navigation';
@@ -100,6 +101,7 @@ describe "Component guide index", :capybara do
 //= require govuk_publishing_components/components/govspeak
 //= require govuk_publishing_components/components/layout-header
 //= require govuk_publishing_components/components/layout-super-navigation-header
+//= require govuk_publishing_components/components/modal-dialogue
 //= require govuk_publishing_components/components/print-link
 //= require govuk_publishing_components/components/search-with-autocomplete
 //= require govuk_publishing_components/components/service-navigation

--- a/spec/components/checkboxes_spec.rb
+++ b/spec/components/checkboxes_spec.rb
@@ -479,6 +479,7 @@ describe "Checkboxes", type: :view do
       description: render(
         "govuk_publishing_components/components/govspeak",
         content: "<p>This is a description about skittles.</p>".html_safe,
+        omit_modal: true,
       ),
       items: [
         { label: "Red", value: "red" },

--- a/spec/components/govspeak_spec.rb
+++ b/spec/components/govspeak_spec.rb
@@ -10,6 +10,7 @@ describe "Govspeak", type: :view do
       content: "<h1>content</h1>".html_safe,
     )
     assert_select ".gem-c-govspeak h1", text: "content"
+    assert_select ".gem-c-modal-dialogue"
   end
 
   it "renders inverse content correctly" do
@@ -60,5 +61,14 @@ describe "Govspeak", type: :view do
     end
 
     expect(rendered).to include("content-via-block")
+  end
+
+  it "does not include the modal" do
+    render_component(
+      content: "<h1>content</h1>".html_safe,
+      omit_modal: true,
+    )
+
+    assert_select ".gem-c-modal-dialogue", false
   end
 end

--- a/spec/components/modal_dialogue_spec.rb
+++ b/spec/components/modal_dialogue_spec.rb
@@ -21,6 +21,14 @@ describe "Modal dialogue", type: :view do
     assert_select ".gem-c-modal-dialogue__box.gem-c-modal-dialogue__box--wide", count: 1
   end
 
+  it "applies modifier class to the full width modal" do
+    render_component(id: "my-modal", full_width: true) do
+      "Content"
+    end
+
+    assert_select ".gem-c-modal-dialogue__box.gem-c-modal-dialogue__box--full-width", count: 1
+  end
+
   it "applies aria-label to the dialog element" do
     render_component(id: "my-modal", aria_label: "My modal") do
       "Content"

--- a/spec/components/modal_dialogue_spec.rb
+++ b/spec/components/modal_dialogue_spec.rb
@@ -10,6 +10,7 @@ describe "Modal dialogue", type: :view do
       "Content"
     end
 
+    assert_select ".gem-c-modal-dialogue[data-module='modal-dialogue']"
     assert_select ".gem-c-modal-dialogue__content", text: "Content"
   end
 
@@ -43,5 +44,14 @@ describe "Modal dialogue", type: :view do
     end
 
     assert_select ".gem-c-modal-dialogue.gem-c-modal-dialogue--scroll-within", count: 1
+  end
+
+  it "can disable the JavaScript module from starting" do
+    render_component(id: "my-modal", disable_module: true) do
+      "Content"
+    end
+
+    assert_select ".gem-c-modal-dialogue"
+    assert_select ".gem-c-modal-dialogue[data-module='modal-dialogue']", false
   end
 end

--- a/spec/components/modal_dialogue_spec.rb
+++ b/spec/components/modal_dialogue_spec.rb
@@ -36,4 +36,12 @@ describe "Modal dialogue", type: :view do
 
     assert_select '.gem-c-modal-dialogue__box[aria-label="My modal"]'
   end
+
+  it "applies modifier class to the scroll within modal" do
+    render_component(id: "my-modal", scroll_within: true) do
+      "Content"
+    end
+
+    assert_select ".gem-c-modal-dialogue.gem-c-modal-dialogue--scroll-within", count: 1
+  end
 end

--- a/spec/components/radio_spec.rb
+++ b/spec/components/radio_spec.rb
@@ -639,6 +639,7 @@ describe "Radio", type: :view do
       description: render(
         "govuk_publishing_components/components/govspeak",
         content: "<p>This is a description about skittles.</p>".html_safe,
+        omit_modal: true,
       ),
       items: [
         { label: "Red", value: "red" },

--- a/spec/javascripts/govuk_publishing_components/lib/govspeak/table-enhancement-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/govspeak/table-enhancement-spec.js
@@ -143,11 +143,15 @@ describe('Table enhancement', function () {
       expect(document.querySelector('.gem-c-modal-dialogue').style.display).toEqual('block')
 
       modalClose.click()
+      expect(document.activeElement).toEqual(buttons[0])
       expect(document.querySelector('.gem-c-modal-dialogue').style.display).toEqual('none')
 
       buttons[1].click()
       expect(modalContents.textContent).toContain('Neck')
       expect(document.querySelector('.gem-c-modal-dialogue').style.display).toEqual('block')
+
+      modalClose.click()
+      expect(document.activeElement).toEqual(buttons[1])
     })
   })
 })

--- a/spec/javascripts/govuk_publishing_components/lib/govspeak/table-enhancement-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/govspeak/table-enhancement-spec.js
@@ -1,0 +1,153 @@
+/* eslint-env jasmine */
+/* global GOVUK */
+
+describe('Table enhancement', function () {
+  'use strict'
+
+  var element
+  var modalElement
+  var modal = `
+    <div id="modal-for-tables" class="gem-c-modal-dialogue gem-c-modal-dialogue--scroll-within">
+      <div class="gem-c-modal-dialogue__overlay"></div>
+      <dialog class="gem-c-modal-dialogue__box gem-c-modal-dialogue__box--full-width" aria-modal="true">
+        <div class="gem-c-modal-dialogue__header"></div>
+        <div class="gem-c-modal-dialogue__content">
+          <div id="modal-content"></div>
+        </div>
+        <button class="gem-c-modal-dialogue__close-button" aria-label="Close modal dialogue">×</button>
+      </dialog>
+    </div>
+  `
+  var simpleTable = `
+    <table>
+      <tr>
+        <th>Fruit</th>
+        <th>Veg</th>
+      </tr>
+      <tr>
+        <td>Strawberry</td>
+        <td>Carrot</td>
+      </tr>
+    </table>
+  `
+
+  var tableWithCaption = `
+    <table>
+      <caption>Random names</caption>
+      <tr>
+        <th>First name</th>
+        <th>Surname</th>
+      </tr>
+      <tr>
+        <td>Jeff</td>
+        <td>Neck</td>
+      </tr>
+    </table>
+  `
+
+  function addTable (table) {
+    element = document.createElement('div')
+    element.classList.add('gem-c-govspeak')
+    element.innerHTML = table
+    document.body.appendChild(element)
+    new GOVUK.GovspeakTableEnhancement(element).init()
+  }
+
+  function addModal () {
+    modalElement = document.createElement('div')
+    modalElement.innerHTML = modal
+    document.body.appendChild(modalElement)
+  }
+
+  afterEach(function () {
+    window.GOVUK.vars.govspeakTableEnhancement = false
+    element.remove()
+    if (modalElement) {
+      modalElement.remove()
+    }
+  })
+
+  describe('when the modal is not present', function () {
+    beforeEach(function () {
+      addTable(simpleTable)
+    })
+
+    it('does not initialise', function () {
+      const buttons = element.querySelectorAll('.js-toggle-modal')
+      expect(buttons.length).toBe(0)
+    })
+  })
+
+  describe('when the code should initialise', function () {
+    beforeEach(function () {
+      addModal()
+      addTable(simpleTable)
+    })
+
+    it('adds a button to open the modal', function () {
+      const buttons = element.querySelectorAll('.js-toggle-modal')
+      expect(buttons.length).toBe(1)
+      expect(buttons[0].textContent).toBe('Open table in a popup')
+    })
+
+    describe('when the button is clicked', function () {
+      beforeEach(function () {
+        const button = element.querySelector('.js-toggle-modal')
+        button.click()
+      })
+
+      it('adds the table into the modal', function () {
+        const modalContents = document.getElementById('modal-content')
+        expect(modalContents.textContent).toContain('Strawberry')
+      })
+
+      it('opens the modal', function () {
+        expect(document.querySelector('.gem-c-modal-dialogue').style.display).toEqual('block')
+      })
+    })
+  })
+
+  describe('when the table has a caption', function () {
+    beforeEach(function () {
+      addModal()
+      addTable(tableWithCaption)
+    })
+
+    it('includes the table caption in the button', function () {
+      const buttons = element.querySelectorAll('.js-toggle-modal')
+      expect(buttons.length).toBe(1)
+      expect(buttons[0].textContent).toBe('Open Random names in a popup')
+    })
+  })
+
+  describe('when there are multiple tables', function () {
+    beforeEach(function () {
+      addModal()
+      addTable(`${simpleTable} ${tableWithCaption}`)
+    })
+
+    it('adds buttons to open the modal', function () {
+      const buttons = element.querySelectorAll('.js-toggle-modal')
+      expect(buttons.length).toBe(2)
+      expect(buttons[0].textContent).toBe('Open table in a popup')
+      expect(buttons[1].textContent).toBe('Open Random names in a popup')
+    })
+
+    it('opens the right modal with each button', function () {
+      const modalContents = document.getElementById('modal-content')
+      const modalClose = document.querySelector('.gem-c-modal-dialogue__close-button')
+      const buttons = element.querySelectorAll('.js-toggle-modal')
+
+      buttons[0].click()
+      expect(modalContents.textContent).toContain('Strawberry')
+      expect(document.querySelector('.gem-c-modal-dialogue').style.display).toEqual('block')
+
+      modalClose.click()
+      expect(document.querySelector('.gem-c-modal-dialogue').style.display).toEqual('none')
+
+      buttons[1].click()
+      expect(modalContents.textContent).toContain('Neck')
+      expect(document.querySelector('.gem-c-modal-dialogue').style.display).toEqual('block')
+    })
+  })
+})


### PR DESCRIPTION
## What
Adds a JS generated button above each occurrence of a table inside govspeak, that allows the contents of that table to be viewed in a modal component. It works like this:

- include the modal component in the govspeak component, but don't initialise it
- only include the modal component once on the page
- loop through any tables in the govspeak and add a button above each of them to open in a popup
- add a click event listener to copy the contents of that buttons table into the modal then open the modal
- buttons not shown on mobile as not really useful there

Also adds a few new options to the modal component to support this:

- `full_width` allows the modal to be the width of the window (there was already a wide option but it only goes as wide as the `govuk-width-container`)
- `scroll_within` allows the bar with the modal close button to always remain at the top, so if you've scrolled to the bottom of a table you don't have to scroll up again to close it
- `disable_module` turns off automatic initialisation of the modal component JS, which is needed in this instance

Some things still to think about...

- currently no detection for whether each specific table needs it or not, there are plenty of tables that fit fine and this would be unnecessary for (although maybe that's a good thing as it would highlight [poor table use](https://www.gov.uk/government/news/vacancies-at-the-british-hallmarking-council))

## Why
Trying something out while thinking about https://github.com/alphagov/govuk_publishing_components/issues/5122

## Visual Changes

Example of new button added before each table. Note that if the table has a caption this is used to make the button text unique (otherwise it just says 'open table in a popup', which is unfortunately what most tables will see).

<img width="1027" height="974" alt="Screenshot 2026-06-19 at 12 12 59" src="https://github.com/user-attachments/assets/12f474b5-0a65-4517-800f-bd7fe98aa81d" />
