### PR TITLE
[DO NOT MERGE] Limit govspeak table heights

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_tables.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_tables.scss
@@ -12,9 +12,24 @@
     border-spacing: 0;
     display: block;
     margin: 0 0 govuk-spacing(6) 0;
-    overflow-x: auto;
+    overflow-x: scroll;
+    overflow-y: scroll;
     width: 100%;
+    max-height: 75vh;
     @include govuk-font($size: 19);
+
+    &::-webkit-scrollbar {
+      -webkit-appearance: none;
+      width: 20px;
+      background-color: #fafafa;
+      border: solid 1px #e7e7e7;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      border-radius: 4px;
+      background-color: #c2c2c2;
+      -webkit-box-shadow: 0 0 1px rgba(255, 255, 255, .5);
+    }
 
     caption {
       text-align: left;
@@ -101,8 +116,14 @@
 @include govuk-media-query($media-type: print) {
   .govspeak,
   .gem-c-govspeak {
-    table a::after {
-      display: none !important; // stylelint-disable-line declaration-no-important
+    table {
+      max-height: none;
+      overflow-x: auto;
+      overflow-y: auto;
+
+      a::after {
+        display: none !important; // stylelint-disable-line declaration-no-important
+      }
     }
   }
 }


### PR DESCRIPTION
## What
Limits the height of tables within govspeak to within the screen height.

On some browsers/hardware combinations scrollbars do not appear by default, notably iOS touch devices. This is already a problem for some existing tables where the width exceeds the page width. 

So we set overflow to scroll to force some browsers to display the scrollbar (downside - it will always be visible even if scroll is not needed). We also style the scrollbar using `webkit-scrollbar` pseudo selectors. This ensures the scrollbars appear for a few more browsers (including Chrome on iOS desktop).

You can also use [scrollbar-width](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/scrollbar-width) and [scrollbar-color](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/scrollbar-color) but these seem to both override the webkit selectors, and then be ignored by those devices (so the scrollbars don't appear anyway). Better to go for the option that displays the scrollbars on the most browsers.

The webkit scrollbars are styled to match scrollbars on other browsers although we take the opportunity to increase their width. Oddly this only seems to apply to the vertical scrollbar, but it makes it easier to use.

Note that this PR includes consideration for print styles, which would be effected by this change.

## Why
Many tables are too wide to fit on a screen. If they are also too tall, users cannot see the scrollbar as it is at the bottom of the table. This change forces the table to be no taller than the screen, so users can more easily see the scrollbar along the bottom, if it exists.

Doing some thinking around https://github.com/alphagov/govuk_publishing_components/issues/5122

## Visual Changes
Firefox.

Before | After
---- | -----
<img width="788" height="1008" alt="Screenshot 2026-04-22 at 13 41 09" src="https://github.com/user-attachments/assets/d6dd98d2-863c-4a82-94ad-39c57b8a3c3f" /> | <img width="735" height="1010" alt="Screenshot 2026-04-22 at 13 41 19" src="https://github.com/user-attachments/assets/fd12877c-bf37-41cc-b142-6a68cb1a3979" />

Chrome (desktop)
Before | After
---- | -----
<img width="861" height="1319" alt="Screenshot 2026-04-22 at 13 42 25" src="https://github.com/user-attachments/assets/df11d63b-92d1-4b2d-a740-1cc3fc1a4f76" /> | <img width="873" height="1328" alt="Screenshot 2026-04-22 at 13 42 33" src="https://github.com/user-attachments/assets/0f7c24af-4f7c-41c8-8aa4-44db6c012907" />

iPhone (still doesn't work, but we have the scroll right/width problem already)

<img width="629" height="1184" alt="Screenshot 2026-04-22 at 13 45 35" src="https://github.com/user-attachments/assets/f1062c60-0f31-4a8f-9e42-f1055a313f76" />
