### PR TITLE
Release version 66.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 66.0.0
 
 * Change feedback component styles ([PR #5382](https://github.com/alphagov/govuk_publishing_components/pull/5382))
 * **BREAKING** Reduce calls to window.GOVUK ([PR #5360](https://github.com/alphagov/govuk_publishing_components/pull/5360))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (65.2.2)
+    govuk_publishing_components (66.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "65.2.2".freeze
+  VERSION = "66.0.0".freeze
 end


### PR DESCRIPTION
## 66.0.0

* Change feedback component styles ([PR #5382](https://github.com/alphagov/govuk_publishing_components/pull/5382))
* **BREAKING** Reduce calls to window.GOVUK ([PR #5360](https://github.com/alphagov/govuk_publishing_components/pull/5360))
* Drop support for Ruby 3.2 ([PR #5296](https://github.com/alphagov/govuk_publishing_components/pull/5296))