### PR TITLE
Improve applications page layout

### DIFF
--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -482,6 +482,13 @@ $code-delete-bg: #fadddd;
   container-name: page;
 }
 
+.table-wrapper {
+  .govuk-table {
+    display: block;
+    overflow-x: scroll;
+  }
+}
+
 @container page (width > 1040px) {
   $w: 960px;
 
@@ -493,6 +500,13 @@ $code-delete-bg: #fadddd;
     margin-right: calc(((-100cqw + $w) / 2) - 1px);
     background: #ffffff;
     padding: 15px;
+
+    .govuk-table {
+      width: auto;
+      display: table;
+      margin-left: auto;
+      margin-right: auto;
+    }
   }
 }
 

--- a/app/controllers/govuk_publishing_components/applications_page_controller.rb
+++ b/app/controllers/govuk_publishing_components/applications_page_controller.rb
@@ -4,7 +4,7 @@ module GovukPublishingComponents
       applications = [
         {
           type: "public-facing",
-          apps: %w[collections email-alert-frontend feedback finder-frontend frontend smart-answers].sort,
+          apps: %w[collections email-alert-frontend feedback finder-frontend frontend govuk_publishing_components smart-answers].sort,
         },
         {
           type: "publishing",

--- a/app/views/govuk_publishing_components/applications_page/show.html.erb
+++ b/app/views/govuk_publishing_components/applications_page/show.html.erb
@@ -1,4 +1,5 @@
 <% content_for :title, "Applications consistency" %>
+<% content_for :body_classes, "table-container" %>
 
 <%= render "govuk_publishing_components/components/back_link", {
   href: "/component-guide",
@@ -16,22 +17,24 @@
 <% end %>
 
 <div data-module="filter-list">
-  <table class="govuk-table">
-    <thead class="govuk-table__head">
-      <tr class="govuk-table__row">
-        <th scope="col" class="govuk-table__header sticky-table-header">Application</th>
-        <th scope="col" class="govuk-table__header sticky-table-header">Type</th>
-        <th scope="col" class="govuk-table__header sticky-table-header">Source</th>
-        <th scope="col" class="govuk-table__header sticky-table-header">Gem version</th>
-        <th scope="col" class="govuk-table__header sticky-table-header">Sass version</th>
-        <th scope="col" class="govuk-table__header sticky-table-header">Ruby version</th>
-        <th scope="col" class="govuk-table__header sticky-table-header">Yarn version</th>
-      </tr>
-    </thead>
-    <tbody class="govuk-table__body">
-      <%= render "table-content", content: @applications_output.select { |a| a[:type] == "public-facing" }, type: "Public facing" %>
-      <%= render "table-content", content: @applications_output.select { |a| a[:type] == "publishing" }, type: "Publishing" %>
-      <%= render "table-content", content: @applications_output.select { |a| a[:type] == "utility" }, type: "Utility" %>
-    </tbody>
-  </table>
+  <div class="table-wrapper">
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header sticky-table-header">Application</th>
+          <th scope="col" class="govuk-table__header sticky-table-header">Type</th>
+          <th scope="col" class="govuk-table__header sticky-table-header">Source</th>
+          <th scope="col" class="govuk-table__header sticky-table-header">Gem version</th>
+          <th scope="col" class="govuk-table__header sticky-table-header">Sass version</th>
+          <th scope="col" class="govuk-table__header sticky-table-header">Ruby version</th>
+          <th scope="col" class="govuk-table__header sticky-table-header">Yarn version</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <%= render "table-content", content: @applications_output.select { |a| a[:type] == "public-facing" }, type: "Public facing" %>
+        <%= render "table-content", content: @applications_output.select { |a| a[:type] == "publishing" }, type: "Publishing" %>
+        <%= render "table-content", content: @applications_output.select { |a| a[:type] == "utility" }, type: "Utility" %>
+      </tbody>
+    </table>
+  </div>
 </div>


### PR DESCRIPTION
## What / why
Small improvements to the applications status page:

- add `govuk_publishing_components` to the list of applications, so we can also see what versions of Ruby etc. the gem itself is using
- use the expanding table styles from the auditing pages here as well, and improve them

## Visual Changes
Before

<img width="1524" height="613" alt="Screenshot 2026-04-21 at 10 50 21" src="https://github.com/user-attachments/assets/8df1e67a-f4aa-4f02-950f-0417b9e38a3a" />

After

<img width="1524" height="583" alt="Screenshot 2026-04-21 at 10 50 31" src="https://github.com/user-attachments/assets/e8865d4d-e193-4747-9fbc-1edda4fb19ed" />
