### PR TITLE
Add default cooldown to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,17 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3
   - package-ecosystem: npm
     directory: "/"
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
I haven't specified exclusions for internal dependencies, as I expect these will generally not be immediately urgent on this repo. It's easily tweaked at a later date if deemed necessary.

I haven't changed the [version update schedule to the suggested monthly](https://docs.publishing.service.gov.uk/manual/manage-dependencies.html#schedule-and-cooldown) because I am not usually involved with maintaining this repo. It might be worth picking up though (or I can change this PR if it would be useful)

NB security updates are not affected by dependabot cooldown configuration.