### PR TITLE
Set `--ignore-scripts true`

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+--ignore-scripts true


### PR DESCRIPTION
## What
Stops post install scripts from running - https://classic.yarnpkg.com/en/docs/cli/install#toc-yarn-install-ignore-scripts

This is the default behaviour in Yarn v4 (Modern) - https://yarnpkg.com/configuration/yarnrc#enableScripts, adding the same rule for Yarn Classic currently used in this repo.