### PR TITLE
Remove reliance on CGI.parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Remove reliance on CGI.parse ([PR #5424](https://github.com/alphagov/govuk_publishing_components/pull/5424))
+
 ## 66.0.0
 
 * Change feedback component styles ([PR #5382](https://github.com/alphagov/govuk_publishing_components/pull/5382))

--- a/lib/govuk_publishing_components/presenters/step_by_step_nav_helper.rb
+++ b/lib/govuk_publishing_components/presenters/step_by_step_nav_helper.rb
@@ -107,8 +107,8 @@ module GovukPublishingComponents
         return href if step_nav_content_id.blank?
 
         uri = URI.parse(href)
-        exisiting_query_params = uri.query.present? ? CGI.parse(uri.query) : {}
-        new_query_params = exisiting_query_params.merge("step-by-step-nav" => step_nav_content_id)
+        existing_query_params = uri.query.present? ? CGI.parse(uri.query) : {}
+        new_query_params = existing_query_params.merge("step-by-step-nav" => step_nav_content_id)
         uri.query = new_query_params.to_query
         uri.to_s
       end

--- a/lib/govuk_publishing_components/presenters/step_by_step_nav_helper.rb
+++ b/lib/govuk_publishing_components/presenters/step_by_step_nav_helper.rb
@@ -107,7 +107,7 @@ module GovukPublishingComponents
         return href if step_nav_content_id.blank?
 
         uri = URI.parse(href)
-        existing_query_params = uri.query.present? ? CGI.parse(uri.query) : {}
+        existing_query_params = uri.query.present? ? Hash[URI.decode_www_form(uri.query)] : {}
         new_query_params = existing_query_params.merge("step-by-step-nav" => step_nav_content_id)
         uri.query = new_query_params.to_query
         uri.to_s

--- a/spec/lib/govuk_publishing_components/presenters/step_by_step_nav_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/step_by_step_nav_helper_spec.rb
@@ -64,5 +64,13 @@ RSpec.describe GovukPublishingComponents::Presenters::StepByStepNavHelper do
 
       expect(list).to eql('<ol class="gem-c-step-nav__list " data-length="2"><li class="gem-c-step-nav__list-item js-list-item "><a data-position="1.1" class="gem-c-step-nav__link js-link" href="/link1?step-by-step-nav=this-is-an-id">Link 1 </a></li><li class="gem-c-step-nav__list-item js-list-item gem-c-step-nav__list-item--active"><a data-position="1.2" class="gem-c-step-nav__link js-link" href="#content"><span class="gem-c-step-nav__link-active-context visuallyhidden">You are currently viewing: </span>Link 2 </a></li></ol>')
     end
+
+    it "generates a basic list when there are already query params" do
+      contents = [{ text: "Link 1", href: "/link1?existing=url-param&another=one" }]
+      options = { link_index: 0, step_index: 0, step_nav_content_id: "this-is-an-id" }
+      list = step_helper.render_step_nav_element({ type: "list", contents: }, options)
+
+      expect(list).to eql('<ol class="gem-c-step-nav__list " data-length="1"><li class="gem-c-step-nav__list-item js-list-item "><a data-position="1.1" class="gem-c-step-nav__link js-link" href="/link1?another=one&amp;existing=url-param&amp;step-by-step-nav=this-is-an-id">Link 1 </a></li></ol>')
+    end
   end
 end


### PR DESCRIPTION
## What
Remove code relying on `CGI.parse` as it has been removed from Ruby 4.

It was used in the step nav helper. The helper outputs links in the step nav component and appends the ID of the current step nav onto those links as URL params, e.g. `gov.uk/page?step-by-step-nav=ehc6wjf7fgsi`

To do this correctly the method first checks for existing URL params, so that it doesn't omit or break them when appending the new one. It's not clear where this occurred (very few GOV.UK pages include URL params outside of step by step navs) but it's possible they could occur so this seems like valid checking (maybe step navs could contain links to search pages, which could have URL params).

There wasn't a test in place for this so I've added one, and it turns out that when using `CGI.parse` it didn't quite work correctly - the resulting object contained attributes of single strings in arrays, instead of single strings, which when output included `%5B%5D` (which is `[]` when encoded for URLs) e.g. `href=\"/link1?another%5B%5D=one&amp;existing%5B%5D=url-param`.

This behaviour has now been corrected. Note that the link converts `&` characters into `&amp;` but browsers correctly interpret this as `&`.

## Why
We want to upgrade to Ruby 4 at some point and this was preventing that.

Fixes https://github.com/alphagov/govuk_publishing_components/issues/5423

## Visual Changes
None.
