### PR TITLE
Fix error in `Ga4FormTracker`

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
@@ -126,13 +126,13 @@
       } else if (elem.checked) {
         var fieldset = elem.closest('fieldset') || null
 
-        if (fieldset.dataset.ga4Redact && !elem.dataset.ga4RedactPermit) {
-          input.answer = '[REDACTED]'
-        } else {
-          input.answer = labelText
-        }
-
         if (fieldset) {
+          if (fieldset.dataset.ga4Redact && !elem.dataset.ga4RedactPermit) {
+            input.answer = '[REDACTED]'
+          } else {
+            input.answer = labelText
+          }
+
           var legend = fieldset.querySelector('legend')
 
           if (legend) {


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

Prevent a check of `dataset` of `fieldset` if `fieldset` is `null`.

## Why

Was resulting in an error preventing form submit being tracked on specific pages without `fieldset` in a tracked `form`.