### PR TITLE
Expand output in rspec failures

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,10 @@ end
 WebMock.disable_net_connect!(allow_localhost: true)
 
 RSpec.configure do |config|
+  config.expect_with :rspec do |c|
+    c.max_formatted_output_length = nil
+  end
+
   config.example_status_persistence_file_path = "tmp/failures.txt"
 
   config.filter_run_excluding not_applicable: true, visual_regression: true


### PR DESCRIPTION
## What
Modify spec helper to output the full diff when an RSpec test fails.

## Why
If the outputted value for `expected` or `got` exceeds a certain number of characters it is automatically truncated. This means that for large diffs it is sometimes impossible to see what is actually different. This change removes that restriction so that the full diff is always shown.

## Visual Changes
Before (note how the expected/got at the bottom of the screenshot are shorter and the middle contracts to `..`)

<img width="1768" height="265" alt="Screenshot 2026-04-27 at 08 40 26" src="https://github.com/user-attachments/assets/d09887e0-37fb-4b13-81d3-aab240473daf" />

After - full expected/got are output

<img width="1768" height="372" alt="Screenshot 2026-04-27 at 08 44 29" src="https://github.com/user-attachments/assets/e223835d-ca1a-4bba-99a8-299ab8acd93e" />
