### PR TITLE
Remove the line that resets the LUX data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Remove reliance on CGI.parse ([PR #5424](https://github.com/alphagov/govuk_publishing_components/pull/5424))
+* Remove the line that resets the LUX data ([PR #5427](https://github.com/alphagov/govuk_publishing_components/pull/5427))
 
 ## 66.0.0
 

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-settings.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-settings.js
@@ -54,7 +54,6 @@
 
         if (name === 'usage' && !value) {
           window.GOVUK.stopSendingAnalytics = true
-          window.GOVUK.LUX = {}
         }
       }
     }


### PR DESCRIPTION
## What

Remove the line that resets the LUX data.

https://gov-uk.atlassian.net/browse/NAV-18727

## Why

Unfortunately, it doesn't appear possible to reset LUX data on this page in this way. We explored updating the line to target the correct property (for example, `window.LUX` as in [https://github.com/alphagov/govuk_publishing_components/pull/5344](https://github.com/alphagov/govuk_publishing_components/pull/5344)), but this wouldn’t have any effect until the user refreshes the page. We also looked at changing `LUX.auto` to toggle automatic tracking, but that approach is quite fiddly and would likely require additional changes elsewhere (such as in the LUX reporter). Finally, we considered excluding this page from tracking, but that’s not desirable either.

The proper fix is to reload the page after the form has been submitted https://github.com/alphagov/govuk_publishing_components/issues/5429.