### PR TITLE
Remove unneeded cookies from category list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Remove unneeded cookies from category list ([PR #5432](https://github.com/alphagov/govuk_publishing_components/pull/5432))
+
 ## 66.0.1
 
 * Remove reliance on CGI.parse ([PR #5424](https://github.com/alphagov/govuk_publishing_components/pull/5424))

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
@@ -140,11 +140,6 @@
       return true
     }
 
-    // Survey cookies are dynamically generated, so we need to check for these separately
-    if (cookieName.match('^govuk_surveySeen') || cookieName.match('^govuk_taken')) {
-      return window.GOVUK.checkConsentCookieCategory(cookieName, 'settings')
-    }
-
     if (COOKIE_CATEGORIES[cookieName]) {
       var cookieCategory = COOKIE_CATEGORIES[cookieName]
 

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
@@ -12,21 +12,15 @@
 
   var COOKIE_CATEGORIES = {
     cookies_policy: 'essential',
-    seen_cookie_message: 'essential',
-    cookie_preferences_set: 'essential',
     cookies_preferences_set: 'essential',
     '_email-alert-frontend_session': 'essential',
     intervention_campaign: 'essential',
     licensing_session: 'essential',
     govuk_contact_referrer: 'essential',
-    multivariatetest_cohort_coronavirus_extremely_vulnerable_rate_limit: 'essential',
     app_promo_banner: 'settings',
-    dgu_beta_banner_dismissed: 'settings',
     global_banner_seen: 'settings',
-    user_nation: 'settings',
     govuk_chat_onboarding_complete: 'settings', // cookie details page to be updated when this is in use
     'JS-Detection': 'usage',
-    TLSversion: 'usage',
     _ga_VBLT2V3FZR: 'usage', // gtag cookie used to persist the session state, integration
     _ga_P1DGM6TVYF: 'usage', // staging
     _ga_S5RQ7FTGVR: 'usage' // production

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
@@ -20,7 +20,6 @@
     app_promo_banner: 'settings',
     global_banner_seen: 'settings',
     govuk_chat_onboarding_complete: 'settings', // cookie details page to be updated when this is in use
-    'JS-Detection': 'usage',
     _ga_VBLT2V3FZR: 'usage', // gtag cookie used to persist the session state, integration
     _ga_P1DGM6TVYF: 'usage', // staging
     _ga_S5RQ7FTGVR: 'usage' // production

--- a/spec/javascripts/govuk_publishing_components/lib/cookie-functions-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/cookie-functions-spec.js
@@ -94,18 +94,18 @@ describe('Cookie helper functions', function () {
     })
 
     it('deletes cookies by setting the expiration date to 1st January 1970', function () {
-      GOVUK.setCookie('JS-Detection', 'test', { days: 99999, domain: '.gov.uk', path: '/' })
-      expect(GOVUK.getCookie('JS-Detection')).toEqual('test')
-      window.GOVUK.expireCookie('JS-Detection', 1234568) // Should set the expiration date to 1970-01-01
-      expect(GOVUK.getCookie('JS-Detection')).toEqual(null)
+      GOVUK.setCookie('app_promo_banner', 'test', { days: 99999, domain: '.gov.uk', path: '/' })
+      expect(GOVUK.getCookie('app_promo_banner')).toEqual('test')
+      window.GOVUK.expireCookie('app_promo_banner', 1234568) // Should set the expiration date to 1970-01-01
+      expect(GOVUK.getCookie('app_promo_banner')).toEqual(null)
     })
 
     it('calls expireCookie in the deleteCookie function', function () {
       spyOn(window.GOVUK, 'expireCookie')
-      GOVUK.setCookie('JS-Detection', 'test', { days: 99999, domain: '.gov.uk', path: '/' })
-      expect(GOVUK.getCookie('JS-Detection')).toEqual('test')
-      window.GOVUK.deleteCookie('JS-Detection')
-      expect(GOVUK.getCookie('JS-Detection')).toEqual(null)
+      GOVUK.setCookie('app_promo_banner', 'test', { days: 99999, domain: '.gov.uk', path: '/' })
+      expect(GOVUK.getCookie('app_promo_banner')).toEqual('test')
+      window.GOVUK.deleteCookie('app_promo_banner')
+      expect(GOVUK.getCookie('app_promo_banner')).toEqual(null)
       expect(window.GOVUK.expireCookie.calls.count()).toBe(1)
     })
 
@@ -113,14 +113,14 @@ describe('Cookie helper functions', function () {
       var date = new Date()
       date.setTime(date.valueOf() + (365 * 24 * 60 * 60 * 1000))
 
-      GOVUK.setCookie('JS-Detection', 'test', { expires: date.toUTCString(), domain: window.location.hostname, path: '/' })
+      GOVUK.setCookie('app_promo_banner', 'test', { expires: date.toUTCString(), domain: window.location.hostname, path: '/' })
 
-      expect(GOVUK.getCookie('JS-Detection')).toBe('test')
+      expect(GOVUK.getCookie('app_promo_banner')).toBe('test')
 
       GOVUK.setDefaultConsentCookie()
 
-      expect(GOVUK.getConsentCookie().usage).toBe(false)
-      expect(GOVUK.getCookie('JS-Detection')).toBeFalsy()
+      expect(GOVUK.getConsentCookie().settings).toBe(false)
+      expect(GOVUK.getCookie('app_promo_banner')).toBeFalsy()
     })
 
     it('deletes cookies regardless of subdomains', function () {
@@ -168,18 +168,18 @@ describe('Cookie helper functions', function () {
     })
 
     it('deletes relevant cookies in that category if consent is set to false', function () {
-      GOVUK.setConsentCookie({ usage: true })
+      GOVUK.setConsentCookie({ settings: true })
 
-      GOVUK.setCookie('JS-Detection', 'this is a usage cookie')
+      GOVUK.setCookie('app_promo_banner', 'this is a usage cookie')
 
-      expect(GOVUK.cookie('JS-Detection')).toBe('this is a usage cookie')
+      expect(GOVUK.cookie('app_promo_banner')).toBe('this is a usage cookie')
 
       spyOn(GOVUK, 'setCookie').and.callThrough()
-      GOVUK.setConsentCookie({ usage: false })
+      GOVUK.setConsentCookie({ settings: false })
 
       expect(GOVUK.setCookie).toHaveBeenCalledWith('cookies_policy', '{"essential":true,"settings":false,"usage":false,"campaigns":false}', Object({ days: 365 }))
-      expect(GOVUK.getConsentCookie().usage).toBe(false)
-      expect(GOVUK.cookie('JS-Detection')).toBeFalsy()
+      expect(GOVUK.getConsentCookie().settings).toBe(false)
+      expect(GOVUK.cookie('app_promo_banner')).toBeFalsy()
     })
   })
 
@@ -214,13 +214,13 @@ describe('Cookie helper functions', function () {
     })
 
     it('returns the consent for a given cookie', function () {
-      GOVUK.setConsentCookie({ usage: false })
+      GOVUK.setConsentCookie({ settings: false })
 
-      expect(GOVUK.checkConsentCookie('JS-Detection', 'set a usage cookie')).toBeFalsy()
+      expect(GOVUK.checkConsentCookie('app_promo_banner', 'set a settings cookie')).toBeFalsy()
 
-      GOVUK.setConsentCookie({ usage: true })
+      GOVUK.setConsentCookie({ settings: true })
 
-      expect(GOVUK.checkConsentCookie('JS-Detection', 'set a usage cookie')).toBeTruthy()
+      expect(GOVUK.checkConsentCookie('app_promo_banner', 'set a settings cookie')).toBeTruthy()
     })
 
     it('denies consent for cookies not in our list of cookies', function () {


### PR DESCRIPTION
## What

- Remove survey banner checks from `checkConsentCookie` in cookie-functions.js
- Remove unneeded cookies from category list

### Cookie categories removed

| name | category | related PR's |
| --- | --- | --- |
| seen_cookie_message | essential | https://github.com/alphagov/govuk_publishing_components/pull/1228 |
| cookie_preferences_set | essential | https://github.com/alphagov/govuk_publishing_components/pull/1228 |
| multivariatetest_cohort_coronavirus extremely_vulnerable_rate_limit | essential | https://github.com/alphagov/govuk_publishing_components/pull/1400, https://github.com/alphagov/frontend/pull/2298 |
| dgu_beta_banner_dismissed | settings | https://github.com/alphagov/govuk_publishing_components/pull/1315 |
| user_nation | settings | https://github.com/alphagov/govuk_publishing_components/pull/1999 |
| TLSversion | usage | https://github.com/alphagov/static/pull/1304, https://github.com/alphagov/govuk_publishing_components/pull/922 |
| JS-Detection | usage | https://github.com/alphagov/govuk-cdn-config/pull/22 |

## Why

To help ensure the cookie categories in the code and cookie details is up-to-date

Jira card: https://gov-uk.atlassian.net/browse/NAV-18747
