### PR TITLE
Version 66.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 66.0.1
 
 * Remove reliance on CGI.parse ([PR #5424](https://github.com/alphagov/govuk_publishing_components/pull/5424))
 * Remove the line that resets the LUX data ([PR #5427](https://github.com/alphagov/govuk_publishing_components/pull/5427))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (66.0.0)
+    govuk_publishing_components (66.0.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "66.0.0".freeze
+  VERSION = "66.0.1".freeze
 end


### PR DESCRIPTION
## 66.0.1

* Remove reliance on CGI.parse ([PR #5424](https://github.com/alphagov/govuk_publishing_components/pull/5424))
* Remove the line that resets the LUX data ([PR #5427](https://github.com/alphagov/govuk_publishing_components/pull/5427))
