### PR TITLE
Add "With signout link" variant to "layout header" component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add "With signout link" variant to the "Layout header" component ([PR #5434](https://github.com/alphagov/govuk_publishing_components/pull/5434))
+
 ## 66.1.0
 
 * Remove unneeded cookies from category list ([PR #5432](https://github.com/alphagov/govuk_publishing_components/pull/5432))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
@@ -59,10 +59,19 @@
   display: flex;
   flex-wrap: wrap;
   row-gap: govuk-spacing(2);
+
+  &:has(+ .gem-c-header__content) {
+    @include govuk-grid-column(three-quarters);
+    padding: govuk-spacing(3) 0 govuk-spacing(2);
+  }
 }
 
 .gem-c-header__content.govuk-header__content {
   width: auto;
+
+  @include govuk-media-query($from: mobile) {
+    @include govuk-responsive-padding(3, "bottom");
+  }
 
   @include govuk-media-query($from: desktop) {
     float: right;

--- a/app/views/govuk_publishing_components/components/_layout_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_header.html.erb
@@ -1,6 +1,7 @@
 <%
   environment ||= nil
   full_width ||= false
+  signout_link ||= false
   navigation_aria_label ||= t("components.layout_header.top_level")
   navigation_items ||= []
   product_name ||= nil
@@ -22,6 +23,7 @@
         environment:,
         logo_link:,
         product_name:,
+        signout_link:,
       } %>
     </div>
     <% if navigation_items.any? %>

--- a/app/views/govuk_publishing_components/components/docs/layout_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_header.yml
@@ -31,6 +31,17 @@ examples:
     data:
       environment: production
       product_name: Product
+  with_signout_link:
+    description: Adds a "signout" link. For use across publishing apps.
+    data:
+      environment: production
+      signout_link: true
+  with_signout_link and product name:
+    description: Adds a "signout" link for use across publishing apps and a product name
+    data:
+      environment: production
+      signout_link: true
+      product_name: Component Guide 999.9.9
   with_navigation:
     description: Note that [remove_bottom_border](#no_bottom_border) automatically gets set to true on the header when navigation items are added.
     data:

--- a/app/views/govuk_publishing_components/components/layout_header/_header_logo.html.erb
+++ b/app/views/govuk_publishing_components/components/layout_header/_header_logo.html.erb
@@ -9,6 +9,7 @@
 
   environment_exists = environment.present?
   deprecated_navigation ||= false
+  signout_link ||= false
 %>
 
 <% if environment_exists && deprecated_navigation %>
@@ -32,3 +33,11 @@
     </div>
   <% end %>
 </div>
+
+<% if signout_link %>
+  <div class="govuk-header__content gem-c-header__content">
+    <nav class="gem-c-header__nav govuk-header__navigation">
+      <a class="govuk-header__link govuk-!-font-weight-bold" href="/auth/gds/sign_out">Sign out</a>
+    </nav>
+  </div>
+<% end %>


### PR DESCRIPTION
## What
Update the "Layout header" component to add a variant including a "Sign out" link. This involves: 
- Updating the documentation for the component
- Updating the `layout_header` view to add `signout` parameter
- Updating the `header_logo` partial to add link
- Updating the `layout-header` styles to set the width of the logo container when the link is present
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
<!-- What are the reasons behind this change being made? -->
Jira card: https://gov-uk.atlassian.net/browse/MAIN-7341
There is a design requirement to introduce a link on Publishing apps (initially on Fact Check Manager and Mainstream Publisher) to allow users to sign out. The preferred positioning for this is on the top right of the header.

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->
When in place on Fact Check Manager

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

| Before | After |
|--------|--------|
| <img width="1182" height="212" alt="Screenshot 2026-04-28 at 15 14 50" src="https://github.com/user-attachments/assets/708d6634-2437-44da-904a-a58c861236d9" /> | <img width="1182" height="212" alt="Screenshot 2026-04-28 at 15 13 47" src="https://github.com/user-attachments/assets/07ce2f40-7563-4566-b58f-0ebf0163923d" /> |
| <img width="750" height="289" alt="Screenshot 2026-04-28 at 15 23 10" src="https://github.com/user-attachments/assets/ec596a72-f2e9-4524-90a2-7ff6fd7966ea" /> | <img width="750" height="289" alt="Screenshot 2026-04-28 at 15 21 47" src="https://github.com/user-attachments/assets/e3ca2b53-68e6-48d5-af3d-7eda65375459" /> |
|<img width="333" height="303" alt="Screenshot 2026-04-28 at 15 26 21" src="https://github.com/user-attachments/assets/36ebaefb-367a-402c-937b-9f23bbeaad35" />|<img width="333" height="303" alt="Screenshot 2026-04-28 at 15 24 47" src="https://github.com/user-attachments/assets/5c13512b-942f-499b-9e7a-fa58982cc9fd" />|
