### PR TITLE
Fix details underline issue

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_details.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_details.scss
@@ -33,3 +33,8 @@
     @include govuk-link-style-inverse;
   }
 }
+
+// fix for issue https://github.com/alphagov/govuk_publishing_components/issues/5436
+.govuk-details__summary {
+  box-shadow: 0 4px transparent;
+}


### PR DESCRIPTION
## What
Apply a transparent box shadow to the default state of the details summary element.

## Why
Fixes https://github.com/alphagov/govuk_publishing_components/issues/5436

## Visual Changes
See linked issue.
