### PR TITLE
Ensure cookie expiry dates are in UTCString format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Ensure cookie expiry dates are in UTCString format ([PR #5442](https://github.com/alphagov/govuk_publishing_components/pull/5442))
+
 ## 66.2.0
 
 * Add "With signout link" variant to the "Layout header" component ([PR #5434](https://github.com/alphagov/govuk_publishing_components/pull/5434))

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
@@ -194,7 +194,7 @@
 
   window.GOVUK.expireCookie = function (cookie, value = '') {
     // We need to handle deleting cookies on the domain and the .domain
-    var thePast = new Date(0) // 0 = 0 seconds since UTC started (1970/01/01)
+    var thePast = new Date(0).toUTCString() // 0 = 0 seconds since UTC started (1970/01/01)
     document.cookie = cookie + '=' + value + ';expires=' + thePast + ';'
     document.cookie = cookie + '=' + value + ';expires=' + thePast + ';domain=' + window.location.hostname + ';path=/'
   }


### PR DESCRIPTION
## What

Ensure cookie expiry date is in UTCString format in `cookie-functions.js`

The current approach works OK in Chrome and deletes cookies immediately, this does not work in Safari however as it requires the date to be in UTCString format, because it is not a valid UTCString, the cookie will expire at the end of the session instead of being deleted immediately.

### Further technical information

> ;expires=date-in-UTCString-format: The expiry date of the cookie. If neither expires nor max-age is specified, it will expire at the end of session.

https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie

> ...
> expires-av        = "Expires=" sane-cookie-date
> sane-cookie-date  = <[rfc1123](https://datatracker.ietf.org/doc/html/rfc1123)-date, defined in [[RFC2616], Section 3.3.1](https://datatracker.ietf.org/doc/html/rfc2616#section-3.3.1)>
> ...

https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.1

## Why

- Fix failing tests in Safari relating to cookie deletion
- Ensure cookies are deleted immediately in Safari rather than at the end of the session

Jira card: https://gov-uk.atlassian.net/browse/NAV-18806
