### PR TITLE
Use consistent approach for deleting cookies in tests

### DIFF
--- a/spec/javascripts/components/app-promo-banner-spec.js
+++ b/spec/javascripts/components/app-promo-banner-spec.js
@@ -65,7 +65,8 @@ describe('App promo banner', function () {
   })
 
   afterAll(function () {
-    GOVUK.setCookie('cookies_policy', null)
+    GOVUK.cookie('cookies_policy', null)
+    GOVUK.cookie('cookies_preferences_set', null)
   })
 
   it('is displayed with the correct attibutes and does not set a cookie on load', function () {

--- a/spec/javascripts/components/cookie-banner-spec.js
+++ b/spec/javascripts/components/cookie-banner-spec.js
@@ -63,8 +63,8 @@ describe('Cookie banner', function () {
 
   afterEach(function () {
     document.body.removeChild(container)
-    window.GOVUK.deleteCookie('cookies_policy')
-    window.GOVUK.deleteCookie('cookies_preferences_set')
+    GOVUK.cookie('cookies_policy', null)
+    GOVUK.cookie('cookies_preferences_set', null)
   })
 
   it('should show the cookie banner when preferences have not been actively set', function () {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-focus-loss-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-focus-loss-tracker.spec.js
@@ -18,7 +18,8 @@ describe('GA4 focus loss tracker', function () {
   })
 
   afterAll(function () {
-    GOVUK.setCookie('cookies_policy', null)
+    GOVUK.cookie('cookies_policy', null)
+    GOVUK.cookie('cookies_preferences_set', null)
     window.dataLayer = []
   })
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.spec.js
@@ -26,7 +26,8 @@ describe('GA4 scroll tracker', function () {
     }
     jasmine.clock().uninstall()
 
-    window.GOVUK.deleteCookie('cookies_policy')
+    GOVUK.cookie('cookies_policy', null)
+    GOVUK.cookie('cookies_preferences_set', null)
     window.GOVUK.analyticsGa4.vars.scrollTrackerStarted = false
   })
 
@@ -76,7 +77,8 @@ describe('GA4 scroll tracker', function () {
     })
 
     it('starts the module on the same page as cookie consent is given', function () {
-      window.GOVUK.deleteCookie('cookies_policy')
+      GOVUK.cookie('cookies_policy', null)
+      GOVUK.cookie('cookies_preferences_set', null)
       var el = document.createElement('div')
       scrollTracker = new GOVUK.Modules.Ga4ScrollTracker(el)
       spyOn(scrollTracker, 'startModule').and.callThrough()

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-smart-answer-results-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-smart-answer-results-tracker.spec.js
@@ -107,7 +107,8 @@ describe('GA4 smart answer results tracking', function () {
     })
 
     it('starts the module on the same page as cookie consent is given', function () {
-      window.GOVUK.deleteCookie('cookies_policy')
+      GOVUK.cookie('cookies_policy', null)
+      GOVUK.cookie('cookies_preferences_set', null)
       var smartAnswerTracker = new GOVUK.Modules.Ga4SmartAnswerResultsTracker(smartAnswerResultsParentEl)
       spyOn(smartAnswerTracker, 'startModule').and.callThrough()
       smartAnswerTracker.init()


### PR DESCRIPTION
## What

Use consistent approach for deleting cookies in tests

## Why

Calling the `setCookie` method directly, does not delete the cookie, but instead creates a cookie with a null value

The `deleteCookie` method works as expected, but these have also been updated use `GOVUK.cookie('cookie_name', null)` for consistency across tests

This fixes an issue with flakey tests when run in a random order could set a cookie_policy, and therefor would not create a default cookie_policy when required

Jira card: https://gov-uk.atlassian.net/browse/NAV-18806