### PR TITLE
Remove unnecessary aria hidden attribute from maybe button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Remove unnecessary aria hidden attribute from maybe button ([PR #5449](https://github.com/alphagov/govuk_publishing_components/pull/5449))
 * Ensure cookie expiry dates are in UTCString format ([PR #5442](https://github.com/alphagov/govuk_publishing_components/pull/5442))
 
 ## 66.2.0

--- a/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
@@ -39,7 +39,6 @@
               class: "gem-c-feedback__prompt-link",
               role: "button",
               hidden: "hidden",
-              'aria-hidden': "true",
             } do %>
               <%= t("components.feedback.maybe") %>
             <% end %>

--- a/spec/javascripts/components/feedback-spec.js
+++ b/spec/javascripts/components/feedback-spec.js
@@ -16,8 +16,7 @@ describe('Feedback component', function () {
               <h2 class="gem-c-feedback__prompt-question">Is this page useful?</h2>
               <ul class="gem-c-feedback__option-list">
                 <li class="gem-c-feedback__option-list-item govuk-visually-hidden" hidden>
-                  <a class="gem-c-feedback__prompt-link" role="button" hidden="hidden" aria-hidden="true"
-                    href="/contact/govuk">
+                  <a class="gem-c-feedback__prompt-link" role="button" hidden="hidden" href="/contact/govuk">
                     Maybe
                   </a>
                 </li>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What

Removed the unnecessary aria-hidden attribute from the 'maybe' button in the Feedback component.

## Why

To resolve the W3C validation warning:
Warning: Attribute aria-hidden is unnecessary for elements that have attribute hidden.

The hidden attribute already hides elements from both the visual layout and the accessibility tree, making aria-hidden redundant. Removing it clears the W3C validation warning. 

Jira card: https://gov-uk.atlassian.net/browse/NAV-18898

## Visual changes

None. This is a markup-only change on a hidden button — removing a redundant HTML attribute has no impact on the rendered page.

## Testing

✅ Confirmed the aria-hidden attribute has been removed from all elements in the Feedback component.
✅ Checked in browsers (Chrome, Firefox, Safari) that the hidden elements remain correctly hidden and the Feedback component still behaves as expected.
✅ Confirmed tests are passing. 
✅ Ran the affected pages through the [W3C validator](https://validator.w3.org/nu/) and confirmed the "Attribute aria-hidden is unnecessary for elements that have attribute hidden" warning no longer appears. (Note: Local and Heroku URLs cannot be run using the validator. Workaround is to paste the page HTML into the validator for comparison)

| Live  | aria-hidden removed |
| ------------- | ------------- |
| <img width="847" height="685" alt="Screenshot 2026-05-06 at 15 52 12" src="https://github.com/user-attachments/assets/5b6e7723-d6e1-4f3c-b320-b57bc8469ddf" /> | <img width="849" height="685" alt="Screenshot 2026-05-06 at 15 54 03" src="https://github.com/user-attachments/assets/3dfc143c-c644-476f-8f68-ea69bc74fbff" /> |

