### PR TITLE
Add flexible sections to the component guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * LUX version 4.5.0 ([PR #5478](https://github.com/alphagov/govuk_publishing_components/pull/5478))
+* Add flexible sections to the component guide ([PR #5450](https://github.com/alphagov/govuk_publishing_components/pull/5450))
 
 ## 66.4.1
 

--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -457,10 +457,6 @@ $code-delete-bg: #fadddd;
   background: govuk-colour("white");
 }
 
-.component-doc__content-list {
-  margin-top: govuk-spacing(5);
-}
-
 .component__application-name {
   display: block;
   font-weight: normal;

--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -473,22 +473,42 @@ $code-delete-bg: #fadddd;
   }
 }
 
-.table-container {
+.gem-full-width__container {
   container-type: inline-size;
-  container-name: page;
+  container-name: gem_page;
 }
 
-.table-wrapper {
+.full-width__table-wrapper {
   .govuk-table {
     display: block;
     overflow-x: scroll;
   }
 }
 
-@container page (width > 1040px) {
+.gem-full-width__element {
+  padding: 0;
+  padding-bottom: 0.1px; // forces child margin inside
+  border: 0;
+  margin-left: -(govuk-spacing(3));
+  margin-right: -(govuk-spacing(3));
+  border-top: solid 1px $govuk-border-colour;
+  border-bottom: solid 1px $govuk-border-colour;
+
+  @include govuk-media-query($from: tablet) {
+    margin-left: -(govuk-spacing(6));
+    margin-right: -(govuk-spacing(6));
+  }
+}
+
+@container gem_page (width > 1040px) {
   $w: 960px;
 
-  .table-wrapper {
+  .gem-full-width__element {
+    margin-left: calc((-100cqw + $w) / 2);
+    margin-right: calc((-100cqw + $w) / 2);
+  }
+
+  .full-width__table-wrapper {
     position: relative;
     z-index: 0;
     box-sizing: border-box;
@@ -509,8 +529,8 @@ $code-delete-bg: #fadddd;
 .govuk-tabs {
   $w: 920px;
 
-  @container page (width > 1040px) {
-    .table-wrapper {
+  @container gem_page (width > 1040px) {
+    .full-width__table-wrapper {
       margin-left: calc(((-100cqw + $w) / 2) - 1px);
       margin-right: calc(((-100cqw + $w) / 2) - 1px);
 

--- a/app/controllers/govuk_publishing_components/component_guide_controller.rb
+++ b/app/controllers/govuk_publishing_components/component_guide_controller.rb
@@ -1,6 +1,7 @@
 module GovukPublishingComponents
   class ComponentGuideController < GovukPublishingComponents::ApplicationController
     append_view_path Rails.root.join("app", "views", GovukPublishingComponents::Config.component_directory_name).to_s
+    append_view_path Rails.root.join("app", "views", GovukPublishingComponents::Config.flexible_sections_directory_name).to_s
 
     MATCH_COMPONENTS = /(?<=govuk_publishing_components\/components\/)[\/a-zA-Z_-]+(?=['"])/
 
@@ -13,28 +14,45 @@ module GovukPublishingComponents
       @unused_components = unused_components_names.get_component_docs
       @components_in_use_sass = components_in_use_sass
       @components_in_use_js = components_in_use_js
+      @flexible_section_docs = flexible_section_docs.all
     end
 
     def show
-      @component_doc = component_docs.get(params[:component])
-      @guide_breadcrumbs = [index_breadcrumb, component_breadcrumb(@component_doc)]
+      if params[:flexible_section]
+        @component_doc = flexible_section_docs.get(params[:flexible_section])
+        @example_path = flexible_section_example_path(@component_doc.id, "default")
+        @preview_path = flexible_section_preview_path(@component_doc.id, "default")
+        @preview_all_path = flexible_section_preview_all_path(@component_doc.id)
+
+        @guide_breadcrumbs = [index_breadcrumb, flexible_section_breadcrumb(@component_doc)]
+      else
+        @component_doc = component_docs.get(params[:component])
+        @example_path = component_example_path(@component_doc.id, "default")
+        @preview_path = component_preview_path(@component_doc.id, "default")
+        @preview_all_path = component_preview_all_path(@component_doc.id)
+
+        @guide_breadcrumbs = [index_breadcrumb, component_breadcrumb(@component_doc)]
+      end
     end
 
     def example
-      @component_doc = component_docs.get(params[:component])
+      @component_doc = params[:flexible_section] ? flexible_section_docs.get(params[:flexible_section]) : component_docs.get(params[:component])
       @component_example = @component_doc.examples.find { |f| f.id == params[:example] }
-      @guide_breadcrumbs = [
-        index_breadcrumb,
-        component_breadcrumb(@component_doc, @component_example),
-        {
-          title: @component_example.name,
-        },
-      ]
+
+      @guide_breadcrumbs = [index_breadcrumb]
+      if params[:flexible_section]
+        @preview_path = flexible_section_preview_path(@component_doc.id, @component_example.id)
+        @guide_breadcrumbs << flexible_section_breadcrumb(@component_doc, @component_example)
+      else
+        @preview_path = component_preview_path(@component_doc.id, @component_example.id)
+        @guide_breadcrumbs << component_breadcrumb(@component_doc, @component_example)
+      end
+      @guide_breadcrumbs << { title: @component_example.name }
     end
 
     def preview
       @component_examples = []
-      @component_doc = component_docs.get(params[:component])
+      @component_doc = params[:flexible_section] ? flexible_section_docs.get(params[:flexible_section]) : component_docs.get(params[:component])
       @preview = true
 
       if params[:example].present?
@@ -71,6 +89,10 @@ module GovukPublishingComponents
 
     def gem_component_docs
       @gem_component_docs ||= ComponentDocs.new(gem_components: true)
+    end
+
+    def flexible_section_docs
+      @flexible_section_docs ||= ComponentDocs.new(flexible_sections: true)
     end
 
     def used_components_names
@@ -164,6 +186,13 @@ module GovukPublishingComponents
       {}.tap do |h|
         h[:title] = component_doc.name
         h[:url] = component_doc_path(component_doc.id) if component_example
+      end
+    end
+
+    def flexible_section_breadcrumb(component_doc, component_example = nil)
+      {}.tap do |h|
+        h[:title] = "#{component_doc.name} (flexible section)"
+        h[:url] = flexible_section_doc_path(component_doc.id) if component_example
       end
     end
   end

--- a/app/models/govuk_publishing_components/component_doc.rb
+++ b/app/models/govuk_publishing_components/component_doc.rb
@@ -7,9 +7,10 @@ module GovukPublishingComponents
                 :component,
                 :accessibility_excluded_rules,
                 :source,
-                :embed
+                :embed,
+                :type
 
-    def initialize(component)
+    def initialize(component, type)
       @component = component
       @id = component[:id]
       @name = component[:name]
@@ -18,6 +19,7 @@ module GovukPublishingComponents
       @accessibility_excluded_rules = component[:accessibility_excluded_rules]
       @source = component[:source]
       @embed = component[:embed]
+      @type = type
     end
 
     def accessibility_criteria
@@ -88,6 +90,8 @@ module GovukPublishingComponents
     def partial_path
       if source == "gem"
         "govuk_publishing_components/components/#{id}"
+      elsif type == "flexible section"
+        "#{GovukPublishingComponents::Config.flexible_sections_directory_name}/#{id}"
       else
         "#{GovukPublishingComponents::Config.component_directory_name}/#{id}"
       end

--- a/app/models/govuk_publishing_components/component_docs.rb
+++ b/app/models/govuk_publishing_components/component_docs.rb
@@ -1,9 +1,11 @@
 module GovukPublishingComponents
   # @private
   class ComponentDocs
-    def initialize(gem_components: false, limit_to: false)
+    def initialize(gem_components: false, limit_to: false, flexible_sections: false)
       @limit_to = limit_to
       @documentation_directory = gem_components ? gem_documentation_directory : app_documentation_directory
+      @documentation_directory = flexible_sections_documentation_directory if flexible_sections
+      @type = flexible_sections ? "flexible section" : "component"
     end
 
     def get(id)
@@ -22,7 +24,7 @@ module GovukPublishingComponents
   private
 
     def build(component)
-      ComponentDoc.new(component)
+      ComponentDoc.new(component, @type)
     end
 
     def fetch_component_doc_files
@@ -55,6 +57,10 @@ module GovukPublishingComponents
 
     def gem_documentation_directory
       Pathname.new(GovukPublishingComponents::Config.gem_directory).join("app", "views", "govuk_publishing_components", "components", "docs")
+    end
+
+    def flexible_sections_documentation_directory
+      Rails.root.join("app", "views", GovukPublishingComponents::Config.flexible_sections_directory_name, "docs")
     end
   end
 end

--- a/app/models/govuk_publishing_components/component_example.rb
+++ b/app/models/govuk_publishing_components/component_example.rb
@@ -83,6 +83,10 @@ module GovukPublishingComponents
       !!context["black_background"]
     end
 
+    def full_width?
+      context["full_width"].present?
+    end
+
     def html_description
       markdown_to_html(description) if description.present?
     end

--- a/app/models/govuk_publishing_components/shared_accessibility_criteria.rb
+++ b/app/models/govuk_publishing_components/shared_accessibility_criteria.rb
@@ -2,7 +2,7 @@ module GovukPublishingComponents
   module SharedAccessibilityCriteria
     def self.link
       "
-Links in the component must:
+Links must:
 
 - accept focus
 - be focusable with a keyboard
@@ -19,7 +19,7 @@ Links in the component must:
 
     def self.button
       "
-Buttons in the component must:
+Buttons must:
 
 - accept focus
 - be focusable with a keyboard

--- a/app/views/govuk_publishing_components/applications_page/show.html.erb
+++ b/app/views/govuk_publishing_components/applications_page/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, "Applications consistency" %>
-<% content_for :body_classes, "table-container" %>
+<% content_for :body_classes, "gem-full-width__container" %>
 
 <%= render "govuk_publishing_components/components/back_link", {
   href: "/component-guide",
@@ -17,7 +17,7 @@
 <% end %>
 
 <div data-module="filter-list">
-  <div class="table-wrapper">
+  <div class="full-width__table-wrapper">
     <table class="govuk-table">
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">

--- a/app/views/govuk_publishing_components/audit/_component_contents.html.erb
+++ b/app/views/govuk_publishing_components/audit/_component_contents.html.erb
@@ -1,7 +1,7 @@
 <p class="govuk-body">
   Numbers in table headers show column totals. Numbers in table cells show number of lines in files. Note that component test files cannot currently be detected in applications that use minitest instead of Rspec.</p>
 </p>
-<div class="table-wrapper">
+<div class="full-width__table-wrapper">
   <table class="govuk-table">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row" <% if show_application_name %> data-audit-headings<% end %>>

--- a/app/views/govuk_publishing_components/audit/show.html.erb
+++ b/app/views/govuk_publishing_components/audit/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, "Component audit" %>
-<% content_for :body_classes, "table-container" %>
+<% content_for :body_classes, "gem-full-width__container" %>
 
 <%= render "govuk_publishing_components/components/back_link", {
   href: "/component-guide",

--- a/app/views/govuk_publishing_components/component_guide/_component_list.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/_component_list.html.erb
@@ -5,7 +5,11 @@
 <ul class="govuk-list govuk-list--bullet govuk-list--spaced">
   <% local_assigns[:components].each do |component_doc| %>
     <li data-filter-item>
-      <%= link_to component_doc.name, component_doc_path(component_doc.id), class: "govuk-link" %>
+      <% if local_assigns[:type] == "flexible_section" %>
+        <%= link_to component_doc.name, flexible_section_doc_path(component_doc.id), class: "govuk-link" %>
+      <% else %>
+        <%= link_to component_doc.name, component_doc_path(component_doc.id), class: "govuk-link" %>
+      <% end %>
       <p class="govuk-body">
         <%= component_doc.description %>
       </p>

--- a/app/views/govuk_publishing_components/component_guide/component_doc/_component.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/component_doc/_component.html.erb
@@ -1,12 +1,10 @@
 <%
-  classes = %w[flexible-section-preview table-wrapper]
-  if @component_doc.type == "component"
-    classes = %w[component-guide-preview component-guide-preview--no-margin]
-    classes << "direction-rtl" if example.right_to_left?
-    classes << "dark-background" if example.dark_background?
-    classes << "black-background" if example.black_background?
-    classes << "component-guide-preview--simple" if preview_page
-  end
+  classes = %w[component-guide-preview component-guide-preview--no-margin]
+  classes << "direction-rtl" if example.right_to_left?
+  classes << "dark-background" if example.dark_background?
+  classes << "black-background" if example.black_background?
+  classes << "component-guide-preview--simple" if preview_page
+  classes << "gem-full-width__element" if example.full_width?
 %>
 
 <%= tag.div class: classes do %>

--- a/app/views/govuk_publishing_components/component_guide/component_doc/_component.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/component_doc/_component.html.erb
@@ -1,7 +1,14 @@
-<div class="component-guide-preview component-guide-preview--no-margin
-            <% if example.right_to_left? %>direction-rtl<% end %>
-            <% if example.dark_background? %>dark-background<% end %>
-            <% if example.black_background? %>black-background<% end %>
-            <% if preview_page %>component-guide-preview--simple<% end %>">
+<%
+  classes = %w[flexible-section-preview table-wrapper]
+  if @component_doc.type == "component"
+    classes = %w[component-guide-preview component-guide-preview--no-margin]
+    classes << "direction-rtl" if example.right_to_left?
+    classes << "dark-background" if example.dark_background?
+    classes << "black-background" if example.black_background?
+    classes << "component-guide-preview--simple" if preview_page
+  end
+%>
+
+<%= tag.div class: classes do %>
   <%= render "govuk_publishing_components/component_guide/component_doc/component_output", example: example, component_doc: component_doc %>
-</div>
+<% end %>

--- a/app/views/govuk_publishing_components/component_guide/component_doc/_component_output.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/component_doc/_component_output.html.erb
@@ -1,3 +1,4 @@
+<% content_for :body_classes, "gem-full-width__container", flush: true %>
 <%
   if @component_doc.type == "component"
     data = example.html_safe_data

--- a/app/views/govuk_publishing_components/component_guide/component_doc/_component_output.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/component_doc/_component_output.html.erb
@@ -1,10 +1,18 @@
+<%
+  if @component_doc.type == "component"
+    data = example.html_safe_data
+  else
+    flexible_section_class = "FlexiblePage::FlexibleSection::#{@component_doc.id.titleize.gsub(" ", "")}".constantize
+    data = { flexible_section: flexible_section_class.new(**example.html_safe_data.deep_symbolize_keys)}
+  end
+%>
 <% component = capture do %>
   <% if example.has_block? %>
-    <%= render component_doc.partial_path, example.html_safe_data do %>
+    <%= render component_doc.partial_path, data do %>
       <%= render inline: example.block %>
     <% end %>
   <% else %>
-    <%= render component_doc.partial_path, example.html_safe_data %>
+    <%= render component_doc.partial_path, data %>
   <% end %>
 <% end %>
 

--- a/app/views/govuk_publishing_components/component_guide/example.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/example.html.erb
@@ -24,7 +24,7 @@
     </div>
     <h2 class="govuk-heading-m">
       How it looks
-      <small class="govuk-!-font-size-16">(<a href="<%= component_preview_path(@component_doc.id, @component_example.id) %>" class="govuk-link">preview</a>)</small>
+      <small class="govuk-!-font-size-16">(<a href="<%= @preview_path %>" class="govuk-link">preview</a>)</small>
     </h2>
     <%= render partial: "govuk_publishing_components/component_guide/component_doc/preview", locals: { component_doc: @component_doc, example: @component_example } %>
 

--- a/app/views/govuk_publishing_components/component_guide/index.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/index.html.erb
@@ -18,6 +18,13 @@
 <div data-module="filter-list" data-filter-label="Search components">
   <% if !ENV["MAIN_COMPONENT_GUIDE"] %>
     <%= render partial: "component_list", locals: {
+      heading: "Flexible sections in this application",
+      size: @flexible_section_docs.length,
+      components: @flexible_section_docs,
+      type: "flexible_section",
+    } %>
+
+    <%= render partial: "component_list", locals: {
       heading: "Components in this application",
       size: @component_docs.length,
       components: @component_docs,

--- a/app/views/govuk_publishing_components/component_guide/preview.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/preview.html.erb
@@ -5,9 +5,17 @@
 <% end %>
 
 <% @component_examples.each do |example| %>
+  <%
+    if @component_doc.type == "component"
+      example_path = component_example_path(@component_doc.id, example.id)
+    else
+      example_path = flexible_section_example_path(@component_doc.id, example.id)
+    end
+  %>
+
   <div class="component-guide-preview-page">
     <% if @component_examples.length > 1 %>
-      <h2 class="preview-title"><a href="<%= component_example_path(@component_doc.id, example.id) %>"><%= example.name %></a></h2>
+      <h2 class="preview-title"><a href="<%= example_path %>"><%= example.name %></a></h2>
     <% end %>
     <div data-module="test-a11y" data-excluded-rules="<%= @component_doc.accessibility_excluded_rules %>">
       <%= render "govuk_publishing_components/component_guide/component_doc/component", component_doc: @component_doc, example: example, preview_page: true %>

--- a/app/views/govuk_publishing_components/component_guide/show.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/show.html.erb
@@ -1,5 +1,4 @@
 <% content_for :title, "#{@component_doc.name} #{@component_doc.type}" %>
-<% content_for :body_classes, "table-container" %>
 
 <% content_for :application_stylesheet do %>
   <% if @component_doc.source == "application" %>

--- a/app/views/govuk_publishing_components/component_guide/show.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/show.html.erb
@@ -1,4 +1,6 @@
-<% content_for :title, "#{@component_doc.name} component" %>
+<% content_for :title, "#{@component_doc.name} #{@component_doc.type}" %>
+<% content_for :body_classes, "table-container" %>
+
 <% content_for :application_stylesheet do %>
   <% if @component_doc.source == "application" %>
     <%= render "application_stylesheet" %>
@@ -7,7 +9,7 @@
 
 <%= render "govuk_publishing_components/components/heading", {
     text: @component_doc.name,
-    context: "Component",
+    context: @component_doc.type.capitalize,
     heading_level: 1,
     font_size: "xl",
     margin_bottom: 8,
@@ -30,7 +32,9 @@
           </div>
         </div>
       <% end %>
-      <p class="govuk-body"><%= link_to "Search for usage of this component on GitHub", @component_doc.github_search_url, class: "govuk-link" %>.</p>
+      <% if @component_doc.type == "component" %>
+        <p class="govuk-body"><%= link_to "Search for usage of this component on GitHub", @component_doc.github_search_url, class: "govuk-link" %>.</p>
+      <% end %>
     </div>
   </div>
 
@@ -52,8 +56,8 @@
           href: "#overview",
           text: "Overview",
           items: [
-            { href: "#how-it-looks", text: "How it looks" },
-            { href: "#how-to-call-this-component", text: "How to call this component" },
+            ({ href: "#how-it-looks", text: "How it looks" } if @component_doc.display_preview? || @component_doc.display_html?),
+            { href: "#how-to-call-this-component", text: @component_doc.type == "component" ? "How to call this component" : "Passing data to this flexible section" },
             ({ href: "#govuk-design-system", text: "GOV.UK Design System" } if @component_doc.govuk_frontend_components.any?),
             ({ href: "#accessibility-acceptance-criteria", text: "Accessibility acceptance criteria" } if @component_doc.accessibility_criteria.present?),
           ].compact,
@@ -72,14 +76,23 @@
   </div>
 
   <h2 class="govuk-heading-l" id="overview">Overview</h2>
-  <h3 class="govuk-heading-m" id="how-it-looks">
-    <a href="<%= component_example_path(@component_doc.id, "default") %>" class="govuk-link">How it looks</a>
-    <small class="govuk-!-font-size-16">(<a href="<%= component_preview_path(@component_doc.id, "default") %>" class="govuk-link">preview</a>)</small>
-    <small class="govuk-!-font-size-16">(<a href="<%= component_preview_all_path(@component_doc.id) %>" class="govuk-link">preview all</a>)</small>
-  </h3>
-  <%= render "govuk_publishing_components/component_guide/component_doc/preview", component_doc: @component_doc, example: @component_doc.example %>
+  <% if @component_doc.display_preview? || @component_doc.display_html? %>
+    <h3 class="govuk-heading-m" id="how-it-looks">
+      <a href="<%= @example_path %>" class="govuk-link">How it looks</a>
+      <small class="govuk-!-font-size-16">(<a href="<%= @preview_path %>" class="govuk-link">preview</a>)</small>
+      <small class="govuk-!-font-size-16">(<a href="<%= @preview_all_path %>" class="govuk-link">preview all</a>)</small>
+    </h3>
+    <%= render "govuk_publishing_components/component_guide/component_doc/preview", component_doc: @component_doc, example: @component_doc.example %>
+  <% end %>
 
-  <h3 class="govuk-heading-m govuk-!-margin-top-4" id="how-to-call-this-component">How to call this component</h3>
+  <% if @component_doc.type == "component" %>
+    <h3 class="govuk-heading-m govuk-!-margin-top-4" id="how-to-call-this-component">How to call this component</h3>
+  <% else %>
+    <h3 class="govuk-heading-m govuk-!-margin-top-4" id="how-to-call-this-component">Passing data to this flexible section</h3>
+    <div class="component-markdown component-markdown--no-margin">
+      <p>Flexible sections are not called in the way shown below, however this information serves as a reference for the data required by this flexible section.</p>
+    </div>
+  <% end %>
   <%= render "govuk_publishing_components/component_guide/component_doc/call", component_doc: @component_doc, example: @component_doc.example %>
 
   <% if @component_doc.govuk_frontend_components.any? %>
@@ -127,8 +140,17 @@
     <% @component_doc.other_examples.each do |example| %>
       <div class="component-example" id="<%= example.id %>">
         <h3 class="govuk-heading-m">
-          <a href="<%= component_example_path(@component_doc.id, example.id) %>" class="govuk-link"><%= example.name %></a>
-          <small>(<a href="<%= component_preview_path(@component_doc.id, example.id) %>" class="govuk-link">preview</a>)</small>
+          <%
+            if @component_doc.type == "component"
+              example_path = component_example_path(@component_doc.id, example.id)
+              preview_path = component_preview_path(@component_doc.id, example.id)
+            else
+              example_path = flexible_section_example_path(@component_doc.id, example.id)
+              preview_path = flexible_section_preview_path(@component_doc.id, example.id)
+            end
+          %>
+          <a href="<%= example_path %>" class="govuk-link"><%= example.name %></a>
+          <small>(<a href="<%= preview_path %>" class="govuk-link">preview</a>)</small>
         </h3>
         <% if example.html_description %>
           <div class="component-markdown component-markdown--no-margin">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,17 @@
 GovukPublishingComponents::Engine.routes.draw do
   get "/audit" => "audit#show", as: :audit
   get "/applications" => "applications_page#show", as: :apps
+
+  scope "/flexible-sections/" do
+    get ":flexible_section" => "component_guide#show", as: :flexible_section_doc
+    get ":flexible_section/preview" => "component_guide#preview", as: :flexible_section_preview_all
+    get ":flexible_section/:example" => "component_guide#example", as: :flexible_section_example
+    get ":flexible_section/:example/preview" => "component_guide#preview", as: :flexible_section_preview
+  end
+
   root to: "component_guide#index", as: :component_guide
-  get ":component/preview" => "component_guide#preview", as: :component_preview_all
-  get ":component/:example/preview" => "component_guide#preview", as: :component_preview
   get ":component" => "component_guide#show", as: :component_doc
+  get ":component/preview" => "component_guide#preview", as: :component_preview_all
   get ":component/:example" => "component_guide#example", as: :component_example
+  get ":component/:example/preview" => "component_guide#preview", as: :component_preview
 end

--- a/lib/govuk_publishing_components/config.rb
+++ b/lib/govuk_publishing_components/config.rb
@@ -25,6 +25,10 @@ module GovukPublishingComponents
       APP_COMPONENT_DIRECTORY
     end
 
+    def self.flexible_sections_directory_name
+      "flexible_page/flexible_sections"
+    end
+
     def self.gem_directory
       Gem::Specification.find_by_name("govuk_publishing_components").gem_dir
     end

--- a/spec/component_guide/component_example_spec.rb
+++ b/spec/component_guide/component_example_spec.rb
@@ -8,6 +8,13 @@ describe "Component example", :capybara do
     expect(page).to have_content('<%= render "components/test_component", {} %>')
   end
 
+  it "illustrates how to use the flexible section" do
+    visit "/component-guide/flexible-sections/test_flexible_section"
+
+    expect(body).to include("Passing data to this flexible section")
+    expect(page).to have_content('<%= render "flexible_page/flexible_sections/test_flexible_section", { title: "Hello" } %>')
+  end
+
   it "includes the component partial" do
     visit "/component-guide/test_component"
 
@@ -16,6 +23,22 @@ describe "Component example", :capybara do
       expect(page).to have_selector(".some-test-component")
       expect(page).to have_selector("h1.something-inside-test-component", text: "Test component heading")
     end
+  end
+
+  it "includes the flexible section partial" do
+    visit "/component-guide/flexible-sections/test_flexible_section"
+
+    expect(body).to include("How it looks")
+    within ".flexible-section-preview", match: :first do
+      expect(page).to have_selector(".some-test-flexible-section")
+      expect(page).to have_selector("h1.something-inside-test-flexible-section", text: "Test flexible section heading")
+    end
+  end
+
+  it "does not include how it looks when not required" do
+    visit "/component-guide/test_component_with_no_preview"
+
+    expect(body).not_to include("How it looks")
   end
 
   it "includes the content list" do

--- a/spec/component_guide/component_example_spec.rb
+++ b/spec/component_guide/component_example_spec.rb
@@ -29,7 +29,7 @@ describe "Component example", :capybara do
     visit "/component-guide/flexible-sections/test_flexible_section"
 
     expect(body).to include("How it looks")
-    within ".flexible-section-preview", match: :first do
+    within ".component-guide-preview", match: :first do
       expect(page).to have_selector(".some-test-flexible-section")
       expect(page).to have_selector("h1.something-inside-test-flexible-section", text: "Test flexible section heading")
     end

--- a/spec/component_guide/component_index_spec.rb
+++ b/spec/component_guide/component_index_spec.rb
@@ -26,6 +26,12 @@ describe "Component guide index", :capybara do
     expect(page).to have_selector('a[href="/component-guide/test_component"]', text: "Test component")
   end
 
+  it "loads a flexible section from the dummy app" do
+    visit "/component-guide"
+    expect(body).to include("A test flexible section for the dummy app")
+    expect(page).to have_selector('a[href="/component-guide/flexible-sections/test_flexible_section"]', text: "Test flexible section")
+  end
+
   it "includes component guide styles and scripts" do
     visit "/component-guide"
     expect(page).to have_selector('link[href*="/assets/component_guide/application"]', visible: :hidden)
@@ -107,5 +113,10 @@ describe "Component guide index", :capybara do
   it "creates a page for the component" do
     visit "/component-guide/test_component"
     expect(body).to include("A test component for the dummy app")
+  end
+
+  it "creates a page for the flexible section" do
+    visit "/component-guide/flexible-sections/test_flexible_section"
+    expect(body).to include("A test flexible section for the dummy app")
   end
 end

--- a/spec/dummy/app/models/flexible_page/flexible_section/base.rb
+++ b/spec/dummy/app/models/flexible_page/flexible_section/base.rb
@@ -1,0 +1,9 @@
+module FlexiblePage::FlexibleSection
+  class Base
+    def initialize(_params); end
+
+    def type
+      self.class.name.split("::").last.underscore
+    end
+  end
+end

--- a/spec/dummy/app/models/flexible_page/flexible_section/test_flexible_section.rb
+++ b/spec/dummy/app/models/flexible_page/flexible_section/test_flexible_section.rb
@@ -1,0 +1,11 @@
+module FlexiblePage::FlexibleSection
+  class TestFlexibleSection < Base
+    attr_reader :title
+
+    def initialize(title:)
+      super
+
+      @title = title
+    end
+  end
+end

--- a/spec/dummy/app/views/components/docs/test_component_with_no_preview.yml
+++ b/spec/dummy/app/views/components/docs/test_component_with_no_preview.yml
@@ -1,0 +1,16 @@
+name: Test component with no preview
+description: A test component for the dummy app
+body: |
+  An example body with [markdown in it](/component-guide).
+
+  This is a list:
+
+  * list item one
+  * list item two
+accessibility_criteria: |
+  * This is some criteria in a list
+display_html: false
+display_preview: false
+examples:
+  default:
+    data: {}

--- a/spec/dummy/app/views/flexible_page/flexible_sections/_test_flexible_section.html.erb
+++ b/spec/dummy/app/views/flexible_page/flexible_sections/_test_flexible_section.html.erb
@@ -1,0 +1,3 @@
+<div class="some-test-flexible-section">
+  <h1 class="something-inside-test-flexible-section">Test flexible section heading</h1>
+</div>

--- a/spec/dummy/app/views/flexible_page/flexible_sections/docs/test_flexible_section.yml
+++ b/spec/dummy/app/views/flexible_page/flexible_sections/docs/test_flexible_section.yml
@@ -1,0 +1,15 @@
+name: Test flexible section
+description: A test flexible section for the dummy app
+body: |
+  An example body with [markdown in it](/component-guide).
+
+  This is a list:
+
+  * list item one
+  * list item two
+accessibility_criteria: |
+  * This is some criteria in a list
+examples:
+  default:
+    data:
+      title: Hello


### PR DESCRIPTION
## What
Adds flexible sections to the component guide pages. Flexible sections will only appear in the component guide for an application, if that application contains flexible sections. Currently this only applies to `frontend`.

To test this, you can run a local copy of `frontend` with this branch - https://github.com/alphagov/frontend/pull/5544 pointed at a local copy of this PR. Flexible sections should appear in the component guide at http://localhost:3005/component-guide

There's a chunk of temporay code in `component_docs.rb` to make this all work (components expect a `data` hash, flexible sections expect a class instance) but a longer term solution will be needed.

Includes a new addition to display components or flexible sections as full width.

Unsolved problems (as yet):

- flexible sections aren't self contained like components, so you can't just pass them data and expect them to work like components e.g. impact header background styles don't work right now (FIXED)
- we currently don't include the flexible section stylesheets in the main application stylesheet, so we either need to do that or have a separate flexible sections stylesheet that can be included in the component guide (FIXED in the accompanying FE PR, just include in the app stylesheet https://github.com/alphagov/frontend/pull/5544)
- probably need some more robustness over matching the flexible section with their appropriate model, currently if it fails it just errors

## Why
We need a way to document flexible sections and their variations, as they increase in number and become more complicated.

## Visual Changes
<img width="1483" height="969" alt="Screenshot 2026-05-08 at 12 34 05" src="https://github.com/user-attachments/assets/43094d6c-a51a-420b-b1ff-99c07e6fc9ca" />
