### PR TITLE
Check if analytics modules already started before initialising

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Remove unnecessary aria hidden attribute from maybe button ([PR #5449](https://github.com/alphagov/govuk_publishing_components/pull/5449))
 * Ensure cookie expiry dates are in UTCString format ([PR #5442](https://github.com/alphagov/govuk_publishing_components/pull/5442))
+* Check if analytics modules already started before initialising ([PR #5451](https://github.com/alphagov/govuk_publishing_components/pull/5451))
 
 ## 66.2.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/init-ga4.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/init-ga4.js
@@ -6,17 +6,23 @@ var initFunction = function () {
     window.GOVUK.analyticsGa4.vars.internalDomains.push(window.GOVUK.analyticsGa4.core.trackFunctions.getHostname())
     window.GOVUK.analyticsGa4.core.trackFunctions.appendDomainsWithoutWWW(window.GOVUK.analyticsGa4.vars.internalDomains)
     window.GOVUK.analyticsGa4.core.load()
-    var analyticsModules = window.GOVUK.analyticsGa4.analyticsModules
-    for (var property in analyticsModules) {
-      var module = analyticsModules[property]
-      if (typeof module.init === 'function') {
-        try {
-          module.init()
-        } catch (e) {
-          // if there's a problem with the module, catch the error to allow other modules to start
-          console.warn('Error starting analytics module ' + property + ': ' + e.message, window.location)
+
+    if (!window.GOVUK.analyticsGa4.analyticsModulesStarted) {
+      // Initialise analytics modules that start on page load
+      // https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/analytics.md#code-structure
+      var analyticsModules = window.GOVUK.analyticsGa4.analyticsModules
+      for (var property in analyticsModules) {
+        var module = analyticsModules[property]
+        if (typeof module.init === 'function') {
+          try {
+            module.init()
+          } catch (e) {
+            // if there's a problem with the module, catch the error to allow other modules to start
+            console.warn('Error starting analytics module ' + property + ': ' + e.message, window.location)
+          }
         }
       }
+      window.GOVUK.analyticsGa4.analyticsModulesStarted = true
     }
   } else {
     window.addEventListener('cookie-consent', window.GOVUK.analyticsGa4.init)

--- a/app/assets/javascripts/govuk_publishing_components/initialise-vars.js
+++ b/app/assets/javascripts/govuk_publishing_components/initialise-vars.js
@@ -5,3 +5,4 @@ window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {}
 window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
 window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analyticsModules || {}
+window.GOVUK.analyticsGa4.analyticsModulesStarted = false

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/init-ga4.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/init-ga4.spec.js
@@ -19,6 +19,7 @@ describe('Initialising GA4', function () {
       spyOn(test, 'functionThatShouldNotBeCalled')
       GOVUK.analyticsGa4.analyticsModules.Test = function () {}
       GOVUK.analyticsGa4.analyticsModules.Test.init = function () { test.functionThatMightBeCalled() }
+      GOVUK.analyticsGa4.analyticsModulesStarted = false
     })
 
     it('calls analytics modules successfully', function () {
@@ -37,6 +38,16 @@ describe('Initialising GA4', function () {
       GOVUK.analyticsGa4.init()
 
       expect(test.functionThatMightBeCalled).not.toHaveBeenCalled()
+    })
+
+    it('does not call analytics modules if the modules have already started', function () {
+      spyOn(GOVUK.analyticsGa4.analyticsModules.Test, 'init').and.callThrough()
+      GOVUK.setCookie('cookies_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true}')
+      GOVUK.analyticsGa4.init()
+      expect(test.functionThatMightBeCalled).toHaveBeenCalled()
+
+      GOVUK.analyticsGa4.init()
+      expect(test.functionThatMightBeCalled.calls.count()).toBe(1)
     })
 
     it('does not error if no init is found at all', function () {


### PR DESCRIPTION
## What

Update `init-ga4.js` to check if [analytics modules that start on page load](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/analytics.md#code-structure) have already started before initialising.

## Why

The init-ga4.js script will loop over all of the analytics modules that should start on page load, then call the init method for each of these modules to initialise them.

Although unlikely in practice, it is possible to call `window.GOVUK.analyticsGa4.init` multiple times to initialise the page load modules more than once, some of which will attach multiple event listeners to the body element, specialist-link-tracker and copy-tracker for example.

By adding a new `window.GOVUK.analyticsGa4.analyticsModulesStarted` variable which is set to `false` by default, we can use this to help prevent the modules from initialising more than once.

Originally spotted the issue in flaky tests when working on https://github.com/alphagov/govuk_publishing_components/pull/5389, adding this as a separate change to help make the changes clearer and to get this change out in advance.

Jira card: https://gov-uk.atlassian.net/browse/NAV-18724

