### PR TITLE
Add body class option to layout for public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add body class option to layout for public ([PR #5455](https://github.com/alphagov/govuk_publishing_components/pull/5455))
 * Remove unnecessary aria hidden attribute from maybe button ([PR #5449](https://github.com/alphagov/govuk_publishing_components/pull/5449))
 * Ensure cookie expiry dates are in UTCString format ([PR #5442](https://github.com/alphagov/govuk_publishing_components/pull/5442))
 * Check if analytics modules already started before initialising ([PR #5451](https://github.com/alphagov/govuk_publishing_components/pull/5451))

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -18,6 +18,7 @@
   draft_watermark ||= false
   title ||= "GOV.UK - The best place to find government services and information"
   title_lang ||= nil
+  body_classes ||= nil
 
   show_account_layout ||= false
   account_nav_location ||= nil
@@ -27,6 +28,7 @@
   body_css_classes = %w(gem-c-layout-for-public govuk-template__body)
   body_css_classes << "gem-c-layout-for-public--draft" if draft_watermark
   body_css_classes << "global-banner-present" if global_banner.present?
+  body_css_classes << body_classes if body_classes
 -%>
 <!DOCTYPE html>
 <html class="govuk-template govuk-template--rebranded" lang="<%= html_lang %>">

--- a/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
@@ -116,3 +116,10 @@ examples:
       title_lang: 'cy'
       block: |
         <h1>Page content goes here</h1>
+  with_body_classes:
+    description: Allows a class to be passed to the body element. Note that this does not work in preview in this guide.
+    data:
+      title: 'Example layout'
+      body_classes: 'example__class'
+      block: |
+        <h1>Page content goes here</h1>

--- a/spec/components/layout_for_public_spec.rb
+++ b/spec/components/layout_for_public_spec.rb
@@ -269,4 +269,9 @@ describe "Layout for public", :capybara, type: :view do
 
     assert_select ".gem-c-cookie-banner + .gem-c-skip-link"
   end
+
+  it "can add a class to the body" do
+    render_component({ body_classes: "passed classes" })
+    assert_select "body.passed.classes"
+  end
 end


### PR DESCRIPTION
## What
- allows a string of classes to be passed to append to the body element in the component

## Why
Needed for this change: https://github.com/alphagov/frontend/pull/5533

The CSS only works if the container is the body element, as this takes into account the scrollbar for width.

## Visual Changes
None.