### PR TITLE
Fix suggested imports feature

### DIFF
--- a/app/controllers/govuk_publishing_components/component_guide_controller.rb
+++ b/app/controllers/govuk_publishing_components/component_guide_controller.rb
@@ -45,9 +45,7 @@ module GovukPublishingComponents
     end
 
     def components_in_use_sass
-      additional_files = "@import 'govuk_publishing_components/govuk_frontend_support';\n"
-      additional_files << "@import 'govuk_publishing_components/component_support';\n"
-
+      additional_files = "@import 'govuk_publishing_components/specific-components';\n"
       components = find_all_partials_in(get_used_component_names)
 
       components.map { |component|

--- a/spec/component_guide/component_index_spec.rb
+++ b/spec/component_guide/component_index_spec.rb
@@ -39,8 +39,7 @@ describe "Component guide index", :capybara do
 
   it "includes suggested sass for the application" do
     visit "/component-guide"
-    expected_main_sass = "@import 'govuk_publishing_components/govuk_frontend_support';
-@import 'govuk_publishing_components/component_support';
+    expected_main_sass = "@import 'govuk_publishing_components/specific-components';
 @import 'govuk_publishing_components/components/accordion';
 @import 'govuk_publishing_components/components/app-promo-banner';
 @import 'govuk_publishing_components/components/back-link';


### PR DESCRIPTION
## What
- the 'suggested imports for this application' textarea that appears in the application component guide hadn't been updated to reflect the changes in our sass structure, made a few months ago
- `govuk_frontend_support` no longer exists, we now use `specific-components`

## Why
Just noticed it.

## Visual Changes
Updates this feature of the component guide:

<img width="1096" height="324" alt="Screenshot 2026-05-13 at 09 40 26" src="https://github.com/user-attachments/assets/189b77bd-d0f8-41ab-9323-ee99e6e0408f" />
