### PR TITLE
Version 66.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 66.3.0
 
 * Add body class option to layout for public ([PR #5455](https://github.com/alphagov/govuk_publishing_components/pull/5455))
 * Remove unnecessary aria hidden attribute from maybe button ([PR #5449](https://github.com/alphagov/govuk_publishing_components/pull/5449))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (66.2.0)
+    govuk_publishing_components (66.3.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "66.2.0".freeze
+  VERSION = "66.3.0".freeze
 end


### PR DESCRIPTION
## 66.3.0

* Add body class option to layout for public ([PR #5455](https://github.com/alphagov/govuk_publishing_components/pull/5455))
* Remove unnecessary aria hidden attribute from maybe button ([PR #5449](https://github.com/alphagov/govuk_publishing_components/pull/5449))
* Ensure cookie expiry dates are in UTCString format ([PR #5442](https://github.com/alphagov/govuk_publishing_components/pull/5442))
* Check if analytics modules already started before initialising ([PR #5451](https://github.com/alphagov/govuk_publishing_components/pull/5451))
