### PR TITLE
Announce big number component as one element in JAWS and NVDA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 ## Unreleased
 
 * Add options to the service navigation component ([PR #5562](https://github.com/alphagov/govuk_publishing_components/pull/5562))
+* Announce big number component as one element in JAWS and NVDA ([PR #5458](https://github.com/alphagov/govuk_publishing_components/pull/5458))
+
 
 ## 66.7.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_big-number.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_big-number.scss
@@ -8,18 +8,13 @@
   font-size: 80px;
   font-size: govuk-px-to-rem(80px);
   @include govuk-font($size: false, $weight: bold);
+  // Make the value an inline element, and the label a block level element to make them stack vertically but be announced as one element by JAWS and NVDA.
+  display: inline-block;
 }
 
 .gem-c-big-number__label {
   @include govuk-font($size: 19, $weight: bold);
-
-  // This pseudo element is to bypass an issue with NVDA where block level elements are dictated separately.
-  // What's happening here is that the label and the number technically have an inline relationship
-  // but appear to have a block relationship thanks to this element
-  &::before {
-    content: "";
-    display: block;
-  }
+  display: block;
 }
 
 .gem-c-big-number__link {


### PR DESCRIPTION
## What
JAWS and NVDA currently announce the [Big Number component](https://components.publishing.service.gov.uk/component-guide/big_number) as two separate items (the label variant) or two separate links (the link variant).

To fix this, we'e made the value (number) an inline-block element and the label (text) one a block level element. This way they stack visually but also get announced as one element by NVDA and JAWS. Whilst the change seems a bit "magic", it also makes sense that we would need a mixed bag of fixes since we’re essentially asking the elements to stack like separate block level items but also to be announced as one item.

[The link variant](https://components.publishing.service.gov.uk/component-guide/big_number/with_link) was already announced as one item in iOS and Mac VoiceOver and Android TalkBack. The issue still remains in the [text-only variant](https://components.publishing.service.gov.uk/component-guide/big_number/with_labels) in iOS and Mac VoiceOver and Android TalkBack, we've raised a separate issue for this: https://github.com/alphagov/govuk_publishing_components/issues/5563. 

This fix has been reviewed by our accessibility specialist who confirmed it fixes the reported issue in JAWS and NVDA.

## Why 
This issue was raised in the 2025 GOV.UK accessibility audit:

> When a text within a semantic element such as a link or a heading is split across multiple child elements, this can mean that instead of being relayed all in one go, it is relayed in pieces, with the ‘link’ or ‘heading’ role relayed after each piece, as if they were separate links or separate headings. For example, screen reader users may encounter only ‘66’, followed by ‘Open consultations’ and assume that these are separate links with different destinations.

## Variations on the fix attempted

1. #### Swapping `display` values around

I also attempted to fix this by setting the CSS properties the other way around ie. by making the first item a block level element and the second one an inline-block element which would (I think?) seem more logical. However, this produced a weird bug on NVDA where the focus outline would break out of the container and take over the page on encountering the first (block level) element (see screen grab below of the red focus outline wrapping the whole page)

<img width="" height="300" alt="Screenshot 2026-05-15 at 13 51 09" src="https://github.com/user-attachments/assets/e40704a7-f40f-4c53-9c8d-0fa020ac3a7c" />

2. #### Using CSS flex and CSS grid

Big thanks to @jon-kirwan for investigating this solution [here](https://github.com/alphagov/govuk_publishing_components/compare/main...big-number-test-with-flex). This fixed the issue in JAWS and NVDA but led to the same NVDA bug as described above.

For completeness, I also tested this with CSS grid (setting the two items to stack using `grid-row`) but again seeing the same NVDA bug. As mentioned in 1., I suspect this is possibly something to do with having the first span it encounters as a block level element.

3. #### Changing `<span>` to `<div>`

Instead of using two spans, I also tried to use two divs on the assumption it might remove the need for [the space character in the template](https://github.com/alphagov/govuk_publishing_components/blob/c75ce63f91ff502360f1ebda6c6f27f5a1fc1182/app/views/govuk_publishing_components/components/_big_number.html.erb#L30) (as it continues to be required by at least JAWS to insert a white space between the elements). If they are both inline-block, they do get announced as one element by JAWS but not by NVDA. They also don’t stack then unless you use CSS grid or flex or make one 100% width; but the NVDA issue remains nevertheless.

4. #### Using `aria-label`
This produces the following error when ran through HTML validator:
> Error: The aria-label attribute must not be specified on any div element unless the element has a role value other than caption, code, deletion, emphasis, generic, insertion, paragraph, presentation, strong, subscript, or superscript.

However, it improved screen reader announcements (3b).

##### 3a. With `aria-hidden`
Using `aria-label` on the outer wrapper, with `aria-hidden=”true”` on both spans containing visible text:

No impact on Mac VoiceOver. Both iOS VoiceOver and Android TalkBack skipped the not-linked example altogether without reading any of the text.

##### 3b. Without `aria-hidden`
Using `aria-label` on the outer wrapper, with NO `aria-hidden` on visible text

~~This fixes the issue on Mac Voiceover~~ I was certain that this fixed the issue Mac VO, but in later testing it I wasn't able to reproduce the fix behaviour. Either I made a mistake, or this could do with more investigation by someone else. No impact on iOS VoiceOver or Android Talkback.

5. #### Using `role=text`
This role never made it into the ARIA spec but our accessibility specialist mentioned it could be interesting to lok at.

It produces the following error when ran through HTML validator:

> Error: Bad value text for attribute role on element div.

However, it improved screen reader announcements (4b).

##### 4a. With `aria-hidden`
WIth `role=text` on the outer wrapper, with `aria-hidden=”true”` on both spans containing visible text. 

No impact on Mac VoiceOver. Both iOS VoiceOver and Android TalkBack skipped the not-linked example altogether without reading any of the text.

##### 4b. Without `aria-hidden`

WIth `role=text` on the outer wrapper, with NO `aria-hidden` on visible text

This fixes the issue on ~~Mac VoiceOver~~ Same as above, I was sure this fixed the issue in my first round of testing but later didn't see the same result. Could something have changed in Safari, I wonder.
AND iOS VoiceOver (I didn't go back to test iOS VoiceOver again as we'd decide not to proceed with this fix). No impact on Android TalkBack.

Our accessibility specialist deems that an undocumented role such as `role=text` is not a robust solution long term. We would have also needed to add it [here](https://github.com/alphagov/govuk_publishing_components/blob/54edb0d4535163478793a894a0f3da31c234d823/lib/govuk_publishing_components/presenters/component_wrapper_helper.rb#L176), which would seem to defeat the point of the check for valid attributes. 

6. #### Setting grouping behaviour on MacVoicer
I tried setting the grouping behaviour in Mac VoiceOver Utility to 'Announce groups' but it didn't improve the announcements on Mac VoiceOver. This would also be a user controlled setting rather than something we could do.

## Why
Screen readers should announce the value and the label as one item to help users to understand the purpose of the element or link.

## Tested on 

### Screen readers
Now announced as one item: 
🟢 Jaws 2025 + Edge
🟢 NVDA 2025 + Chrome

The link variant is announced as one item. The text-only variant is still announced as two items (no regression):
🟠  iOS VoiceOver + Safari *
🟠  Mac VoiceOver + Safari *
🟠  Android TalkBack + Chrome

### Browsers
No visual changes in the three variants (with label, with suffix, as link)
### Windows 
🟢 Edge
🟢 Chrome
### MacOS 
🟢 Safari 
🟢 Chrome 
### iOS
🟢 Safari
### Android
🟢 Chrome
🟢 Samsung Internet

[Jira card](https://gov-uk.atlassian.net/jira/software/c/projects/NAV/boards/1422?quickFilter=2319&selectedIssue=NAV-18199)