### PR TITLE
Remove data.gov.uk from audits

### DIFF
--- a/app/controllers/govuk_publishing_components/applications_page_controller.rb
+++ b/app/controllers/govuk_publishing_components/applications_page_controller.rb
@@ -8,7 +8,7 @@ module GovukPublishingComponents
         },
         {
           type: "publishing",
-          apps: %w[content-data-admin collections-publisher travel-advice-publisher whitehall datagovuk_find local-links-manager places-manager support manuals-publisher service-manual-publisher short-url-manager specialist-publisher content-tagger publisher transition search-admin fact-check-manager content-block-manager].sort,
+          apps: %w[content-data-admin collections-publisher travel-advice-publisher whitehall local-links-manager places-manager support manuals-publisher service-manual-publisher short-url-manager specialist-publisher content-tagger publisher transition search-admin fact-check-manager content-block-manager].sort,
         },
         {
           type: "utility",

--- a/app/controllers/govuk_publishing_components/audit_controller.rb
+++ b/app/controllers/govuk_publishing_components/audit_controller.rb
@@ -8,7 +8,6 @@ module GovukPublishingComponents
         content-block-manager
         content-data-admin
         content-tagger
-        datagovuk_find
         email-alert-frontend
         fact-check-manager
         feedback


### PR DESCRIPTION
## What / why
Removes `datagovuk_find` from the components auditing and applications status pages.

- we've included this one in the audits for quite a while, but we're not responsible for it
- recently been rebuilt and moved to another platform, so continuing to audit it like this seems unnecessary

## Visual Changes
None.
