### PR TITLE
Fix govspeak inverse link styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix govspeak inverse link styles ([PR #5461](https://github.com/alphagov/govuk_publishing_components/pull/5461))
+
 ## 66.3.0
 
 * Add body class option to layout for public ([PR #5455](https://github.com/alphagov/govuk_publishing_components/pull/5455))

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
@@ -88,7 +88,7 @@
 .gem-c-govspeak--inverse {
   color: govuk-colour("white");
 
-  a {
+  a:not(.govuk-button) {
     @include govuk-link-common;
     @include govuk-link-style-inverse;
   }

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_markdown-typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_markdown-typography.scss
@@ -61,6 +61,10 @@
     &:focus {
       @include govuk-focused-text;
     }
+
+    @include govuk-media-query($media-type: print) {
+      color: $govuk-print-text-colour !important; // stylelint-disable-line declaration-no-important
+    }
   }
 
   // Lists


### PR DESCRIPTION
## What
Fix a contrast issue and related print style colour issue with govspeak links when inverted. See individual commits.

## Why
Noticed while doing something unrelated.

## Visual Changes

Inverse link colour problem:

Before | After
------ | ------
<img width="331" height="422" alt="Screenshot 2026-05-14 at 10 49 30" src="https://github.com/user-attachments/assets/b1cc3633-5bf6-4a08-b332-5b9a755f8146" /> | <img width="340" height="411" alt="Screenshot 2026-05-14 at 10 49 36" src="https://github.com/user-attachments/assets/18b92b46-a745-4e21-ba7a-991777377ee2" />

Link print colour problem (all links should be black when printed):

Before | After
------ | ------
<img width="491" height="367" alt="Screenshot 2026-05-14 at 10 54 26" src="https://github.com/user-attachments/assets/c50a4ce3-8bf0-4934-8140-06bbf36c9909" /> | <img width="487" height="348" alt="Screenshot 2026-05-14 at 11 10 32" src="https://github.com/user-attachments/assets/03b716a6-11ba-417c-becf-cc3cd6af6045" />
