### PR TITLE
Add missing cookies to COOKIE_CATEGORIES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Fix govspeak inverse link styles ([PR #5461](https://github.com/alphagov/govuk_publishing_components/pull/5461))
+* Add missing cookies to COOKIE_CATEGORIES ([PR #5463](https://github.com/alphagov/govuk_publishing_components/pull/5463))
 
 ## 66.3.0
 

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
@@ -20,9 +20,13 @@
     app_promo_banner: 'settings',
     global_banner_seen: 'settings',
     govuk_chat_onboarding_complete: 'settings', // cookie details page to be updated when this is in use
+    'ABTest-BankHolidaysTest': 'usage',
+    'ABTest-SearchFreshnessBoost': 'usage',
+    _ga: 'usage',
     _ga_VBLT2V3FZR: 'usage', // gtag cookie used to persist the session state, integration
     _ga_P1DGM6TVYF: 'usage', // staging
-    _ga_S5RQ7FTGVR: 'usage' // production
+    _ga_S5RQ7FTGVR: 'usage', // production
+    lux_uid: 'usage'
   }
 
   /*


### PR DESCRIPTION
## What
Add the usage cookies listed below to COOKIE_CATEGORIES:

- `ABTest-BankHolidaysTest`
- `ABTest-SearchFreshnessBoost`
- `_ga`
- `lux_uid`

## Why
These usage cookies are used on the site, but were not included in the COOKIE_CATEGORIES list - https://www.gov.uk/help/cookie-details. Adding the missing usage to COOKIE_CATEGORIES will help ensure the cookie are deleted when the `setConsentCookie` method is called.

Jira card: https://gov-uk.atlassian.net/browse/NAV-18887
