### PR TITLE
Release version 66.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 66.4.0
 
 * Fix govspeak inverse link styles ([PR #5461](https://github.com/alphagov/govuk_publishing_components/pull/5461))
 * Add missing cookies to COOKIE_CATEGORIES ([PR #5463](https://github.com/alphagov/govuk_publishing_components/pull/5463))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (66.3.0)
+    govuk_publishing_components (66.4.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "66.3.0".freeze
+  VERSION = "66.4.0".freeze
 end


### PR DESCRIPTION
## 66.4.0

* Fix govspeak inverse link styles ([PR #5461](https://github.com/alphagov/govuk_publishing_components/pull/5461))
* Add missing cookies to COOKIE_CATEGORIES ([PR #5463](https://github.com/alphagov/govuk_publishing_components/pull/5463))
* Migrate 'main navigation' component from frontend ([PR #5448](https://github.com/alphagov/govuk_publishing_components/pull/5448))