### PR TITLE
Reintroduce z-index on focus on sub navigation menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Reintroduce z-index on focus on sub navigation menu ([PR #5466](https://github.com/alphagov/govuk_publishing_components/pull/5466))
+
 ## 66.4.0
 
 * Fix govspeak inverse link styles ([PR #5461](https://github.com/alphagov/govuk_publishing_components/pull/5461))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_sub-navigation-menu.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_sub-navigation-menu.scss
@@ -44,6 +44,9 @@
 }
 
 .gem-c-sub-navigation-menu__button:focus {
+
+  z-index: 999;
+
   &.gem-c-sub-navigation-menu__button::before {
     border-color: govuk-colour("black");
   }


### PR DESCRIPTION
## What/Why
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Reintroduces a `z-index` to the sub navigation menu button on focus
- This was in the original component styles but was removed when moved to this gem (we thought it wasn't needed)
- Turns out it's needed so that the focus outline appears above surrounding elements on `/missions` pages
- Jira card: https://gov-uk.atlassian.net/browse/PNP-9971

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

| Before | After |
|--------|--------|
| <img width="780" height="330" alt="image" src="https://github.com/user-attachments/assets/34f68c3c-e56f-4302-b7df-953999436f67" /> | <img width="780" height="330" alt="image" src="https://github.com/user-attachments/assets/c95d48e7-cb68-4310-aa89-6b190c5905f3" /> |
