### PR TITLE
Sanitise HTML strings in toggle.js

### DIFF
--- a/.github/codeql/extensions/qlpack.yml
+++ b/.github/codeql/extensions/qlpack.yml
@@ -1,0 +1,8 @@
+# See https://docs.github.com/en/code-security/tutorials/customize-code-scanning/creating-and-working-with-codeql-packs#creating-a-codeql-model-pack
+name: govuk_publishing_components/javascript-sanitizers
+version: 1.0.0
+library: true
+extensionTargets:
+  codeql/javascript-all: '*'
+dataExtensions:
+  - sanitizers.yml

--- a/.github/codeql/extensions/sanitizers.yml
+++ b/.github/codeql/extensions/sanitizers.yml
@@ -1,0 +1,8 @@
+# See https://codeql.github.com/docs/codeql-language-guides/customizing-library-models-for-javascript/#example-adding-flow-through-decodeuricomponent
+extensions:
+  - addsTo:
+      pack: codeql/javascript-all
+      extensible: barrierModel
+    data:
+      # Format: [ type, path, kind ]
+      - [ "global", "Member[sanitiseHTML].ReturnValue", "html-injection" ]

--- a/app/assets/javascripts/govuk_publishing_components/lib/toggle.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/toggle.js
@@ -124,13 +124,59 @@
         }
       }
 
-      var toggledText = this.getAttribute('data-toggled-text')
+      var rawToggledText = this.getAttribute('data-toggled-text')
+      var sanitisedText = sanitiseHTML(rawToggledText)
 
-      if (typeof toggledText === 'string') {
+      if (typeof rawToggledText === 'string') {
         this.setAttribute('data-toggled-text', this.innerHTML)
-        this.innerHTML = toggledText
+        this.innerHTML = sanitisedText
       }
     })
+  }
+
+  /*
+   * Sanitises a string representation of HTML so it can be safely rendered on the page
+   * @param {string} htmlString - HTML string, eg <span>hello</span>
+   * @returns {string} - the sanitised version of the string
+   */
+  const sanitiseHTML = function (htmlString) {
+    /* global DOMParser, Node */
+
+    const ALLOWED_TAGS = ['SPAN']
+    const ALLOWED_ATTRS = [/class/, /aria/]
+
+    const parser = new DOMParser()
+
+    // Suppressing alert here because this is the HTML that will be sanitised
+    // codeql[js/xss-through-dom]
+    var htmlDoc = parser.parseFromString(htmlString, 'text/html')
+
+    sanitiseNode(htmlDoc)
+    return htmlDoc.body.innerHTML
+
+    function sanitiseNode (node) {
+      const childNodes = Array.from(node.childNodes)
+      childNodes.forEach(childNode => {
+        // only sanitize element type nodes
+        if (childNode.nodeType === Node.ELEMENT_NODE) {
+          // forbidden nodes are replaced with their children (which might be nothing, ie they are removed)
+          if (!ALLOWED_TAGS.includes(childNode.tagName)) {
+            childNode.removeAttribute(childNode.children)
+          } else {
+            // allowed nodes have any forbidden attributes removed
+            const attributes = Array.from(childNode.attributes)
+            attributes.forEach(attribute => {
+              if (!ALLOWED_ATTRS.some(pattern => pattern.test(attribute.name))) {
+                childNode.removeAttribute(attribute.name)
+              }
+            })
+          }
+        }
+
+        // sanitize all this node's children too
+        sanitiseNode(childNode)
+      })
+    }
   }
 
   Modules.GemToggle = GemToggle

--- a/spec/javascripts/components/toggle-spec.js
+++ b/spec/javascripts/components/toggle-spec.js
@@ -111,4 +111,46 @@ describe('A toggle module', function () {
       document.body.removeChild(container)
     })
   })
+
+  describe('when a forbidden tag in used in the toggled text', function () {
+    beforeEach(function () {
+      container = document.createElement('div')
+      container.innerHTML = `
+        <a href="#" class="my-toggle" data-expanded="false" data-controls="target" data-toggled-text="<script>alert('hi');</script>">Toggle</a>
+        <div id="target" class="js-hidden">Target</div>
+      `
+      document.body.appendChild(container)
+      new GOVUK.Modules.GemToggle(container).init()
+      container.querySelector('.my-toggle').click()
+    })
+
+    afterEach(function () {
+      document.body.removeChild(container)
+    })
+
+    it('does not render the forbidden tag', function () {
+      expect(container.querySelector('script')).toBeNull()
+    })
+  })
+
+  describe('when a forbidden attributes in used in the toggled text', function () {
+    beforeEach(function () {
+      container = document.createElement('div')
+      container.innerHTML = `
+        <a href="#" class="my-toggle" data-expanded="false" data-controls="target" data-toggled-text="<span onerror='forbidden'>Hello</span>>">Toggle</a>
+        <div id="target" class="js-hidden">Target</div>
+      `
+      document.body.appendChild(container)
+      new GOVUK.Modules.GemToggle(container).init()
+      container.querySelector('.my-toggle').click()
+    })
+
+    afterEach(function () {
+      document.body.removeChild(container)
+    })
+
+    it('does not render the forbidden attribute', function () {
+      expect(container.querySelector('span').hasAttribute('onerror')).toBe(false)
+    })
+  })
 })


### PR DESCRIPTION
## What
This change ensures that the value of the `data-toggled-text` attribute conforms to a list of allowed tags and attributes, by adding some sanitisation logic to the `toggle.js` module used by the `metadata_block` and `published_dates` components.

This is limited to only allow spans (and text type nodes) at the moment, based on a check of [where `data-toggled-text` is used in `alphagov`](https://github.com/search?q=org%3Aalphagov%20data-toggled-text&type=code), this should be ok.

I've also added some config to codeql that should mean it will consider any return value from `sanitiseHTML` as safe from xss attacks.  I'm hoping this will dismiss security alert #48 when it is merged, but we might have to do that manually still.

## Why
CodeQL flagged the interpretation of DOM text (in this case in `data-toggled-text` attribute) as a possible XSS injection vector.

Fixes security alert #48, but this could be refactored out into its own module or helper if needed.  I'll look at some of the other HTML injection warnings next and see if this can be refactored to fix those, if people are happy with this approach and this gets merged.


## Visual Changes

None expected.
