### PR TITLE
Improve usability by adding em dash to link text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Remove unused 'services_cookies' option from cookie banner ([PR #5488](https://github.com/alphagov/govuk_publishing_components/pull/5488))
 * Fix signup link having data='false' attribute ([PR #5356](https://github.com/alphagov/govuk_publishing_components/pull/5356))
+* Add em dash to show/hide updates and remove link to history ([PR #5475](https://github.com/alphagov/govuk_publishing_components/pull/5475))
 
 ## 66.4.2
 

--- a/app/views/govuk_publishing_components/components/_published_dates.html.erb
+++ b/app/views/govuk_publishing_components/components/_published_dates.html.erb
@@ -3,7 +3,6 @@
   history ||= []
   history = Array(history)
   last_updated ||= false
-  link_to_history ||= false
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-published-dates")
@@ -20,17 +19,19 @@
     <% end %>
     <% if last_updated %>
       <%= t("components.published_dates.last_updated", date: last_updated) %>
-      <% if link_to_history && history.empty? %>
-        <span aria-hidden="true">— </span><a href="#history" class="govuk-link"><%= t("components.published_dates.see_all_updates", locale: :en) %></a>
-      <% elsif history.any? %>
-        <a href="#full-history"
-        class="gem-c-published-dates__toggle govuk-link"
-        data-controls="full-history"
-        data-expanded="false"
-        data-toggled-text="<span aria-hidden='true'>‐ </span><%= t("components.published_dates.hide_all_updates", locale: :en) %>"
-        data-module="ga4-event-tracker"
-        data-ga4-event="<%= {event_name: "select_content", type: "content history", section: "Footer"}.to_json %>"
-        data-ga4-expandable><span aria-hidden="true">+ </span><%= t("components.published_dates.show_all_updates", locale: :en) %></a>
+      <% if history.any? %>
+        <span aria-hidden="true">&#8212; </span>
+        <a
+          href="#full-history"
+          class="gem-c-published-dates__toggle govuk-link"
+          data-controls="full-history"
+          data-expanded="false"
+          data-toggled-text='<%= t("components.published_dates.hide_all_updates", locale: :en) %>'
+          data-module="ga4-event-tracker"
+          data-ga4-event='<%= { event_name: "select_content", type: "content history", section: "Footer" }.to_json %>'
+          data-ga4-expandable>
+          <%= t("components.published_dates.show_all_updates", locale: :en) %>
+        </a>
         <div class="gem-c-published-dates__change-history js-hidden" id="full-history">
           <ol class="gem-c-published-dates__list">
             <% history.each do |change| %>

--- a/app/views/govuk_publishing_components/components/docs/published_dates.yml
+++ b/app/views/govuk_publishing_components/components/docs/published_dates.yml
@@ -20,12 +20,6 @@ examples:
     data:
       published: 1st January 1990
       last_updated: 20th October 2016
-  link_to_page_history:
-    description: This will set up a link to a '#history' anchor on the page. This can be used to link to another instance of this component, see [Display Page History example](/component-guide/published_dates/display_page_history)
-    data:
-      published: 1st January 1990
-      last_updated: 20th October 2016
-      link_to_history: true
   display_page_history:
     description: This will set up an expandable section on the page, with a top border, to let users toggle the display of the page history.
     data:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -284,11 +284,11 @@ en:
       text: Print this page
     published_dates:
       hidden_heading: Updates to this page
-      hide_all_updates: hide all updates
+      hide_all_updates: Hide all updates
       last_updated: Last updated %{date}
       published: Published %{date}
       see_all_updates: See all updates
-      show_all_updates: show all updates
+      show_all_updates: Show all updates
     radio:
       or: or
     related_footer_navigation:

--- a/spec/components/published_dates_spec.rb
+++ b/spec/components/published_dates_spec.rb
@@ -24,11 +24,6 @@ describe "Published dates", type: :view do
     }
   end
 
-  it "links to full page history" do
-    render_component(published: "1st November 2000", last_updated: "15th July 2015", link_to_history: true)
-    assert_select ".gem-c-published-dates a[href=\"#history\"]"
-  end
-
   it "renders full page history" do
     render_component(
       published: "1st November 2000",
@@ -99,7 +94,7 @@ describe "Published dates", type: :view do
     render_component(
       published: "1st January 1990",
       last_updated: "20th October 2016",
-      link_to_history: true,
+      history: [{ display_time: "23 August 2013", note: "Updated with new data" }],
     )
     assert_select "span", text: "—" # This is an em dash
     assert_select "span", text: "-", count: 0 # This is a hyphen


### PR DESCRIPTION
## What

Replace the small “+” and “–” icons in the show/hide all updates section with an em dash “—”, matching the metadata section at the top of the page.

Example pages:
[Collections](https://www.gov.uk/government/collections/drug-driving#full-publication-update-history)
[Detailed guides ](https://www.gov.uk/guidance/verify-your-identity-for-companies-house)
[Statistics](https://www.gov.uk/government/statistics/indicators-of-species-abundance-in-england)
[Research papers](https://www.gov.uk/government/publications/understanding-the-growth-potential-of-creative-clusters)

The [link_to_page_history](https://components.publishing.service.gov.uk/component-guide/published_dates/link_to_page_history#history) component has been identified as redundant and can be removed.

**FROM** 
Last updated {date} **+ show all updates** (em dash is inside the anchor tag, lowercase)

**TO**
Last updated {date} — **Show all updates** (em dash is outside the anchor tag, sentence case)

[**Metadata block example - Updated with links to see details**](https://components.publishing.service.gov.uk/component-guide/metadata/updated_with_links_to_see_details)
`_metadata.html.erb` uses a small script in `metadata.js` to listens for a click on the "see all updates" link and triggers the separate history toggle drawer in `_published_dates.html.erb` (display page history) to open if it isn't already expanded.

[**Published dates example - Display page history**](https://components.publishing.service.gov.uk/component-guide/published_dates/display_page_history)
`_published_dates.html.erb` uses the `toggle.js` module to target the template's data attributes which configure the link for accessibility while keeping the history section hidden with a `js-hidden` class. When a user clicks the link, the script toggle that class instantly showing or hiding the updates and dynamically swapping the link text to match the new state.

Frontend PR to update the tests with changing the "show all updates" text to sentence case.
https://github.com/alphagov/frontend/pull/5569

## Why
The small “+” and “–” icons in the show/hide all updates section do not clearly explain to users that the section is expandable or collapsible.
Jira card: https://gov-uk.atlassian.net/browse/NAV-18202

## Visual Changes

| Before | After |
|--------|--------|
| <img width="992" height="634" alt="Screenshot 2026-06-05 at 14 08 29" src="https://github.com/user-attachments/assets/c68fb85e-33be-4b6a-90c1-3ef663d31f4c" /> | <img width="998" height="629" alt="Screenshot 2026-06-05 at 14 08 35" src="https://github.com/user-attachments/assets/ebf38845-f397-4b73-b210-3b52e7e2fa51" /> |
