### PR TITLE
Move any phase banner components to the header element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Remove unused 'services_cookies' option from cookie banner ([PR #5488](https://github.com/alphagov/govuk_publishing_components/pull/5488))
 * Fix signup link having data='false' attribute ([PR #5356](https://github.com/alphagov/govuk_publishing_components/pull/5356))
 * Add em dash to show/hide updates and remove link to history ([PR #5475](https://github.com/alphagov/govuk_publishing_components/pull/5475))
+* Move any phase banner components to the header element ([PR #5481](https://github.com/alphagov/govuk_publishing_components/pull/5481))
 
 ## 66.4.2
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -553,7 +553,9 @@ $search-icon-height: 20px;
 
 // Ensure the dropdown menu background is offset from the menu height and
 // takes up the full screen width
-.govuk-frontend-supported .gem-c-layout-super-navigation-header {
+.govuk-frontend-supported .gem-c-layout-super-navigation-header__nav-wrapper {
+  position: relative;
+
   &::before {
     content: "";
     position: absolute;
@@ -563,6 +565,10 @@ $search-icon-height: 20px;
     background: $govuk-rebrand-template-background-colour;
     box-shadow: 0 1px govuk-colour("mid-grey");
   }
+}
+
+.gem-c-phase-banner-wrapper {
+  background: govuk-colour("white");
 }
 
 // JS available - styles the links in the dropdown menu

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -1,6 +1,7 @@
 <%
   emergency_banner ||= nil
   global_banner ||= nil
+  phase_banner ||= nil
   html_lang ||= "en"
   homepage ||= false
   layout_helper = GovukPublishingComponents::Presenters::PublicLayoutHelper.new(local_assigns)
@@ -90,7 +91,8 @@
         <% I18n.with_locale(:en) do %>
           <%= render "govuk_publishing_components/components/layout_super_navigation_header", {
             homepage:,
-            logo_link: logo_link,
+            logo_link:,
+            phase_banner:,
           } %>
         <% end %>
       <% end %>

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -2,6 +2,7 @@
   logo_link ||= "https://www.gov.uk/"
   logo_link_title ||= t("components.layout_super_navigation_header.logo_link_title")
 
+  phase_banner ||= nil
   homepage ||= false
 
   navigation_links_columns = t("components.layout_super_navigation_header.navigation_links_columns")
@@ -38,241 +39,250 @@
   component_helper.add_data_attribute({ module: "ga4-event-tracker ga4-link-tracker", ga4_expandable: "" })
 %>
 <%= tag.header(**component_helper.all_attributes) do %>
-<div class="gem-c-layout-super-navigation-header__container govuk-width-container">
-  <nav
-    aria-labelledby="super-navigation-menu-heading"
-    class="gem-c-layout-super-navigation-header__content"
-    data-module="super-navigation-mega-menu">
-    <%= content_tag(:div, {
-      class: header_logo_classes,
-    }) do %>
-      <%= link_to logo_link, {
-        class: header_link_classes,
-        data: {
-          "ga4-link": {
-            "event_name": "navigation",
-            "type": "header menu bar",
-            "external": "false",
-            "text": "GOV.UK",
-            "section": "Logo",
-            "index_link": 1,
-            "index_section": 0,
-            "index_section_count": 2,
-            "index_total": 1,
-          }.to_json,
-        },
-        id: "logo",
-        aria: {
-          label: logo_link_title,
-        },
-      } do %>
-        <%= render "govuk_publishing_components/components/govuk_logo/govuk_logo" %>
-      <% end %>
-    <% end %>
-    <h2 id="super-navigation-menu-heading" class="govuk-visually-hidden">
-      <%= navigation_menu_heading %>
-    </h2>
-
-    <%
-      link = t("components.layout_super_navigation_header.navigation_link")
-      show_menu_text = show_navigation_menu_text
-      hide_menu_text = hide_navigation_menu_text
-    %>
-
-    <div class="gem-c-layout-super-navigation-header__navigation-item">
-      <%= link_to link[:href], {
-        class: item_link_classes,
-      } do %>
-        <% content_tag(:span, {
-          class: item_link_inner_classes,
-        }) do %>
-          <%= link[:label] %>
+<div class="gem-c-layout-super-navigation-header__nav-wrapper">
+  <div class="gem-c-layout-super-navigation-header__container govuk-width-container">
+    <nav
+      aria-labelledby="super-navigation-menu-heading"
+      class="gem-c-layout-super-navigation-header__content"
+      data-module="super-navigation-mega-menu">
+      <%= content_tag(:div, {
+        class: header_logo_classes,
+      }) do %>
+        <%= link_to logo_link, {
+          class: header_link_classes,
+          data: {
+            "ga4-link": {
+              "event_name": "navigation",
+              "type": "header menu bar",
+              "external": "false",
+              "text": "GOV.UK",
+              "section": "Logo",
+              "index_link": 1,
+              "index_section": 0,
+              "index_section_count": 2,
+              "index_total": 1,
+            }.to_json,
+          },
+          id: "logo",
+          aria: {
+            label: logo_link_title,
+          },
+        } do %>
+          <%= render "govuk_publishing_components/components/govuk_logo/govuk_logo" %>
         <% end %>
       <% end %>
+      <h2 id="super-navigation-menu-heading" class="govuk-visually-hidden">
+        <%= navigation_menu_heading %>
+      </h2>
 
-      <%= content_tag(:button, {
-        aria: {
-          controls: "super-navigation-menu",
-          expanded: false,
-          label: show_menu_text,
-        },
-        class: top_toggle_button_classes,
-        data: {
-          text_for_hide: hide_menu_text,
-          text_for_show: show_menu_text,
-          toggle_desktop_group: "top",
-          toggle_mobile_group: "top",
-          ga4_event: {
-            event_name: "select_content",
-            type: "header menu bar",
-            text: link[:label],
-            index_section: 1,
-            index_section_count: 2,
-            section: link[:label],
+      <%
+        link = t("components.layout_super_navigation_header.navigation_link")
+        show_menu_text = show_navigation_menu_text
+        hide_menu_text = hide_navigation_menu_text
+      %>
+
+      <div class="gem-c-layout-super-navigation-header__navigation-item">
+        <%= link_to link[:href], {
+          class: item_link_classes,
+        } do %>
+          <% content_tag(:span, {
+            class: item_link_inner_classes,
+          }) do %>
+            <%= link[:label] %>
+          <% end %>
+        <% end %>
+
+        <%= content_tag(:button, {
+          aria: {
+            controls: "super-navigation-menu",
+            expanded: false,
+            label: show_menu_text,
           },
-        },
-        hidden: true,
-        id: "super-navigation-menu-toggle",
-        type: "button",
-      }) do %>
-        <%= tag.span link[:label], class: top_toggle_button_inner_classes %>
-      <% end %>
-    </div>
-    <%= content_tag(:div, {
-      id: "super-navigation-menu",
-      hidden: "",
-      class: dropdown_menu_classes,
-    }) do %>
-      <div class="govuk-grid-row gem-c-layout-super-navigation-header__navigation-items">
-
-        <% navigation_links_columns.each_with_index do | column, column_index | %>
-          <%
-            case column[:size]
-            when 2
-              width_class = "govuk-grid-column-two-thirds-from-desktop"
-            when 3
-              width_class = "govuk-grid-column-full-from-desktop"
-            else
-              width_class = "govuk-grid-column-one-third-from-desktop"
-            end
-          %>
-
-          <div class="<%= width_class %> gem-c-layout-super-navigation-header__column--<%= column[:label].downcase.gsub(" ", "-") %>">
-            <h3 class="govuk-heading-m gem-c-layout-super-navigation-header__column-header">
-              <%= column[:label] %>
-            </h3>
-            <ul class="gem-c-layout-super-navigation-header__navigation-second-items gem-c-layout-super-navigation-header__navigation-second-items--<%= column[:label].downcase.gsub(" ", "-") %>">
-              <% index_total = column[:menu_contents].length %>
-              <% column[:menu_contents].each_with_index do | item, index | %>
-                  <%
-                    has_description = item[:description].present?
-                    link_classes = %w[govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link]
-                    link_classes << "gem-c-layout-super-navigation-header__navigation-second-item-link--with-description" if has_description
-                  %>
-                  <li class="gem-c-layout-super-navigation-header__dropdown-list-item">
-                    <%= link_to item[:label], item[:href], {
-                      class: link_classes,
-                      data: {
-                        ga4_link: {
-                          "event_name": "navigation",
-                          "type": "header menu bar",
-                          "index_section": column_index + 1,
-                          "index_link": index + 1,
-                          "index_section_count": 3,
-                          "index_total": index_total,
-                          "section": column[:label],
-                        },
-                      },
-                    } %>
-                    <%= tag.p item[:description], class: "gem-c-layout-super-navigation-header__navigation-second-item-description" if has_description %>
-                  </li>
-              <% end %>
-            </ul>
-          </div>
+          class: top_toggle_button_classes,
+          data: {
+            text_for_hide: hide_menu_text,
+            text_for_show: show_menu_text,
+            toggle_desktop_group: "top",
+            toggle_mobile_group: "top",
+            ga4_event: {
+              event_name: "select_content",
+              type: "header menu bar",
+              text: link[:label],
+              index_section: 1,
+              index_section_count: 2,
+              section: link[:label],
+            },
+          },
+          hidden: true,
+          id: "super-navigation-menu-toggle",
+          type: "button",
+        }) do %>
+          <%= tag.span link[:label], class: top_toggle_button_inner_classes %>
         <% end %>
       </div>
-    <% end %>
-    <div class="gem-c-layout-super-navigation-header__search-item">
-      <%= content_tag(:button, {
-        id: "super-search-menu-toggle",
-        class: search_toggle_button_classes,
-        aria: {
-          controls: "super-search-menu",
-          expanded: "true",
-          label: hide_search_menu_text,
-        },
-        data: {
-          "text-for-hide": hide_search_menu_text,
-          "text-for-show": show_search_menu_text,
-          "toggle-mobile-group": "top",
-          "toggle-desktop-group": "top",
-          "ga4-event": "#{{
-            "event_name": "select_content",
-            "type": "header menu bar",
-            "text": "Search",
-            "index_section": 2,
-            "index_section_count": 2,
-            "section": "Search",
-            }.to_json
-          }",
-        },
-        hidden: true,
-        type: "button",
+      <%= content_tag(:div, {
+        id: "super-navigation-menu",
+        hidden: "",
+        class: dropdown_menu_classes,
       }) do %>
-        <span class="govuk-visually-hidden">
-          <%= search_text %>
-        </span>
-        <%=
-          render "govuk_publishing_components/components/search/search_icon", {
-            classes: %w[gem-c-layout-super-navigation-header__search-toggle-button-link-icon],
-          }
-        %>
-        <span
-          aria-hidden="true"
-          class="gem-c-layout-super-navigation-header__navigation-top-toggle-close-icon">
-          &times;
-        </span>
-      <% end %>
+        <div class="govuk-grid-row gem-c-layout-super-navigation-header__navigation-items">
 
-      <%= link_to "/search", {
-        class: search_item_link_classes,
-      } do %>
-        <span class="govuk-visually-hidden">
-          <%= search_text %>
-        </span>
-        <%=
-          render "govuk_publishing_components/components/search/search_icon", {
-            classes: %w[gem-c-layout-super-navigation-header__search-item-link-icon],
-          }
-        %>
+          <% navigation_links_columns.each_with_index do | column, column_index | %>
+            <%
+              case column[:size]
+              when 2
+                width_class = "govuk-grid-column-two-thirds-from-desktop"
+              when 3
+                width_class = "govuk-grid-column-full-from-desktop"
+              else
+                width_class = "govuk-grid-column-one-third-from-desktop"
+              end
+            %>
+
+            <div class="<%= width_class %> gem-c-layout-super-navigation-header__column--<%= column[:label].downcase.gsub(" ", "-") %>">
+              <h3 class="govuk-heading-m gem-c-layout-super-navigation-header__column-header">
+                <%= column[:label] %>
+              </h3>
+              <ul class="gem-c-layout-super-navigation-header__navigation-second-items gem-c-layout-super-navigation-header__navigation-second-items--<%= column[:label].downcase.gsub(" ", "-") %>">
+                <% index_total = column[:menu_contents].length %>
+                <% column[:menu_contents].each_with_index do | item, index | %>
+                    <%
+                      has_description = item[:description].present?
+                      link_classes = %w[govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link]
+                      link_classes << "gem-c-layout-super-navigation-header__navigation-second-item-link--with-description" if has_description
+                    %>
+                    <li class="gem-c-layout-super-navigation-header__dropdown-list-item">
+                      <%= link_to item[:label], item[:href], {
+                        class: link_classes,
+                        data: {
+                          ga4_link: {
+                            "event_name": "navigation",
+                            "type": "header menu bar",
+                            "index_section": column_index + 1,
+                            "index_link": index + 1,
+                            "index_section_count": 3,
+                            "index_total": index_total,
+                            "section": column[:label],
+                          },
+                        },
+                      } %>
+                      <%= tag.p item[:description], class: "gem-c-layout-super-navigation-header__navigation-second-item-description" if has_description %>
+                    </li>
+                <% end %>
+              </ul>
+            </div>
+          <% end %>
+        </div>
       <% end %>
-    </div>
-    <%= content_tag(:div, {
-      id: "super-search-menu",
-      hidden: "",
-      class: dropdown_menu_classes,
-    }) do %>
-      <div class="gem-c-layout-super-navigation-header__search-container gem-c-layout-super-navigation-header__search-items">
-        <h3 class="govuk-visually-hidden">
-          <%= navigation_search_subheading %>
-        </h3>
-        <div class="govuk-grid-row">
-          <div class="govuk-grid-column-full">
-            <%= tag.form(
-              class: "gem-c-layout-super-navigation-header__search-form",
-              id: "search",
-              data: {
-                module: "ga4-search-tracker",
-                ga4_search_type: "header menu bar",
-                ga4_search_url: "/search/all",
-                ga4_search_section: "Search GOV.UK",
-                ga4_search_index_section: 3,
-                ga4_search_index_section_count: 3,
-              },
-              action: "/search/all",
-              method: "get",
-              role: "search",
-              aria: {
-                label: "Site-wide",
-              },
-            ) do %>
-              <%= render "govuk_publishing_components/components/search_with_autocomplete", {
-                name: "keywords",
-                inline_label: false,
-                label_size: "m",
-                label_text: search_text,
-                label_custom_class: "gem-c-layout-super-navigation-header__search-label--large-navbar",
-                size: "large",
-                margin_bottom: 0,
-                disable_corrections: true,
-                source_url: [Plek.new.website_root, "/api/search/autocomplete.json"].join,
-                source_key: "suggestions",
-              } %>
-            <% end %>
+      <div class="gem-c-layout-super-navigation-header__search-item">
+        <%= content_tag(:button, {
+          id: "super-search-menu-toggle",
+          class: search_toggle_button_classes,
+          aria: {
+            controls: "super-search-menu",
+            expanded: "true",
+            label: hide_search_menu_text,
+          },
+          data: {
+            "text-for-hide": hide_search_menu_text,
+            "text-for-show": show_search_menu_text,
+            "toggle-mobile-group": "top",
+            "toggle-desktop-group": "top",
+            "ga4-event": "#{{
+              "event_name": "select_content",
+              "type": "header menu bar",
+              "text": "Search",
+              "index_section": 2,
+              "index_section_count": 2,
+              "section": "Search",
+              }.to_json
+            }",
+          },
+          hidden: true,
+          type: "button",
+        }) do %>
+          <span class="govuk-visually-hidden">
+            <%= search_text %>
+          </span>
+          <%=
+            render "govuk_publishing_components/components/search/search_icon", {
+              classes: %w[gem-c-layout-super-navigation-header__search-toggle-button-link-icon],
+            }
+          %>
+          <span
+            aria-hidden="true"
+            class="gem-c-layout-super-navigation-header__navigation-top-toggle-close-icon">
+            &times;
+          </span>
+        <% end %>
+
+        <%= link_to "/search", {
+          class: search_item_link_classes,
+        } do %>
+          <span class="govuk-visually-hidden">
+            <%= search_text %>
+          </span>
+          <%=
+            render "govuk_publishing_components/components/search/search_icon", {
+              classes: %w[gem-c-layout-super-navigation-header__search-item-link-icon],
+            }
+          %>
+        <% end %>
+      </div>
+      <%= content_tag(:div, {
+        id: "super-search-menu",
+        hidden: "",
+        class: dropdown_menu_classes,
+      }) do %>
+        <div class="gem-c-layout-super-navigation-header__search-container gem-c-layout-super-navigation-header__search-items">
+          <h3 class="govuk-visually-hidden">
+            <%= navigation_search_subheading %>
+          </h3>
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-full">
+              <%= tag.form(
+                class: "gem-c-layout-super-navigation-header__search-form",
+                id: "search",
+                data: {
+                  module: "ga4-search-tracker",
+                  ga4_search_type: "header menu bar",
+                  ga4_search_url: "/search/all",
+                  ga4_search_section: "Search GOV.UK",
+                  ga4_search_index_section: 3,
+                  ga4_search_index_section_count: 3,
+                },
+                action: "/search/all",
+                method: "get",
+                role: "search",
+                aria: {
+                  label: "Site-wide",
+                },
+              ) do %>
+                <%= render "govuk_publishing_components/components/search_with_autocomplete", {
+                  name: "keywords",
+                  inline_label: false,
+                  label_size: "m",
+                  label_text: search_text,
+                  label_custom_class: "gem-c-layout-super-navigation-header__search-label--large-navbar",
+                  size: "large",
+                  margin_bottom: 0,
+                  disable_corrections: true,
+                  source_url: [Plek.new.website_root, "/api/search/autocomplete.json"].join,
+                  source_key: "suggestions",
+                } %>
+              <% end %>
+            </div>
           </div>
         </div>
-      </div>
-    <% end %>
-  </nav>
+      <% end %>
+    </nav>
+  </div>
 </div>
+<% if phase_banner %>
+  <div class="gem-c-phase-banner-wrapper">
+    <div class="govuk-width-container">
+      <%= render "govuk_publishing_components/components/phase_banner", phase_banner %>
+    </div>
+  </div>
+<% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
@@ -54,9 +54,18 @@ examples:
     description: This allows the HTML for the emergency banner to be added to the page in the correct place. This is only the slot for the emergency banner - the markup for the banner needs to be passed in.
     data:
       emergency_banner: <div class="govuk-!-padding-top-3 govuk-!-padding-bottom-3">This is the emergency banner slot</div>
-  with_global_and_emergency_banner:
-    description: Both global banner and emergency banner should be usable together.
+  with_phase_banner:
+    description: This allows the phase banner to be added to the page within the header.
     data:
+      phase_banner:
+        phase: "beta"
+        message: "This is a custom test message for the public layout phase banner."
+  with_all_banners:
+    description: The phase banner, global banner and emergency banner should be usable together.
+    data:
+      phase_banner:
+          phase: "beta"
+          message: "This is the phase banner banner"
       emergency_banner: <div class="govuk-!-padding-top-3 govuk-!-padding-bottom-3">This is the emergency banner slot</div>
       global_banner: <div class="govuk-!-padding-top-5 govuk-!-padding-bottom-3">This is the global banner slot</div>
   with_account_layout_enabled:

--- a/spec/components/layout_for_public_spec.rb
+++ b/spec/components/layout_for_public_spec.rb
@@ -187,10 +187,74 @@ describe "Layout for public", :capybara, type: :view do
     expect(page).not_to have_selector("html > head > script[src*='lux/lux-reporter']", visible: :hidden)
   end
 
+  it "does not render a phase banner by default" do
+    render_component({})
+
+    assert_select "header.gem-c-layout-super-navigation-header .gem-c-phase-banner", false
+  end
+
   it "account layout renders with a phase banner by default" do
     render_component({ show_account_layout: true })
 
-    assert_select ".gem-c-layout-for-public .gem-c-phase-banner"
+    assert_select ".gem-c-layout-for-public :not(.gem-c-layout-super-navigation-header) > .gem-c-phase-banner"
+  end
+
+  it "does not render the phase banner if the header is omitted" do
+    render_component({
+      omit_header: true,
+      phase_banner: {
+        phase: "beta",
+        message: "This should not show",
+      },
+    })
+
+    assert_select ".gem-c-phase-banner", false
+  end
+
+  it "does not render the super navigation phase banner when the cross-service header is shown" do
+    render_component({
+      show_cross_service_header: true,
+      one_login_navigation_items: {
+        one_login_home: {
+          href: "/one-login-home",
+          data: {},
+        },
+        one_login_sign_out: {
+          href: "/sign-out",
+          data: {},
+        },
+      },
+      phase_banner: {
+        phase: "beta",
+        message: "This should not show",
+      },
+    })
+
+    assert_select "header.gem-c-layout-super-navigation-header", false
+    assert_select ".gem-c-phase-banner", false
+  end
+
+  it "renders the phase banner within the navigation header" do
+    render_component({
+      phase_banner: {
+        phase: "beta",
+        message: "This is a preview phase banner test",
+      },
+    })
+
+    assert_select "header.gem-c-layout-super-navigation-header .gem-c-phase-banner"
+  end
+
+  it "correctly passes the phase and message through to the phase banner markup" do
+    render_component({
+      phase_banner: {
+        phase: "beta",
+        message: "This is a custom beta layout test",
+      },
+    })
+
+    assert_select "header .gem-c-phase-banner .govuk-tag", text: "Beta"
+    assert_select "header .gem-c-phase-banner .govuk-phase-banner__text", text: "This is a custom beta layout test"
   end
 
   it "account layout renders with an account nav by default" do


### PR DESCRIPTION
## What
Adds support for rendering the phase banner component inside the semantic header element, aligning with updated GOV.UK Design System patterns.

Updated layout_for_public and layout_super_navigation_header to optionally accept phase banner parameters. Introduced an inner wrapping element around the primary navigation inside the header template.

Moved the ::before pseudo-element background inside _layout-super-navigation-header.scss away from the root header and attached it to the new nav wrapper. This prevents the absolute-positioned backdrop from expanding over and covering the phase banner when it is appended inside the header container.

Introduced .govuk-phase-banner-wrapper to colour a clean full-width white bar beneath the navigation wrapper, which contains a centred govuk-width-container to maintain text alignment.

## Why
This change fulfills the accessibility requirement raised in https://github.com/alphagov/govuk-design-system/issues/5123. Placing the phase banner within the header element ensures assistive technologies read the banner within the proper page landmark rather than leaving it isolated in the outer body space.

Jira card: https://gov-uk.atlassian.net/browse/[NAV-18918]

## Visual Changes
The phase banner now sits inside the bottom of the global header frame. Verified that expanding the desktop mega-menu dropdowns or search bars does not result in the menu layer clipping or being hidden behind the banner.

Mobile Breakpoints: Confirmed that the banner stacks gracefully beneath the mobile menu navigation triggers without overlapping.

| Before | After |
|--------|--------|
| <img width="999" height="872" alt="Screenshot 2026-06-02 at 10 35 25" src="https://github.com/user-attachments/assets/2a275908-c139-4a9e-9b99-e0acf3526b4b" /> | <img width="983" height="874" alt="Screenshot 2026-06-02 at 10 35 42" src="https://github.com/user-attachments/assets/08461346-c655-4de9-9125-2126e0a5bac0" /> | 
<img width="518" height="284" alt="Screenshot 2026-06-02 at 10 37 54" src="https://github.com/user-attachments/assets/2192d9a6-00f5-41e5-a2c7-13fb24fa77ee" /> | <img width="512" height="177" alt="Screenshot 2026-06-02 at 10 38 48" src="https://github.com/user-attachments/assets/702b7687-7e37-4379-92a2-e30a24a9b082" /> |

[NAV-18918]: https://gov-uk.atlassian.net/browse/NAV-18918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ