### PR TITLE
Version 66.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 66.4.2
 
 * LUX version 4.5.0 ([PR #5478](https://github.com/alphagov/govuk_publishing_components/pull/5478))
 * Add flexible sections to the component guide ([PR #5450](https://github.com/alphagov/govuk_publishing_components/pull/5450))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (66.4.1)
+    govuk_publishing_components (66.4.2)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "66.4.1".freeze
+  VERSION = "66.4.2".freeze
 end


### PR DESCRIPTION
## 66.4.2

* LUX version 4.5.0 ([PR #5478](https://github.com/alphagov/govuk_publishing_components/pull/5478))
* Add flexible sections to the component guide ([PR #5450](https://github.com/alphagov/govuk_publishing_components/pull/5450))
