### PR TITLE
Pin node version to `24.15` in visual-regression-test.yml

### DIFF
--- a/.github/workflows/visual-regression-tests.yml
+++ b/.github/workflows/visual-regression-tests.yml
@@ -46,7 +46,7 @@ jobs:
           bundler-cache: true # Also runs `bundle install`
       - uses: actions/setup-node@v6.4.0
         with:
-          node-version: lts/* # use the latest LTS release
+          node-version: '24.15'
           cache: yarn
       - run: yarn install --frozen-lockfile
       - run: bundle exec rake app:dartsass:build


### PR DESCRIPTION
## What
Pin node version to 24.15 in visual-regression-test.yml

## Why
To fix percy visual regegression tests, following the recent release of node v24.16, percy visual regression tests are no longer working.

The cause of this appears to be related to the extract-zip dependency which is not compatible with the latest release of node 24 and 26.

Further info: https://github.com/percy/cli/issues/2255