### PR TITLE
Remove unused 'services_cookies' option from cookie banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Remove unused 'services_cookies' option from cookie banner
+ ([PR #5488](https://github.com/alphagov/govuk_publishing_components/pull/5488))
+
 ## 66.4.2
 
 * LUX version 4.5.0 ([PR #5478](https://github.com/alphagov/govuk_publishing_components/pull/5478))

--- a/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
@@ -20,12 +20,10 @@
                                   cookie_preferences_href,
                                   class: "govuk-link",
                                 )))
-  services_cookies ||= nil
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.set_id(id)
   component_helper.add_class("gem-c-cookie-banner govuk-clearfix govuk-cookie-banner js-banner-wrapper")
-  component_helper.add_class("gem-c-cookie-banner--services") if services_cookies
 
   component_helper.add_data_attribute({ module: "cookie-banner", nosnippet: "" })
   component_helper.add_role("region")
@@ -54,38 +52,22 @@
       </div>
     </div>
     <div class="js-confirmation-buttons govuk-button-group">
-      <% if services_cookies %>
-        <%= render "govuk_publishing_components/components/button", {
+      <%= render "govuk_publishing_components/components/button", {
           name: "cookies",
-          text: services_cookies.dig(:yes, :text) || "Yes",
-          data_attributes: { "accept-cookies": "true" }.merge(services_cookies.dig(:yes, :data_attributes) || {}),
-        } %>
-        <%= render "govuk_publishing_components/components/button", {
+          text: t("components.cookie_banner.buttons.accept_cookies"),
+          data_attributes: {
+            "accept-cookies": "true",
+            "cookie-types": "all",
+          },
+      } %>
+      <%= render "govuk_publishing_components/components/button", {
           name: "cookies",
-          text: services_cookies.dig(:no, :text) || "No",
-          data_attributes: { "reject-cookies": "true" }.merge(services_cookies.dig(:no, :data_attributes) || {}),
-        } %>
-        <% if services_cookies[:cookie_preferences] %>
-          <%= link_to services_cookies.dig(:cookie_preferences, :text), services_cookies.dig(:cookie_preferences, :href), class: "govuk-link" %>
-        <% end %>
-      <% else %>
-        <%= render "govuk_publishing_components/components/button", {
-            name: "cookies",
-            text: t("components.cookie_banner.buttons.accept_cookies"),
-            data_attributes: {
-              "accept-cookies": "true",
-              "cookie-types": "all",
-            },
-        } %>
-        <%= render "govuk_publishing_components/components/button", {
-            name: "cookies",
-            text: t("components.cookie_banner.buttons.reject_cookies"),
-            data_attributes: {
-              "reject-cookies": "true",
-            },
-        } %>
-        <a class="govuk-link" href="<%= cookie_preferences_href %>"><%= t("components.cookie_banner.buttons.view_cookies") %></a>
-      <% end %>
+          text: t("components.cookie_banner.buttons.reject_cookies"),
+          data_attributes: {
+            "reject-cookies": "true",
+          },
+      } %>
+      <a class="govuk-link" href="<%= cookie_preferences_href %>"><%= t("components.cookie_banner.buttons.view_cookies") %></a>
     </div>
     <div hidden class="js-hide-button govuk-button-group">
       <%

--- a/app/views/govuk_publishing_components/components/docs/cookie_banner.yml
+++ b/app/views/govuk_publishing_components/components/docs/cookie_banner.yml
@@ -30,25 +30,6 @@ examples:
   with_custom_cookie_preferences_href:
     data:
       cookie_preferences_href: "/cookies"
-  in_services_asking_for_analytics_only:
-    description: Use this type of banner in your service if it only uses cookies for analytics.
-    data:
-      title: Can we store analytics cookies on your device?
-      text: Analytics cookies help us understand how our website is being used.
-      confirmation_message: You’ve accepted all cookies. You can `<a class='govuk-link' href='/cookies'>change your cookie settings</a>` at any time.
-      services_cookies:
-        # yes and no must be quoted or are converted into booleans in the guide
-        "yes":
-          text: "Yes"
-          data_attributes:
-            an_attribute: some_value1
-        "no":
-          text: "No"
-          data_attributes:
-            an_attribute: some_value2
-        cookie_preferences:
-          text: How we use cookies
-          href: "/cookies"
   without_ga4_tracking:
     description: |
       Disables GA4 tracking on the banner. Tracking is enabled by default. This includes link tracking on the "You have accepted cookies" section, and allows the pageview event that is sent when GA4 initialises to record the presence of the cookie acceptance message.

--- a/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
@@ -90,26 +90,6 @@ examples:
       block: |
         <h2 class="govuk-heading-l">This is a title</h2>
         <p class="govuk-body">This is some body text with <a href="https://example.com">a link</a>.</p>
-  with_custom_cookie_banner:
-    description: Passes content through to the [cookie banner component](/component-guide/cookie_banner/).
-    data:
-      cookie_banner_data:
-        title: Can we use cookies to collect information about how you use GOV.UK?
-        text: Cookies help us see where we can make improvements to GOV.UK.
-        confirmation_message: You have accepted cookies.
-        cookie_preferences_href: https://www.gov.uk/government/publications/govuk-accounts-trial-full-privacy-notice-and-accessibility-statement
-        services_cookies:
-          yes:
-            text: Yes
-            data_attributes:
-              an_attribute: some_value1
-          no:
-            text: No
-            data_attributes:
-              an_attribute: some_value2
-          cookie_preferences:
-            text: How GOV.UK accounts use cookies
-            href: https://www.gov.uk/government/publications/govuk-accounts-trial-full-privacy-notice-and-accessibility-statement
   with_title_lang_attribute:
     data:
       title: 'Example layout'

--- a/spec/components/layout_for_public_spec.rb
+++ b/spec/components/layout_for_public_spec.rb
@@ -205,39 +205,6 @@ describe "Layout for public", :capybara, type: :view do
     assert_select ".gem-c-layout-for-public-account-nav li.gem-c-layout-for-public-account-menu__item.gem-c-layout-for-public-account-menu__item--current a[aria-current=page]", text: "Settings"
   end
 
-  it "can accept custom cookie banner content" do
-    render_component({
-      cookie_banner_data: {
-        title: "Can we use cookies to collect information about how you use GOV.UK?",
-        text: "Cookies help us see where we can make improvements to GOV.UK.",
-        confirmation_message: "You have accepted cookies.",
-        cookie_preferences_href: "https://www.gov.uk/government/publications/govuk-accounts-trial-full-privacy-notice-and-accessibility-statement",
-        services_cookies: {
-          yes: {
-            text: "Yes",
-            data_attributes: {
-              "an_attribute": "some_value1",
-            },
-          },
-          no: {
-            text: "No",
-            data_attributes: {
-              "an_attribute": "some_value2",
-            },
-          },
-          cookie_preferences: {
-            text: "How GOV.UK accounts use cookies",
-            href: "https://www.gov.uk/government/publications/govuk-accounts-trial-full-privacy-notice-and-accessibility-statement",
-          },
-        },
-      },
-    })
-
-    assert_select ".govuk-cookie-banner__heading.govuk-heading-m", text: "Can we use cookies to collect information about how you use GOV.UK?"
-    assert_select ".govuk-cookie-banner .gem-c-button[data-an-attribute='some_value1']", text: "Yes"
-    assert_select ".govuk-cookie-banner .gem-c-button[data-an-attribute='some_value2']", text: "No"
-  end
-
   it "displays as draft watermark" do
     render_component({ draft_watermark: true })
 


### PR DESCRIPTION
## What

Remove unused `services_cookies` option from cookie banner

## Why

No longer used anywhere https://github.com/search?q=org%3Aalphagov%20services_cookies&type=code.