### PR TITLE
Update colours to Design System v6

### DIFF
--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -222,7 +222,7 @@ html {
 // Rouge syntax highlighting
 // Based on https://github.com/alphagov/tech-docs-template/blob/master/template/source/stylesheets/palette/_syntax-highlighting.scss
 
-$code-00: color.scale(govuk-colour("light-grey"), $lightness: 50%); // Default Background
+$code-00: color.scale(govuk-colour("black", $variant: "tint-95"), $lightness: 50%); // Default Background
 $code-01: #f5f5f5; // Lighter Background (Unused)
 $code-02: #bfc1c3; // Selection Background
 $code-03: color.adjust($govuk-secondary-text-colour, $lightness: -2%); // Comments, Invisibles, Line Highlighting

--- a/app/assets/stylesheets/govuk_publishing_components/components/_app-promo-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_app-promo-banner.scss
@@ -46,7 +46,7 @@
 .gem-c-app-promo-banner__close-button {
   border: 0;
   padding: 0;
-  color: govuk-tint(govuk-colour("black"), 25%);
+  color: govuk-colour("black", $variant: "tint-25");
   background: none;
   flex: 0 0 24px;
   height: 24px;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
@@ -5,7 +5,7 @@ $thumbnail-background: govuk-colour("white");
 $thumbnail-border-colour: rgba(11, 12, 12, .1);
 $thumbnail-shadow-colour: rgba(11, 12, 12, .4);
 $thumbnail-shadow-width: 0 2px 2px;
-$thumbnail-icon-border-colour: govuk-colour("mid-grey");
+$thumbnail-icon-border-colour: govuk-colour("black", $variant: "tint-80");
 
 .gem-c-attachment {
   position: relative;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_checkboxes.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_checkboxes.scss
@@ -6,7 +6,7 @@
   box-sizing: border-box;
   border-left-style: solid;
   border-left-width: 4px;
-  border-color: govuk-colour("mid-grey");
+  border-color: govuk-colour("black", $variant: "tint-80");
   margin-top: govuk-spacing(2);
   margin-bottom: govuk-spacing(2);
   padding: govuk-spacing(2) govuk-spacing(4);

--- a/app/assets/stylesheets/govuk_publishing_components/components/_contents-list-with-body.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_contents-list-with-body.scss
@@ -53,7 +53,7 @@
 }
 
 .gem-c-contents-list-with-body__link-wrapper.gem-c-contents-list-with-body__sticky-element--stuck-to-window {
-  background-color: govuk-colour("light-grey");
+  background-color: govuk-colour("black", $variant: "tint-95");
   bottom: -1px; // 'Fix' for anomalous 1px margin which sporadically appears below this element.
   left: 0;
   margin: 0;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_contextual-sidebar.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_contextual-sidebar.scss
@@ -26,7 +26,7 @@
 .gem-c-contextual-sidebar__cta {
   border-top: 2px solid $govuk-brand-colour;
   margin-bottom: govuk-spacing(6);
-  background-color: govuk-colour("light-grey");
+  background-color: govuk-colour("black", $variant: "tint-95");
   display: block;
   padding: 0 govuk-spacing(3) govuk-spacing(3);
   text-decoration: none;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cross-service-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cross-service-header.scss
@@ -259,7 +259,7 @@ $toggle-border-height: 3px;
     padding: govuk-spacing(3) 0;
 
     &:not(:last-child) {
-      border-bottom: 1px solid govuk-colour("mid-grey");
+      border-bottom: 1px solid govuk-colour("black", $variant: "tint-80");
     }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_devolved-nations.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_devolved-nations.scss
@@ -1,5 +1,5 @@
 .gem-c-devolved-nations {
-  background: govuk-colour("light-grey");
+  background: govuk-colour("black", $variant: "tint-95");
   margin-bottom: govuk-spacing(3);
   padding: govuk-spacing(3);
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -94,7 +94,7 @@
 }
 
 .gem-c-document-list__item--highlight {
-  border: 1px solid govuk-colour("mid-grey");
+  border: 1px solid govuk-colour("black", $variant: "tint-80");
   padding: govuk-spacing(6);
   margin-bottom: govuk-spacing(6);
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -50,7 +50,7 @@
 }
 
 .gem-c-document-list__item-context {
-  color: govuk-colour("dark-grey");
+  color: govuk-colour("black", $variant: "tint-25");
 }
 
 .gem-c-document-list__item-description {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_emergency-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_emergency-banner.scss
@@ -1,5 +1,5 @@
 .gem-c-emergency-banner {
-  background-color: govuk-colour("mid-grey");
+  background-color: govuk-colour("black", $variant: "tint-80");
   color: govuk-colour("white");
   margin-top: 2px;
   padding: govuk-spacing(3) 0;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -119,7 +119,7 @@ $feedback-prompt-border-top-colour: $govuk-blue-tint-50;
   }
 
   &:hover {
-    background: govuk-colour("mid-grey");
+    background: govuk-colour("black", $variant: "tint-80");
     color: govuk-colour("black");
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_glance-metric.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_glance-metric.scss
@@ -55,7 +55,7 @@
     }
 
     &-icon {
-      color: govuk-colour("dark-grey");
+      color: govuk-colour("black", $variant: "tint-25");
 
       @include govuk-media-query($until: mobile) {
         @include govuk-font(19);

--- a/app/assets/stylesheets/govuk_publishing_components/components/_govspeak-html-publication.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_govspeak-html-publication.scss
@@ -113,7 +113,7 @@
       // total and subtotal rows
       tr.subtotal > *,
       tr.total > * {
-        border-top: 3px solid govuk-colour("mid-grey");
+        border-top: 3px solid govuk-colour("black", $variant: "tint-80");
       }
 
       tr.total > *,

--- a/app/assets/stylesheets/govuk_publishing_components/components/_govspeak-html-publication.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_govspeak-html-publication.scss
@@ -67,7 +67,7 @@
       // and make all of thead and tfoot stand out
       thead,
       tfoot {
-        background-color: govuk-colour("light-grey");
+        background-color: govuk-colour("black", $variant: "tint-95");
       }
 
       thead th,
@@ -124,7 +124,7 @@
       // the total is usually in the tfoot, so already has that background colour
       // but when it's used inside the tbody, it should also be highlighted
       tr.total {
-        background-color: govuk-colour("light-grey");
+        background-color: govuk-colour("black", $variant: "tint-95");
       }
     }
     // stylelint-enable selector-no-qualifying-type

--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -75,7 +75,7 @@
   font-size: 16px;
   font-size: govuk-px-to-rem(16px);
   margin: 0 0 calc(govuk-spacing(3) / 2);
-  color: govuk-colour("dark-grey");
+  color: govuk-colour("black", $variant: "tint-25");
   @include govuk-font($size: false);
 
   @include govuk-media-query($from: tablet) {
@@ -102,7 +102,7 @@
   }
 
   .gem-c-image-card__list-item--text {
-    color: govuk-colour("dark-grey");
+    color: govuk-colour("black", $variant: "tint-25");
   }
 
   .gem-c-image-card__list-item-link {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_intervention.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_intervention.scss
@@ -1,5 +1,5 @@
 .gem-c-intervention {
-  background-color: govuk-colour("light-grey");
+  background-color: govuk-colour("black", $variant: "tint-95");
   border-left: 10px solid $govuk-success-colour;
   @include govuk-text-colour;
   @include govuk-responsive-padding(3);

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -563,7 +563,7 @@ $search-icon-height: 20px;
     bottom: 0;
     width: 100%;
     background: $govuk-rebrand-template-background-colour;
-    box-shadow: 0 1px govuk-colour("mid-grey");
+    box-shadow: 0 1px govuk-colour("black", $variant: "tint-80");
   }
 }
 
@@ -607,7 +607,7 @@ $search-icon-height: 20px;
 // JS available - styling for the "services-and-information" group of links
 .gem-c-layout-super-navigation-header__navigation-second-items--services-and-information {
   @include govuk-media-query($until: "desktop") {
-    border-bottom: 1px solid govuk-colour("mid-grey");
+    border-bottom: 1px solid govuk-colour("black", $variant: "tint-80");
   }
 
   @include govuk-media-query($from: "desktop") {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_print-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_print-link.scss
@@ -27,7 +27,7 @@ $gem-c-print-link-background-height: 18px;
   }
 
   &:hover {
-    background-color: govuk-colour("light-grey");
+    background-color: govuk-colour("black", $variant: "tint-95");
   }
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_print-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_print-link.scss
@@ -32,7 +32,7 @@ $gem-c-print-link-background-height: 18px;
 }
 
 .gem-c-print-link__link {
-  box-shadow: inset 0 0 0 1px govuk-colour("dark-grey");
+  box-shadow: inset 0 0 0 1px govuk-colour("black", $variant: "tint-25");
 
   &:focus {
     border: 0;
@@ -41,7 +41,7 @@ $gem-c-print-link-background-height: 18px;
 }
 
 .gem-c-print-link__button {
-  border: 1px solid govuk-colour("dark-grey");
+  border: 1px solid govuk-colour("black", $variant: "tint-25");
   color: $govuk-link-colour;
   cursor: pointer;
   margin: govuk-spacing(0);

--- a/app/assets/stylesheets/govuk_publishing_components/components/_related-navigation.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_related-navigation.scss
@@ -11,7 +11,7 @@
 }
 
 .gem-c-related-navigation__sub-heading {
-  border-top: 1px solid govuk-colour("mid-grey");
+  border-top: 1px solid govuk-colour("black", $variant: "tint-80");
   margin: 0;
   padding-top: govuk-spacing(3);
   @include govuk-font(16);

--- a/app/assets/stylesheets/govuk_publishing_components/components/_reorderable-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_reorderable-list.scss
@@ -18,7 +18,7 @@
 }
 
 .gem-c-reorderable-list__item--chosen {
-  background-color: govuk-colour("light-grey");
+  background-color: govuk-colour("black", $variant: "tint-95");
   outline: 2px dotted $govuk-border-colour;
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search-with-autocomplete.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search-with-autocomplete.scss
@@ -75,7 +75,7 @@ $large-input-size: 50px;
 .gem-c-search-with-autocomplete__option--focused,
 .gem-c-search-with-autocomplete__option:hover,
 .gem-c-search-with-autocomplete__option:focus-visible {
-  background-color: govuk-colour("light-grey");
+  background-color: govuk-colour("black", $variant: "tint-95");
   outline: none;
 
   @include govuk-link-decoration;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search-with-autocomplete.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search-with-autocomplete.scss
@@ -98,7 +98,7 @@ $large-input-size: 50px;
   align-items: center;
   margin: 0 govuk-spacing(3);
   padding: govuk-spacing(1) 0;
-  border-bottom: 1px solid govuk-colour("mid-grey");
+  border-bottom: 1px solid govuk-colour("black", $variant: "tint-80");
 }
 
 .gem-c-search-with-autocomplete__option:last-child .gem-c-search-with-autocomplete__option-wrapper {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_select-with-search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_select-with-search.scss
@@ -124,7 +124,7 @@ $choices-button-dimension: 12px !default;
     border: 0;
     padding: 0 0 0 govuk-spacing(2);
     margin: govuk-spacing(2) govuk-spacing(2) 0 0;
-    background-color: govuk-colour("light-grey");
+    background-color: govuk-colour("black", $variant: "tint-95");
     box-shadow: 0 $govuk-border-width-form-element 0 govuk-colour("black", $variant: "tint-80");
     line-height: 1;
     color: $govuk-text-colour;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_select-with-search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_select-with-search.scss
@@ -46,13 +46,13 @@ $choices-button-dimension: 12px !default;
 
   .choices[data-type*="select-multiple"] .choices__button,
   .choices[data-type*="text"] .choices__button {
-    border-color: govuk-colour("mid-grey");
-    border-right: 1px solid govuk-colour("mid-grey");
+    border-color: govuk-colour("black", $variant: "tint-80");
+    border-right: 1px solid govuk-colour("black", $variant: "tint-80");
     padding: govuk-spacing(2) govuk-spacing(4) govuk-spacing(2) govuk-spacing(2);
     margin-right: 0;
 
     &:hover {
-      background-color: govuk-colour("mid-grey");
+      background-color: govuk-colour("black", $variant: "tint-80");
       border-color: govuk-colour("black", $variant: "tint-25");
       box-shadow: 0 $govuk-border-width-form-element 0 govuk-colour("black", $variant: "tint-25");
     }
@@ -125,7 +125,7 @@ $choices-button-dimension: 12px !default;
     padding: 0 0 0 govuk-spacing(2);
     margin: govuk-spacing(2) govuk-spacing(2) 0 0;
     background-color: govuk-colour("light-grey");
-    box-shadow: 0 $govuk-border-width-form-element 0 govuk-colour("mid-grey");
+    box-shadow: 0 $govuk-border-width-form-element 0 govuk-colour("black", $variant: "tint-80");
     line-height: 1;
     color: $govuk-text-colour;
 
@@ -149,7 +149,7 @@ $choices-button-dimension: 12px !default;
   .choices__list--dropdown .choices__item,
   .choices__list[aria-expanded] .choices__item {
     position: relative;
-    border-bottom: 1px solid govuk-colour("mid-grey");
+    border-bottom: 1px solid govuk-colour("black", $variant: "tint-80");
 
     &:last-child {
       border-bottom: 0;
@@ -168,7 +168,7 @@ $choices-button-dimension: 12px !default;
     @include govuk-typography-weight-bold;
     color: govuk-colour("black"); // Choices.js doesn't use a variable for this color for some reason :(
     padding: govuk-spacing(6) govuk-spacing(2) govuk-spacing(2);
-    border-bottom: 1px solid govuk-colour("mid-grey");
+    border-bottom: 1px solid govuk-colour("black", $variant: "tint-80");
     cursor: default;
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_select-with-search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_select-with-search.scss
@@ -53,8 +53,8 @@ $choices-button-dimension: 12px !default;
 
     &:hover {
       background-color: govuk-colour("mid-grey");
-      border-color: govuk-colour("dark-grey");
-      box-shadow: 0 $govuk-border-width-form-element 0 govuk-colour("dark-grey");
+      border-color: govuk-colour("black", $variant: "tint-25");
+      box-shadow: 0 $govuk-border-width-form-element 0 govuk-colour("black", $variant: "tint-25");
     }
 
     &:focus {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_share-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_share-links.scss
@@ -128,7 +128,7 @@ $column-width: 9.5em;
 
 .gem-c-share-links--square-icons {
   .gem-c-share-links__link-icon {
-    background-color: govuk-colour("light-grey");
+    background-color: govuk-colour("black", $variant: "tint-95");
     color: govuk-colour("black");
     padding: govuk-spacing(2);
   }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_signup-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_signup-link.scss
@@ -21,7 +21,7 @@
 
 .gem-c-signup-link--with-background-and-border {
   padding: govuk-spacing(6);
-  background-color: govuk-colour("light-grey");
+  background-color: govuk-colour("black", $variant: "tint-95");
   border: 1px solid $govuk-border-colour;
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_single-page-notification-button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_single-page-notification-button.scss
@@ -13,7 +13,7 @@
   }
 
   &:hover {
-    background-color: govuk-colour("light-grey");
+    background-color: govuk-colour("black", $variant: "tint-95");
     color: $govuk-link-hover-colour;
 
     &:focus {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_single-page-notification-button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_single-page-notification-button.scss
@@ -1,7 +1,7 @@
 .gem-c-single-page-notification-button__submit {
   padding: govuk-spacing(2);
   margin: govuk-spacing(0);
-  border: 1px solid govuk-colour("dark-grey");
+  border: 1px solid govuk-colour("black", $variant: "tint-25");
   color: $govuk-link-colour;
   cursor: pointer;
   background: none;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-header.scss
@@ -1,7 +1,7 @@
 .gem-c-step-nav-header {
   position: relative;
   padding: 10px;
-  background: govuk-colour("light-grey");
+  background: govuk-colour("black", $variant: "tint-95");
   border-bottom: solid 1px govuk-colour("blue");
   margin-top: govuk-spacing(3);
   @include govuk-font(24, $weight: bold);

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
@@ -1,7 +1,7 @@
 $stroke-width: 1px;
 $number-circle-size: 30px;
 $number-circle-size-large: 35px;
-$top-border: solid 1px govuk-colour("mid-grey");
+$top-border: solid 1px govuk-colour("black", $variant: "tint-80");
 
 @mixin step-nav-vertical-line($line-style: solid) {
   content: "";
@@ -9,7 +9,7 @@ $top-border: solid 1px govuk-colour("mid-grey");
   z-index: 2;
   width: 0;
   height: 100%;
-  border-left: $line-style $stroke-width govuk-colour("mid-grey");
+  border-left: $line-style $stroke-width govuk-colour("black", $variant: "tint-80");
   background: govuk-colour("white");
 }
 
@@ -261,7 +261,7 @@ $top-border: solid 1px govuk-colour("mid-grey");
     margin-left: calc($number-circle-size / 4);
     width: calc($number-circle-size / 2);
     height: 0;
-    border-bottom: solid $stroke-width govuk-colour("mid-grey");
+    border-bottom: solid $stroke-width govuk-colour("black", $variant: "tint-80");
   }
 
   &::after {
@@ -319,7 +319,7 @@ $top-border: solid 1px govuk-colour("mid-grey");
 }
 
 .gem-c-step-nav__circle--number {
-  border: solid $stroke-width govuk-colour("mid-grey");
+  border: solid $stroke-width govuk-colour("black", $variant: "tint-80");
   @include step-nav-font(16, $weight: bold, $line-height: 29px);
 
   .gem-c-step-nav--large & {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
@@ -119,7 +119,7 @@ $top-border: solid 1px govuk-colour("black", $variant: "tint-80");
   margin: 0;
 
   &:hover {
-    background: govuk-colour("light-grey");
+    background: govuk-colour("black", $variant: "tint-95");
     // Chevron icon interaction states
     .gem-c-step-nav__chevron {
       color: govuk-colour("black");
@@ -127,7 +127,7 @@ $top-border: solid 1px govuk-colour("black", $variant: "tint-80");
     }
 
     .gem-c-step-nav__chevron::after {
-      color: govuk-colour("light-grey");
+      color: govuk-colour("black", $variant: "tint-95");
     }
 
     .gem-c-step-nav__button-text {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
@@ -530,7 +530,7 @@ $top-border: solid 1px govuk-colour("mid-grey");
 .gem-c-step-nav__context {
   display: inline-block;
   font-weight: normal;
-  color: govuk-colour("dark-grey");
+  color: govuk-colour("black", $variant: "tint-25");
 
   &::before {
     content: " \2013\00a0"; // dash followed by &nbsp;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_sub-navigation-menu.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_sub-navigation-menu.scss
@@ -4,7 +4,7 @@
 }
 
 .gem-c-sub-navigation-menu__button-container {
-  background-color: govuk-colour("light-grey");
+  background-color: govuk-colour("black", $variant: "tint-95");
   border-bottom: 1px solid govuk-colour("black", $variant: "tint-80");
 }
 
@@ -21,7 +21,7 @@
   padding-right: govuk-spacing(3);
   // Invisible border so the width of the collapsed button is the same as the expanded one.
   border-left: 1px solid rgba(0, 0, 0, 0);
-  border-right: 1px solid govuk-colour("light-grey");
+  border-right: 1px solid govuk-colour("black", $variant: "tint-95");
   cursor: pointer;
   position: relative;
   @include govuk-font(19);
@@ -63,7 +63,7 @@
   background-color: govuk-colour("white");
 
   @include govuk-media-query($until: tablet) {
-    border-left: 1px solid govuk-colour("light-grey"); // Hide left border on mobile while preserving button width.
+    border-left: 1px solid govuk-colour("black", $variant: "tint-95"); // Hide left border on mobile while preserving button width.
   }
 
   // Expanded arrow icon

--- a/app/assets/stylesheets/govuk_publishing_components/components/_sub-navigation-menu.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_sub-navigation-menu.scss
@@ -98,7 +98,7 @@
 }
 
 .gem-c-sub-navigation-menu__button:hover::before {
-  border-color: govuk-colour("dark-blue");
+  border-color: govuk-colour("blue", $variant: "shade-50");
 }
 
 .gem-c-sub-navigation-menu__nav-container {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_sub-navigation-menu.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_sub-navigation-menu.scss
@@ -5,7 +5,7 @@
 
 .gem-c-sub-navigation-menu__button-container {
   background-color: govuk-colour("light-grey");
-  border-bottom: 1px solid govuk-colour("mid-grey");
+  border-bottom: 1px solid govuk-colour("black", $variant: "tint-80");
 }
 
 .gem-c-sub-navigation-menu__button-container--collapsed {
@@ -59,7 +59,7 @@
 }
 
 .gem-c-sub-navigation-menu__button[aria-expanded="true"] {
-  border-color: govuk-colour("mid-grey");
+  border-color: govuk-colour("black", $variant: "tint-80");
   background-color: govuk-colour("white");
 
   @include govuk-media-query($until: tablet) {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_subscription-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_subscription-links.scss
@@ -94,7 +94,7 @@
 .gem-c-subscription-links__feed-box {
   padding: govuk-spacing(3);
   margin-bottom: govuk-spacing(3);
-  background: govuk-colour("light-grey");
+  background: govuk-colour("black", $variant: "tint-95");
 
   .govuk-frontend-supported &.js-hidden {
     display: none;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_table.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_table.scss
@@ -3,13 +3,13 @@
 $table-border-width: 1px;
 $table-border-colour: govuk-colour("black", $variant: "tint-80");
 $table-header-border-width: 2px;
-$table-header-background-colour: govuk-colour("light-grey");
+$table-header-background-colour: govuk-colour("black", $variant: "tint-95");
 $sort-link-active-colour: govuk-colour("white");
 $sort-link-arrow-size: 14px;
 $sort-link-arrow-size-small: 8px;
 $sort-link-arrow-spacing: calc($sort-link-arrow-size / 2);
 $table-row-hover-background-colour: rgba(43, 140, 196, .2);
-$table-row-even-background-colour: govuk-colour("light-grey");
+$table-row-even-background-colour: govuk-colour("black", $variant: "tint-95");
 
 .govuk-table__cell:empty,
 .govuk-table__cell--empty {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_table.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_table.scss
@@ -1,7 +1,7 @@
 @import "govuk/components/table/table";
 
 $table-border-width: 1px;
-$table-border-colour: govuk-colour("mid-grey");
+$table-border-colour: govuk-colour("black", $variant: "tint-80");
 $table-header-border-width: 2px;
 $table-header-background-colour: govuk-colour("light-grey");
 $sort-link-active-colour: govuk-colour("white");

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
@@ -44,8 +44,8 @@
       }
 
       svg {
-        fill: govuk-colour("mid-grey");
-        stroke: govuk-colour("mid-grey");
+        fill: govuk-colour("black", $variant: "tint-80");
+        stroke: govuk-colour("black", $variant: "tint-80");
       }
 
       @include govuk-media-query($media-type: print) {

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_call-to-action.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_call-to-action.scss
@@ -10,7 +10,7 @@
 .gem-c-govspeak {
   .call-to-action {
     margin: 0 0 govuk-spacing(4) 0;
-    background-color: govuk-colour("light-grey");
+    background-color: govuk-colour("black", $variant: "tint-95");
     padding: govuk-spacing(6);
     padding-bottom: govuk-spacing(2);
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_contact.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_contact.scss
@@ -12,7 +12,7 @@
   // .address is used by the `$A` markdown pattern
   .address,
   .contact {
-    border-left: 1px solid govuk-colour("mid-grey");
+    border-left: 1px solid govuk-colour("black", $variant: "tint-80");
     padding-left: govuk-spacing(3);
     margin: 0 0 govuk-spacing(6) 0;
   }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_example.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_example.scss
@@ -8,7 +8,7 @@
 .govspeak, // Legacy class name that's still used in some content items - needs to be kept until `.govspeak` is removed from the content items.
 .gem-c-govspeak {
   .example {
-    border-left: 10px solid govuk-colour("mid-grey");
+    border-left: 10px solid govuk-colour("black", $variant: "tint-80");
     padding: govuk-spacing(4) 0 0.1234px govuk-spacing(4); // non-zero padding on bottom keeps margin of last element inside parent, simulating padding
     margin: 0 0 govuk-spacing(4) 0;
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_footnotes.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_footnotes.scss
@@ -14,7 +14,7 @@
 .govspeak, // Legacy class name that's still used in some content items - needs to be kept until `.govspeak` is removed from the content items.
 .gem-c-govspeak {
   .footnotes {
-    border-top: 1px solid govuk-colour("mid-grey");
+    border-top: 1px solid govuk-colour("black", $variant: "tint-80");
     margin: 0 0 govuk-spacing(4) 0;
     padding-top: govuk-spacing(4);
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_footnotes.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_footnotes.scss
@@ -31,7 +31,7 @@
     }
 
     li:target {
-      background: govuk-colour("light-grey");
+      background: govuk-colour("black", $variant: "tint-95");
       border-bottom: solid 3px $govuk-border-colour;
     }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_information-callout.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_information-callout.scss
@@ -9,7 +9,7 @@
 .govspeak, // Legacy class name that's still used in some content items - needs to be kept until `.govspeak` is removed from the content items.
 .gem-c-govspeak {
   .info-notice {
-    border-left: 10px solid govuk-colour("mid-grey");
+    border-left: 10px solid govuk-colour("black", $variant: "tint-80");
     padding: govuk-spacing(4) 0 0.1234px govuk-spacing(4); // non-zero padding on bottom keeps margin of last element inside parent, simulating padding
     margin: 0 0 govuk-spacing(4) 0;
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_media-player.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_media-player.scss
@@ -35,7 +35,7 @@
   position: relative;
   padding: govuk-spacing(6);
   padding-bottom: govuk-spacing(8);
-  background: govuk-colour("light-grey");
+  background: govuk-colour("black", $variant: "tint-95");
   border: solid 2px $govuk-border-colour;
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_place.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_place.scss
@@ -3,7 +3,7 @@
 .gem-c-govspeak {
   .place {
     margin: 0 0 govuk-spacing(4) 0;
-    border-bottom: solid 1px govuk-colour("mid-grey");
+    border-bottom: solid 1px govuk-colour("black", $variant: "tint-80");
     padding-bottom: 1.5em;
 
     .address {

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_tables.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_tables.scss
@@ -25,7 +25,7 @@
     td {
       vertical-align: top;
       padding: govuk-spacing(2) govuk-spacing(4) govuk-spacing(2) 0;
-      border-bottom: 1px solid govuk-colour("mid-grey");
+      border-bottom: 1px solid govuk-colour("black", $variant: "tint-80");
 
       &:last-child {
         padding: govuk-spacing(2) 0 govuk-spacing(2) 0;

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_colours.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_colours.scss
@@ -7,8 +7,8 @@ $gem-quiet-button-colour: govuk-colour("black", $variant: "tint-25");
 $gem-quiet-button-hover-colour: darken($gem-quiet-button-colour, 5%);
 
 // Brand refresh
-$govuk-blue-tint-95: govuk-tint($govuk-brand-colour, 95%);
-$govuk-blue-tint-80: govuk-tint(govuk-colour("blue"), 80%);
-$govuk-blue-tint-50: govuk-tint(govuk-colour("blue"), 50%);
+$govuk-blue-tint-95: govuk-colour("blue", $variant: "tint-95");
+$govuk-blue-tint-80: govuk-colour("blue", $variant: "tint-80");
+$govuk-blue-tint-50: govuk-colour("blue", $variant: "tint-50");
 
 $govuk-rebrand-template-background-colour: $govuk-blue-tint-95;

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_colours.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_colours.scss
@@ -1,7 +1,7 @@
 $gem-secondary-button-colour: #00823b;
 $gem-secondary-button-hover-colour: darken($gem-secondary-button-colour, 5%);
 $gem-secondary-button-background-colour: govuk-colour("white");
-$gem-secondary-button-hover-background-colour: govuk-colour("light-grey");
+$gem-secondary-button-hover-background-colour: govuk-colour("black", $variant: "tint-95");
 
 $gem-quiet-button-colour: govuk-colour("black", $variant: "tint-25");
 $gem-quiet-button-hover-colour: darken($gem-quiet-button-colour, 5%);

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_colours.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_colours.scss
@@ -3,7 +3,7 @@ $gem-secondary-button-hover-colour: darken($gem-secondary-button-colour, 5%);
 $gem-secondary-button-background-colour: govuk-colour("white");
 $gem-secondary-button-hover-background-colour: govuk-colour("light-grey");
 
-$gem-quiet-button-colour: govuk-colour("dark-grey");
+$gem-quiet-button-colour: govuk-colour("black", $variant: "tint-25");
 $gem-quiet-button-hover-colour: darken($gem-quiet-button-colour, 5%);
 
 // Brand refresh

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_markdown-typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_markdown-typography.scss
@@ -121,6 +121,6 @@
   code {
     padding: 0 5px;
     color: #d13118;
-    background-color: govuk-colour("light-grey");
+    background-color: govuk-colour("black", $variant: "tint-95");
   }
 }

--- a/app/views/govuk_publishing_components/components/_tag.html.erb
+++ b/app/views/govuk_publishing_components/components/_tag.html.erb
@@ -8,7 +8,7 @@
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("govuk-tag gem-c-tag")
 
-  colours = %w[grey green turquoise blue light-blue purple pink red orange yellow]
+  colours = %w[grey green teal blue purple magenta red orange yellow]
   colour ||= nil
   component_helper.add_class("govuk-tag--#{colour}") if colours.include?(colour)
 %>

--- a/app/views/govuk_publishing_components/components/docs/tag.yml
+++ b/app/views/govuk_publishing_components/components/docs/tag.yml
@@ -23,26 +23,22 @@ examples:
     data:
       text: Hello world!
       colour: green
-  turquoise:
+  teal:
     data:
       text: Hello world!
-      colour: turquoise
+      colour: teal
   blue:
     data:
       text: Hello world!
       colour: blue
-  light_blue:
-    data:
-      text: Hello world!
-      colour: light-blue
   purple:
     data:
       text: Hello world!
       colour: purple
-  pink:
+  magenta:
     data:
       text: Hello world!
-      colour: pink
+      colour: magenta
   red:
     data:
       text: Hello world!

--- a/spec/components/tag_spec.rb
+++ b/spec/components/tag_spec.rb
@@ -29,7 +29,7 @@ describe "Tag", type: :view do
   end
 
   it "adds a colour if a valid one is supplied" do
-    colours = %w[grey green turquoise blue light-blue purple pink red orange yellow]
+    colours = %w[grey green teal blue purple magenta red orange yellow]
     colours.each do |colour|
       render_component({ text: "Hello", colour: colour })
       assert_select "strong.govuk-tag.govuk-tag--#{colour}"


### PR DESCRIPTION
## What
Prepare for the update to Design System v6.0.0 by updating colours that were deprecated or replaced in that release.

This PR addresses the changes under "Use GOV.UK brand colours" in the [GOV.UK Frontend v6.0.0 release notes](https://github.com/alphagov/govuk-frontend/releases/tag/v6.0.0).

## Why
Jira card: https://gov-uk.atlassian.net/jira/software/c/projects/NAV/boards/1422?quickFilter=2319&selectedIssue=NAV-18921

