### PR TITLE
Create new datetime fields component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Remove unused 'services_cookies' option from cookie banner
  ([PR #5488](https://github.com/alphagov/govuk_publishing_components/pull/5488))
+* Create new datetime fields component ([PR #5492](https://github.com/alphagov/govuk_publishing_components/pull/5492))
 
 ## 66.4.2
 

--- a/app/assets/stylesheets/govuk_publishing_components/all-components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/all-components.scss
@@ -30,6 +30,7 @@
 @import "components/cookie-banner";
 @import "components/cross-service-header";
 @import "components/date-input";
+@import "components/datetime-fields";
 @import "components/details";
 @import "components/devolved-nations";
 @import "components/document-list";

--- a/app/assets/stylesheets/govuk_publishing_components/all-components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/all-components.scss
@@ -31,6 +31,7 @@
 @import "components/cookie-banner";
 @import "components/cross-service-header";
 @import "components/date-input";
+@import "components/datetime-fields";
 @import "components/details";
 @import "components/devolved-nations";
 @import "components/document-list";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_datetime-fields.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_datetime-fields.scss
@@ -1,9 +1,11 @@
 .gem-c-datetime-fields__date-time-wrapper {
-  display: inline-flex;
+  margin-top: govuk-spacing(-2);
 }
 
 .gem-c-datetime-fields__date-time {
+  display: inline-block;
   margin-right: govuk-spacing(2);
+  margin-top: govuk-spacing(2);
 }
 
 .govuk-select {
@@ -19,6 +21,7 @@
 }
 
 .gem-c-datetime-fields__time-separator {
+  display: inline-block;
   margin: govuk-spacing(6) + 5 govuk-spacing(2) 0 0;
   margin-bottom: 0;
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_datetime-fields.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_datetime-fields.scss
@@ -1,0 +1,24 @@
+.gem-c-datetime-fields__date-time-wrapper {
+  display: inline-flex;
+}
+
+.gem-c-datetime-fields__date-time {
+  margin-right: govuk-spacing(2);
+}
+
+.govuk-select {
+  &.gem-c-datetime-fields__date-time-input {
+    max-width: 4.5em;
+    min-width: 4.5em;
+  }
+
+  &.gem-c-datetime-fields__date-time-input--large {
+    max-width: 7.5em;
+    min-width: 7.5em;
+  }
+}
+
+.gem-c-datetime-fields__time-separator {
+  margin: govuk-spacing(6) + 5 govuk-spacing(2) 0 0;
+  margin-bottom: 0;
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/_datetime-fields.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_datetime-fields.scss
@@ -6,22 +6,39 @@
   display: inline-block;
   margin-right: govuk-spacing(2);
   margin-top: govuk-spacing(2);
+
+  // For using the select component
+  .govuk-select {
+    max-width: 4.5em;
+    min-width: 4.5em;
+  }
 }
 
+// This is not needed when using the select component
 .govuk-select {
   &.gem-c-datetime-fields__date-time-input {
     max-width: 4.5em;
     min-width: 4.5em;
   }
 
+  // Is this ever used? Pretty sure it isn't
   &.gem-c-datetime-fields__date-time-input--large {
     max-width: 7.5em;
     min-width: 7.5em;
   }
 }
 
+// Probably better to do this as generated text rather than a <p> element
 .gem-c-datetime-fields__time-separator {
   display: inline-block;
   margin: govuk-spacing(6) + 5 govuk-spacing(2) 0 0;
   margin-bottom: 0;
 }
+
+// Don't think this is ever used but if it is will need to be restored
+// .gem-c-datetime-fields__date-time-input--large {
+//   .govuk-select {
+//     max-width: 7.5em;
+//     min-width: 7.5em;
+//   }
+// }

--- a/app/views/govuk_publishing_components/components/_date_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_date_input.html.erb
@@ -8,6 +8,8 @@
   ]
   autocomplete_date_of_birth ||= nil
   legend_text ||= nil
+  legend_level ||= nil
+  legend_size ||= nil
   hint ||= nil
   error_message ||= nil
   error_items ||= []
@@ -29,9 +31,11 @@
     aria_described_by << describedby if describedby
     aria_described_by = aria_described_by.join(" ")
   end
+
+  data_attributes ||= {}
 %>
 
-<%= content_tag :div, class: form_group_css_classes do %>
+<%= content_tag :div, class: form_group_css_classes, data: data_attributes do %>
   <% fieldset_content = capture do %>
     <% if hint %>
       <%= render "govuk_publishing_components/components/hint", {
@@ -75,6 +79,8 @@
     <%= render "govuk_publishing_components/components/fieldset", {
       describedby: aria_described_by,
       legend_text: legend_text,
+      heading_level: legend_level,
+      heading_size: legend_size,
       text: fieldset_content,
       role: "group",
     } %>

--- a/app/views/govuk_publishing_components/components/_datetime_fields.html.erb
+++ b/app/views/govuk_publishing_components/components/_datetime_fields.html.erb
@@ -1,0 +1,144 @@
+<%
+  prefix ||= nil
+  field_name ||= nil
+  id = id
+  date_id = "#{id}_date"
+  date_only ||= false
+  date_heading ||= "Date (required)"
+  time_heading ||= "Time"
+
+  error_items = error_items ||= nil
+  error_items_date = error_items_date ||= nil
+  error_items_time = error_items_time ||= nil
+  error_id_time = "error-#{SecureRandom.hex(4)}"
+
+  heading_level = heading_level ||= nil
+  heading_size = heading_size ||= nil
+
+  date_hint = date_hint ||= nil
+  time_hint = time_hint ||= nil
+  time_hint_id = "time-hint-#{SecureRandom.hex(4)}"
+
+  year ||= nil
+  month ||= nil
+  day ||= nil
+  date_input_items = []
+  date_input_items << day if day
+  date_input_items << month if month
+  date_input_items << year if year
+  date_input_items = nil unless date_input_items.any?
+
+  hour ||= {}
+  hour_value = hour[:value]
+  hour_select_id = hour[:id] || "select-hour-#{SecureRandom.hex(4)}"
+  hour_label_id = "hour-#{SecureRandom.hex(4)}"
+
+  minute ||= {}
+  minute_value = minute[:value]
+  minute_select_id = minute[:id] || "select-minute-#{SecureRandom.hex(4)}"
+  minute_label_id = "minute-#{SecureRandom.hex(4)}"
+
+  date_ga4_form_section = date_heading
+  time_ga4_form_section = time_heading
+
+  root_classes = %w[gem-c-datetime-fields govuk-form-group]
+  root_classes << "govuk-form-group--error" if error_items.present?
+
+  time_group_classes = %w[govuk-form-group]
+  time_group_classes << "govuk-form-group--error" if error_items_time.present?
+
+  time_select_classes = %w[govuk-select gem-c-datetime-fields__date-time-input]
+  time_select_classes << "govuk-select--error" if (error_items.present? || error_items_time.present?)
+
+  data_attributes ||= {}
+%>
+
+<%= tag.div id: do %>
+  <% if prefix && field_name %>
+    <%= tag.div class: root_classes, data: data_attributes do %>
+      <%= render "govuk_publishing_components/components/date_input", {
+        id: date_id,
+        hint: date_hint,
+        error_items: (error_items.presence || error_items_date),
+        items: date_input_items,
+        legend_text: date_heading,
+        legend_level: heading_level,
+        legend_size: heading_size,
+        data_attributes: {
+          ga4_form_section: date_ga4_form_section,
+        },
+    } %>
+      <% unless date_only %>
+        <%= tag.div class: time_group_classes do %>
+          <%= render "govuk_publishing_components/components/fieldset", {
+            legend_text: time_heading,
+            heading_level: heading_level,
+            heading_size: heading_size,
+            classes: "govuk-date-input",
+            data_attributes: {
+              ga4_form_section: time_ga4_form_section,
+            },
+          } do %>
+            <% if time_hint %>
+              <%= render "govuk_publishing_components/components/hint", {
+                text: time_hint,
+                id: time_hint_id,
+              } %>
+            <% end %>
+
+            <% if error_items_time %>
+              <%= render "govuk_publishing_components/components/error_message", {
+                id:  error_id_time,
+                items: error_items_time,
+              } %>
+            <% end %>
+
+            <div class="gem-c-datetime-fields__date-time-wrapper">
+              <div class="gem-c-datetime-fields__date-time">
+                <%= render "govuk_publishing_components/components/label", {
+                  text: "Hour",
+                  html_for: hour_select_id,
+                  id: hour_label_id,
+                } %>
+
+                <%= select_hour hour_value,
+                                {
+                                  include_blank: true,
+                                  prefix: prefix,
+                                  field_name: "#{field_name}(4i)",
+                                },
+                                {
+                                  id: hour_select_id,
+                                  class: time_select_classes,
+                                  "aria-describedby": "#{hour_label_id} #{time_hint_id if time_hint.present?}".strip,
+                                } %>
+              </div>
+
+              <p class="govuk-body gem-c-datetime-fields__time-separator">:</p>
+
+              <div class="gem-c-datetime-fields__date-time">
+                <%= render "govuk_publishing_components/components/label", {
+                  text: "Minute",
+                  html_for: minute_select_id,
+                  id: minute_label_id,
+                } %>
+
+                <%= select_minute minute_value,
+                                  {
+                                    include_blank: true,
+                                    prefix: prefix,
+                                    field_name: "#{field_name}(5i)",
+                                  },
+                                  {
+                                    id: minute_select_id,
+                                    class: time_select_classes,
+                                    "aria-describedby": "#{minute_label_id} #{time_hint_id if time_hint.present?}".strip,
+                                  } %>
+              </div>
+            </div>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/govuk_publishing_components/components/_datetime_fields.html.erb
+++ b/app/views/govuk_publishing_components/components/_datetime_fields.html.erb
@@ -7,16 +7,16 @@
   date_heading ||= "Date (required)"
   time_heading ||= "Time"
 
-  error_items = error_items ||= nil
-  error_items_date = error_items_date ||= nil
-  error_items_time = error_items_time ||= nil
+  error_items ||= nil
+  error_items_date ||= nil
+  error_items_time ||= nil
   error_id_time = "error-#{SecureRandom.hex(4)}"
 
-  heading_level = heading_level ||= nil
-  heading_size = heading_size ||= nil
+  heading_level ||= nil
+  heading_size ||= nil
 
-  date_hint = date_hint ||= nil
-  time_hint = time_hint ||= nil
+  date_hint ||= nil
+  time_hint ||= nil
   time_hint_id = "time-hint-#{SecureRandom.hex(4)}"
 
   year ||= nil

--- a/app/views/govuk_publishing_components/components/_datetime_fields.html.erb
+++ b/app/views/govuk_publishing_components/components/_datetime_fields.html.erb
@@ -4,7 +4,7 @@
   id = id
   date_id = "#{id}_date"
   date_only ||= false
-  date_heading ||= "Date (required)"
+  date_heading ||= "Date"
   time_heading ||= "Time"
 
   error_items ||= nil

--- a/app/views/govuk_publishing_components/components/_datetime_fields.html.erb
+++ b/app/views/govuk_publishing_components/components/_datetime_fields.html.erb
@@ -10,7 +10,15 @@
   error_items_time ||= nil
   error_id = "error-#{SecureRandom.hex(4)}"
   error_id_time = "error-time-#{SecureRandom.hex(4)}"
-  error_id_date = "error-date-#{SecureRandom.hex(4)}"
+  # error_id_date = "error-date-#{SecureRandom.hex(4)}"
+
+  if error_items
+    error_id_times = error_id
+  elsif error_items_time
+    error_id_times = error_id_time
+  else
+    error_id_times = nil
+  end
 
   heading_level ||= nil
   heading_size ||= nil
@@ -22,60 +30,95 @@
   year ||= nil
   month ||= nil
   day ||= nil
-  hour ||= nil
-  minute ||= nil
 
-  year_name = year ? year[:name] : "year"
-  year_id = year ? year[:id] : nil
-  year_value = year ? year[:value] : nil
-  month_name = month ? month[:name] : "month"
-  month_id = month ? month[:id] : nil
-  month_value = month ? month[:value] : nil
-  day_name = day ? day[:name] : "day"
-  day_id = day ? day[:id] : nil
-  day_value = day ? day[:value] : nil
-  hour_name = hour ? hour[:name] : "hour"
-  hour_id = if hour && hour[:id].present?
-              hour[:id]
-            else
-              "select-hour-#{SecureRandom.hex(4)}"
-            end
-  minute_name = minute ? minute[:name] : "minute"
-  minute_id = if minute && minute[:id].present?
-              minute[:id]
-            else
-              "select-minute-#{SecureRandom.hex(4)}"
-            end
+  # year_name = year ? year[:name] : "year"
+  # year_id = year ? year[:id] : nil
+  # year_value = year ? year[:value] : nil
 
+  # month_name = month ? month[:name] : "month"
+  # month_id = month ? month[:id] : nil
+  # month_value = month ? month[:value] : nil
+
+  # day_name = day ? day[:name] : "day"
+  # day_id = day ? day[:id] : nil
+  # day_value = day ? day[:value] : nil
+  
   date_input_items = [
-    { :label => "Day", :name => day_name, :width => 2, :id => day_id, :value => day_value },
-    { :label => "Month", :name => month_name, :width => 2, :id => month_id, :value => month_value },
-    { :label => "Year", :name => year_name, :width => 4, :id => year_id, :value => year_value },
+    {
+      :label => "Day", 
+      :name => day ? day[:name] : "day", # day_name, 
+      :width => 2, 
+      :id => day ? day[:id] : nil, # day_id, 
+      :value => day ? day[:value] : nil # day_value
+    },
+    {
+      :label => "Month", 
+      :name => month ? month[:name] : "month", # month_name, 
+      :width => 2, 
+      :id => month ? month[:id] : nil, # month_id, 
+      :value => month_value = month ? month[:value] : nil # month_value 
+    },
+    {
+      :label => "Year", 
+      :name => year ? year[:name] : "year", # year_name, 
+      :width => 4, 
+      :id => year ? year[:id] : nil, # year_id, 
+      :value => year ? year[:value] : nil # year_value 
+    },
   ]
   # date_input_items << day # if day
   # date_input_items << month # if month
   # date_input_items << year # if year
   # date_input_items = nil unless date_input_items.any?
 
-  # hour ||= {}
-  hour_value =  # hour[:value]
-                if hour && hour[:value].present?
-                  hour[:value]
-                else
-                  ""
-                end
+  hour ||= {}
+  # hour ||= nil
+  minute ||= {}
+  # minute ||= nil
+
+  hour_name = hour ? hour[:name] : "hour"  
+  hour_id = (hour && hour[:id].present?) ? hour[:id] : "select-hour-#{SecureRandom.hex(4)}"
+  # hour_id = if hour && hour[:id].present?
+  #             hour[:id]
+  #           else
+  #             "select-hour-#{SecureRandom.hex(4)}"
+  #           end
+  hour_value =  (hour && hour[:value].present?) ? hour[:value] : ""
+  # hour_value =  if hour && hour[:value].present?
+  #                 hour[:value]
+  #               else
+  #                 ""
+  #               end
+  minute_name = minute ? minute[:name] : "minute"
+  minute_id = (minute && minute[:id].present?) ? minute[:id] : "select-minute-#{SecureRandom.hex(4)}"
+  # minute_id = if minute && minute[:id].present?
+  #             minute[:id]
+  #           else
+  #             "select-minute-#{SecureRandom.hex(4)}"
+  #           end
   # hour_select_id = hour[:id] || "select-hour-#{SecureRandom.hex(4)}"
   # hour_label_id = "hour-#{SecureRandom.hex(4)}"
-
-  # minute ||= {}
-  minute_value =  # minute[:value]
-                  if minute && minute[:value].present?
-                    minute[:value]
-                  else
-                    ""
-                  end
+  minute_value =  (minute && minute[:value].present?) ? minute[:value] : ""
+  # minute_value =  if minute && minute[:value].present?
+  #                   minute[:value]
+  #                 else
+  #                   ""
+  #                 end
   # minute_select_id = minute[:id] || "select-minute-#{SecureRandom.hex(4)}"
   # minute_label_id = "minute-#{SecureRandom.hex(4)}"
+
+  hours = (0..23).to_a
+  hour_options = [{text: "", value: ""}]
+  minutes = (0..59).to_a
+  minute_options = [{text: "", value: ""}]
+
+  hours.each do |hour|
+    hour_options << {text: hour.to_s.rjust(2, "0"), value: hour.to_s.rjust(2, "0"), selected: hour == hour_value}
+  end
+
+  minutes.each do |minute|
+    minute_options << {text: minute.to_s.rjust(2, "0"), value: minute.to_s.rjust(2, "0"), selected: minute == minute_value}
+  end
 
   date_ga4_form_section = date_heading
   time_ga4_form_section = time_heading
@@ -90,19 +133,6 @@
   time_select_classes << "govuk-select--error" if (error_items.present? || error_items_time.present?)
 
   data_attributes ||= {}
-
-  hours = (0..23).to_a
-  hour_options = [{text: "", value: ""}]
-  minutes = (0..59).to_a
-  minute_options = [{text: "", value: ""}]
-
-  hours.each do |hour|
-    hour_options << {text: hour.to_s.rjust(2, "0"), value: hour.to_s.rjust(2, "0"), selected: hour == hour_value}
-  end
-
-  minutes.each do |minute|
-    minute_options << {text: minute.to_s.rjust(2, "0"), value: minute.to_s.rjust(2, "0"), selected: minute == minute_value}
-  end
 %>
 
 <%= tag.div id: do %>
@@ -150,16 +180,6 @@
               items: error_items_time,
             } %>
           <% end %>
-
-          <%
-            if error_items
-              error_id_times = error_id
-            elsif error_items_time
-              error_id_times = error_id_time
-            else
-              error_id_times = nil
-            end
-          %>
 
           <div class="gem-c-datetime-fields__date-time-wrapper">
             <div class="gem-c-datetime-fields__date-time">

--- a/app/views/govuk_publishing_components/components/_datetime_fields.html.erb
+++ b/app/views/govuk_publishing_components/components/_datetime_fields.html.erb
@@ -1,6 +1,4 @@
 <%
-  prefix ||= nil
-  field_name ||= nil
   id = id
   date_id = "#{id}_date"
   date_only ||= false
@@ -22,21 +20,61 @@
   year ||= nil
   month ||= nil
   day ||= nil
-  date_input_items = []
-  date_input_items << day if day
-  date_input_items << month if month
-  date_input_items << year if year
-  date_input_items = nil unless date_input_items.any?
+  hour ||= nil
+  minute ||= nil
 
-  hour ||= {}
-  hour_value = hour[:value]
-  hour_select_id = hour[:id] || "select-hour-#{SecureRandom.hex(4)}"
-  hour_label_id = "hour-#{SecureRandom.hex(4)}"
+  year_name = year ? year[:name] : "year"
+  year_id = year ? year[:id] : nil
+  year_value = year ? year[:value] : nil
+  month_name = month ? month[:name] : "month"
+  month_id = month ? month[:id] : nil
+  month_value = month ? month[:value] : nil
+  day_name = day ? day[:name] : "day"
+  day_id = day ? day[:id] : nil
+  day_value = day ? day[:value] : nil
+  hour_name = hour ? hour[:name] : "hour"
+  hour_id = if hour && hour[:id].present?
+              hour[:id]
+            else
+              "hour"
+            end
+  minute_name = minute ? minute[:name] : "minute"
+  # minute_id = minute ? minute[:id] : "minute"
+  minute_id = if minute && minute[:id].present?
+              minute[:id]
+            else
+              "minute"
+            end
 
-  minute ||= {}
-  minute_value = minute[:value]
-  minute_select_id = minute[:id] || "select-minute-#{SecureRandom.hex(4)}"
-  minute_label_id = "minute-#{SecureRandom.hex(4)}"
+  date_input_items = [
+    { :label => "Day", :name => day_name, :width => 2, :id => day_id, :value => day_value },
+    { :label => "Month", :name => month_name, :width => 2, :id => month_id, :value => month_value },
+    { :label => "Year", :name => year_name, :width => 4, :id => year_id, :value => year_value },
+  ]
+  # date_input_items << day # if day
+  # date_input_items << month # if month
+  # date_input_items << year # if year
+  # date_input_items = nil unless date_input_items.any?
+
+  # hour ||= {}
+  hour_value =  # hour[:value]
+                if hour && hour[:value].present?
+                  hour[:value]
+                else
+                  ""
+                end
+  # hour_select_id = hour[:id] || "select-hour-#{SecureRandom.hex(4)}"
+  # hour_label_id = "hour-#{SecureRandom.hex(4)}"
+
+  # minute ||= {}
+  minute_value =  # minute[:value]
+                  if minute && minute[:value].present?
+                    minute[:value]
+                  else
+                    ""
+                  end
+  # minute_select_id = minute[:id] || "select-minute-#{SecureRandom.hex(4)}"
+  # minute_label_id = "minute-#{SecureRandom.hex(4)}"
 
   date_ga4_form_section = date_heading
   time_ga4_form_section = time_heading
@@ -51,92 +89,83 @@
   time_select_classes << "govuk-select--error" if (error_items.present? || error_items_time.present?)
 
   data_attributes ||= {}
+
+  hours = (0..23).to_a
+  hour_options = [{text: "", value: ""}]
+  minutes = (0..59).to_a
+  minute_options = [{text: "", value: ""}]
+
+  hours.each do |hour|
+    hour_options << {text: hour.to_s.rjust(2, "0"), value: hour.to_s.rjust(2, "0"), selected: hour == hour_value}
+  end
+
+  minutes.each do |minute|
+    minute_options << {text: minute.to_s.rjust(2, "0"), value: minute.to_s.rjust(2, "0"), selected: minute == minute_value}
+  end
 %>
 
 <%= tag.div id: do %>
-  <% if prefix && field_name %>
-    <%= tag.div class: root_classes, data: data_attributes do %>
-      <%= render "govuk_publishing_components/components/date_input", {
-        id: date_id,
-        hint: date_hint,
-        error_items: (error_items.presence || error_items_date),
-        items: date_input_items,
-        legend_text: date_heading,
-        legend_level: heading_level,
-        legend_size: heading_size,
-        data_attributes: {
-          ga4_form_section: date_ga4_form_section,
-        },
-    } %>
-      <% unless date_only %>
-        <%= tag.div class: time_group_classes do %>
-          <%= render "govuk_publishing_components/components/fieldset", {
-            legend_text: time_heading,
-            heading_level: heading_level,
-            heading_size: heading_size,
-            classes: "govuk-date-input",
-            data_attributes: {
-              ga4_form_section: time_ga4_form_section,
-            },
-          } do %>
-            <% if time_hint %>
-              <%= render "govuk_publishing_components/components/hint", {
-                text: time_hint,
-                id: time_hint_id,
-              } %>
-            <% end %>
-
-            <% if error_items_time %>
-              <%= render "govuk_publishing_components/components/error_message", {
-                id:  error_id_time,
-                items: error_items_time,
-              } %>
-            <% end %>
-
-            <div class="gem-c-datetime-fields__date-time-wrapper">
-              <div class="gem-c-datetime-fields__date-time">
-                <%= render "govuk_publishing_components/components/label", {
-                  text: "Hour",
-                  html_for: hour_select_id,
-                  id: hour_label_id,
-                } %>
-
-                <%= select_hour hour_value,
-                                {
-                                  include_blank: true,
-                                  prefix: prefix,
-                                  field_name: "#{field_name}(4i)",
-                                },
-                                {
-                                  id: hour_select_id,
-                                  class: time_select_classes,
-                                  "aria-describedby": "#{hour_label_id} #{time_hint_id if time_hint.present?}".strip,
-                                } %>
-              </div>
-
-              <p class="govuk-body gem-c-datetime-fields__time-separator">:</p>
-
-              <div class="gem-c-datetime-fields__date-time">
-                <%= render "govuk_publishing_components/components/label", {
-                  text: "Minute",
-                  html_for: minute_select_id,
-                  id: minute_label_id,
-                } %>
-
-                <%= select_minute minute_value,
-                                  {
-                                    include_blank: true,
-                                    prefix: prefix,
-                                    field_name: "#{field_name}(5i)",
-                                  },
-                                  {
-                                    id: minute_select_id,
-                                    class: time_select_classes,
-                                    "aria-describedby": "#{minute_label_id} #{time_hint_id if time_hint.present?}".strip,
-                                  } %>
-              </div>
-            </div>
+  <%= tag.div class: root_classes, data: data_attributes do %>
+    <%= render "govuk_publishing_components/components/date_input", {
+      id: date_id,
+      hint: date_hint,
+      error_items: (error_items.presence || error_items_date),
+      items: date_input_items,
+      legend_text: date_heading,
+      legend_level: heading_level,
+      legend_size: heading_size,
+      data_attributes: {
+        ga4_form_section: date_ga4_form_section,
+      },
+  } %>
+    <% unless date_only %>
+      <%= tag.div class: time_group_classes do %>
+        <%= render "govuk_publishing_components/components/fieldset", {
+          legend_text: time_heading,
+          heading_level: heading_level,
+          heading_size: heading_size,
+          classes: "govuk-date-input",
+          data_attributes: {
+            ga4_form_section: time_ga4_form_section,
+          },
+        } do %>
+          <% if time_hint %>
+            <%= render "govuk_publishing_components/components/hint", {
+              text: time_hint,
+              id: time_hint_id,
+            } %>
           <% end %>
+
+          <% if error_items_time %>
+            <%= render "govuk_publishing_components/components/error_message", {
+              id:  error_id_time,
+              items: error_items_time,
+            } %>
+          <% end %>
+
+          <div class="gem-c-datetime-fields__date-time-wrapper">
+            <div class="gem-c-datetime-fields__date-time">
+              <%= render "govuk_publishing_components/components/select", {
+                id: hour_id, # hour_select_id,
+                label: "Hour",
+                name: hour_name,
+                error_id: error_items || error_items_time ? error_id_time : nil,
+                options: hour_options,
+              } %>
+            </div>
+
+            <p class="govuk-body gem-c-datetime-fields__time-separator">:</p>
+
+            <div class="gem-c-datetime-fields__date-time">
+              <%= render "govuk_publishing_components/components/select", {
+                id: minute_id, # minute_select_id,
+                label: "Minute",
+                name:  minute_name,
+                error_id: error_id_times,
+                options: minute_options,
+              } %>
+            </div>
+          </div>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/govuk_publishing_components/components/_datetime_fields.html.erb
+++ b/app/views/govuk_publishing_components/components/_datetime_fields.html.erb
@@ -8,7 +8,9 @@
   error_items ||= nil
   error_items_date ||= nil
   error_items_time ||= nil
-  error_id_time = "error-#{SecureRandom.hex(4)}"
+  error_id = "error-#{SecureRandom.hex(4)}"
+  error_id_time = "error-time-#{SecureRandom.hex(4)}"
+  error_id_date = "error-date-#{SecureRandom.hex(4)}"
 
   heading_level ||= nil
   heading_size ||= nil
@@ -36,14 +38,13 @@
   hour_id = if hour && hour[:id].present?
               hour[:id]
             else
-              "hour"
+              "select-hour-#{SecureRandom.hex(4)}"
             end
   minute_name = minute ? minute[:name] : "minute"
-  # minute_id = minute ? minute[:id] : "minute"
   minute_id = if minute && minute[:id].present?
               minute[:id]
             else
-              "minute"
+              "select-minute-#{SecureRandom.hex(4)}"
             end
 
   date_input_items = [
@@ -106,10 +107,17 @@
 
 <%= tag.div id: do %>
   <%= tag.div class: root_classes, data: data_attributes do %>
+    <% if error_items %>
+      <%= render "govuk_publishing_components/components/error_message", {
+        id:  error_id,
+        items: error_items,
+      } %>
+    <% end %>
+
     <%= render "govuk_publishing_components/components/date_input", {
       id: date_id,
       hint: date_hint,
-      error_items: (error_items.presence || error_items_date),
+      error_items: error_items_date,
       items: date_input_items,
       legend_text: date_heading,
       legend_level: heading_level,
@@ -143,13 +151,23 @@
             } %>
           <% end %>
 
+          <%
+            if error_items
+              error_id_times = error_id
+            elsif error_items_time
+              error_id_times = error_id_time
+            else
+              error_id_times = nil
+            end
+          %>
+
           <div class="gem-c-datetime-fields__date-time-wrapper">
             <div class="gem-c-datetime-fields__date-time">
               <%= render "govuk_publishing_components/components/select", {
-                id: hour_id, # hour_select_id,
+                id: hour_id,
                 label: "Hour",
                 name: hour_name,
-                error_id: error_items || error_items_time ? error_id_time : nil,
+                error_id: error_id_times,
                 options: hour_options,
               } %>
             </div>
@@ -158,7 +176,7 @@
 
             <div class="gem-c-datetime-fields__date-time">
               <%= render "govuk_publishing_components/components/select", {
-                id: minute_id, # minute_select_id,
+                id: minute_id,
                 label: "Minute",
                 name:  minute_name,
                 error_id: error_id_times,

--- a/app/views/govuk_publishing_components/components/docs/date_input.yml
+++ b/app/views/govuk_publishing_components/components/docs/date_input.yml
@@ -36,6 +36,11 @@ examples:
   with_legend:
     data:
       legend_text: "What is your date of birth?"
+  with_legend_level_and_size:
+    data:
+      legend_text: "What is your date of birth?"
+      legend_level: 2
+      legend_size: "l"
   with_hint:
     data:
       legend_text: "What is your date of birth?"

--- a/app/views/govuk_publishing_components/components/docs/date_input.yml
+++ b/app/views/govuk_publishing_components/components/docs/date_input.yml
@@ -57,6 +57,11 @@ examples:
       error_items:
         - text: "Error 1"
         - text: "Error 2"
+  with_data_attributes:
+    data:
+      data_attributes:
+        module: "some-module"
+        other_attribute: "something-else"
   with_custom_items:
     data:
       legend_text: "Beth yw eich dyddiad geni?"

--- a/app/views/govuk_publishing_components/components/docs/datetime_fields.yml
+++ b/app/views/govuk_publishing_components/components/docs/datetime_fields.yml
@@ -48,6 +48,11 @@ examples:
       field_name: first_published_at
       date_hint: For example, 01 August 2022
       time_hint: For example, 09:30 or 19:30
+  with_id_value:
+    data:
+      prefix: edition
+      field_name: first_published_at
+      id: edition_first_published_at
   with_custom_ids:
     data:
       prefix: edition

--- a/app/views/govuk_publishing_components/components/docs/datetime_fields.yml
+++ b/app/views/govuk_publishing_components/components/docs/datetime_fields.yml
@@ -1,0 +1,133 @@
+name: Datetime fields (experimental)
+description: Use the datetime fields component to help users enter a datetime for a specific event.
+body: |
+  This differs from the [Date fields][] component in a few notable ways:
+
+  * In addition, to day, month and year, it also takes hour and minute
+  * It generates select fields in place of inputs
+  * As this uses the `ActionView::Helpers::DateHelper` helpers you must provide a prefix and field_name to construct the fields
+
+    - the prefix must be the downcased and underscored model name
+    - the field_name is the attribute for the model
+
+  [Date fields]: https://design-system.service.gov.uk/components/date-input/
+accessibility_criteria: |
+  Inputs in the component must:
+
+  * accept focus
+  * be focusable with a keyboard
+  * be usable with a keyboard
+  * be usable with touch
+  * indicate when they have focus
+  * be recognisable as form input elements
+  * have correctly associated labels
+
+govuk_frontend_components:
+  - date-input
+examples:
+  default:
+    data:
+      prefix: edition
+      field_name: first_published_at
+
+  with_heading_level_and_size:
+    data:
+      prefix: edition
+      field_name: first_published_at
+      heading_level: 1
+      heading_size: l
+  with_custom_heading_text:
+    data:
+      prefix: edition
+      field_name: first_published_at
+      date_heading: "The date"
+      time_heading: "The time"
+  with_hint_text:
+    data:
+      prefix: edition
+      field_name: first_published_at
+      date_hint: For example, 01 August 2022
+      time_hint: For example, 09:30 or 19:30
+  with_custom_ids:
+    data:
+      prefix: edition
+      field_name: first_published_at
+      year:
+        id: edition_first_published_year
+        name: Year
+        width: 4
+      month:
+        id: edition_first_published_month
+        name: Month
+        width: 2
+      day:
+        id: edition_first_published_day
+        name: Day
+        width: 2
+      hour:
+        id: edition_first_published_hour
+      minute:
+        id: edition_first_published_minute
+  with_values:
+    data:
+      prefix: edition
+      field_name: first_published_at
+      year:
+        name: Year
+        value: 2022
+        width: 4
+      month:
+        name: Month
+        value: 1
+        width: 2
+      day:
+        name: Day
+        value: 1
+        width: 2
+      hour:
+        value: 9
+      minute:
+        value: 30
+  with_a_prepopulated_time:
+    data:
+      prefix: edition
+      field_name: first_published_at
+      hour:
+        value: 10
+        id: myhour
+      minute:
+        value: 51
+        id: myminute
+  with_error_items:
+    data:
+      prefix: edition
+      field_name: first_published_at
+      error_items:
+      - text: Descriptive error 1
+      - text: Descriptive error 2
+  with_separate_date_time_error_items:
+    data:
+      prefix: edition
+      field_name: first_published_at
+      error_items_date:
+      - text: Descriptive date error 1
+      - text: Descriptive date error 2
+      error_items_time:
+      - text: Descriptive time error 1
+      - text: Descriptive time error 2
+  with_data_attributes:
+    data:
+      prefix: edition
+      field_name: first_published_at
+      data_attributes:
+        module: "some-module"
+        other_attribute: "something-else"
+
+  with_date_only_option:
+    description: |
+      This is used to render the component to display only the date input fields.
+    data:
+      prefix: edition
+      field_name: first_published_at
+      date_heading: "An optional heading for the date fields"
+      date_only: true

--- a/app/views/govuk_publishing_components/components/docs/datetime_fields.yml
+++ b/app/views/govuk_publishing_components/components/docs/datetime_fields.yml
@@ -5,10 +5,6 @@ body: |
 
   * In addition, to day, month and year, it also takes hour and minute
   * It generates select fields in place of inputs
-  * As this uses the `ActionView::Helpers::DateHelper` helpers you must provide a prefix and field_name to construct the fields
-
-    - the prefix must be the downcased and underscored model name
-    - the field_name is the attribute for the model
 
   [Date fields]: https://design-system.service.gov.uk/components/date-input/
 accessibility_criteria: |
@@ -26,94 +22,71 @@ govuk_frontend_components:
   - date-input
 examples:
   default:
+    data: {}
+  with_field_names:
     data:
-      prefix: edition
-      field_name: first_published_at
-
+      year:
+        name: year_field_name
+      month:
+        name: month_field_name
+      day:
+        name: day_field_name
+      hour:
+        name: hour_field_name
+      minute:
+        name: minute_field_name
   with_heading_level_and_size:
     data:
-      prefix: edition
-      field_name: first_published_at
       heading_level: 1
       heading_size: l
   with_custom_heading_text:
     data:
-      prefix: edition
-      field_name: first_published_at
       date_heading: "The date"
       time_heading: "The time"
   with_hint_text:
     data:
-      prefix: edition
-      field_name: first_published_at
       date_hint: For example, 01 August 2022
       time_hint: For example, 09:30 or 19:30
   with_id_value:
     data:
-      prefix: edition
-      field_name: first_published_at
-      id: edition_first_published_at
+      id: date_time_id
   with_custom_ids:
     data:
-      prefix: edition
-      field_name: first_published_at
       year:
-        id: edition_first_published_year
-        name: Year
-        width: 4
+        id: year_id
       month:
-        id: edition_first_published_month
-        name: Month
-        width: 2
+        id: month_id
       day:
-        id: edition_first_published_day
-        name: Day
-        width: 2
+        id: day_id
       hour:
-        id: edition_first_published_hour
+        id: hour_id
       minute:
-        id: edition_first_published_minute
+        id: minute_id
   with_values:
     data:
-      prefix: edition
-      field_name: first_published_at
       year:
-        name: Year
         value: 2022
-        width: 4
       month:
-        name: Month
         value: 1
-        width: 2
       day:
-        name: Day
-        value: 1
-        width: 2
+        value: 2
       hour:
         value: 9
       minute:
         value: 30
   with_a_prepopulated_time:
     data:
-      prefix: edition
-      field_name: first_published_at
       hour:
         value: 10
-        id: myhour
       minute:
         value: 51
-        id: myminute
   with_error_items:
     data:
-      prefix: edition
-      field_name: first_published_at
       error_items:
       - text: Descriptive error 1
       - text: Descriptive error 2
   with_separate_date_time_error_items:
     data:
-      prefix: edition
-      field_name: first_published_at
       error_items_date:
       - text: Descriptive date error 1
       - text: Descriptive date error 2
@@ -122,17 +95,12 @@ examples:
       - text: Descriptive time error 2
   with_data_attributes:
     data:
-      prefix: edition
-      field_name: first_published_at
       data_attributes:
         module: "some-module"
         other_attribute: "something-else"
-
   with_date_only_option:
     description: |
       This is used to render the component to display only the date input fields.
     data:
-      prefix: edition
-      field_name: first_published_at
       date_heading: "An optional heading for the date fields"
       date_only: true

--- a/spec/components/date_input_spec.rb
+++ b/spec/components/date_input_spec.rb
@@ -42,8 +42,6 @@ describe "Date input", type: :view do
     )
 
     assert_select ".govuk-fieldset[role=group] .govuk-fieldset__legend", text: "What is your date of birth?"
-    assert_select ".govuk-fieldset[role=group] .govuk-date-input", 1
-    assert_select ".govuk-fieldset[role=group] .govuk-date-input__item", 3
   end
 
   it "renders with custom legend and fieldset level and size" do
@@ -55,8 +53,6 @@ describe "Date input", type: :view do
 
     assert_select ".govuk-fieldset[role=group] .govuk-fieldset__legend.govuk-fieldset__legend--l"
     assert_select ".govuk-fieldset[role=group] .govuk-fieldset__legend h1", text: "What is your date of birth?"
-    assert_select ".govuk-fieldset[role=group] .govuk-date-input", 1
-    assert_select ".govuk-fieldset[role=group] .govuk-date-input__item", 3
   end
 
   it "renders with hint" do

--- a/spec/components/date_input_spec.rb
+++ b/spec/components/date_input_spec.rb
@@ -46,6 +46,19 @@ describe "Date input", type: :view do
     assert_select ".govuk-fieldset[role=group] .govuk-date-input__item", 3
   end
 
+  it "renders with custom legend and fieldset level and size" do
+    render_component(
+      legend_text: "What is your date of birth?",
+      legend_level: 1,
+      legend_size: "l",
+    )
+
+    assert_select ".govuk-fieldset[role=group] .govuk-fieldset__legend.govuk-fieldset__legend--l"
+    assert_select ".govuk-fieldset[role=group] .govuk-fieldset__legend h1", text: "What is your date of birth?"
+    assert_select ".govuk-fieldset[role=group] .govuk-date-input", 1
+    assert_select ".govuk-fieldset[role=group] .govuk-date-input__item", 3
+  end
+
   it "renders with hint" do
     render_component(
       legend_text: "What is your date of birth?",
@@ -63,6 +76,17 @@ describe "Date input", type: :view do
 
     assert_select ".govuk-form-group--error .govuk-fieldset[role=group] .govuk-error-message", text: "Error: Error message goes here"
     assert_select ".govuk-form-group--error .govuk-fieldset[role=group] .govuk-date-input__item .govuk-input--error", 3
+  end
+
+  it "renders with data attributes" do
+    render_component(
+      data_attributes: {
+        module: "not-a-real-module",
+        something_else: "i-just-thought-of",
+      },
+    )
+
+    assert_select ".govuk-form-group[data-module='not-a-real-module'][data-something-else='i-just-thought-of']"
   end
 
   it "renders with custom items" do

--- a/spec/components/datetime_fields_spec.rb
+++ b/spec/components/datetime_fields_spec.rb
@@ -1,0 +1,188 @@
+require "rails_helper"
+
+describe "Date input", type: :view do
+  def component_name
+    "datetime_fields"
+  end
+
+  it "renders the basic component" do
+    render_component({
+      prefix: "prefix",
+      field_name: "field_name",
+    })
+
+    assert_select ".gem-c-datetime-fields"
+    assert_select ".govuk-fieldset__legend", text: "Date (required)"
+    assert_select ".govuk-input[name='day']"
+    assert_select ".govuk-input[name='month']"
+    assert_select ".govuk-input[name='year']"
+    assert_select ".govuk-fieldset__legend", text: "Time"
+    assert_select ".govuk-label", text: "Hour"
+    assert_select ".govuk-label", text: "Minute"
+  end
+
+  it "allows heading level and size" do
+    render_component({
+      prefix: "prefix",
+      field_name: "field_name",
+      heading_level: 1,
+      heading_size: "l",
+    })
+
+    assert_select "h1.govuk-fieldset__heading", text: "Date (required)"
+    assert_select "h1.govuk-fieldset__heading", text: "Time"
+  end
+
+  it "allows custom test for the date and time headings" do
+    render_component({
+      prefix: "prefix",
+      field_name: "field_name",
+      date_heading: "The date",
+      time_heading: "The time",
+    })
+
+    assert_select "legend.govuk-fieldset__legend", text: "The date"
+    assert_select "legend.govuk-fieldset__legend", text: "The time"
+  end
+
+  it "shows hint text" do
+    render_component({
+      prefix: "prefix",
+      field_name: "field_name",
+      date_hint: "For example, 01 August 2022",
+      time_hint: "For example, 09:30 or 19:30",
+    })
+
+    assert_select ".govuk-hint", text: "For example, 01 August 2022"
+    assert_select ".govuk-hint", text: "For example, 09:30 or 19:30"
+  end
+
+  it "accepts an id" do
+    render_component({
+      prefix: "prefix",
+      field_name: "field_name",
+      id: "kevin",
+    })
+
+    assert_select "[id='kevin']"
+    assert_select ".govuk-date-input[id='kevin_date']"
+  end
+
+  it "renders custom date fields" do
+    render_component({
+      prefix: "prefix",
+      field_name: "field_name",
+      year: {
+        id: "year_id",
+        name: "year_name",
+        width: 4,
+        value: "2024",
+      },
+      month: {
+        id: "month_id",
+        name: "month_name",
+        width: 3,
+        value: "1",
+      },
+      day: {
+        id: "day_id",
+        name: "day_name",
+        width: 2,
+        value: "14",
+      },
+    })
+
+    assert_select ".govuk-input.govuk-input--width-4[id='year_id'][name='year_name'][value='2024']"
+    assert_select ".govuk-input.govuk-input--width-3[id='month_id'][name='month_name'][value='1']"
+    assert_select ".govuk-input.govuk-input--width-2[id='day_id'][name='day_name'][value='14']"
+  end
+
+  it "accepts values and ids for hour and minute elements" do
+    render_component({
+      prefix: "prefix",
+      field_name: "field_name",
+      hour: {
+        value: 2,
+        id: "my-hour-id",
+      },
+      minute: {
+        value: 3,
+        id: "my-minute-id",
+      },
+    })
+
+    assert_select "select[id='my-hour-id'] option[value='02'][selected='selected']"
+    assert_select "select[id='my-minute-id'] option[value='03'][selected='selected']"
+  end
+
+  it "renders error fields for the whole component" do
+    render_component({
+      prefix: "prefix",
+      field_name: "field_name",
+      error_items: [
+        {
+          text: "Descriptive error 1",
+        },
+        {
+          text: "Descriptive error 2",
+        },
+      ],
+    })
+
+    assert_select ".gem-c-datetime-fields.govuk-form-group--error"
+    assert_select ".govuk-form-group--error .govuk-error-message", text: "Error: Descriptive error 1Descriptive error 2"
+  end
+
+  it "renders separate error fields for the date and time sections" do
+    render_component({
+      prefix: "prefix",
+      field_name: "field_name",
+      error_items_date: [
+        {
+          text: "Descriptive date error 1",
+        },
+        {
+          text: "Descriptive date error 2",
+        },
+      ],
+      error_items_time: [
+        {
+          text: "Descriptive time error 1",
+        },
+        {
+          text: "Descriptive time error 2",
+        },
+      ],
+    })
+
+    assert_select ".gem-c-datetime-fields .govuk-form-group--error"
+    assert_select ".govuk-form-group--error .govuk-error-message", text: "Error: Descriptive date error 1Descriptive date error 2"
+    assert_select ".govuk-form-group--error .govuk-error-message", text: "Error: Descriptive time error 1Descriptive time error 2"
+  end
+
+  it "accepts data attributes" do
+    render_component({
+      prefix: "prefix",
+      field_name: "field_name",
+      data_attributes: {
+        module: "not-a-real-module",
+        something_else: "i-just-thought-of",
+      },
+    })
+
+    assert_select ".gem-c-datetime-fields[data-module='not-a-real-module'][data-something-else='i-just-thought-of']"
+  end
+
+  it "with date only option" do
+    render_component({
+      prefix: "prefix",
+      field_name: "field_name",
+      date_only: true,
+    })
+
+    assert_select ".govuk-input[name='day']"
+    assert_select ".govuk-input[name='month']"
+    assert_select ".govuk-input[name='year']"
+    assert_select ".gem-c-datetime-fields__date-time-wrapper", false
+  end
+end

--- a/spec/components/datetime_fields_spec.rb
+++ b/spec/components/datetime_fields_spec.rb
@@ -29,7 +29,9 @@ describe "Date input", type: :view do
       heading_size: "l",
     })
 
+    assert_select "legend.govuk-fieldset__legend--l", text: "Date (required)"
     assert_select "h1.govuk-fieldset__heading", text: "Date (required)"
+    assert_select "legend.govuk-fieldset__legend--l", text: "Time"
     assert_select "h1.govuk-fieldset__heading", text: "Time"
   end
 

--- a/spec/components/datetime_fields_spec.rb
+++ b/spec/components/datetime_fields_spec.rb
@@ -43,8 +43,8 @@ describe "Date input", type: :view do
       time_heading: "The time",
     })
 
-    assert_select "legend.govuk-fieldset__legend", text: "The date"
-    assert_select "legend.govuk-fieldset__legend", text: "The time"
+    assert_select "[data-ga4-form-section='The date'] .govuk-fieldset__legend", text: "The date"
+    assert_select "[data-ga4-form-section='The time'] .govuk-fieldset__legend", text: "The time"
   end
 
   it "shows hint text" do
@@ -55,8 +55,8 @@ describe "Date input", type: :view do
       time_hint: "For example, 09:30 or 19:30",
     })
 
-    assert_select ".govuk-hint", text: "For example, 01 August 2022"
-    assert_select ".govuk-hint", text: "For example, 09:30 or 19:30"
+    assert_select "[data-ga4-form-section='Date (required)'] .govuk-hint", text: "For example, 01 August 2022"
+    assert_select "[data-ga4-form-section='Time'] .govuk-hint", text: "For example, 09:30 or 19:30"
   end
 
   it "accepts an id" do
@@ -157,9 +157,8 @@ describe "Date input", type: :view do
       ],
     })
 
-    assert_select ".gem-c-datetime-fields .govuk-form-group--error"
-    assert_select ".govuk-form-group--error .govuk-error-message", text: "Error: Descriptive date error 1Descriptive date error 2"
-    assert_select ".govuk-form-group--error .govuk-error-message", text: "Error: Descriptive time error 1Descriptive time error 2"
+    assert_select "[data-ga4-form-section='Date (required)'] .govuk-error-message", text: "Error: Descriptive date error 1Descriptive date error 2"
+    assert_select "[data-ga4-form-section='Time'] .govuk-error-message", text: "Error: Descriptive time error 1Descriptive time error 2"
   end
 
   it "accepts data attributes" do

--- a/spec/components/datetime_fields_spec.rb
+++ b/spec/components/datetime_fields_spec.rb
@@ -35,7 +35,7 @@ describe "Date input", type: :view do
     assert_select "h1.govuk-fieldset__heading", text: "Time"
   end
 
-  it "allows custom test for the date and time headings" do
+  it "allows custom text for the date and time headings" do
     render_component({
       prefix: "prefix",
       field_name: "field_name",

--- a/spec/components/datetime_fields_spec.rb
+++ b/spec/components/datetime_fields_spec.rb
@@ -6,13 +6,10 @@ describe "Date input", type: :view do
   end
 
   it "renders the basic component" do
-    render_component({
-      prefix: "prefix",
-      field_name: "field_name",
-    })
+    render_component({})
 
     assert_select ".gem-c-datetime-fields"
-    assert_select ".govuk-fieldset__legend", text: "Date (required)"
+    assert_select ".govuk-fieldset__legend", text: "Date"
     assert_select ".govuk-input[name='day']"
     assert_select ".govuk-input[name='month']"
     assert_select ".govuk-input[name='year']"
@@ -21,24 +18,36 @@ describe "Date input", type: :view do
     assert_select ".govuk-label", text: "Minute"
   end
 
+  it "renders the correct names for the inputs" do
+    render_component({
+      year: { name: "year_field_name" },
+      month: { name: "month_field_name" },
+      day: { name: "day_field_name" },
+      hour: { name: "hour_field_name" },
+      minute: { name: "minute_field_name" },
+    })
+
+    assert_select ".govuk-input[name='year_field_name']"
+    assert_select ".govuk-input[name='month_field_name']"
+    assert_select ".govuk-input[name='day_field_name']"
+    assert_select ".govuk-select[name='hour_field_name']"
+    assert_select ".govuk-select[name='minute_field_name']"
+  end
+
   it "allows heading level and size" do
     render_component({
-      prefix: "prefix",
-      field_name: "field_name",
       heading_level: 1,
       heading_size: "l",
     })
 
-    assert_select "legend.govuk-fieldset__legend--l", text: "Date (required)"
-    assert_select "h1.govuk-fieldset__heading", text: "Date (required)"
+    assert_select "legend.govuk-fieldset__legend--l", text: "Date"
+    assert_select "h1.govuk-fieldset__heading", text: "Date"
     assert_select "legend.govuk-fieldset__legend--l", text: "Time"
     assert_select "h1.govuk-fieldset__heading", text: "Time"
   end
 
   it "allows custom text for the date and time headings" do
     render_component({
-      prefix: "prefix",
-      field_name: "field_name",
       date_heading: "The date",
       time_heading: "The time",
     })
@@ -49,20 +58,16 @@ describe "Date input", type: :view do
 
   it "shows hint text" do
     render_component({
-      prefix: "prefix",
-      field_name: "field_name",
       date_hint: "For example, 01 August 2022",
       time_hint: "For example, 09:30 or 19:30",
     })
 
-    assert_select "[data-ga4-form-section='Date (required)'] .govuk-hint", text: "For example, 01 August 2022"
+    assert_select "[data-ga4-form-section='Date'] .govuk-hint", text: "For example, 01 August 2022"
     assert_select "[data-ga4-form-section='Time'] .govuk-hint", text: "For example, 09:30 or 19:30"
   end
 
   it "accepts an id" do
     render_component({
-      prefix: "prefix",
-      field_name: "field_name",
       id: "kevin",
     })
 
@@ -70,39 +75,43 @@ describe "Date input", type: :view do
     assert_select ".govuk-date-input[id='kevin_date']"
   end
 
-  it "renders custom date fields" do
+  it "renders custom field ids" do
     render_component({
-      prefix: "prefix",
-      field_name: "field_name",
       year: {
         id: "year_id",
-        name: "year_name",
-        width: 4,
-        value: "2024",
       },
       month: {
         id: "month_id",
-        name: "month_name",
-        width: 3,
-        value: "1",
       },
       day: {
         id: "day_id",
-        name: "day_name",
-        width: 2,
-        value: "14",
+      },
+      hour: {
+        id: "hour_id",
+      },
+      minute: {
+        id: "minute_id",
       },
     })
 
-    assert_select ".govuk-input.govuk-input--width-4[id='year_id'][name='year_name'][value='2024']"
-    assert_select ".govuk-input.govuk-input--width-3[id='month_id'][name='month_name'][value='1']"
-    assert_select ".govuk-input.govuk-input--width-2[id='day_id'][name='day_name'][value='14']"
+    assert_select ".govuk-input[id='year_id']"
+    assert_select ".govuk-input[id='month_id']"
+    assert_select ".govuk-input[id='day_id']"
+    assert_select ".govuk-select[id='hour_id']"
+    assert_select ".govuk-select[id='minute_id']"
   end
 
-  it "accepts values and ids for hour and minute elements" do
+  it "renders field values" do
     render_component({
-      prefix: "prefix",
-      field_name: "field_name",
+      year: {
+        value: 2024,
+      },
+      month: {
+        value: 1,
+      },
+      day: {
+        value: 14,
+      },
       hour: {
         value: 2,
         id: "my-hour-id",
@@ -113,14 +122,15 @@ describe "Date input", type: :view do
       },
     })
 
+    assert_select ".govuk-input[value='2024']"
+    assert_select ".govuk-input[value='1']"
+    assert_select ".govuk-input[value='14']"
     assert_select "select[id='my-hour-id'] option[value='02'][selected='selected']"
     assert_select "select[id='my-minute-id'] option[value='03'][selected='selected']"
   end
 
   it "renders error fields for the whole component" do
     render_component({
-      prefix: "prefix",
-      field_name: "field_name",
       error_items: [
         {
           text: "Descriptive error 1",
@@ -137,8 +147,6 @@ describe "Date input", type: :view do
 
   it "renders separate error fields for the date and time sections" do
     render_component({
-      prefix: "prefix",
-      field_name: "field_name",
       error_items_date: [
         {
           text: "Descriptive date error 1",
@@ -157,14 +165,12 @@ describe "Date input", type: :view do
       ],
     })
 
-    assert_select "[data-ga4-form-section='Date (required)'] .govuk-error-message", text: "Error: Descriptive date error 1Descriptive date error 2"
+    assert_select "[data-ga4-form-section='Date'] .govuk-error-message", text: "Error: Descriptive date error 1Descriptive date error 2"
     assert_select "[data-ga4-form-section='Time'] .govuk-error-message", text: "Error: Descriptive time error 1Descriptive time error 2"
   end
 
   it "accepts data attributes" do
     render_component({
-      prefix: "prefix",
-      field_name: "field_name",
       data_attributes: {
         module: "not-a-real-module",
         something_else: "i-just-thought-of",
@@ -176,8 +182,6 @@ describe "Date input", type: :view do
 
   it "with date only option" do
     render_component({
-      prefix: "prefix",
-      field_name: "field_name",
       date_only: true,
     })
 


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
Add a new "Datetime fields" component to the gem based on the [existing component](https://whitehall-admin.integration.publishing.service.gov.uk/component-guide/datetime_fields) on Whitehall.
The newly created component differs from the Whitehall component in a few ways in order to make it more generic: 
- the date and time headings are not set to a specific level or size: this is done via a "With heading level and size" option
- it introduces a "With separate date time error items" option which is required on Publisher 

In order to do this there are also some changes introduced to the existing "Form date input" component which is used in the new component. These are 
- add a new "With legend level and size" option
- add a new "With data attributes" option
<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
<!-- What are the reasons behind this change being made? -->
Jira card: https://gov-uk.atlassian.net/browse/MAIN-1311

This is a piece of maintenance work on the Mainstream Publisher app. We added a component on Publisher that is similar to the Whitehall component but this was mainly copied and pasted from Whitehall as the full component was not available on the gem. 

This task is to reproduce the component on the gem and then introduce that back to Whitehall in place of the local component and also onto Publisher. 

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

| Option | Component on Whitehall | Component on Gem |
|--------|--------|--------|
| Default | <img width="248" height="263" alt="Screenshot 2026-06-05 at 12 14 39" src="https://github.com/user-attachments/assets/f4cdb1da-8ea9-444f-a9dc-c3ad66cc173e" /> | <img width="248" height="263" alt="Screenshot 2026-06-05 at 12 14 55" src="https://github.com/user-attachments/assets/edbfdcf5-858c-4b2b-a49d-5ae0db3d6896" /> |
|With heading level and size | <img width="264" height="286" alt="Screenshot 2026-06-05 at 12 17 08" src="https://github.com/user-attachments/assets/b272affd-c9df-4d22-897b-9f8cf4e01f6c" /> | <img width="264" height="286" alt="Screenshot 2026-06-05 at 12 17 19" src="https://github.com/user-attachments/assets/6edfda38-4b8e-4397-9d95-d4036b42ea55" /> |
| With custom heading text | New option | <img width="249" height="246" alt="Screenshot 2026-06-05 at 12 19 15" src="https://github.com/user-attachments/assets/f8205bbd-de67-4d73-bb33-3d738a3d3875" /> |
| With hint text | <img width="247" height="332" alt="Screenshot 2026-06-05 at 12 20 21" src="https://github.com/user-attachments/assets/70347a54-e4ba-4184-a288-c4c4f3ae7356" /> | <img width="247" height="332" alt="Screenshot 2026-06-05 at 12 21 13" src="https://github.com/user-attachments/assets/de65a796-6ade-44b5-85ea-d18390a6535b" /> |
| With values | <img width="247" height="264" alt="Screenshot 2026-06-05 at 12 22 40" src="https://github.com/user-attachments/assets/168f4240-47f0-465f-b39b-74d5418d12f0" /> | <img width="247" height="264" alt="Screenshot 2026-06-05 at 12 22 51" src="https://github.com/user-attachments/assets/0b9fedbd-2356-43b6-8951-27c631b9d1ad" /> |
| With a prepopulated time | <img width="247" height="264" alt="Screenshot 2026-06-05 at 12 23 58" src="https://github.com/user-attachments/assets/0367fc28-5145-4c75-811f-16be98b74dea" /> | <img width="247" height="264" alt="Screenshot 2026-06-05 at 12 24 09" src="https://github.com/user-attachments/assets/c0f5f4e6-9334-4657-9ca0-fe0afdacc005" /> |
| With error items | <img width="269" height="345" alt="Screenshot 2026-06-05 at 12 25 37" src="https://github.com/user-attachments/assets/cb86a49b-fdd8-4c26-bf75-aa4c58e25734" /> | <img width="269" height="345" alt="Screenshot 2026-06-05 at 12 25 48" src="https://github.com/user-attachments/assets/e0b22cc9-d441-4518-86d8-6791dd3efb80" /> |
| With separate date time error items | New option | <img width="269" height="390" alt="Screenshot 2026-06-05 at 12 27 21" src="https://github.com/user-attachments/assets/5937495e-de1e-4045-92dc-559438e95356" /> |
| With date only option | <img width="419" height="127" alt="Screenshot 2026-06-05 at 12 28 24" src="https://github.com/user-attachments/assets/6a9a64dc-0ec2-4614-97fc-743f7c07e8b7" /> | <img width="419" height="127" alt="Screenshot 2026-06-05 at 12 28 33" src="https://github.com/user-attachments/assets/37741b66-54c7-45b2-94a6-55abad8e9b05" /> |
