### PR TITLE
Add auto layout option to cards component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add auto layout option to cards component ([PR #5499](https://github.com/alphagov/govuk_publishing_components/pull/5499))
+
 ## 66.5.0
 
 * Remove unused 'services_cookies' option from cookie banner ([PR #5488](https://github.com/alphagov/govuk_publishing_components/pull/5488))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
@@ -60,6 +60,89 @@
   }
 }
 
+.gem-c-cards--auto-layout {
+  .gem-c-cards__list {
+    container-type: inline-size;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    column-gap: 30px;
+
+    // pseudo elements form invisible elements to fill in
+    // the final row if it is incomplete, or fit below
+    &::before,
+    &::after {
+      content: "";
+      height: 0.1px;
+      opacity: 0;
+      order: 100;
+      transform: translateY(-5px);
+    }
+  }
+
+  .gem-c-cards__link {
+    &::before {
+      top: 27px;
+    }
+  }
+
+  .gem-c-cards__description {
+    max-width: none;
+    margin: 0;
+  }
+
+  .gem-c-cards__list::before,
+  .gem-c-cards__list::after,
+  .gem-c-cards__list-item {
+    box-sizing: border-box;
+    width: 100%;
+    flex-grow: 1;
+    flex-shrink: 1;
+  }
+
+  @include govuk-media-query($from: tablet) {
+    .gem-c-cards__list::before,
+    .gem-c-cards__list::after,
+    .gem-c-cards__list-item {
+      width: 25%;
+    }
+
+    @container (width < 560px) {
+      .gem-c-cards__list::before,
+      .gem-c-cards__list::after,
+      .gem-c-cards__list-item {
+        width: 30%;
+      }
+    }
+
+    @container (width < 360px) {
+      .gem-c-cards__list::before,
+      .gem-c-cards__list::after,
+      .gem-c-cards__list-item {
+        width: 100%;
+      }
+    }
+  }
+
+  @include govuk-media-query($from: desktop) {
+    @container (width < 660px) {
+      .gem-c-cards__list::before,
+      .gem-c-cards__list::after,
+      .gem-c-cards__list-item {
+        width: 31%;
+      }
+    }
+
+    @container (width < 360px) {
+      .gem-c-cards__list::before,
+      .gem-c-cards__list::after,
+      .gem-c-cards__list-item {
+        width: 100%;
+      }
+    }
+  }
+}
+
 .gem-c-cards__list-item {
   border-top: 1px solid $govuk-border-colour;
   padding: govuk-spacing(1) 0 govuk-spacing(4) 0;

--- a/app/views/govuk_publishing_components/components/_cards.html.erb
+++ b/app/views/govuk_publishing_components/components/_cards.html.erb
@@ -12,6 +12,7 @@
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-cards")
+  component_helper.add_class("gem-c-cards--auto-layout") if columns == "auto"
 %>
 <% if items.present? %>
   <%= tag.div(**component_helper.all_attributes) do %>

--- a/app/views/govuk_publishing_components/components/docs/cards.yml
+++ b/app/views/govuk_publishing_components/components/docs/cards.yml
@@ -114,6 +114,41 @@ examples:
             text: Citizenship and living in the&nbsp;UK
             path: http://www.gov.uk
           description: Voting, community participation, life in the UK, international projects
+  auto_layout:
+    description: |
+      Automatically adjusts the number of columns used by the component based on the container size, as well as the screen size. Based on the size of the govuk-grid. If the component is in a full width container, it will show three columns - in a two thirds container, two columns - in a one third, one column.
+
+      The example below shows how it appears in a two thirds column.
+    data:
+      columns: auto
+      heading: Services and information
+      items:
+        - link:
+            text: Benefits
+            path: http://www.gov.uk
+          description: Includes eligibility, appeals, tax credits and Universal Credit
+        - link:
+            text: Births, deaths, marriages and&nbsp;care
+            path: http://www.gov.uk
+          description: Parenting, civil partnerships, divorce and Lasting Power of Attorney
+        - link:
+            text: Business and self-employed
+            path: http://www.gov.uk
+          description: Tools and guidance for businesses
+        - link:
+            text: Childcare and parenting
+            path: http://www.gov.uk
+          description: Includes giving birth, fostering, adopting, benefits for children, childcare and schools
+        - link:
+            text: Citizenship and living in the&nbsp;UK
+            path: http://www.gov.uk
+          description: Voting, community participation, life in the UK, international projects
+    embed: |
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <%= component %>
+        </div>
+      </div>
   custom_heading_levels:
     description: |
       Override default heading level by passing through `heading_level` parameter (defaults to `<h2>`).

--- a/spec/components/cards_spec.rb
+++ b/spec/components/cards_spec.rb
@@ -9,6 +9,26 @@ describe "Cards", type: :view do
     assert_empty render_component({})
   end
 
+  it "renders the default component with the correct default classes" do
+    test_data = {
+      heading: "Topics",
+      items: [
+        {
+          link: {
+            text: "Benefits",
+            path: "http://www.gov.uk",
+          },
+        },
+      ],
+    }
+    render_component(test_data)
+    assert_select ".gem-c-cards"
+    assert_select "gem-c-cards__list--one-column", false
+    assert_select "gem-c-cards__list--two-column-desktop", false
+    assert_select "gem-c-cards__list--three-column-desktop", false
+    assert_select ".gem-c-cards--auto-layout", false
+  end
+
   it "renders list heading using default heading level" do
     test_data = {
       heading: "Topics",
@@ -119,6 +139,22 @@ describe "Cards", type: :view do
     }
     render_component(test_data)
     assert_select "ul.gem-c-cards__list.gem-c-cards__list--three-column-desktop", count: 1
+  end
+
+  it "renders the auto layout variant" do
+    test_data = {
+      columns: "auto",
+      items: [
+        {
+          link: {
+            text: "Benefits",
+            path: "http://www.gov.uk",
+          },
+        },
+      ],
+    }
+    render_component(test_data)
+    assert_select ".gem-c-cards.gem-c-cards--auto-layout", count: 1
   end
 
   it "renders sub-heading using default heading level" do


### PR DESCRIPTION
## What
Adds an option to the cards component to make it adapt to its container size.

- automatically adjusts the number of columns used by the component based on the size of its parent container, as well as the screen size
- columns are based on the govuk-grid system
- so if the component is in a full width column, it will show three columns of cards
- in a two thirds column, two columns
- in a one third column, one column
- it still respects the normal screen size rules, so on mobile it collapses to a single column as usual

## Why
We want to try out this kind of behaviour in flexible pages, where components could be positioned anywhere in a page and it would be good to be able to do that without having to specifically configure each instance.

## Visual Changes
Example in the component guide shows the behaviour in a two thirds column. You can see how it behaves by modifying the width of a container in the dev tools.

<img width="1088" height="983" alt="Screenshot 2026-06-10 at 14 11 44" src="https://github.com/user-attachments/assets/76063df9-37c6-4359-9602-d21a70a02e68" />

