### PR TITLE
Remove extra breadcrumbs padding on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Remove extra breadcrumbs padding on mobile ([PR #5501](https://github.com/alphagov/govuk_publishing_components/pull/5501))
 * Add auto layout option to cards component ([PR #5499](https://github.com/alphagov/govuk_publishing_components/pull/5499))
 
 ## 66.5.0

--- a/app/assets/stylesheets/govuk_publishing_components/components/_breadcrumbs.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_breadcrumbs.scss
@@ -11,28 +11,6 @@
   }
 }
 
-.govuk-breadcrumbs--collapse-on-mobile {
-  @include govuk-media-query($until: tablet) {
-    .govuk-breadcrumbs__list-item {
-      padding-top: 14px;
-      padding-bottom: 14px;
-    }
-
-    .govuk-breadcrumbs__list-item::before {
-      top: 20px;
-    }
-
-    .govuk-breadcrumbs__link::after {
-      content: "";
-      position: absolute;
-      top: 0;
-      right: 0;
-      left: 0;
-      bottom: 0;
-    }
-  }
-}
-
 .gem-c-breadcrumbs[dir="rtl"] {
   text-align: start;
 

--- a/app/views/govuk_publishing_components/components/docs/breadcrumbs.yml
+++ b/app/views/govuk_publishing_components/components/docs/breadcrumbs.yml
@@ -3,7 +3,7 @@ description: "Navigational breadcrumbs, showing page hierarchy"
 body: |
   Accepts an array of breadcrumb objects. Each crumb must have a title and a URL.
 
-  We recommend that if using the breadcrumbs for navigation purposes, you set `collapse_on_mobile` to `true` to make things more readable for mobile users. However, you can specify `collapse_on_mobile:``false` or remove the flag completely to stop this behaviour.
+  We recommend that if using the breadcrumbs for navigation purposes, you set `collapse_on_mobile` to `true` to make things more readable for mobile users. However, you can omit this option to stop this behaviour.
 shared_accessibility_criteria:
   - link
 accessibility_criteria: |
@@ -81,9 +81,8 @@ examples:
       - title: 'Education of disadvantaged children appended with some extra long content to make this a very very very very long taxon'
         url: '/education'
   stop_collapsing_on_mobile:
-    description: We recommend that if using the breadcrumbs for navigation purposes, you set `collapse_on_mobile` to `true` to make things more readable for mobile users. However, you can specify `collapse_on_mobile:``false` or remove the flag completely to stop this behaviour.
+    description: We recommend that if using the breadcrumbs for navigation purposes, you set `collapse_on_mobile` to `true` to make things more readable for mobile users. However, you can omit this option to stop this behaviour.
     data:
-      collapse_on_mobile: false
       breadcrumbs:
       - title: 'Home'
         url: '/'

--- a/app/views/govuk_publishing_components/components/docs/breadcrumbs.yml
+++ b/app/views/govuk_publishing_components/components/docs/breadcrumbs.yml
@@ -20,10 +20,12 @@ examples:
     data:
       collapse_on_mobile: true
       breadcrumbs:
-      - title: 'Section'
-        url: '/section'
-      - title: 'Sub-section'
-        url: '/section/sub-section'
+      - title: 'Home'
+        url: '/'
+      - title: 'Passports, travel and living abroad'
+        url: '/browse/abroad'
+      - title: 'Travel abroad'
+        url: '/browse/abroad/travel-abroad'
   inverse:
     description: On a dark background, such as the header of topic pages
     data:
@@ -67,16 +69,6 @@ examples:
         url: '/service-manual'
       - title: 'Agile Delivery'
         url: '/service-manual/agile-delivery'
-  real:
-    data:
-      collapse_on_mobile: true
-      breadcrumbs:
-      - title: 'Home'
-        url: '/'
-      - title: 'Passports, travel and living abroad'
-        url: '/browse/abroad'
-      - title: 'Travel abroad'
-        url: '/browse/abroad/travel-abroad'
   long_taxon:
     description: This is an example of a breadcrumb with long taxons to demonstrate the wrapping behaviour and touch target area on mobile
     data:


### PR DESCRIPTION
## What
Remove some custom styles from the breadcrumb component, to better align it with the Design System and reduce inconsistency.

Also update some of the examples in the component guide.

## Why
Fixes https://github.com/alphagov/govuk_publishing_components/issues/5022

## Visual Changes
This change removes some extra padding we added around the breadcrumb when the `collapse_on_mobile` option is enabled (which seems to be the case for most instances of the component).

Before | After
----- | -------
<img width="401" height="259" alt="Screenshot 2026-06-12 at 10 39 10" src="https://github.com/user-attachments/assets/3bc16a01-e64f-4169-9bd2-b7a1d220c006" /> | <img width="400" height="243" alt="Screenshot 2026-06-12 at 10 39 20" src="https://github.com/user-attachments/assets/aa796df2-5336-4f2c-8a9f-dd980db31142" />
