### PR TITLE
Use multiple box shadows in attachment components in place of outline and box shadow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 * Remove extra breadcrumbs padding on mobile ([PR #5501](https://github.com/alphagov/govuk_publishing_components/pull/5501))
 * Add auto layout option to cards component ([PR #5499](https://github.com/alphagov/govuk_publishing_components/pull/5499))
+* Use multiple box shadows in attachment components in place of outline and box shadow ([PR #5503](https://github.com/alphagov/govuk_publishing_components/pull/5503))
 
 ## 66.5.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
@@ -1,7 +1,6 @@
 $thumbnail-width: 99px;
 $thumbnail-height: 140px;
 $thumbnail-border-width: 5px;
-$thumbnail-background: govuk-colour("white");
 $thumbnail-shadow-colour: rgba(11, 12, 12, .4);
 $thumbnail-shadow-width: 0 2px 2px;
 
@@ -24,7 +23,7 @@ $thumbnail-shadow-width: 0 2px 2px;
   max-width: calc($thumbnail-width / 1.5);
   height: calc($thumbnail-height / 1.5);
   outline: $govuk-border-width solid color.adjust(govuk-colour("black"), $alpha: -0.9);
-  background: $thumbnail-background;
+  background: govuk-colour("white");
   box-shadow: $thumbnail-shadow-width $thumbnail-shadow-colour;
   fill: govuk-colour("mid-grey");
   stroke: govuk-colour("mid-grey");

--- a/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
@@ -25,7 +25,6 @@ $thumbnail-icon-border-colour: govuk-colour("mid-grey");
   width: auto; // for IE8
   max-width: calc($thumbnail-width / 1.5);
   height: calc($thumbnail-height / 1.5);
-  border: $thumbnail-border-colour; // for IE9 & IE10
   outline: $thumbnail-border-width solid $thumbnail-border-colour;
   background: $thumbnail-background;
   box-shadow: $thumbnail-shadow-width $thumbnail-shadow-colour;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
@@ -1,8 +1,6 @@
 $thumbnail-width: 99px;
 $thumbnail-height: 140px;
 $thumbnail-border-width: 5px;
-$thumbnail-shadow-colour: rgba(11, 12, 12, .4);
-$thumbnail-shadow-width: 0 2px 2px;
 
 .gem-c-attachment {
   position: relative;
@@ -24,7 +22,7 @@ $thumbnail-shadow-width: 0 2px 2px;
   height: calc($thumbnail-height / 1.5);
   outline: $govuk-border-width solid color.adjust(govuk-colour("black"), $alpha: -0.9);
   background: govuk-colour("white");
-  box-shadow: $thumbnail-shadow-width $thumbnail-shadow-colour;
+  box-shadow: 0 2px 2px rgba(govuk-colour("black"), .4);
   fill: govuk-colour("mid-grey");
   stroke: govuk-colour("mid-grey");
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
@@ -4,7 +4,6 @@ $thumbnail-border-width: 5px;
 $thumbnail-background: govuk-colour("white");
 $thumbnail-shadow-colour: rgba(11, 12, 12, .4);
 $thumbnail-shadow-width: 0 2px 2px;
-$thumbnail-icon-border-colour: govuk-colour("mid-grey");
 
 .gem-c-attachment {
   position: relative;
@@ -27,8 +26,8 @@ $thumbnail-icon-border-colour: govuk-colour("mid-grey");
   outline: $govuk-border-width solid color.adjust(govuk-colour("black"), $alpha: -0.9);
   background: $thumbnail-background;
   box-shadow: $thumbnail-shadow-width $thumbnail-shadow-colour;
-  fill: $thumbnail-icon-border-colour;
-  stroke: $thumbnail-icon-border-colour;
+  fill: govuk-colour("mid-grey");
+  stroke: govuk-colour("mid-grey");
 
   @include govuk-media-query($from: tablet) {
     max-width: $thumbnail-width;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
@@ -2,7 +2,6 @@ $thumbnail-width: 99px;
 $thumbnail-height: 140px;
 $thumbnail-border-width: 5px;
 $thumbnail-background: govuk-colour("white");
-$thumbnail-border-colour: rgba(11, 12, 12, .1);
 $thumbnail-shadow-colour: rgba(11, 12, 12, .4);
 $thumbnail-shadow-width: 0 2px 2px;
 $thumbnail-icon-border-colour: govuk-colour("mid-grey");
@@ -25,7 +24,7 @@ $thumbnail-icon-border-colour: govuk-colour("mid-grey");
   width: auto; // for IE8
   max-width: calc($thumbnail-width / 1.5);
   height: calc($thumbnail-height / 1.5);
-  outline: $thumbnail-border-width solid $thumbnail-border-colour;
+  outline: $govuk-border-width solid color.adjust(govuk-colour("black"), $alpha: -0.9);
   background: $thumbnail-background;
   box-shadow: $thumbnail-shadow-width $thumbnail-shadow-colour;
   fill: $thumbnail-icon-border-colour;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
@@ -31,6 +31,8 @@ $thumbnail-border-width: 5px;
     max-width: $thumbnail-width;
     height: $thumbnail-height;
   }
+
+  @include high-contrast-outline;
 }
 
 .gem-c-attachment__details {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
@@ -2,6 +2,8 @@ $thumbnail-width: 99px;
 $thumbnail-height: 140px;
 $thumbnail-border-width: 5px;
 
+@use "sass:color";
+
 .gem-c-attachment {
   position: relative;
   @include govuk-font(19);
@@ -20,9 +22,8 @@ $thumbnail-border-width: 5px;
   width: auto; // for IE8
   max-width: calc($thumbnail-width / 1.5);
   height: calc($thumbnail-height / 1.5);
-  outline: $govuk-border-width solid color.adjust(govuk-colour("black"), $alpha: -0.9);
   background: govuk-colour("white");
-  box-shadow: 0 2px 2px rgba(govuk-colour("black"), .4);
+  box-shadow: 0 2px 2px rgba(govuk-colour("black"), .4), 0 0 0 5px color.adjust(govuk-colour("black"), $alpha: -0.9);
   fill: govuk-colour("mid-grey");
   stroke: govuk-colour("mid-grey");
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
@@ -40,6 +40,8 @@
         height: 140px;
         background: govuk-colour("white");
         box-shadow: 0 2px 2px rgba(govuk-colour("black"), .4), 0 0 0 5px color.adjust(govuk-colour("black"), $alpha: -0.9);
+
+        @include high-contrast-outline;
       }
 
       svg {

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
@@ -39,8 +39,7 @@
         width: $thumbnail-width;
         height: 140px;
         background: govuk-colour("white");
-        outline: $govuk-border-width solid color.adjust(govuk-colour("black"), $alpha: -0.9);
-        box-shadow: 0 2px 2px rgba(govuk-colour("black"), .4);
+        box-shadow: 0 2px 2px rgba(govuk-colour("black"), .4), 0 0 0 5px color.adjust(govuk-colour("black"), $alpha: -0.9);
       }
 
       svg {

--- a/app/assets/stylesheets/govuk_publishing_components/components/mixins/_high-contrast-outline.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/mixins/_high-contrast-outline.scss
@@ -1,0 +1,8 @@
+@mixin high-contrast-outline {
+  color-scheme: dark;
+
+  @media (forced-colors: active) {
+    outline: 5px solid currentcolor;
+    forced-color-adjust: auto;
+  }
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/mixins/_index.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/mixins/_index.scss
@@ -1,4 +1,5 @@
 @import "grid-helper";
+@import "_high-contrast-outline";
 @import "margins";
 @import "prefixed-transform";
 @import "scale";


### PR DESCRIPTION
## What

- Standardise some aspects of the attachment components (the Whitehall block attachment used in Govspeak and the attachment component).
- Use multiple box shadows to achieve the same visual effect as having both a box shadow and an outline.
- Make the high-contrast outline consistent throughout, following current Firefox behaviour

## Why

This relates to investigating issues encountered during the v6 upgrade, where we've found that the use of `color.adjust` and, in some cases, `darken` can cause compilation failures. Following a design review, we'd like to standardise these colours using GOV.UK Frontend colours where possible https://docs.google.com/document/d/10bvnIGAgSv4BE1tzP-c2FTEtmB4cp_Qr9e59H7Jn3jA/edit?disco=AAAB9F6l1fQ.

As these colours also use semi-transparency, some reworking is needed to ensure the box shadow remains visible; I've used multiple box shadows to achieve the same visual effect (which has good browser support https://caniuse.com/?search=multiple+box+shadows).

I've also removed some older border styles that appear to have been intended for IE9/IE10 support and are no longer needed (see attached screenshots).

## Visual Changes (unchanged except in high contrast mode - see separate screenshots below)

### IE9 (Before)

<img width="2496" height="1524" alt="bs_win7_IE_9 0 (1)" src="https://github.com/user-attachments/assets/3d2fc679-8ee7-46c8-a3ce-dfd8798bd6f8" />

### IE9 (After, no difference)

<img width="2496" height="1524" alt="bs_win7_IE_9 0" src="https://github.com/user-attachments/assets/a9b42003-6a36-4355-9a98-9af7afd93502" />

### IE10 (Before)

<img width="2496" height="1524" alt="bs_win8_IE_10 0" src="https://github.com/user-attachments/assets/975c32e4-aaac-42fb-837e-21082b14e4c3" />

### IE10 (After, no difference)

<img width="2496" height="1524" alt="bs_win8_IE_10 0 (1)" src="https://github.com/user-attachments/assets/b8b14d3d-9be8-4c76-b304-c5e6ccacf2ce" />

## Visual Changes (high contrast mode)

### Chrome, forced colours (Before)

<img width="1728" height="1117" alt="Screenshot 2026-06-24 at 14 52 40" src="https://github.com/user-attachments/assets/9f6d639d-4d41-41c7-841a-4b477b52996a" />

### Chrome, forced colours (After)

<img width="1728" height="1117" alt="Screenshot 2026-06-24 at 14 52 50" src="https://github.com/user-attachments/assets/8e42f7fd-3555-461d-b691-33b4cf73a000" />

### MS High Contrast mode

#### Edge (Before)

<img width="1728" height="1117" alt="Screenshot 2026-06-24 at 11 27 58" src="https://github.com/user-attachments/assets/f4c52ab0-0f5d-41b1-8f2e-a467e9c68bd4" />

#### Edge (After)

<img width="1728" height="1117" alt="Screenshot 2026-06-24 at 11 27 09" src="https://github.com/user-attachments/assets/bd7e4e82-4d7e-40a9-b5f1-28f6d7dc1fb2" />

#### Firefox, custom settings (Before)

<img width="1728" height="1117" alt="Screenshot 2026-06-24 at 11 29 03" src="https://github.com/user-attachments/assets/fe023dc1-4299-426f-b848-483966b82632" />

#### Firefox, custom settings After, no difference)

<img width="1728" height="1117" alt="Screenshot 2026-06-24 at 11 28 32" src="https://github.com/user-attachments/assets/3eb168f4-a9d9-47b8-8c77-4d0d2fc6665b" />

#### Firefox automatic (system settings) (Before)

<img width="1728" height="1117" alt="Screenshot 2026-06-24 at 11 29 14" src="https://github.com/user-attachments/assets/d859d599-9ac3-4125-a6a8-b70974abcc8d" />

#### Firefox automatic (system settings) (After, no difference)

<img width="1728" height="1117" alt="Screenshot 2026-06-24 at 11 28 22" src="https://github.com/user-attachments/assets/4f34249a-8089-433e-b99e-463987f9a665" />

## Anything else

- I’m not sure why earlier versions of IE add a blue border around the image (as it still appears to do after the change), but since it’s an existing issue and not causing any problems, I haven’t tried to fix it.
- It was also noticed that the current high-contrast styling adds an outline, but this only showed in Firefox. The recent changes removed that outline, so I’ve made another update to bring the behaviour back in line across all tested browsers. That said, this still might not be the best way to handle high-contrast mode in these components, and it probably needs a bit more design input to figure out the right approach.
- I spent some time trying to get this approach to work in Chrome with Auto Dark Mode enabled, but ultimately had to abandon it due to a range of inconsistent behaviours. Since this is an experimental feature on Android and is otherwise only available through DevTools, I've not supported it.