### PR TITLE
Remove innerHTML from filter-list.js

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/lib/filter-list.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/filter-list.js
@@ -16,10 +16,21 @@
   FilterList.prototype.appendFilterInput = function () {
     const form = document.createElement('div')
     form.classList.add('govuk-form-group')
-    form.innerHTML = `
-      <label for="filterInput" class="gem-c-label govuk-label">${this.labelText}</label>
-      <input class="gem-c-input govuk-input" id="filterInput" name="name" spellcheck="false" type="text">
-    `
+
+    const formLabel = document.createElement('label')
+    formLabel.htmlFor = 'filterInput'
+    formLabel.classList.add('gem-c-label', 'govuk-label')
+    formLabel.textContent = this.labelText
+
+    const formInput = document.createElement('input')
+    formInput.classList.add('gem-c-input', 'govuk-input')
+    formInput.id = 'filterInput'
+    formInput.name = 'name'
+    formInput.spellcheck = false
+    formInput.type = 'text'
+
+    form.append(formLabel, formInput)
+
     this.module.prepend(form)
     const input = form.querySelector('.govuk-input')
     input.addEventListener('submit', function (e) { e.preventDefault() })


### PR DESCRIPTION
## What
Refactor  the `appendFilterInput` method in `/lib/filter-list.js` to remove the use of innerHTML and replace with textContent

## Why
Improve code quality and security, as recommended in https://cheatsheetseries.owasp.org/cheatsheets/DOM_based_XSS_Prevention_Cheat_Sheet.html#rule-6-populate-the-dom-using-safe-javascript-functions-or-properties
