### PR TITLE
Add helper tests to component auditing

### DIFF
--- a/app/models/govuk_publishing_components/audit_applications.rb
+++ b/app/models/govuk_publishing_components/audit_applications.rb
@@ -64,6 +64,7 @@ module GovukPublishingComponents
           tests_path: "spec/components/",
           javascript_tests_path: "spec/javascripts/components/",
           helpers_path: "app/helpers/",
+          helpers_tests_path: "spec/helpers/",
         }
         application_components = AuditComponents.new(path, options)
         application_components = application_components.data if application_components

--- a/app/models/govuk_publishing_components/audit_components.rb
+++ b/app/models/govuk_publishing_components/audit_components.rb
@@ -11,6 +11,7 @@ module GovukPublishingComponents
       @tests_path = options[:tests_path] || "spec/components"
       @javascript_tests_path = options[:javascript_tests_path] || "spec/javascripts/components"
       @helpers_path = options[:helpers_path] || "lib/govuk_publishing_components/presenters"
+      @helpers_tests_path = options[:helpers_tests_path] || "spec/lib/govuk_publishing_components/presenters"
 
       @application_name = options[:application_name] || "govuk_publishing_components"
       @application_dir = options[:application_dir] || "govuk_publishing_components"
@@ -27,6 +28,7 @@ module GovukPublishingComponents
         test: 0,
         javascript_test: 0,
         helper: 0,
+        helper_test: 0,
       }
 
       @data = {
@@ -90,6 +92,10 @@ module GovukPublishingComponents
           {
             type: "helper",
             file: "#{[path, @helpers_path].join('/')}/#{component.gsub(' ', '_')}_helper.rb",
+          },
+          {
+            type: "helper_test",
+            file: "#{[path, @helpers_tests_path].join('/')}/#{component.gsub(' ', '_')}_helper_spec.rb",
           },
         ]
         file_details.each do |detail|
@@ -162,6 +168,7 @@ module GovukPublishingComponents
         .gsub(".js", "")
         .gsub("spec", "")
         .gsub("helper.rb", "")
+        .gsub("helper_spec.rb", "")
         .gsub(".rb", "")
         .strip
     end
@@ -244,6 +251,7 @@ module GovukPublishingComponents
       link = "#{url}/#{repo}/#{blob}/#{@tests_path}/#{component.gsub(' ', '_')}_spec.rb" if a_thing == "test"
       link = "#{url}/#{repo}/#{blob}/#{@javascript_tests_path}/#{component.gsub(' ', '-')}-spec.js" if a_thing == "javascript_test"
       link = "#{url}/#{repo}/#{blob}/#{@helpers_path}/#{component.gsub(' ', '_')}_helper.rb" if a_thing == "helper"
+      link = "#{url}/#{repo}/#{blob}/#{@helpers_tests_path}/#{component.gsub(' ', '_')}_helper_spec.rb" if a_thing == "helper_test"
 
       link
     end

--- a/app/views/govuk_publishing_components/audit/_component_contents.html.erb
+++ b/app/views/govuk_publishing_components/audit/_component_contents.html.erb
@@ -60,6 +60,12 @@
             <span class="component__count"><%= passed_components[:component_numbers][:helper] %></span>
           <% end %>
         </th>
+        <th scope="col" class="govuk-table__header sticky-table-header" data-component-type="helper_test" title="Component has a helper test file">
+          Helper test
+          <% unless show_application_name %>
+            <span class="component__count"><%= passed_components[:component_numbers][:helper_test] %></span>
+          <% end %>
+        </th>
       </tr>
     </thead>
     <tbody class="govuk-table__body" <% if show_application_name %> data-audit-list<% end %>>
@@ -145,6 +151,14 @@
               <a href="<%= component[:helper_link] %>" class="govuk-link" title="This file has <%= component[:helper_lines] %> lines">
                 <%= component[:helper_lines] %>
                 <span class="govuk-visually-hidden">lines of code in <%= component[:name] %> helper</span>
+              </a>
+            <% end %>
+          </td>
+          <td class="govuk-table__cell" data-component-type="helper_test">
+            <% if component[:helper_test_exists] %>
+              <a href="<%= component[:helper_test_link] %>" class="govuk-link" title="This file has <%= component[:helper_test_lines] %> lines">
+                <%= component[:helper_test_lines] %>
+                <span class="govuk-visually-hidden">lines of code in <%= component[:name] %> helper test</span>
               </a>
             <% end %>
           </td>

--- a/spec/component_guide/audit_applications_spec.rb
+++ b/spec/component_guide/audit_applications_spec.rb
@@ -184,6 +184,7 @@ describe "Auditing the components in applications" do
         ],
         component_numbers: {
           helper: 0,
+          helper_test: 0,
           javascript: 0,
           javascript_test: 0,
           print_stylesheet: 0,

--- a/spec/component_guide/audit_components_spec.rb
+++ b/spec/component_guide/audit_components_spec.rb
@@ -56,6 +56,9 @@ describe "Auditing the components in the gem" do
           helper_exists: true,
           helper_lines: 6,
           helper_link: "https://github.com/alphagov/govuk_publishing_components/blob/main/lib/govuk_publishing_components/presenters/test_component_helper.rb",
+          helper_test_exists: true,
+          helper_test_lines: 4,
+          helper_test_link: "https://github.com/alphagov/govuk_publishing_components/blob/main/spec/lib/govuk_publishing_components/presenters/test_component_helper_spec.rb",
           uses_govuk_frontend_css: true,
         },
         {
@@ -83,6 +86,7 @@ describe "Auditing the components in the gem" do
         test: 1,
         javascript_test: 1,
         helper: 1,
+        helper_test: 1,
         uses_govuk_frontend_css: 1,
         uses_govuk_frontend_js: 1,
       },

--- a/spec/dummy_gem/spec/lib/govuk_publishing_components/presenters/test_component_helper_spec.rb
+++ b/spec/dummy_gem/spec/lib/govuk_publishing_components/presenters/test_component_helper_spec.rb
@@ -1,0 +1,4 @@
+# this file is needed to test the component auditing
+def not_a_thing
+  # need some lines in here for testing purposes to ensure line counting works correctly
+end


### PR DESCRIPTION
## What
- include spec files for component presenters/helpers in the auditing
- adds a new column to the 'Component files' section of the 'Components' tab in the auditing, showing if a component has a spec/test file for any helpers, or not

## Why
Was not included in the auditing, and should be - initial checks show not all helpers have an associated test file.

## Visual Changes
New column 'Helper test' added to the right.

<img width="1698" height="847" alt="Screenshot 2026-06-19 at 16 34 27" src="https://github.com/user-attachments/assets/58c580ed-6d92-4676-b99b-913130945e80" />
