### PR TITLE
Replace colours generated by the adjust and darken functions

### DIFF
--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -225,7 +225,7 @@ html {
 $code-00: color.scale(govuk-colour("black", $variant: "tint-95"), $lightness: 50%); // Default Background
 $code-01: #f5f5f5; // Lighter Background (Unused)
 $code-02: #bfc1c3; // Selection Background
-$code-03: color.adjust($govuk-secondary-text-colour, $lightness: -2%); // Comments, Invisibles, Line Highlighting
+$code-03: $govuk-secondary-text-colour; // Comments, Invisibles, Line Highlighting
 $code-04: #e8e8e8; // Dark Foreground (Unused)
 $code-05: $govuk-text-colour; // Default Foreground, Caret, Delimiters, Operators
 $code-06: #ffffff; // Light Foreground (Unused)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_button.scss
@@ -92,7 +92,7 @@
   &:hover {
     border-color: $gem-quiet-button-hover-colour;
     color: $gem-quiet-button-hover-colour;
-    background-color: $gem-secondary-button-hover-background-colour;
+    background-color: $gem-quiet-button-hover-background-colour;
     text-decoration: none;
   }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -206,7 +206,7 @@ $search-submit-button-hover-colour: $govuk-blue-tint-95;
     color: govuk-colour("white");
 
     &:hover {
-      background-color: color.adjust(govuk-colour("blue"), $lightness: 5%);
+      background-color: govuk-colour("blue", $variant: "shade-25");
     }
   }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_colours.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_colours.scss
@@ -4,7 +4,8 @@ $gem-secondary-button-background-colour: govuk-colour("white");
 $gem-secondary-button-hover-background-colour: govuk-colour("black", $variant: "tint-95");
 
 $gem-quiet-button-colour: govuk-colour("black", $variant: "tint-25");
-$gem-quiet-button-hover-colour: darken($gem-quiet-button-colour, 5%);
+$gem-quiet-button-hover-colour: govuk-colour("black");
+$gem-quiet-button-hover-background-colour: govuk-colour("black", $variant: "tint-80");
 
 // Brand refresh
 $govuk-blue-tint-95: govuk-colour("blue", $variant: "tint-95");

--- a/app/assets/stylesheets/govuk_publishing_components/lib/_link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/lib/_link.scss
@@ -8,7 +8,7 @@
   &:visited,
   &:hover,
   &:active {
-    color: darken($govuk-error-colour, 5%);
+    color: govuk-colour("red", $variant: "shade-25");
   }
 
   &:focus {


### PR DESCRIPTION
## What

Replace colours generated by the `adjust` and `darken` functions.

## Why

The use of these functions in v6 causes compilation errors.

## Visual changes

### Before (Code and syntax highlighting)

<img width="1728" height="1117" alt="Screenshot 2026-06-24 at 09 23 43" src="https://github.com/user-attachments/assets/e1c8da82-916b-4dd2-aae5-e265cd13ee1f" />

### After (Code and syntax highlighting)

<img width="1728" height="1117" alt="Screenshot 2026-06-24 at 09 24 55" src="https://github.com/user-attachments/assets/43cc7d11-6006-4470-8788-68165b196e6f" />

### Before (Search on white background: submit button hover state)

<img width="1728" height="1117" alt="Screenshot 2026-06-24 at 09 27 37" src="https://github.com/user-attachments/assets/8dbb6575-89e3-4a27-95b1-0a37fcf95f2d" />

### After (Search on white background: submit button hover state)

<img width="1728" height="1117" alt="Screenshot 2026-06-24 at 09 27 49" src="https://github.com/user-attachments/assets/38231b10-44c2-466e-ab04-910c227c76be" />

### Before (Destructive link: visited, hover, and active states)

<img width="1728" height="1117" alt="Screenshot 2026-06-24 at 09 32 10" src="https://github.com/user-attachments/assets/4f4c877d-a41f-4c39-9232-9297876c9b61" />

### After (Destructive link: visited, hover, and active states)

<img width="1728" height="1117" alt="Screenshot 2026-06-24 at 09 32 03" src="https://github.com/user-attachments/assets/e419a769-ff02-4198-839e-0af1b4e3d8ae" />

### Before (Secondary quiet button: hover state)

<img width="1728" height="1117" alt="Screenshot 2026-06-24 at 09 55 03" src="https://github.com/user-attachments/assets/070deffe-9919-4717-8436-0f25c52b6ac7" />

### After (Secondary quiet button: hover state)

<img width="1728" height="1117" alt="Screenshot 2026-06-24 at 09 55 53" src="https://github.com/user-attachments/assets/259921fb-cbf6-47eb-be3b-9b756911601a" />

## Anything else

See the linked discussion doc for details on the issues and the reasoning behind the selected colour replacements:

https://docs.google.com/document/d/10bvnIGAgSv4BE1tzP-c2FTEtmB4cp_Qr9e59H7Jn3jA/edit?usp=sharing