### PR TITLE
Add styles for cards in govspeak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add styles for cards in govspeak ([PR #5516](https://github.com/alphagov/govuk_publishing_components/pull/5516))
+
 ## 66.6.0
 
 * Remove extra breadcrumbs padding on mobile ([PR #5501](https://github.com/alphagov/govuk_publishing_components/pull/5501))

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
@@ -30,6 +30,13 @@
     }
   }
 
+  // restore styles for cards component inside govspeak
+  .gem-c-cards__list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+
   // Block quotes
 
   blockquote {


### PR DESCRIPTION
## What
- we're adding the cards component into govspeak
- cards is based on an unordered list, which in the component is styled correctly to override the browser defaults of margin, padding and list item display
- however in govspeak the default unordered lists are given those things back, and since that's all under the `.govspeak ul` structure it has higher precedence, and breaks the appearance of the cards component
- overriding like this fixes the problem (but feels inefficient)

## Why
Needed for https://github.com/alphagov/govspeak/pull/489

## Visual changes
Screenshots below are from the govspeak preview app.

Before | After
---- | -----
<img width="1077" height="452" alt="Screenshot 2026-06-22 at 09 28 32" src="https://github.com/user-attachments/assets/e7b4526d-89eb-4f87-aae2-6465fbd37316" /> | <img width="1081" height="415" alt="Screenshot 2026-06-22 at 09 28 43" src="https://github.com/user-attachments/assets/7b1b8ae7-6182-455c-be2a-566c49b27b5f" />
