### PR TITLE
Remove all 'rebrand' references with move to Design System v6

### DIFF
--- a/app/assets/config/govuk_publishing_components_manifest.js
+++ b/app/assets/config/govuk_publishing_components_manifest.js
@@ -1,6 +1,6 @@
 // Pre-compile image and font assets from here and govuk-frontend
 //= link_tree ../images
-//= link_tree ../../../node_modules/govuk-frontend/dist/govuk/assets/rebrand/images
+//= link_tree ../../../node_modules/govuk-frontend/dist/govuk/assets/images
 //= link_tree ../../../node_modules/govuk-frontend/dist/govuk/assets/fonts
 
 // Create asset files of each of the files in these directory

--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -557,9 +557,3 @@ $code-delete-bg: #fadddd;
     }
   }
 }
-
-// Note: This is a temporary override to ensure the background color on component preview
-// pages remains white, this can be removed once the --rebrand flag is removed from govuk-frontend
-.govuk-template--rebranded {
-  background: #ffffff;
-}

--- a/app/assets/stylesheets/govuk_publishing_components/components/_app-promo-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_app-promo-banner.scss
@@ -2,7 +2,7 @@
   display: none;
   padding: govuk-spacing(5) 0;
   border-top: 4px solid $govuk-brand-colour;
-  background-color: $govuk-rebrand-template-background-colour;
+  background-color: $govuk-blue-tint-95;
   @include govuk-text-colour;
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -381,7 +381,7 @@ $search-icon-height: 20px;
   }
 
   @include focus-not-focus-visible {
-    background: $govuk-rebrand-template-background-colour;
+    background: $govuk-blue-tint-95;
 
     &::after {
       background-color: $govuk-link-colour;
@@ -496,8 +496,8 @@ $search-icon-height: 20px;
     }
 
     @include focus-not-focus-visible {
-      background: $govuk-rebrand-template-background-colour;
-      outline: 1px solid $govuk-rebrand-template-background-colour; // overlap the border of the nav menu so it won't appear when menu open
+      background: $govuk-blue-tint-95;
+      outline: 1px solid $govuk-blue-tint-95; // overlap the border of the nav menu so it won't appear when menu open
 
       color: govuk-colour("blue");
 
@@ -543,7 +543,7 @@ $search-icon-height: 20px;
 .gem-c-layout-super-navigation-header__navigation-dropdown-menu {
   width: 100%;
   order: 1; // Ensure the dropdown menu appears after the super navigation buttons which have a default order of 0
-  background: $govuk-rebrand-template-background-colour;
+  background: $govuk-blue-tint-95;
   padding-top: govuk-spacing(6);
 
   @include govuk-media-query($from: "desktop") {
@@ -562,7 +562,7 @@ $search-icon-height: 20px;
     top: $navbar-height;
     bottom: 0;
     width: 100%;
-    background: $govuk-rebrand-template-background-colour;
+    background: $govuk-blue-tint-95;
     box-shadow: 0 1px govuk-colour("black", $variant: "tint-80");
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_colours.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_colours.scss
@@ -7,9 +7,6 @@ $gem-quiet-button-colour: govuk-colour("black", $variant: "tint-25");
 $gem-quiet-button-hover-colour: govuk-colour("black");
 $gem-quiet-button-hover-background-colour: govuk-colour("black", $variant: "tint-80");
 
-// Brand refresh
 $govuk-blue-tint-95: govuk-colour("blue", $variant: "tint-95");
 $govuk-blue-tint-80: govuk-colour("blue", $variant: "tint-80");
 $govuk-blue-tint-50: govuk-colour("blue", $variant: "tint-50");
-
-$govuk-rebrand-template-background-colour: $govuk-blue-tint-95;

--- a/app/views/govuk_publishing_components/components/_layout_for_admin.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_admin.html.erb
@@ -8,7 +8,7 @@
 %>
 
 <!DOCTYPE html>
-<html lang="en" class="govuk-template govuk-template--rebranded">
+<html lang="en" class="govuk-template">
   <head>
     <meta charset="utf-8">
     <title><%= browser_title %> - GOV.UK <%= product_name %></title>

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -32,7 +32,7 @@
   body_css_classes << body_classes if body_classes
 -%>
 <!DOCTYPE html>
-<html class="govuk-template govuk-template--rebranded" lang="<%= html_lang %>">
+<html class="govuk-template" lang="<%= html_lang %>">
   <head>
     <meta charset="utf-8">
     <%= tag.title title, lang: title_lang %>

--- a/app/views/layouts/govuk_publishing_components/application.html.erb
+++ b/app/views/layouts/govuk_publishing_components/application.html.erb
@@ -23,7 +23,7 @@
   <% end %>
 <% end %>
 <!DOCTYPE html>
-<html lang="en" class="<%= "govuk-template" unless @preview %> govuk-template--rebranded">
+<html lang="en" class="<%= "govuk-template" unless @preview %>">
   <head>
     <meta charset="utf-8">
     <title>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -9,7 +9,7 @@ return unless Rails.application.config.respond_to?(:assets)
 Rails.application.config.assets.precompile += %w[govuk_publishing_components_manifest.js]
 
 Rails.application.config.assets.paths += %W[
-  #{__dir__}/../../node_modules/govuk-frontend/dist/govuk/assets/rebrand/images
+  #{__dir__}/../../node_modules/govuk-frontend/dist/govuk/assets/images
   #{__dir__}/../../node_modules/govuk-frontend/dist/govuk/assets/fonts
   #{__dir__}/../../node_modules/govuk-frontend/dist
   #{__dir__}/../../node_modules/

--- a/spec/component_guide/component_preview_spec.rb
+++ b/spec/component_guide/component_preview_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 describe "Component preview", :capybara do
   it "shows all component examples on a page without header or footer" do
     visit "/component-guide/test_component_with_params/preview"
-    expect(page).to have_selector(".govuk-template--rebranded")
     expect(page).to have_selector(".govuk-width-container")
 
     expect(page).not_to have_selector("body > header")
@@ -18,7 +17,6 @@ describe "Component preview", :capybara do
 
   it "shows a specific example on a page without header or footer" do
     visit "/component-guide/test_component_with_params/another_example/preview"
-    expect(page).to have_selector(".govuk-template--rebranded")
     expect(page).to have_selector(".govuk-width-container")
 
     expect(page).not_to have_selector("body > header")
@@ -31,7 +29,6 @@ describe "Component preview", :capybara do
 
   it "shows all component examples using the full page width without header or footer" do
     visit "/component-guide/test_component_using_full_page_width/preview"
-    expect(page).to have_selector(".govuk-template--rebranded")
     expect(page).to have_selector(".govuk-full-width-container")
 
     expect(page).not_to have_selector("body > header")


### PR DESCRIPTION
## What
Remove all 'rebrand' code, including feature flags, rebrand-related classes, and any references to the rebrand folder

## Why
https://gov-uk.atlassian.net/jira/software/c/projects/NAV/boards/1422?selectedIssue=NAV-18917


