### PR TITLE
Version 66.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 66.6.1
 
 * Add styles for cards in govspeak ([PR #5516](https://github.com/alphagov/govuk_publishing_components/pull/5516))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (66.6.0)
+    govuk_publishing_components (66.6.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "66.6.0".freeze
+  VERSION = "66.6.1".freeze
 end


### PR DESCRIPTION
## 66.6.1

* Add styles for cards in govspeak ([PR #5516](https://github.com/alphagov/govuk_publishing_components/pull/5516))
