### PR TITLE
Fix tabs documentation

### DIFF
--- a/app/views/govuk_publishing_components/components/_tabs.html.erb
+++ b/app/views/govuk_publishing_components/components/_tabs.html.erb
@@ -26,7 +26,7 @@
       <% tabs.each_with_index do |tab, index| %>
       <li class="govuk-tabs__list-item <%= "govuk-tabs__list-item--selected" if tab[:active] %>">
         <%
-          tab[:tab_data_attributes] ||= {}
+          data_attributes = tab[:tab_data_attributes] || {}
           unless disable_ga4
             ga4_attributes = {
               event_name: "select_content",
@@ -36,8 +36,8 @@
               index_section_count: tabs.length,
             }
             ga4_attributes[:event_name] = "navigation" if as_links
-            tab[:tab_data_attributes][:ga4_link] = ga4_attributes if as_links
-            tab[:tab_data_attributes][:ga4_event] = ga4_attributes unless as_links
+            data_attributes[:ga4_link] = ga4_attributes if as_links
+            data_attributes[:ga4_event] = ga4_attributes unless as_links
           end
 
           tab_link = "##{tab[:id]}"
@@ -46,7 +46,7 @@
         <%= link_to(tab[:label],
                     tab_link,
                     class: "govuk-tabs__tab",
-                    data: tab[:tab_data_attributes]) %>
+                    data: data_attributes) %>
       </li>
       <% end %>
     </ul>

--- a/app/views/govuk_publishing_components/components/docs/tabs.yml
+++ b/app/views/govuk_publishing_components/components/docs/tabs.yml
@@ -10,13 +10,14 @@ body: |
 
   The content block MUST be passed as a block to avoid the risk of unsanitised HTML.
 accessibility_criteria: |
-  - Tabs must:
-    * accept focus
-    * be usable with a keyboard
-    * indicate when they have focus
-    * be usable with touch
-    * be usable with voice commands
-    * have visible text
+  Tabs must:
+
+  * accept focus
+  * be usable with a keyboard
+  * indicate when they have focus
+  * be usable with touch
+  * be usable with voice commands
+  * have visible text
 uses_component_wrapper_helper: true
 examples:
   default:

--- a/spec/components/tabs_spec.rb
+++ b/spec/components/tabs_spec.rb
@@ -79,6 +79,31 @@ describe "Tabs", type: :view do
     assert_select ".govuk-tabs__tab[data-ga4-event='{\"event_name\":\"select_content\",\"type\":\"tabs\",\"text\":\"Third section\",\"index_section\":3,\"index_section_count\":3}']"
   end
 
+  it "renders data attributes on tabs" do
+    render_component(
+      tabs: [
+        {
+          id: "tab1",
+          label: "First section",
+          content: "<p>Fusce at dictum tellus, ac accumsan est. Nulla vitae turpis in nulla gravida tincidunt.</p>",
+          tab_data_attributes: {
+            hello: "world",
+          },
+        },
+        {
+          id: "tab2",
+          label: "Second section",
+          content: "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>",
+          tab_data_attributes: {
+            goodbye: "mr chips",
+          },
+        },
+      ],
+    )
+    assert_select ".govuk-tabs__tab[href='#tab1'][data-hello='world']"
+    assert_select ".govuk-tabs__tab[href='#tab2'][data-goodbye='mr chips']"
+  end
+
   it "renders without GA4 tracking on tabs" do
     render_component(
       disable_ga4: true,


### PR DESCRIPTION
## What
- the code example for the tabs component was showing a load of data attributes in the code snippet that weren't being passed to the component from the YML
- these attributes weren't needed for the example shown and shouldn't have been there
- on investigation, it turns out that when the component was rendered the default data attributes for tracking were being created but then appended into the data passed to the the component, hence the corruption of the code example in the guide page
- replacing this with a simple variable fixes the issues

## Why
The documentation was inaccurate, suggesting that data attributes needed to be passed when they did not.

## Visual Changes
Before
<img width="1070" height="466" alt="Screenshot 2026-06-24 at 15 57 00" src="https://github.com/user-attachments/assets/2df8b731-39c7-4423-a578-5f28765068fd" />


After
<img width="1073" height="458" alt="Screenshot 2026-06-24 at 15 57 07" src="https://github.com/user-attachments/assets/a4717fc2-27a6-4270-9777-0c00935dd986" />

