### PR TITLE
Replace the custom colours used in the attachment components

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
@@ -23,9 +23,9 @@ $thumbnail-border-width: 5px;
   max-width: calc($thumbnail-width / 1.5);
   height: calc($thumbnail-height / 1.5);
   background: govuk-colour("white");
-  box-shadow: 0 2px 2px rgba(govuk-colour("black"), .4), 0 0 0 5px color.adjust(govuk-colour("black"), $alpha: -0.9);
-  fill: govuk-colour("mid-grey");
-  stroke: govuk-colour("mid-grey");
+  box-shadow: 0 2px 2px govuk-colour("black", $variant: "tint-50"), 0 0 0 5px govuk-colour("black", $variant: "tint-80");
+  fill: govuk-colour("black", $variant: "tint-50");
+  stroke: govuk-colour("black", $variant: "tint-50");
 
   @include govuk-media-query($from: tablet) {
     max-width: $thumbnail-width;

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
@@ -39,14 +39,14 @@
         width: $thumbnail-width;
         height: 140px;
         background: govuk-colour("white");
-        box-shadow: 0 2px 2px rgba(govuk-colour("black"), .4), 0 0 0 5px color.adjust(govuk-colour("black"), $alpha: -0.9);
+        box-shadow: 0 2px 2px govuk-colour("black", $variant: "tint-50"), 0 0 0 5px govuk-colour("black", $variant: "tint-80");
 
         @include high-contrast-outline;
       }
 
       svg {
-        fill: govuk-colour("black", $variant: "tint-80");
-        stroke: govuk-colour("black", $variant: "tint-80");
+        fill: govuk-colour("black", $variant: "tint-50");
+        stroke: govuk-colour("black", $variant: "tint-50");
       }
 
       @include govuk-media-query($media-type: print) {


### PR DESCRIPTION
## What

Replace the custom colours used in the attachment components with:

- Outline: `govuk-colour("black", $variant: "tint-80")`
- Shadow: `govuk-colour("black", $variant: "tint-50")`
- SVG fills: `govuk-colour("black", $variant: "tint-50")`

**Review URL**: https://components-gem-pr-5529.herokuapp.com/component-guide/attachment/default/preview

## Why

* Replace the existing colours with the GOV.UK Frontend colour palette.
* Standardise the two attachment components.

## Visual Changes

### Before

<img width="1290" height="639" alt="components publishing service gov uk_component-guide_attachment_default_preview(iPhone 14 Pro Max)" src="https://github.com/user-attachments/assets/e51f692e-6913-42b4-a1a4-ad08a77550bc" />

### After

<img width="1290" height="639" alt="components-gem-pr-5529 herokuapp com_component-guide_attachment_default_preview(iPhone 14 Pro Max)" src="https://github.com/user-attachments/assets/f440928b-ec04-43da-beb4-aef83937d864" />
