### PR TITLE
Add information for external services on using govuk components

### DIFF
--- a/app/views/govuk_publishing_components/component_guide/index.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/index.html.erb
@@ -13,6 +13,7 @@
     <li><a href="/component-guide/audit">View component audits</a></li>
     <li><a href="/component-guide/applications">View application information</a></li>
   </ul>
+  <p>These components are maintained for www.gov.uk and GOV.UK Publishing services and have not been tested in other contexts. You are still free to use them if you are not developing for GOV.UK or GOV.UK Publishing, however you will need to do work to ensure they function in your code's ecosystem. We cannot provide support on using these components in your service.</p>
 </div>
 
 <div data-module="filter-list" data-filter-label="Search components">


### PR DESCRIPTION
## What

Adds information to the component guide homepage on using govuk components if you are working on a service external to the govuk website or publishing apps.

Co-authored with @maxgds and @MartinJJones 

## Why

The design system team have noticed through support rota questions and user research that sometimes our users (people working on distinct services out in departments), when trying to find a specific component to use in their service that isn't in the design system, will end up on the component guide and won't understand that this is for dub dub dub govuk/publishing only and not part of the design system, so they can't just plug a given component into their service the way they can with govuk-frontend.

There's a bigger bit of work there around articulating the whole system to service teams, how the design system interacts with govuk and govuk services and other departmental design systems etc. This is a stopfix to try to prompt those users that this component guide is specific to the govuk website, rather than pluggable into any prototype the way that govuk-frontend components are.

