### PR TITLE
Stop using size 14 from the type scale

### DIFF
--- a/app/views/govuk_publishing_components/components/_glance_metric.html.erb
+++ b/app/views/govuk_publishing_components/components/_glance_metric.html.erb
@@ -30,6 +30,6 @@
         <% end %>
     <% end %>
     </span>
-    <p class="gem-c-glance-metric__context govuk-body-xs"><%= context %></p>
+    <p class="gem-c-glance-metric__context govuk-body-s"><%= context %></p>
   <% end %>
 <% end %>


### PR DESCRIPTION
## What
We are replacing all instances of 14px typography across GOV.UK Publishing Components and frontend apps. This involves removing or updating Sass mixins passing $size: 14, eliminating utility classes like govuk-body-xs and govuk-!-font-size-14, and clearing out any raw 14px/rem equivalents.

## Why
Size 14 is being officially removed from the type scale. We want to update these references to an approved font size to avoid Sass triggering a compilation error and fail to build.

Jira card: https://gov-uk.atlassian.net/browse/NAV-18915

## Visual Changes
| Before | After |
|--------|--------|
| <img width="483" height="464" alt="Screenshot 2026-06-29 at 15 37 50" src="https://github.com/user-attachments/assets/0dd4f1cd-4c5e-4836-a9db-512551528072" /> | <img width="506" height="481" alt="Screenshot 2026-06-29 at 15 39 28" src="https://github.com/user-attachments/assets/2929bc94-97b2-4027-ba14-e430cbfccad3" /> |
