### PR TITLE
Fix service navigation menu expand/collapse

### DIFF
--- a/app/views/govuk_publishing_components/components/_service_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_service_navigation.html.erb
@@ -13,6 +13,7 @@
   component_helper.add_data_attribute({ module: "govuk-service-navigation" })
 
   full_width ||= false
+  nav_id = "navigation-#{SecureRandom.hex(4)}"
 %>
 <% if service_name.present? || navigation_items.present? %>
   <% service_navigation_content = capture do %>
@@ -31,11 +32,11 @@
         <% if navigation_items.present? %>
           <nav aria-label="<%= navigation_aria_label %>" class="govuk-service-navigation__wrapper">
             <% if collapse_navigation_on_mobile %>
-              <button type="button" class="govuk-service-navigation__toggle govuk-js-service-navigation-toggle" aria-controls="navigation" hidden aria-hidden="true">
+              <button type="button" class="govuk-service-navigation__toggle govuk-js-service-navigation-toggle" aria-controls="<%= nav_id %>" hidden aria-hidden="true">
                 Menu
               </button>
             <% end %>
-            <ul class="govuk-service-navigation__list" id="navigation">
+            <ul class="govuk-service-navigation__list" id="<%= nav_id %>">
               <% navigation_items.each do |nav| %>
                 <%
                   nav_classes = %w(govuk-service-navigation__item)


### PR DESCRIPTION
## What / why
- [multiple instances of this component on the same page](https://components.publishing.service.gov.uk/component-guide/service_navigation/preview) weren't toggling the menu on mobile correctly, looked like following instances actually toggled the first instance, rather than themselves
- [the component JS in govuk-frontend](https://github.com/alphagov/govuk-frontend/blob/main/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.mjs#L52-L68) looks like it gets the ID of the thing its supposed to toggle by first reading the `aria-controls` attribute of the menu button, then working from there
- on the Design System site they're all using the same ID but each example is in a separate iframe, so this problem doesn't occur
- our component guide renders all the examples on the same page, so to fix this we need to generate a unique id for each component to use
- in practice we aren't likely to have more than one service navigation on a page anyway, but it's nice if it works properly in the component guide

## Visual changes
None.