### PR TITLE
Update references to Sass variables to use the govuk-functional-colour function

### DIFF
--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -44,7 +44,7 @@ $gem-guide-border-width: 1px;
   }
 
   &[contenteditable]:focus {
-    outline: 3px solid $govuk-focus-colour;
+    outline: 3px solid govuk-functional-colour(focus);
   }
 
   > pre {

--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -12,7 +12,7 @@ $gem-guide-border-width: 1px;
 }
 
 .component-violation {
-  border: 3px solid $govuk-error-colour;
+  border: 3px solid govuk-functional-colour(error);
   margin: 0 0 govuk-spacing(6);
   padding: govuk-spacing(6);
   @include govuk-text-colour;
@@ -24,7 +24,7 @@ $gem-guide-border-width: 1px;
 
   .component-violation__link {
     display: block;
-    color: $govuk-error-colour;
+    color: govuk-functional-colour(error);
     margin: govuk-spacing(3) 0;
     @include govuk-font($size: 19, $weight: bold);
   }

--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -37,7 +37,7 @@ $gem-guide-border-width: 1px;
   font-family: Consolas, Monaco, "Andale Mono", monospace;
   font-size: 16px;
   line-height: 1.5;
-  border: $gem-guide-border-width solid $govuk-border-colour;
+  border: $gem-guide-border-width solid govuk-functional-colour(border);
 
   &[contenteditable]:hover {
     cursor: text;
@@ -69,7 +69,7 @@ $gem-guide-border-width: 1px;
 
 .component-guide-preview {
   padding: govuk-spacing(8) govuk-spacing(6) govuk-spacing(6) govuk-spacing(6);
-  border: $gem-guide-border-width solid $govuk-border-colour;
+  border: $gem-guide-border-width solid govuk-functional-colour(border);
   position: relative;
   margin-bottom: govuk-spacing(8);
 
@@ -491,8 +491,8 @@ $code-delete-bg: #fadddd;
   border: 0;
   margin-left: -(govuk-spacing(3));
   margin-right: -(govuk-spacing(3));
-  border-top: solid 1px $govuk-border-colour;
-  border-bottom: solid 1px $govuk-border-colour;
+  border-top: solid 1px govuk-functional-colour(border);
+  border-bottom: solid 1px govuk-functional-colour(border);
 
   @include govuk-media-query($from: tablet) {
     margin-left: -(govuk-spacing(6));
@@ -543,8 +543,8 @@ $code-delete-bg: #fadddd;
         bottom: -1px;
         width: calc((100cqw - 960px) / 2);
         box-sizing: border-box;
-        border-top: solid 1px $govuk-border-colour;
-        border-bottom: solid 1px $govuk-border-colour;
+        border-top: solid 1px govuk-functional-colour(border);
+        border-bottom: solid 1px govuk-functional-colour(border);
       }
 
       &::before {

--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -225,7 +225,7 @@ html {
 $code-00: color.scale(govuk-colour("black", $variant: "tint-95"), $lightness: 50%); // Default Background
 $code-01: #f5f5f5; // Lighter Background (Unused)
 $code-02: #bfc1c3; // Selection Background
-$code-03: $govuk-secondary-text-colour; // Comments, Invisibles, Line Highlighting
+$code-03: govuk-functional-colour(secondary-text); // Comments, Invisibles, Line Highlighting
 $code-04: #e8e8e8; // Dark Foreground (Unused)
 $code-05: govuk-functional-colour(text); // Default Foreground, Caret, Delimiters, Operators
 $code-06: #ffffff; // Light Foreground (Unused)

--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -227,7 +227,7 @@ $code-01: #f5f5f5; // Lighter Background (Unused)
 $code-02: #bfc1c3; // Selection Background
 $code-03: $govuk-secondary-text-colour; // Comments, Invisibles, Line Highlighting
 $code-04: #e8e8e8; // Dark Foreground (Unused)
-$code-05: $govuk-text-colour; // Default Foreground, Caret, Delimiters, Operators
+$code-05: govuk-functional-colour(text); // Default Foreground, Caret, Delimiters, Operators
 $code-06: #ffffff; // Light Foreground (Unused)
 $code-07: #ffffff; // Light Background (Unused)
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
@@ -83,7 +83,7 @@
 @include govuk-media-query($media-type: print) {
   .gem-c-action-link {
     * {
-      color: $govuk-print-text-colour !important; // stylelint-disable-line declaration-no-important
+      color: govuk-functional-colour(print-text) !important; // stylelint-disable-line declaration-no-important
     }
 
     .gem-c-action-link__icon {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_app-promo-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_app-promo-banner.scss
@@ -1,7 +1,7 @@
 .gem-c-app-promo-banner {
   display: none;
   padding: govuk-spacing(5) 0;
-  border-top: 4px solid $govuk-brand-colour;
+  border-top: 4px solid govuk-functional-colour(brand);
   background-color: $govuk-blue-tint-95;
   @include govuk-text-colour;
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_attachment-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_attachment-link.scss
@@ -6,7 +6,7 @@
 // stylelint-disable declaration-no-important
 @include govuk-media-query($media-type: print) {
   .gem-c-attachment-link .govuk-link {
-    color: $govuk-print-text-colour !important;
+    color: govuk-functional-colour(print-text) !important;
 
     &::after {
       font-size: inherit;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
@@ -92,7 +92,7 @@ $thumbnail-border-width: 5px;
   }
 
   .gem-c-attachment__metadata {
-    color: $govuk-print-text-colour;
+    color: govuk-functional-colour(print-text);
   }
 
   .gem-c-attachment__metadata,

--- a/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
@@ -56,7 +56,7 @@ $thumbnail-border-width: 5px;
 
 .gem-c-attachment__metadata {
   margin: 0 0 govuk-spacing(3);
-  color: $govuk-secondary-text-colour;
+  color: govuk-functional-colour(secondary-text);
   @include govuk-font($size: 19);
   @include govuk-text-break-word;
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_breadcrumbs.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_breadcrumbs.scss
@@ -1,7 +1,7 @@
 @import "govuk/components/breadcrumbs/breadcrumbs";
 
 .gem-c-breadcrumbs--border-bottom {
-  border-bottom: 1px solid $govuk-border-colour;
+  border-bottom: 1px solid govuk-functional-colour(border);
   padding-bottom: govuk-spacing(1);
 
   &.govuk-breadcrumbs--collapse-on-mobile {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_breadcrumbs.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_breadcrumbs.scss
@@ -37,11 +37,11 @@
     .govuk-breadcrumbs__list-item {
       .govuk-breadcrumbs__link:link,
       .govuk-breadcrumbs__link:visited {
-        color: $govuk-print-text-colour;
+        color: govuk-functional-colour(print-text);
       }
 
       &::before {
-        border-color: $govuk-print-text-colour;
+        border-color: govuk-functional-colour(print-text);
       }
     }
   }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_button.scss
@@ -107,7 +107,7 @@
     display: inline-block;
     padding: govuk-spacing(1);
     border: solid 1px govuk-colour("black");
-    color: $govuk-print-text-colour !important; // stylelint-disable-line declaration-no-important
+    color: govuk-functional-colour(print-text) !important; // stylelint-disable-line declaration-no-important
     text-decoration: none;
 
     &::after {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
@@ -180,8 +180,8 @@
     $dimension: 7px;
     $width: 3px;
 
-    border-right: $width solid $govuk-brand-colour;
-    border-top: $width solid $govuk-brand-colour;
+    border-right: $width solid govuk-functional-colour(brand);
+    border-top: $width solid govuk-functional-colour(brand);
     content: "";
     display: block;
     height: $dimension;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
@@ -201,7 +201,7 @@
 
   &:focus {
     &::before {
-      border-color: $govuk-focus-text-colour;
+      border-color: govuk-functional-colour(focus-text);
     }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
@@ -195,7 +195,7 @@
 
   &:hover {
     &::before {
-      border-color: $govuk-link-hover-colour;
+      border-color: govuk-functional-colour(link-hover);
     }
   }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
@@ -35,7 +35,7 @@
 }
 
 .gem-c-cards__heading--underline + .gem-c-cards__list {
-  border-top: 1px solid $govuk-border-colour;
+  border-top: 1px solid govuk-functional-colour(border);
 
   .gem-c-cards__list-item {
     &:first-child {
@@ -144,7 +144,7 @@
 }
 
 .gem-c-cards__list-item {
-  border-top: 1px solid $govuk-border-colour;
+  border-top: 1px solid govuk-functional-colour(border);
   padding: govuk-spacing(1) 0 govuk-spacing(4) 0;
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_contextual-guidance.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_contextual-guidance.scss
@@ -35,13 +35,13 @@
 
 .gem-c-contextual-guidance__guidance {
   padding-left: govuk-spacing(3);
-  border-left: 4px solid $govuk-focus-colour;
+  border-left: 4px solid govuk-functional-colour(focus);
   background: govuk-colour("white");
 
   @include govuk-media-query($from: tablet) {
     padding-top: govuk-spacing(5);
     padding-left: 0;
-    border-top: 5px solid $govuk-focus-colour;
+    border-top: 5px solid govuk-functional-colour(focus);
     border-left: 0;
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_contextual-sidebar.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_contextual-sidebar.scss
@@ -1,5 +1,5 @@
 .gem-c-contextual-sidebar__related-links {
-  border-top: 2px solid $govuk-brand-colour;
+  border-top: 2px solid govuk-functional-colour(brand);
 }
 
 .gem-c-contextual-sidebar__heading {
@@ -24,7 +24,7 @@
 }
 
 .gem-c-contextual-sidebar__cta {
-  border-top: 2px solid $govuk-brand-colour;
+  border-top: 2px solid govuk-functional-colour(brand);
   margin-bottom: govuk-spacing(6);
   background-color: govuk-colour("black", $variant: "tint-95");
   display: block;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_contextual-sidebar.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_contextual-sidebar.scss
@@ -5,7 +5,7 @@
 .gem-c-contextual-sidebar__heading {
   margin-top: govuk-spacing(3);
   margin-bottom: govuk-spacing(2);
-  color: $govuk-text-colour;
+  color: govuk-functional-colour(text);
 }
 
 .gem-c-contextual-sidebar__list {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cross-service-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cross-service-header.scss
@@ -8,7 +8,7 @@ $toggle-border-height: 3px;
 .gem-c-rebranded-one-login-header {
   color: govuk-colour("white");
   position: relative;
-  background: $govuk-brand-colour;
+  background: govuk-functional-colour(brand);
   @include govuk-font($size: 16);
 }
 
@@ -122,7 +122,7 @@ $toggle-border-height: 3px;
   }
 
   &:not(:focus) {
-    background-color: $govuk-brand-colour;
+    background-color: govuk-functional-colour(brand);
   }
 }
 
@@ -188,7 +188,7 @@ $toggle-border-height: 3px;
     &:link:visited,
     &:visited:link,
     &:visited:visited {
-      color: $govuk-brand-colour;
+      color: govuk-functional-colour(brand);
 
       &:focus {
         color: $govuk-focus-text-colour;
@@ -222,7 +222,7 @@ $toggle-border-height: 3px;
 
   @include govuk-media-query($until: tablet) {
     background-color: govuk-colour("white");
-    color: $govuk-brand-colour;
+    color: govuk-functional-colour(brand);
     margin-right: -(govuk-spacing(3));
     margin-left: -(govuk-spacing(3));
     padding: 0 govuk-spacing(3);
@@ -313,7 +313,7 @@ $toggle-border-height: 3px;
 
   &.gem-c-rebranded-cross-service-header__toggle--open {
     background-color: govuk-colour("white");
-    color: $govuk-brand-colour;
+    color: govuk-functional-colour(brand);
   }
 }
 
@@ -364,7 +364,7 @@ $toggle-border-height: 3px;
 
     .gem-c-rebranded-cross-service-header__toggle--open &,
     .gem-c-rebranded-cross-service-header__toggle--open:hover & {
-      background-color: $govuk-brand-colour;
+      background-color: govuk-functional-colour(brand);
     }
 
     .gem-c-rebranded-cross-service-header__toggle:focus &,

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cross-service-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cross-service-header.scss
@@ -177,7 +177,7 @@ $toggle-border-height: 3px;
 
         &::after {
           display: block;
-          background-color: $govuk-focus-text-colour;
+          background-color: govuk-functional-colour(focus-text);
         }
       }
     }
@@ -191,7 +191,7 @@ $toggle-border-height: 3px;
       color: govuk-functional-colour(brand);
 
       &:focus {
-        color: $govuk-focus-text-colour;
+        color: govuk-functional-colour(focus-text);
       }
     }
   }
@@ -289,7 +289,7 @@ $toggle-border-height: 3px;
   @include govuk-font($size: 16, $weight: bold);
 
   @mixin toggle-button-focus {
-    color: $govuk-focus-text-colour;
+    color: govuk-functional-colour(focus-text);
     background-color: govuk-functional-colour(focus);
     outline: 3px solid transparent;
   }
@@ -369,10 +369,10 @@ $toggle-border-height: 3px;
 
     .gem-c-rebranded-cross-service-header__toggle:focus &,
     .gem-c-rebranded-cross-service-header__toggle:focus-visible & {
-      background-color: $govuk-focus-text-colour;
+      background-color: govuk-functional-colour(focus-text);
 
       &:hover {
-        background-color: $govuk-focus-text-colour;
+        background-color: govuk-functional-colour(focus-text);
       }
     }
   }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cross-service-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cross-service-header.scss
@@ -66,7 +66,7 @@ $toggle-border-height: 3px;
     &:focus {
       // Replicate the focus box shadow but without the -2px y-offset of the first yellow shadow
       // This is to stop the logo getting cut off by the box shadow when focused on above a product name
-      box-shadow: 0 0 $govuk-focus-colour;
+      box-shadow: 0 0 govuk-functional-colour(focus);
     }
   }
 
@@ -290,7 +290,7 @@ $toggle-border-height: 3px;
 
   @mixin toggle-button-focus {
     color: $govuk-focus-text-colour;
-    background-color: $govuk-focus-colour;
+    background-color: govuk-functional-colour(focus);
     outline: 3px solid transparent;
   }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_devolved-nations.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_devolved-nations.scss
@@ -11,11 +11,11 @@
 
 @include govuk-media-query($media-type: print) {
   .gem-c-devolved-nations {
-    border: 2pt solid $govuk-print-text-colour;
+    border: 2pt solid govuk-functional-colour(print-text);
     margin: 0 0 5mm;
 
     * {
-      color: $govuk-print-text-colour !important; // stylelint-disable-line declaration-no-important
+      color: govuk-functional-colour(print-text) !important; // stylelint-disable-line declaration-no-important
     }
 
     .govuk-list li {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -137,7 +137,7 @@
     left: 0;
     width: govuk-spacing(3);
     overflow: hidden;
-    border-top: solid 1px $govuk-text-colour;
+    border-top: solid 1px govuk-functional-colour(text);
     transform: translate(0, 0.5em);
   }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -84,7 +84,7 @@
 
   & { // stylelint-disable-line no-duplicate-selectors
     // overriding govuk-text-colour mixin
-    color: $govuk-secondary-text-colour;
+    color: govuk-functional-colour(secondary-text);
   }
 
   .direction-rtl & {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -172,7 +172,7 @@
     break-inside: avoid;
 
     * {
-      color: $govuk-print-text-colour;
+      color: govuk-functional-colour(print-text);
     }
   }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -8,7 +8,7 @@
 .gem-c-document-list__item {
   margin-top: govuk-spacing(5);
   padding-top: govuk-spacing(2);
-  border-top: 1px solid $govuk-border-colour;
+  border-top: 1px solid govuk-functional-colour(border);
   list-style: none;
 
   &:first-child {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_error-alert.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_error-alert.scss
@@ -32,5 +32,5 @@
 }
 
 .gem-c-error-alert:focus {
-  outline: $govuk-focus-width solid $govuk-focus-colour;
+  outline: $govuk-focus-width solid govuk-functional-colour(focus);
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_error-alert.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_error-alert.scss
@@ -1,5 +1,5 @@
 .gem-c-error-alert {
-  color: $govuk-text-colour;
+  color: govuk-functional-colour(text);
   padding: govuk-spacing(3);
   border: $govuk-border-width-narrow solid $govuk-error-colour;
   @include govuk-responsive-margin(8, "bottom");

--- a/app/assets/stylesheets/govuk_publishing_components/components/_error-alert.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_error-alert.scss
@@ -1,7 +1,7 @@
 .gem-c-error-alert {
   color: govuk-functional-colour(text);
   padding: govuk-spacing(3);
-  border: $govuk-border-width-narrow solid $govuk-error-colour;
+  border: $govuk-border-width-narrow solid govuk-functional-colour(error);
   @include govuk-responsive-margin(8, "bottom");
 
   @include govuk-media-query($from: tablet) {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_error-summary.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_error-summary.scss
@@ -1,6 +1,6 @@
 @import "govuk/components/error-summary/error-summary";
 
 .gem-c-error-summary__list-item {
-  color: $govuk-error-colour;
+  color: govuk-functional-colour(error);
   @include govuk-font($size: 19, $weight: bold);
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -166,7 +166,7 @@ $feedback-prompt-border-top-colour: $govuk-blue-tint-50;
   clear: both;
 
   &:focus {
-    outline: solid 3px $govuk-focus-colour;
+    outline: solid 3px govuk-functional-colour(focus);
   }
 
   @include govuk-media-query($from: desktop) {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -130,7 +130,7 @@ $feedback-prompt-border-top-colour: $govuk-blue-tint-50;
 
   &:focus,
   &:active {
-    color: $govuk-focus-text-colour;
+    color: govuk-functional-colour(focus-text);
   }
 }
 
@@ -253,6 +253,6 @@ $feedback-prompt-border-top-colour: $govuk-blue-tint-50;
 
   &:focus,
   &:active {
-    color: $govuk-focus-text-colour;
+    color: govuk-functional-colour(focus-text);
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -162,7 +162,7 @@ $feedback-prompt-border-top-colour: $govuk-blue-tint-50;
 .gem-c-feedback__error-summary {
   margin-bottom: govuk-spacing(3);
   padding: govuk-spacing(3);
-  border: solid $govuk-border-width-narrow $govuk-error-colour;
+  border: solid $govuk-border-width-narrow govuk-functional-colour(error);
   clear: both;
 
   &:focus {
@@ -196,7 +196,7 @@ $feedback-prompt-border-top-colour: $govuk-blue-tint-50;
 .gem-c-feedback__error-message {
   display: block;
   padding: 4px 0 0;
-  color: $govuk-error-colour;
+  color: govuk-functional-colour(error);
   @include govuk-font(19, $weight: bold);
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -54,7 +54,7 @@ $feedback-prompt-border-top-colour: $govuk-blue-tint-50;
 }
 
 .gem-c-feedback__prompt-questions--something-is-wrong {
-  border-top: 1px solid $govuk-border-colour;
+  border-top: 1px solid govuk-functional-colour(border);
   @include govuk-media-query($from: tablet) {
     border: 0;
   }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_figure.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_figure.scss
@@ -21,6 +21,6 @@ $gap: govuk-spacing(1);
 
 .gem-c-figure__figcaption-text {
   margin: govuk-spacing(2) 0 0 0;
-  color: $govuk-secondary-text-colour;
+  color: govuk-functional-colour(secondary-text);
   @include govuk-font(19);
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_glance-metric.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_glance-metric.scss
@@ -1,5 +1,5 @@
 .gem-c-glance-metric {
-  border-top: 1px solid $govuk-border-colour;
+  border-top: 1px solid govuk-functional-colour(border);
   border-bottom: 0;
   @include govuk-responsive-margin(6, "bottom");
 
@@ -36,7 +36,7 @@
 
   &__context {
     min-height: 5em;
-    border-bottom: 1px solid $govuk-border-colour;
+    border-bottom: 1px solid govuk-functional-colour(border);
 
     @include govuk-media-query($until: mobile) {
       @include govuk-font(16);

--- a/app/assets/stylesheets/govuk_publishing_components/components/_heading.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_heading.scss
@@ -43,8 +43,8 @@
   // Override margins and colors
   .gem-c-heading {
     margin: 0 !important;
-    color: $govuk-print-text-colour !important;
-    border-color: $govuk-print-text-colour !important;
+    color: govuk-functional-colour(print-text) !important;
+    border-color: govuk-functional-colour(print-text) !important;
     padding: 0;
   }
 
@@ -55,7 +55,7 @@
   .gem-c-heading--inverse {
     .gem-c-heading__context,
     .gem-c-heading__text {
-      color: $govuk-print-text-colour;
+      color: govuk-functional-colour(print-text);
     }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -36,7 +36,7 @@
   height: auto;
   width: 100%;
   border: 0;
-  border-top: 1px solid $govuk-border-colour;
+  border-top: 1px solid govuk-functional-colour(border);
 }
 
 .gem-c-image-card__title {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_intervention.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_intervention.scss
@@ -41,7 +41,7 @@
   .gem-c-intervention {
     break-inside: avoid;
     background: none;
-    border-color: $govuk-print-text-colour;
+    border-color: govuk-functional-colour(print-text);
 
     .govuk-body {
       margin: 0;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_intervention.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_intervention.scss
@@ -1,6 +1,6 @@
 .gem-c-intervention {
   background-color: govuk-colour("black", $variant: "tint-95");
-  border-left: 10px solid $govuk-success-colour;
+  border-left: 10px solid govuk-functional-colour(success);
   @include govuk-text-colour;
   @include govuk-responsive-padding(3);
   @include govuk-responsive-margin(6, "bottom");

--- a/app/assets/stylesheets/govuk_publishing_components/components/_inverse-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_inverse-header.scss
@@ -45,11 +45,11 @@
     background: none;
     padding-left: 0;
     padding-right: 0;
-    border-bottom: 2pt solid $govuk-print-text-colour;
+    border-bottom: 2pt solid govuk-functional-colour(print-text);
 
     &,
     & * {
-      color: $govuk-print-text-colour !important; // stylelint-disable-line declaration-no-important
+      color: govuk-functional-colour(print-text) !important; // stylelint-disable-line declaration-no-important
     }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-footer.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-footer.scss
@@ -21,7 +21,7 @@
     background: none;
     margin: 25mm 0 0;
     padding: 5mm 0 0;
-    border-top: 2pt solid $govuk-print-text-colour;
+    border-top: 2pt solid govuk-functional-colour(print-text);
 
     .govuk-width-container {
       margin: 0;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-for-public.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-for-public.scss
@@ -45,6 +45,6 @@ $current-indicator-width: 4px;
   @include govuk-font(19, $weight: "bold");
 
   &:not(:focus):hover {
-    color: $govuk-link-colour;
+    color: govuk-functional-colour(link);
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
@@ -82,7 +82,7 @@
 
 @include govuk-media-query($media-type: print) {
   .gem-c-layout-header .govuk-header__container {
-    border-color: $govuk-print-text-colour;
+    border-color: govuk-functional-colour(print-text);
 
     .govuk-grid-column-two-thirds {
       width: auto;
@@ -95,7 +95,7 @@
     }
 
     .gem-c-header__product-name {
-      color: $govuk-print-text-colour;
+      color: govuk-functional-colour(print-text);
       background: none;
     }
   }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -92,8 +92,8 @@ $search-icon-height: 20px;
 
 // stylelint-disable max-nesting-depth
 .gem-c-layout-super-navigation-header {
-  background: $govuk-brand-colour;
-  border-top: 1px solid $govuk-brand-colour;
+  background: govuk-functional-colour(brand);
+  border-top: 1px solid govuk-functional-colour(brand);
   margin-top: -1px;
   position: relative;
 
@@ -107,7 +107,7 @@ $search-icon-height: 20px;
   // the background color is set again on the nav container to ensure the menu buttons are still
   // visible when the text scale is increased
   // related issue: https://github.com/alphagov/govuk_publishing_components/issues/4208
-  background: $govuk-brand-colour;
+  background: govuk-functional-colour(brand);
 
   // add a transparent bottom border for forced-color modes
   @media (forced-colors: active) {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -211,7 +211,7 @@ $search-icon-height: 20px;
 
   &:focus {
     .gem-c-layout-super-navigation-header__navigation-item-link-inner {
-      border-right-color: $govuk-focus-colour;
+      border-right-color: govuk-functional-colour(focus);
     }
   }
 }
@@ -296,7 +296,7 @@ $search-icon-height: 20px;
     }
 
     .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
-      border-right-color: $govuk-focus-colour;
+      border-right-color: govuk-functional-colour(focus);
 
       &::before {
         @include chevron(govuk-colour("black"), true);
@@ -371,7 +371,7 @@ $search-icon-height: 20px;
 
     .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
       color: govuk-colour("black");
-      border-right-color: $govuk-focus-colour;
+      border-right-color: govuk-functional-colour(focus);
 
       &::before {
         @include chevron(govuk-colour("black"), true);
@@ -433,7 +433,7 @@ $search-icon-height: 20px;
   @include focus-and-focus-visible {
     z-index: 11;
     // these declarations override govuk-focused-text because the compiler prefers @include to be last
-    border-color: $govuk-focus-colour !important; // stylelint-disable-line declaration-no-important
+    border-color: govuk-functional-colour(focus) !important; // stylelint-disable-line declaration-no-important
     box-shadow: none !important; // stylelint-disable-line declaration-no-important
     @include govuk-focused-text;
 
@@ -478,7 +478,7 @@ $search-icon-height: 20px;
 
     @include focus-and-focus-visible {
       // these declarations override govuk-focused-text because the compiler prefers @include to be last
-      border-color: $govuk-focus-colour !important; // stylelint-disable-line declaration-no-important
+      border-color: govuk-functional-colour(focus) !important; // stylelint-disable-line declaration-no-important
       box-shadow: none !important; // stylelint-disable-line declaration-no-important
       @include govuk-focused-text;
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -189,10 +189,10 @@ $search-icon-height: 20px;
 
     &:focus {
       box-shadow: none;
-      color: $govuk-focus-text-colour;
+      color: govuk-functional-colour(focus-text);
 
       &::after {
-        background: $govuk-focus-text-colour;
+        background: govuk-functional-colour(focus-text);
       }
     }
   }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -685,7 +685,7 @@ $search-icon-height: 20px;
 @include govuk-media-query($media-type: print) {
   .gem-c-layout-super-navigation-header {
     border-top: 0;
-    border-bottom: 2pt solid $govuk-print-text-colour;
+    border-bottom: 2pt solid govuk-functional-colour(print-text);
     margin: 0 0 5mm;
     background: transparent;
 
@@ -695,7 +695,7 @@ $search-icon-height: 20px;
     }
 
     * {
-      color: $govuk-print-text-colour;
+      color: govuk-functional-colour(print-text);
     }
 
     .govuk-width-container {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -384,16 +384,16 @@ $search-icon-height: 20px;
     background: $govuk-blue-tint-95;
 
     &::after {
-      background-color: $govuk-link-colour;
+      background-color: govuk-functional-colour(link);
     }
 
     .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
-      color: $govuk-link-colour;
+      color: govuk-functional-colour(link);
       border-right-color: $button-pipe-colour;
 
       @include govuk-media-query($from: $chevron-breakpoint) {
         &::before {
-          @include chevron($govuk-link-colour, true);
+          @include chevron(govuk-functional-colour(link), true);
           @include prefixed-transform($rotate: 225deg, $translateY: 1px);
         }
       }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_lead-paragraph.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_lead-paragraph.scss
@@ -13,6 +13,6 @@
 
 @include govuk-media-query($media-type: print) {
   .gem-c-lead-paragraph {
-    color: $govuk-print-text-colour;
+    color: govuk-functional-colour(print-text);
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_metadata.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_metadata.scss
@@ -88,13 +88,13 @@
 @include govuk-media-query($media-type: print) {
   .gem-c-metadata {
     break-inside: avoid;
-    color: $govuk-print-text-colour !important;
+    color: govuk-functional-colour(print-text) !important;
     background: none;
     margin-bottom: 5mm;
 
     a,
     a:visited {
-      color: $govuk-print-text-colour !important;
+      color: govuk-functional-colour(print-text) !important;
     }
   }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_modal-dialogue.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_modal-dialogue.scss
@@ -32,7 +32,7 @@ $govuk-modal-wide-breakpoint: $govuk-page-width + $govuk-modal-margin * 2 + $gov
   border: 0;
 
   &:focus {
-    outline: $govuk-focus-width solid $govuk-focus-colour;
+    outline: $govuk-focus-width solid govuk-functional-colour(focus);
   }
 
   @include govuk-font($size: 19);
@@ -129,7 +129,7 @@ $govuk-modal-wide-breakpoint: $govuk-page-width + $govuk-modal-margin * 2 + $gov
     outline: none;
     box-shadow: none;
     color: govuk-colour("black");
-    background: $govuk-focus-colour;
+    background: govuk-functional-colour(focus);
     @include govuk-focused-text;
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_modal-dialogue.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_modal-dialogue.scss
@@ -47,7 +47,7 @@ $govuk-modal-wide-breakpoint: $govuk-page-width + $govuk-modal-margin * 2 + $gov
     max-width: calc($govuk-page-width * (2 / 3));
     height: auto;
     margin: $govuk-modal-margin auto;
-    border: $govuk-border-width-form-element solid $govuk-input-border-colour;
+    border: $govuk-border-width-form-element solid govuk-functional-colour(input-border);
   }
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_option-select.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_option-select.scss
@@ -2,7 +2,7 @@
   position: relative;
   padding: 0 0 govuk-spacing(2);
   margin-bottom: govuk-spacing(2);
-  border-bottom: 1px solid $govuk-border-colour;
+  border-bottom: 1px solid govuk-functional-colour(border);
 
   @include govuk-media-query($from: desktop) {
     // Redefine scrollbars on desktop where these lists are scrollable

--- a/app/assets/stylesheets/govuk_publishing_components/components/_option-select.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_option-select.scss
@@ -156,7 +156,7 @@
 
 .gem-c-option-select__selected-counter {
   margin-left: 44px;
-  color: $govuk-text-colour;
+  color: govuk-functional-colour(text);
   @include govuk-font($size: 16, $line-height: 1);
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_option-select.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_option-select.scss
@@ -37,7 +37,7 @@
   text-align: left;
   padding: 0;
   cursor: pointer;
-  color: $govuk-link-colour;
+  color: govuk-functional-colour(link);
 
   &:hover {
     text-decoration: underline;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_organisation-logo.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_organisation-logo.scss
@@ -65,7 +65,7 @@
   }
 
   &:hover {
-    color: $govuk-link-hover-colour;
+    color: govuk-functional-colour(link-hover);
   }
 
   &:active {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_organisation-logo.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_organisation-logo.scss
@@ -77,7 +77,7 @@
     // Using `@include govuk-focused-text;` would obscure the text. Tweaked
     // spacing needed to prevent overlap of the text and the focus state's thick
     // black line.
-    box-shadow: 0 -2px govuk-functional-colour(focus), 0 4px govuk-functional-colour(focus), 0 8px $govuk-focus-text-colour;
+    box-shadow: 0 -2px govuk-functional-colour(focus), 0 4px govuk-functional-colour(focus), 0 8px govuk-functional-colour(focus-text);
     text-decoration: none;
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_organisation-logo.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_organisation-logo.scss
@@ -77,7 +77,7 @@
     // Using `@include govuk-focused-text;` would obscure the text. Tweaked
     // spacing needed to prevent overlap of the text and the focus state's thick
     // black line.
-    box-shadow: 0 -2px $govuk-focus-colour, 0 4px $govuk-focus-colour, 0 8px $govuk-focus-text-colour;
+    box-shadow: 0 -2px govuk-functional-colour(focus), 0 4px govuk-functional-colour(focus), 0 8px $govuk-focus-text-colour;
     text-decoration: none;
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_pagination.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_pagination.scss
@@ -3,7 +3,7 @@
 // stylelint-disable declaration-no-important
 @include govuk-media-query($media-type: print) {
   .gem-c-pagination * {
-    color: $govuk-print-text-colour !important;
+    color: govuk-functional-colour(print-text) !important;
   }
 }
 // stylelint-enable declaration-no-important

--- a/app/assets/stylesheets/govuk_publishing_components/components/_phase-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_phase-banner.scss
@@ -10,7 +10,7 @@
 .gem-c-phase-banner--inverse {
   .govuk-phase-banner__content__tag {
     background: govuk-colour("white");
-    color: $govuk-brand-colour;
+    color: govuk-functional-colour(brand);
   }
 
   .govuk-phase-banner__content__app-name,

--- a/app/assets/stylesheets/govuk_publishing_components/components/_phase-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_phase-banner.scss
@@ -30,11 +30,11 @@
     &,
     & * {
       background: none !important;
-      color: $govuk-print-text-colour !important;
+      color: govuk-functional-colour(print-text) !important;
     }
 
     .govuk-tag {
-      border: 1pt solid $govuk-print-text-colour;
+      border: 1pt solid govuk-functional-colour(print-text);
     }
   }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_print-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_print-link.scss
@@ -36,7 +36,7 @@ $gem-c-print-link-background-height: 18px;
 
   &:focus {
     border: 0;
-    box-shadow: 0 $govuk-focus-width $govuk-text-colour;
+    box-shadow: 0 $govuk-focus-width govuk-functional-colour(text);
   }
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_print-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_print-link.scss
@@ -48,7 +48,7 @@ $gem-c-print-link-background-height: 18px;
   @include govuk-font(16);
 
   &:focus {
-    background-color: $govuk-focus-colour;
+    background-color: govuk-functional-colour(focus);
     border-color: transparent;
     @include govuk-focused-text;
   }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_print-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_print-link.scss
@@ -42,7 +42,7 @@ $gem-c-print-link-background-height: 18px;
 
 .gem-c-print-link__button {
   border: 1px solid govuk-colour("black", $variant: "tint-25");
-  color: $govuk-link-colour;
+  color: govuk-functional-colour(link);
   cursor: pointer;
   margin: govuk-spacing(0);
   @include govuk-font(16);

--- a/app/assets/stylesheets/govuk_publishing_components/components/_published-dates.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_published-dates.scss
@@ -40,7 +40,7 @@
 
 .gem-c-published-dates--history {
   padding-top: govuk-spacing(2);
-  border-top: 1px solid $govuk-border-colour;
+  border-top: 1px solid govuk-functional-colour(border);
 }
 
 .govuk-frontend-supported .gem-c-published-dates .js-hidden {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_reorderable-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_reorderable-list.scss
@@ -13,13 +13,13 @@
 
 .gem-c-reorderable-list__item {
   margin-bottom: govuk-spacing(3);
-  border: 1px solid $govuk-border-colour;
+  border: 1px solid govuk-functional-colour(border);
   padding: govuk-spacing(3);
 }
 
 .gem-c-reorderable-list__item--chosen {
   background-color: govuk-colour("black", $variant: "tint-95");
-  outline: 2px dotted $govuk-border-colour;
+  outline: 2px dotted govuk-functional-colour(border);
 }
 
 .gem-c-reorderable-list__item--drag {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search-with-autocomplete.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search-with-autocomplete.scss
@@ -89,7 +89,7 @@ $large-input-size: 50px;
 // Styling specifically _only_ for keyboard focus
 .gem-c-search-with-autocomplete__option:focus-visible {
   .gem-c-search-with-autocomplete__suggestion-text {
-    background-color: $govuk-focus-colour;
+    background-color: govuk-functional-colour(focus);
   }
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search-with-autocomplete.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search-with-autocomplete.scss
@@ -82,7 +82,7 @@ $large-input-size: 50px;
   @include govuk-link-hover-decoration;
 
   .gem-c-search-with-autocomplete__suggestion-icon {
-    background-color: $govuk-text-colour;
+    background-color: govuk-functional-colour(text);
   }
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search-with-autocomplete.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search-with-autocomplete.scss
@@ -26,7 +26,7 @@ $large-input-size: 50px;
   padding: 0;
   overflow-x: hidden;
   background-color: govuk-colour("white");
-  border: 1px solid $govuk-border-colour;
+  border: 1px solid govuk-functional-colour(border);
   border-top: 0;
 
   @include enhance-autocomplete-menu-width($input-size);
@@ -138,7 +138,7 @@ $large-input-size: 50px;
 // Fix top border styling on "borderless" search input when rendered on a GOV.UK blue background
 .gem-c-search-with-autocomplete.gem-c-search-with-autocomplete--on-govuk-blue {
   .gem-c-search-with-autocomplete__menu {
-    border-top: 1px solid $govuk-border-colour;
+    border-top: 1px solid govuk-functional-colour(border);
   }
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search-with-autocomplete.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search-with-autocomplete.scss
@@ -112,7 +112,7 @@ $large-input-size: 50px;
   flex: none;
   mask-image: url("govuk_publishing_components/icon-autocomplete-search-suggestion.svg");
   -webkit-mask-image: url("govuk_publishing_components/icon-autocomplete-search-suggestion.svg");
-  background-color: $govuk-secondary-text-colour;
+  background-color: govuk-functional-colour(secondary-text);
 }
 
 .gem-c-search-with-autocomplete__suggestion-text {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -31,7 +31,7 @@ $search-submit-button-hover-colour: $govuk-blue-tint-95;
 
 .gem-c-search__label {
   display: block;
-  color: $govuk-text-colour;
+  color: govuk-functional-colour(text);
   cursor: text;
   text-overflow: ellipsis;
   height: 90%;
@@ -59,7 +59,7 @@ $search-submit-button-hover-colour: $govuk-blue-tint-95;
   // match label colour with the label component colour
   // when javascript is enabled and inline_label option  is set to false
   .govuk-frontend-supported .gem-c-search--separate-label & {
-    color: $govuk-text-colour;
+    color: govuk-functional-colour(text);
   }
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -77,7 +77,7 @@ $search-submit-button-hover-colour: $govuk-blue-tint-95;
   width: 100%;
   height: govuk-em(40, 19);
   padding: govuk-em(6, 19);
-  border: $govuk-border-width-form-element solid $govuk-input-border-colour;
+  border: $govuk-border-width-form-element solid govuk-functional-colour(input-border);
   background: govuk-colour("white");
   border-radius: 0; // otherwise iphones apply an automatic border radius
   box-sizing: border-box;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -52,7 +52,7 @@ $search-submit-button-hover-colour: $govuk-blue-tint-95;
     max-width: 68%;
     padding-left: govuk-spacing(3);
     z-index: 1;
-    color: $govuk-secondary-text-colour;
+    color: govuk-functional-colour(secondary-text);
     background: govuk-colour("white");
   }
 
@@ -195,7 +195,7 @@ $search-submit-button-hover-colour: $govuk-blue-tint-95;
 
   .govuk-frontend-supported & {
     .gem-c-search__label {
-      color: $govuk-secondary-text-colour;
+      color: govuk-functional-colour(secondary-text);
     }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -64,7 +64,7 @@ $search-submit-button-hover-colour: $govuk-blue-tint-95;
 }
 
 @mixin gem-c-search-input-focus {
-  outline: $govuk-focus-width solid $govuk-focus-colour;
+  outline: $govuk-focus-width solid govuk-functional-colour(focus);
   // Ensure outline appears outside of the element
   outline-offset: 0;
   // Double the border by adding its width again. Use `box-shadow` for this // instead of changing `border-width`
@@ -137,7 +137,7 @@ $search-submit-button-hover-colour: $govuk-blue-tint-95;
 
   &:focus {
     z-index: 2;
-    outline: $govuk-focus-width solid $govuk-focus-colour;
+    outline: $govuk-focus-width solid govuk-functional-colour(focus);
     // Double the border by adding its width again. Use `box-shadow` for this // instead of changing `border-width` - this is for consistency with
     // Also, `outline` cannot be utilised
     // here as it is already used for the yellow focus state.

--- a/app/assets/stylesheets/govuk_publishing_components/components/_secondary-navigation.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_secondary-navigation.scss
@@ -75,7 +75,7 @@
   .gem-c-secondary-navigation__list-item-link:link,
   .gem-c-secondary-navigation__list-item-link:visited {
     border-color: govuk-colour("blue");
-    color: $govuk-text-colour;
+    color: govuk-functional-colour(text);
   }
 
   .gem-c-secondary-navigation__list-item-link:focus {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_secondary-navigation.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_secondary-navigation.scss
@@ -60,7 +60,7 @@
   }
 
   .gem-c-secondary-navigation__list-item-link:focus {
-    border-color: $govuk-focus-text-colour;
+    border-color: govuk-functional-colour(focus-text);
     border-left-color: transparent;
     position: relative;
     @include govuk-focused-text;
@@ -79,7 +79,7 @@
   }
 
   .gem-c-secondary-navigation__list-item-link:focus {
-    border-color: $govuk-focus-text-colour;
+    border-color: govuk-functional-colour(focus-text);
     border-left-color: transparent;
     @include govuk-focused-text;
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_secondary-navigation.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_secondary-navigation.scss
@@ -56,7 +56,7 @@
   }
 
   .gem-c-secondary-navigation__list-item-link:hover {
-    color: $govuk-link-hover-colour;
+    color: govuk-functional-colour(link-hover);
   }
 
   .gem-c-secondary-navigation__list-item-link:focus {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_secondary-navigation.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_secondary-navigation.scss
@@ -3,7 +3,7 @@
   @include govuk-responsive-margin(6, "bottom");
 
   @include govuk-media-query($from: tablet) {
-    box-shadow: inset 0 -1px 0 $govuk-border-colour;
+    box-shadow: inset 0 -1px 0 govuk-functional-colour(border);
     display: flex;
   }
 }
@@ -22,7 +22,7 @@
 }
 
 .gem-c-secondary-navigation__list-item {
-  box-shadow: inset 0 -1px 0 $govuk-border-colour;
+  box-shadow: inset 0 -1px 0 govuk-functional-colour(border);
 
   @include govuk-media-query($from: tablet) {
     display: flex;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_select-with-search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_select-with-search.scss
@@ -127,7 +127,7 @@ $choices-button-dimension: 12px !default;
     background-color: govuk-colour("black", $variant: "tint-95");
     box-shadow: 0 $govuk-border-width-form-element 0 govuk-colour("black", $variant: "tint-80");
     line-height: 1;
-    color: $govuk-text-colour;
+    color: govuk-functional-colour(text);
 
     .is-disabled & {
       opacity: 0.5;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_select-with-search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_select-with-search.scss
@@ -84,7 +84,7 @@ $choices-button-dimension: 12px !default;
   }
 
   &.govuk-form-group--error .choices:not(.is-active):not(.is-focused):not(.is-open) .choices__inner {
-    border-color: $govuk-error-colour;
+    border-color: govuk-functional-colour(error);
   }
 
   .choices.is-focused,

--- a/app/assets/stylesheets/govuk_publishing_components/components/_select-with-search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_select-with-search.scss
@@ -113,7 +113,7 @@ $choices-button-dimension: 12px !default;
 
     &:not(:empty) {
       margin-block-start: 6px;
-      border-block-start: 1px solid $govuk-border-colour;
+      border-block-start: 1px solid govuk-functional-colour(border);
       padding-block-end: 5px;
     }
   }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_select-with-search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_select-with-search.scss
@@ -58,7 +58,7 @@ $choices-button-dimension: 12px !default;
     }
 
     &:focus {
-      background-color: $govuk-focus-colour;
+      background-color: govuk-functional-colour(focus);
       box-shadow: 0 $govuk-border-width-form-element 0 $govuk-focus-text-colour;
     }
   }
@@ -99,7 +99,7 @@ $choices-button-dimension: 12px !default;
 
   .choices.is-focused .choices__inner,
   .choices.is-open .choices__inner {
-    outline: $govuk-focus-width solid $govuk-focus-colour;
+    outline: $govuk-focus-width solid govuk-functional-colour(focus);
     // Ensure outline appears outside of the element
     outline-offset: 0;
     // Double the border by adding its width again. Use `box-shadow` to do

--- a/app/assets/stylesheets/govuk_publishing_components/components/_select-with-search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_select-with-search.scss
@@ -59,7 +59,7 @@ $choices-button-dimension: 12px !default;
 
     &:focus {
       background-color: govuk-functional-colour(focus);
-      box-shadow: 0 $govuk-border-width-form-element 0 $govuk-focus-text-colour;
+      box-shadow: 0 $govuk-border-width-form-element 0 govuk-functional-colour(focus-text);
     }
   }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_share-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_share-links.scss
@@ -138,7 +138,7 @@ $column-width: 9.5em;
   }
 
   .gem-c-share-links__link:focus {
-    box-shadow: 0 0 $govuk-focus-colour, 0 4px govuk-colour("black");
+    box-shadow: 0 0 govuk-functional-colour(focus), 0 4px govuk-colour("black");
   }
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_signup-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_signup-link.scss
@@ -22,7 +22,7 @@
 .gem-c-signup-link--with-background-and-border {
   padding: govuk-spacing(6);
   background-color: govuk-colour("black", $variant: "tint-95");
-  border: 1px solid $govuk-border-colour;
+  border: 1px solid govuk-functional-colour(border);
 }
 
 .gem-c-signup-link--link-only .gem-c-signup-link__link {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_single-page-notification-button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_single-page-notification-button.scss
@@ -2,7 +2,7 @@
   padding: govuk-spacing(2);
   margin: govuk-spacing(0);
   border: 1px solid govuk-colour("black", $variant: "tint-25");
-  color: $govuk-link-colour;
+  color: govuk-functional-colour(link);
   cursor: pointer;
   background: none;
   @include govuk-font(16);

--- a/app/assets/stylesheets/govuk_publishing_components/components/_single-page-notification-button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_single-page-notification-button.scss
@@ -14,7 +14,7 @@
 
   &:hover {
     background-color: govuk-colour("black", $variant: "tint-95");
-    color: $govuk-link-hover-colour;
+    color: govuk-functional-colour(link-hover);
 
     &:focus {
       color: govuk-functional-colour(text);

--- a/app/assets/stylesheets/govuk_publishing_components/components/_single-page-notification-button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_single-page-notification-button.scss
@@ -17,8 +17,8 @@
     color: $govuk-link-hover-colour;
 
     &:focus {
-      color: $govuk-text-colour;
-      box-shadow: 0 $govuk-focus-width $govuk-text-colour;
+      color: govuk-functional-colour(text);
+      box-shadow: 0 $govuk-focus-width govuk-functional-colour(text);
     }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-header.scss
@@ -21,7 +21,7 @@
   .gem-c-step-nav-header {
     padding: 0 0 govuk-spacing(4) 0;
     background: none;
-    border-color: $govuk-print-text-colour;
+    border-color: govuk-functional-colour(print-text);
   }
 
   .gem-c-step-nav-header__part-of {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-related.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-related.scss
@@ -46,6 +46,6 @@
 @include govuk-media-query($media-type: print) {
   .gem-c-step-nav-related {
     background: none;
-    border-color: $govuk-print-text-colour;
+    border-color: govuk-functional-colour(print-text);
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
@@ -131,7 +131,7 @@ $top-border: solid 1px govuk-colour("black", $variant: "tint-80");
     }
 
     .gem-c-step-nav__button-text {
-      color: $govuk-text-colour;
+      color: govuk-functional-colour(text);
     }
   }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
@@ -112,7 +112,7 @@ $top-border: solid 1px govuk-colour("black", $variant: "tint-80");
 }
 
 .gem-c-step-nav__button {
-  color: $govuk-link-colour;
+  color: govuk-functional-colour(link);
   cursor: pointer;
   background: none;
   border: 0;
@@ -404,7 +404,7 @@ $top-border: solid 1px govuk-colour("black", $variant: "tint-80");
 
 .gem-c-step-nav__toggle-link {
   display: block;
-  color: $govuk-link-colour;
+  color: govuk-functional-colour(link);
   text-transform: capitalize;
   padding-bottom: govuk-spacing(6);
   @include step-nav-font(15, $line-height: 1.2);

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
@@ -144,7 +144,7 @@ $top-border: solid 1px govuk-colour("black", $variant: "tint-80");
     }
 
     .gem-c-step-nav__chevron::after {
-      color: $govuk-focus-colour;
+      color: govuk-functional-colour(focus);
     }
 
     .gem-c-step-nav____title-text-focus,

--- a/app/assets/stylesheets/govuk_publishing_components/components/_sub-navigation-menu.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_sub-navigation-menu.scss
@@ -73,8 +73,8 @@
 }
 
 .gem-c-sub-navigation-menu__button[aria-expanded="true"]:focus {
-  background-color: $govuk-focus-colour;
-  border-color: $govuk-focus-colour;
+  background-color: govuk-functional-colour(focus);
+  border-color: govuk-functional-colour(focus);
 }
 
 // Adds a white border at the bottom of the button when the button is expanded.

--- a/app/assets/stylesheets/govuk_publishing_components/components/_sub-navigation-menu.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_sub-navigation-menu.scss
@@ -1,5 +1,5 @@
 .gem-c-sub-navigation-menu {
-  border-bottom: 1px solid $govuk-border-colour;
+  border-bottom: 1px solid govuk-functional-colour(border);
   @include govuk-font(19);
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_subscription-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_subscription-links.scss
@@ -66,7 +66,7 @@
   }
 
   &:not(.brand__color) {
-    color: $govuk-link-colour;
+    color: govuk-functional-colour(link);
   }
 
   &:hover {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_subscription-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_subscription-links.scss
@@ -70,7 +70,7 @@
   }
 
   &:hover {
-    color: $govuk-link-hover-colour;
+    color: govuk-functional-colour(link-hover);
   }
 
   &:visited,

--- a/app/assets/stylesheets/govuk_publishing_components/components/_subscription-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_subscription-links.scss
@@ -80,7 +80,7 @@
   }
 
   &:focus {
-    color: $govuk-focus-text-colour;
+    color: govuk-functional-colour(focus-text);
     border: 1px solid govuk-functional-colour(focus);
     outline: 3px solid transparent;
   }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_subscription-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_subscription-links.scss
@@ -81,7 +81,7 @@
 
   &:focus {
     color: $govuk-focus-text-colour;
-    border: 1px solid $govuk-focus-colour;
+    border: 1px solid govuk-functional-colour(focus);
     outline: 3px solid transparent;
   }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_success-alert.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_success-alert.scss
@@ -5,14 +5,14 @@
   .gem-c-success-alert {
     break-inside: avoid;
     background: none;
-    border-color: $govuk-print-text-colour;
+    border-color: govuk-functional-colour(print-text);
 
     * {
-      color: $govuk-print-text-colour !important;
+      color: govuk-functional-colour(print-text) !important;
     }
 
     .govuk-notification-banner__header {
-      border-bottom: 1pt solid $govuk-print-text-colour;
+      border-bottom: 1pt solid govuk-functional-colour(print-text);
     }
 
     .govuk-notification-banner__title {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_summary-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_summary-banner.scss
@@ -1,6 +1,6 @@
 .gem-c-summary-banner {
   direction: ltr;
-  background: $govuk-brand-colour;
+  background: govuk-functional-colour(brand);
   color: govuk-colour("white");
   padding: govuk-spacing(6) govuk-spacing(3) govuk-spacing(3);
   clear: both;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_table.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_table.scss
@@ -35,7 +35,7 @@ $table-row-even-background-colour: govuk-colour("black", $variant: "tint-95");
       display: inline-block;
       position: relative;
       padding-right: $sort-link-arrow-size;
-      color: $govuk-link-colour;
+      color: govuk-functional-colour(link);
       text-decoration: none;
       @include govuk-link-style-no-visited-state;
     }
@@ -63,7 +63,7 @@ $table-row-even-background-colour: govuk-colour("black", $variant: "tint-95");
 
   .govuk-table__header--active {
     color: $sort-link-active-colour;
-    background: $govuk-link-colour;
+    background: govuk-functional-colour(link);
 
     .app-table__sort-link {
       padding-right: govuk-spacing(4);

--- a/app/assets/stylesheets/govuk_publishing_components/components/_table.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_table.scss
@@ -139,13 +139,13 @@ $table-row-even-background-colour: govuk-colour("black", $variant: "tint-95");
     outline: none;
 
     * {
-      color: $govuk-print-text-colour !important;
+      color: govuk-functional-colour(print-text) !important;
       background: none !important;
     }
 
     .govuk-table__header,
     .govuk-table__cell {
-      border-bottom: 1px solid $govuk-print-text-colour !important;
+      border-bottom: 1px solid govuk-functional-colour(print-text) !important;
     }
 
     .govuk-table__header {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_table.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_table.scss
@@ -76,7 +76,7 @@ $table-row-even-background-colour: govuk-colour("black", $variant: "tint-95");
       }
 
       &:focus {
-        color: $govuk-focus-text-colour;
+        color: govuk-functional-colour(focus-text);
       }
     }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_table.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_table.scss
@@ -13,7 +13,7 @@ $table-row-even-background-colour: govuk-colour("black", $variant: "tint-95");
 
 .govuk-table__cell:empty,
 .govuk-table__cell--empty {
-  color: $govuk-secondary-text-colour;
+  color: govuk-functional-colour(secondary-text);
 }
 
 .govuk-table--sortable {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_tag.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_tag.scss
@@ -6,7 +6,7 @@
 
 @include govuk-media-query($media-type: print) {
   .gem-c-tag.govuk-tag {
-    color: $govuk-print-text-colour;
+    color: govuk-functional-colour(print-text);
     background: none;
     border: 2px solid govuk-colour("black");
   }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_translation-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_translation-nav.scss
@@ -1,6 +1,6 @@
 .gem-c-translation-nav {
   margin-bottom: govuk-spacing(6);
-  border-bottom: 1px solid $govuk-border-colour;
+  border-bottom: 1px solid govuk-functional-colour(border);
   @include govuk-text-colour;
   @include govuk-font(16);
 }
@@ -17,14 +17,14 @@
   padding-left: govuk-spacing(2);
   padding-right: govuk-spacing(2);
   margin-bottom: govuk-spacing(2);
-  border-right: 1px solid $govuk-border-colour;
+  border-right: 1px solid govuk-functional-colour(border);
   height: 16px;
 
   .direction-rtl & {
     direction: rtl;
     float: right;
     text-align: start;
-    border-left: 1px solid $govuk-border-colour;
+    border-left: 1px solid govuk-functional-colour(border);
     border-right: 0;
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_warning-text.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_warning-text.scss
@@ -18,7 +18,7 @@
 }
 
 .gem-c-warning-text__text--highlight {
-  color: $govuk-error-colour;
+  color: govuk-functional-colour(error);
 }
 
 @include govuk-media-query($media-type: print) {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_warning-text.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_warning-text.scss
@@ -23,11 +23,11 @@
 
 @include govuk-media-query($media-type: print) {
   .gem-c-warning-text * {
-    color: $govuk-print-text-colour;
+    color: govuk-functional-colour(print-text);
   }
 
   .govuk-warning-text__icon {
     background: none;
-    color: $govuk-print-text-colour;
+    color: govuk-functional-colour(print-text);
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
@@ -127,7 +127,7 @@
         a,
         a:link,
         a:link:visited {
-          color: $govuk-print-text-colour !important;
+          color: govuk-functional-colour(print-text) !important;
 
           &::after {
             display: block;

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_call-to-action.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_call-to-action.scss
@@ -16,7 +16,7 @@
 
     @include govuk-media-query($media-type: print) {
       background: none;
-      border: 1pt solid $govuk-border-colour;
+      border: 1pt solid govuk-functional-colour(border);
       padding: govuk-spacing(3);
       margin: govuk-spacing(3) 0;
     }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_footnotes.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_footnotes.scss
@@ -32,7 +32,7 @@
 
     li:target {
       background: govuk-colour("black", $variant: "tint-95");
-      border-bottom: solid 3px $govuk-border-colour;
+      border-bottom: solid 3px govuk-functional-colour(border);
     }
 
     @include govuk-media-query($media-type: print) {

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_footnotes.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_footnotes.scss
@@ -36,7 +36,7 @@
     }
 
     @include govuk-media-query($media-type: print) {
-      border-top: 1px solid $govuk-text-colour;
+      border-top: 1px solid govuk-functional-colour(text);
 
       a[role="doc-backlink"] {
         display: none;

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_highlight-answer.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_highlight-answer.scss
@@ -48,7 +48,7 @@ $highlight-answer-color: govuk-colour("white");
 
       &,
       & * {
-        color: $govuk-print-text-colour !important; // stylelint-disable-line declaration-no-important
+        color: govuk-functional-colour(print-text) !important; // stylelint-disable-line declaration-no-important
       }
     }
   }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_images.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_images.scss
@@ -32,7 +32,7 @@
 
     figcaption p {
       margin: govuk-spacing(2) 0 0 0;
-      color: $govuk-secondary-text-colour;
+      color: govuk-functional-colour(secondary-text);
       @include govuk-font(19);
     }
   }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_media-player.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_media-player.scss
@@ -36,7 +36,7 @@
   padding: govuk-spacing(6);
   padding-bottom: govuk-spacing(8);
   background: govuk-colour("black", $variant: "tint-95");
-  border: solid 2px $govuk-border-colour;
+  border: solid 2px govuk-functional-colour(border);
 }
 
 .gem-c-govspeak__youtube-placeholder-text {

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_tables.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_tables.scss
@@ -34,7 +34,7 @@
 
     th {
       text-align: left;
-      color: $govuk-text-colour;
+      color: govuk-functional-colour(text);
       @include govuk-font($size: 19, $weight: bold);
     }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
@@ -101,10 +101,10 @@
   }
 
   @include govuk-media-query($media-type: print) {
-    color: $govuk-print-text-colour;
+    color: govuk-functional-colour(print-text);
 
     a:link {
-      color: $govuk-print-text-colour;
+      color: govuk-functional-colour(print-text);
     }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_warning-callout.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_warning-callout.scss
@@ -34,7 +34,7 @@
 
       &::before {
         background-color: govuk-colour("white");
-        color: $govuk-print-text-colour;
+        color: govuk-functional-colour(print-text);
       }
     }
   }

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
@@ -37,7 +37,7 @@
 
     &:hover,
     &:focus {
-      color: $govuk-focus-text-colour;
+      color: govuk-functional-colour(focus-text);
     }
   }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_markdown-typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_markdown-typography.scss
@@ -63,7 +63,7 @@
     }
 
     @include govuk-media-query($media-type: print) {
-      color: $govuk-print-text-colour !important; // stylelint-disable-line declaration-no-important
+      color: govuk-functional-colour(print-text) !important; // stylelint-disable-line declaration-no-important
     }
   }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_markdown-typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_markdown-typography.scss
@@ -115,7 +115,7 @@
   hr {
     margin-top: govuk-spacing(6) - 1px;
     margin-bottom: govuk-spacing(6);
-    border-top: 1px solid $govuk-border-colour;
+    border-top: 1px solid govuk-functional-colour(border);
   }
 
   code {

--- a/app/assets/stylesheets/govuk_publishing_components/lib/_link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/lib/_link.scss
@@ -2,7 +2,7 @@
   @include govuk-font(19);
 
   &:link {
-    color: $govuk-error-colour;
+    color: govuk-functional-colour(error);
   }
 
   &:visited,

--- a/app/assets/stylesheets/govuk_publishing_components/lib/_link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/lib/_link.scss
@@ -12,6 +12,6 @@
   }
 
   &:focus {
-    color: $govuk-focus-text-colour;
+    color: govuk-functional-colour(focus-text);
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/lib/_print_support.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/lib/_print_support.scss
@@ -57,7 +57,7 @@
     &,
     &:link,
     &:visited {
-      color: $govuk-print-text-colour !important;
+      color: govuk-functional-colour(print-text) !important;
     }
 
     &::after {
@@ -65,7 +65,7 @@
       margin: 1mm auto;
       font-size: 12pt;
       font-weight: normal;
-      color: $govuk-print-text-colour !important;
+      color: govuk-functional-colour(print-text) !important;
     }
   }
 }

--- a/docs/component_branding.md
+++ b/docs/component_branding.md
@@ -51,7 +51,7 @@ Then a new class in `_brand_colours.scss` will need to be created, that is names
 
     &:hover,
     &:focus {
-      color: $govuk-focus-text-colour;
+      color: govuk-functional-colour(focus-text);
     }
   }
 

--- a/docs/component_conventions.md
+++ b/docs/component_conventions.md
@@ -253,10 +253,10 @@ Print styles should be included in the main stylesheet for a component, using th
 
 ### Print style conventions
 
-Ensure that colours are reset to black using the print specific variable `$govuk-print-text-colour`, for example:
+Ensure that colours are reset to black using `govuk-functional-colour(print-text)`, for example:
 
-- Text: `color: $govuk-print-text-colour;`
-- Borders: `border-color: $govuk-print-text-colour;`
+- Text: `color: govuk-functional-colour(print-text);`
+- Borders: `border-color: govuk-functional-colour(print-text);`
 
 Some elements such as background images do not print by default in most browsers. To force these to print as intended, use the CSS property `print-color-adjust`, for example:
 ```


### PR DESCRIPTION
## What
Update references to Sass variables to use the govuk-functional-colour function

## Why

The Sass variables for accessing functional colours are deprecated, and will be removed in a future breaking release of govuk-frontend

Jira card: https://gov-uk.atlassian.net/browse/NAV-18923
