### PR TITLE
Add option to change Service navigation toggle text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add option to change Service navigation toggle text ([PR #5549](https://github.com/alphagov/govuk_publishing_components/pull/5549))
 * Use multiple box shadows in attachment components in place of outline and box shadow ([PR #5503](https://github.com/alphagov/govuk_publishing_components/pull/5503))
 * Add X as an option to share_links component ([PR #5526](https://github.com/alphagov/govuk_publishing_components/pull/5526))
 * Reintroduce chart component ([PR #5484](https://github.com/alphagov/govuk_publishing_components/pull/5484))

--- a/app/views/govuk_publishing_components/components/_service_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_service_navigation.html.erb
@@ -3,7 +3,7 @@
   service_name_url ||= nil
   navigation_items ||= []
   navigation_aria_label ||= t("components.layout_header.menu")
-  toggle_text ||= "Menu"
+  toggle_text ||= t("components.service_navigation.menu_toggle")
   inverse ||= false
   collapse_navigation_on_mobile = local_assigns.fetch(:collapse_navigation_on_mobile, navigation_items.length > 1)
 

--- a/app/views/govuk_publishing_components/components/_service_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_service_navigation.html.erb
@@ -3,6 +3,7 @@
   service_name_url ||= nil
   navigation_items ||= []
   navigation_aria_label ||= t("components.layout_header.menu")
+  toggle_text ||= "Menu"
   inverse ||= false
   collapse_navigation_on_mobile = local_assigns.fetch(:collapse_navigation_on_mobile, navigation_items.length > 1)
 
@@ -33,7 +34,7 @@
           <nav aria-label="<%= navigation_aria_label %>" class="govuk-service-navigation__wrapper">
             <% if collapse_navigation_on_mobile %>
               <button type="button" class="govuk-service-navigation__toggle govuk-js-service-navigation-toggle" aria-controls="<%= nav_id %>" hidden aria-hidden="true">
-                Menu
+                <%= toggle_text %>
               </button>
             <% end %>
             <ul class="govuk-service-navigation__list" id="<%= nav_id %>">

--- a/app/views/govuk_publishing_components/components/docs/service_navigation.yml
+++ b/app/views/govuk_publishing_components/components/docs/service_navigation.yml
@@ -24,6 +24,17 @@ examples:
         href: "#"
       - text: Navigation item 3
         href: "#"
+  with_custom_mobile_toggle_text:
+    data:
+      toggle_text: See the menu
+      navigation_items:
+      - text: Navigation item 1
+        href: "#"
+        active: true
+      - text: Navigation item 2
+        href: "#"
+      - text: Navigation item 3
+        href: "#"
   with_service_name:
     data:
       service_name: My service name

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -227,6 +227,8 @@ ar:
       input_title: بحث
       label: بحث على GOV.UK
       search_button: بحث
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -224,6 +224,8 @@ az:
       input_title: Axtar
       label: GOV.UK-də axtar
       search_button: Axtar
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -230,6 +230,8 @@ be:
       input_title: Пошук
       label: Шукаць на GOV.UK
       search_button: Пошук
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -228,6 +228,8 @@ bg:
       input_title: Търсене
       label: Търсене в GOV.UK
       search_button: Търсене
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -225,6 +225,8 @@ bn:
       input_title: খুঁজুন
       label: GOV.UK-এ অনুসন্ধান করুন
       search_button: খুঁজুন
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -229,6 +229,8 @@ cs:
       input_title: Vyhledávání
       label: Vyhledávání na GOV.UK
       search_button: Vyhledávání
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -228,6 +228,8 @@ cy:
       input_title: Chwilio
       label: Chwilio ar GOV.UK
       search_button: Chwilio
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab: Bydd rhannu yn agor y dudalen hon mewn tab newydd
       opens_in_new_tab:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -225,6 +225,8 @@ da:
       input_title: Søge
       label: Søg i GOV.UK
       search_button: Søge
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -228,6 +228,8 @@ de:
       input_title: Suche
       label: Auf GOV.UK suchen
       search_button: Suche
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -226,6 +226,8 @@ dr:
       input_title: جستجو نمایید
       label: در GOV.UK جستجو نمایید
       search_button: جستجو نمایید
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -224,6 +224,8 @@ el:
       input_title: Αναζήτηση
       label: Αναζήτηση στο GOV.UK
       search_button: Αναζήτηση
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -339,6 +339,8 @@ en:
       input_title: Search
       label: Search on GOV.UK
       search_button: Search
+    service_navigation:
+      menu_toggle: Menu
     share_links:
       all_opens_in_new_tab: The following links open in a new tab
       opens_in_new_tab: "(opens in new tab)"

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -224,6 +224,8 @@ es-419:
       input_title: Buscar
       label: Buscar en GOV.UK
       search_button: Buscar
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -224,6 +224,8 @@ es:
       input_title: Buscar
       label: Buscar en GOV.UK
       search_button: Buscar
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -227,6 +227,8 @@ et:
       input_title: Otsing
       label: Otsige saidilt GOV.UK
       search_button: Otsing
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -223,6 +223,8 @@ fa:
       input_title: جستجو
       label: جستجو در GOV.UK
       search_button: جستجو
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -226,6 +226,8 @@ fi:
       input_title: Hae
       label: Hae osoitteesta GOV.UK
       search_button: Hae
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -224,6 +224,8 @@ fr:
       input_title: Rechercher
       label: Rechercher sur GOV.UK
       search_button: Rechercher
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -226,6 +226,8 @@ gd:
       input_title: Taighde
       label: Cuardaigh ar GOV.UK
       search_button: Taighde
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -224,6 +224,8 @@ gu:
       input_title: શોધો
       label: GOV.UK પર શોધો
       search_button: શોધો
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -224,6 +224,8 @@ he:
       input_title: 'חפש '
       label: 'חפש ב- GOV.UK '
       search_button: חפש
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -224,6 +224,8 @@ hi:
       input_title: खोजें
       label: GOV.UK खोजें
       search_button: खोजें
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -225,6 +225,8 @@ hr:
       input_title: Pretraga
       label: Pretražujte na GOV.UK
       search_button: Pretraga
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -227,6 +227,8 @@ hu:
       input_title: Keresés
       label: Keresés a GOV.UK-n
       search_button: Keresés
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -228,6 +228,8 @@ hy:
       input_title: Որոնում
       label: Որոնել GOV.UK կայքում
       search_button: Որոնում
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -224,6 +224,8 @@ id:
       input_title: Cari
       label: Cari di GOV.UK
       search_button: Cari
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -224,6 +224,8 @@ is:
       input_title: Leita
       label: Leita á GOV.UK
       search_button: Leita
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -224,6 +224,8 @@ it:
       input_title: Cerca
       label: Cerca su GOV.UK
       search_button: Cerca
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -220,6 +220,8 @@ ja:
       input_title: 検索
       label: GOV.UKで検索
       search_button: 検索
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -227,6 +227,8 @@ ka:
       input_title: ძიება
       label: ძიება GOV.UK-ზე
       search_button: ძიება
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -224,6 +224,8 @@ kk:
       input_title: Іздеу
       label: GOV.UK веб-сайтында іздеу
       search_button: Іздеу
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -219,6 +219,8 @@ ko:
       input_title:
       label:
       search_button:
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/ku.yml
+++ b/config/locales/ku.yml
@@ -223,6 +223,8 @@ ku:
       input_title: گەڕان
       label: گەڕان لە ماڵپەڕی GOV.UK
       search_button: گەڕان
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab: ئەم بەستەرانەی خوارەوە لە تابێکی نوێدا دەکرێنەوە
       opens_in_new_tab: "(لە تابی نوێدا دەکرێتەوە)"

--- a/config/locales/ky.yml
+++ b/config/locales/ky.yml
@@ -220,6 +220,8 @@ ky:
       input_title: Издөө
       label: GOV.UK ичинен издөө
       search_button: Издөө
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab: Төмөнкү шилтемелер жаңы өтмөктө ачылат
       opens_in_new_tab: "(жаңы таблицада ачат)"

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -229,6 +229,8 @@ lt:
       input_title: Ieškoti
       label: Ieškoti GOV.UK
       search_button: Ieškoti
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -228,6 +228,8 @@ lv:
       input_title: Meklēt
       label: Meklēt GOV.UK
       search_button: Meklēt
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -223,6 +223,8 @@ ms:
       input_title: Carian
       label: Carian di GOV.UK
       search_button: Carian
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -226,6 +226,8 @@ mt:
       input_title: Fittex
       label: Fittex fuq GOV.UK
       search_button: Fittex
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -220,6 +220,8 @@ ne:
       input_title:
       label:
       search_button:
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -224,6 +224,8 @@ nl:
       input_title: Zoeken
       label: Zoeken op GOV.UK
       search_button: Zoeken
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -224,6 +224,8 @@
       input_title: Søk
       label: Søk på GOV.UK
       search_button: Søk
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -220,6 +220,8 @@ pa-pk:
       input_title: کھوج
       label: GOV.UK اُتے کھوج کرو
       search_button: کھوج
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -224,6 +224,8 @@ pa:
       input_title: ਖੋਜ
       label: GOV.UK ਤੇ ਖੋਜ ਕਰੋ
       search_button: ਖੋਜ
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -228,6 +228,8 @@ pl:
       input_title: Szukaj
       label: Szukaj na GOV.UK
       search_button: Szukaj
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -221,6 +221,8 @@ ps:
       input_title: لټون
       label: په GOV.UK کې لټون وکړئ
       search_button: لټون
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -224,6 +224,8 @@ pt:
       input_title: Pesquisar
       label: Pesquisar em GOV.UK
       search_button: Pesquisar
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -225,6 +225,8 @@ ro:
       input_title: Căutați
       label: Căutați pe GOV.UK
       search_button: Căutați
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -228,6 +228,8 @@ ru:
       input_title: Поиск
       label: Поиск на GOV.UK
       search_button: Поиск
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -224,6 +224,8 @@ si:
       input_title: සොයන්න
       label: GOV.UK මත සොයන්න
       search_button: සොයන්න
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -229,6 +229,8 @@ sk:
       input_title: Vyhľadávanie
       label: Vyhľadávanie na GOV.UK
       search_button: Vyhľadávanie
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -231,6 +231,8 @@ sl:
       input_title: Iskanje
       label: Iskanje po GOV.UK
       search_button: Iskanje
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -224,6 +224,8 @@ so:
       input_title: Baadh
       label: Baadh GOV.UK
       search_button: Baadh
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -224,6 +224,8 @@ sq:
       input_title: Kërko
       label: Kërko në GOV.UK
       search_button: Kërko
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -225,6 +225,8 @@ sr:
       input_title: Pretraži
       label: Pretraži na GOV.UK
       search_button: Pretraži
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -224,6 +224,8 @@ sv:
       input_title: Sök på
       label: Sök på GOV.UK
       search_button: Sök på
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -224,6 +224,8 @@ sw:
       input_title: Tafuta
       label: Tafuta kwenye tovuti ya GOV.UK
       search_button: Tafuta
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -225,6 +225,8 @@ ta:
       input_title: தேடு
       label: GOV.UK-யில் தேடுக
       search_button: தேடு
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -222,6 +222,8 @@ th:
       input_title: ค้นหา
       label: ค้นหาใน GOV.UK
       search_button: ค้นหา
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/ti.yml
+++ b/config/locales/ti.yml
@@ -223,6 +223,8 @@ ti:
       input_title: ምድላይ / ሰርች ምግባር
       label: ኣብ ጎቭ.ዩኬ/GOV.UK ድለዩ።
       search_button: ምድላይ / ሰርች ምግባር
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab: እዞም ዝስዕቡ መላግቦታት ኣብ ሓድሽ ክፍሊ/ታብ ይኽፈቱ
       opens_in_new_tab: "(ኣብ ሓድሽ ክፍሊ/ታብ ይኽፈት)"

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -225,6 +225,8 @@ tk:
       input_title: Gözlemek
       label: GOV.UK-de gözle
       search_button: Gözlemek
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -225,6 +225,8 @@ tr:
       input_title: Ara
       label: GOV.UK adresini ara
       search_button: Ara
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -231,6 +231,8 @@ uk:
       input_title: Пошук
       label: Пошук на GOV.UK
       search_button: Пошук
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -221,6 +221,8 @@ ur:
       input_title: تلاش
       label: GOV.UK پر تلاش کریں
       search_button: تلاش
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -226,6 +226,8 @@ uz:
       input_title: Излаш
       label: GOV.UKда излаш
       search_button: Излаш
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -223,6 +223,8 @@ vi:
       input_title: Tìm kiếm
       label: Tìm kiếm trên GOV.UK
       search_button: Tìm kiếm
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -222,6 +222,8 @@ zh-hk:
       input_title: 搜尋
       label: 搜尋 GOV.UK
       search_button: 搜尋
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -222,6 +222,8 @@ zh-tw:
       input_title: 搜尋
       label: 在英國政府網站上搜尋
       search_button: 搜尋
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -222,6 +222,8 @@ zh:
       input_title: 搜索
       label: 搜索GOV.UK
       search_button: 搜索
+    service_navigation:
+      menu_toggle:
     share_links:
       all_opens_in_new_tab:
       opens_in_new_tab:

--- a/spec/components/service_navigation_spec.rb
+++ b/spec/components/service_navigation_spec.rb
@@ -44,6 +44,11 @@ describe "Service navigation", type: :view do
     assert_select(".govuk-service-navigation__item:nth-child(3) .govuk-service-navigation__link", text: "Navigation item 3")
   end
 
+  it "renders custom toggle text" do
+    render_component({ navigation_items:, toggle_text: "Toggle me" })
+    assert_select(".govuk-service-navigation__toggle", text: "Toggle me")
+  end
+
   it "renders with data attributes on links" do
     render_component({ navigation_items: })
     assert_select("div.gem-c-service-navigation")


### PR DESCRIPTION
## What
- adds an option to the service navigation component to change the text of the menu toggle on mobile, that shows/hides the rest of the menu items
- previously was only 'menu'

## Why
We're going to need this option for some upcoming work.

## Visual Changes

<img width="608" height="426" alt="Screenshot 2026-07-03 at 15 32 12" src="https://github.com/user-attachments/assets/d5f3dccb-bd9c-4884-a17e-594872a1914d" />
