### PR TITLE
Improve the look of the metadata component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Improve the look of the metadata component ([PR #5552](https://github.com/alphagov/govuk_publishing_components/pull/5552))
 * Merge published dates component into metadata component ([PR #5572](https://github.com/alphagov/govuk_publishing_components/pull/5572))
 * Remove the unused "app name" option from the phase banner component ([PR #5579](https://github.com/alphagov/govuk_publishing_components/pull/5579))
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_metadata.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_metadata.scss
@@ -2,7 +2,6 @@
   @include govuk-text-colour;
   @include govuk-font(16);
   @include responsive-bottom-margin;
-  @include govuk-clearfix;
 
   a {
     font-weight: bold;
@@ -31,6 +30,11 @@
 
 .gem-c-metadata__list {
   margin: 0;
+
+  @include govuk-media-query($from: tablet) {
+    display: grid;
+    grid-template-columns: auto 1fr;
+  }
 }
 
 .gem-c-metadata--inverse-padded {
@@ -58,10 +62,8 @@
   margin-top: .5em;
 
   @include govuk-media-query($from: tablet) {
-    box-sizing: border-box;
-    float: inline-start;
     padding-inline-start: 0;
-    padding-inline-end: govuk-spacing(1);
+    padding-inline-end: govuk-spacing(2);
     margin-top: 0;
   }
 }
@@ -71,7 +73,7 @@
 
   @include govuk-media-query($from: tablet) {
     &:not(:last-of-type) {
-      margin-bottom: govuk-spacing(1);
+      margin-bottom: govuk-spacing(2);
     }
   }
 }

--- a/app/views/govuk_publishing_components/components/_metadata.html.erb
+++ b/app/views/govuk_publishing_components/components/_metadata.html.erb
@@ -64,11 +64,11 @@
       <dd class="gem-c-metadata__definition"><%= history %></dd>
     <% end %>
     <% if local_assigns.include?(:first_published) && first_published %>
-      <dt class="gem-c-metadata__term"><%= t("components.metadata.published") %></dt>
+      <dt class="gem-c-metadata__term"><%= t("components.metadata.published") %>:</dt>
       <dd class="gem-c-metadata__definition"><%= first_published %></dd>
     <% end %>
     <% if local_assigns.include?(:last_updated) && last_updated %>
-      <dt class="gem-c-metadata__term"><%= t("components.metadata.last_updated") %></dt>
+      <dt class="gem-c-metadata__term"><%= t("components.metadata.last_updated") %>:</dt>
       <dd class="gem-c-metadata__definition" data-module="gem-toggle">
         <%= last_updated %>
         <% if local_assigns.include?(:see_updates_link) %>


### PR DESCRIPTION
## What
Visually improve the style of the metadata component. See individual commits for details.


## Why
This started with a fix to remove some default browser margin and turned into an exploration of whether CSS grid could be used to improve the look and layout of the component - spoiler alert, it can 🎉 

**However** it's worth noting the history of this component (thanks to @AshGDS for digging). The component used to look more like this change (in separate columns), but it was [changed in 2021](https://github.com/alphagov/govuk_publishing_components/pull/2046) to look as it is currently (single column). The reasoning was:

1. The change was made originally because the two column layout was inconsistent across pages — each instance of the metadata component had its own spacing between the columns that was dependent on the length of the content in the first column.
1. We decided this looked messy, didn't serve the user from page to page (elements jumping around isn't great for accessibility and predicting where content is).
1. Additionally, the gap between the columns would be baffling to screen magnification users.
1. Everything was put into a single column to improve usability and accessibility.

I think there's an argument to be made for making this change again:

- we now use CSS grid to define the columns based on the content (previously the first column was set to 30%). This means that the gap between DT and DD elements will adapt to the content and in most situations be limited and sensible
- the spacing between rows has been increased to further distinguish them
- (personally) I find separate columns easier to read, but I'm one person

Additionally, restoring the colons at the end of the `Published` and `Updated` improves the consistency of the component overall (the PR referenced above doesn't explain why they were removed in the first place).

I've run this change by two of our designers and they're happy with it 👍 

## Visual Changes

**Before**

<img width="1190" height="273" alt="Screenshot 2026-07-07 at 10 41 15" src="https://github.com/user-attachments/assets/c3339599-3973-445c-bcda-75aac411e34d" />

**After**

<img width="1224" height="297" alt="Screenshot 2026-07-07 at 10 41 19" src="https://github.com/user-attachments/assets/9add59ed-5de0-4318-8204-75628f810580" />


## Applications impacted
The metadata component is used in a few places so it's important to check these changes won't cause any problems.

- `collections-publisher` uses the component but completely restyles it. These changes would break that so I've raised a separate PR to not use the component in that app and just have some custom styling, which seems simpler: https://github.com/alphagov/collections-publisher/pull/2783
- `content-data-admin` uses the component on the [URL detail screen](https://github.com/alphagov/content-data-admin/blob/main/app/views/metrics/show.html.erb) but the usage is standard and these changes should be fine
- `finder-frontend` uses the component in the [header of some finders](https://github.com/alphagov/finder-frontend/blob/main/app/views/finders/_show_header.html.erb) such as [Notifiable animal disease cases and control zones](https://www.gov.uk/animal-disease-cases-england) but the usage is standard and these changes should be fine (it should actually improve things as removing the top margin of the metadata component will better align it with other page elements on desktop).

`frontend` has multiple instances:

- at the bottom of the [bank holidays page](https://www.gov.uk/bank-holidays), which should be fine
- at the bottom of the [clocks change page](https://www.gov.uk/when-do-the-clocks-change), which should be fine
- on [fatality notice pages](https://www.gov.uk/government/fatalities/ministry-of-defence-confirms-the-death-of-lance-bombardier-ciara-sullivan), which should be fine
- on [service manual guide pages](https://www.gov.uk/service-manual/helping-people-to-use-your-service/understanding-wcag), which should be fine
- on [call for evidence pages](https://www.gov.uk/government/calls-for-evidence/informing-the-mental-health-strategy-for-england), which should be fine
- on [HMRC manuals](https://www.gov.uk/hmrc-internal-manuals/pensions-tax-manual), which should be fine
- on [specialist documents](https://www.gov.uk/find-hmrc-contacts/income-tax-enquiries), which should be fine
- on [speech pages](https://www.gov.uk/government/speeches/next-steps-for-veterinary-services-for-household-pets-what-the-cmas-remedies-mean-in-practice), which should be fine
- on [statistics announcements](https://www.gov.uk/government/statistics/announcements/key-stage-2-attainment-2026-national-headlines), which should be fine
- on [travel advice pages](https://www.gov.uk/foreign-travel-advice/united-arab-emirates), which should be fine
