### PR TITLE
Do not render hidden "share" text elements if no hidden text is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add chartkick to the gemspec ([PR #5558](https://github.com/alphagov/govuk_publishing_components/pull/5558))
+* Do not render hidden "share" text elements if no hidden text is provided ([PR #5554](https://github.com/alphagov/govuk_publishing_components/pull/5554))
 
 ## 66.7.0
 

--- a/app/views/govuk_publishing_components/components/_share_links.html.erb
+++ b/app/views/govuk_publishing_components/components/_share_links.html.erb
@@ -33,13 +33,13 @@
     <ul class="gem-c-share-links__list">
       <% links.each_with_index do |link, index| %>
         <% link_text = capture do %>
-          <span class="govuk-visually-hidden">
-            <% if link[:hidden_text] %>
-              <%= link[:hidden_text] %>
-            <% else %>
-              Share on
+          <% if link.include?(:hidden_text) %>
+            <% if link[:hidden_text].present? %>
+              <span class="govuk-visually-hidden"><%= link[:hidden_text] %></span>
             <% end %>
-          </span>
+          <% else %>
+            <span class="govuk-visually-hidden">Share on</span>
+          <% end %>
           <%= link[:text] %>
           <span class="govuk-visually-hidden">
             <%= t("components.share_links.opens_in_new_tab") %>

--- a/spec/components/share_links_spec.rb
+++ b/spec/components/share_links_spec.rb
@@ -140,6 +140,26 @@ describe "ShareLinks", type: :view do
     assert_select ".gem-c-share-links .gem-c-share-links__link[href=\"/twitter\"] .govuk-visually-hidden", text: "Tweet to"
   end
 
+  it "displays without visually hidden text" do
+    links_with_no_hidden_text = [
+      {
+        href: "/facebook",
+        text: "Share on Facebook",
+        icon: "facebook",
+        hidden_text: "",
+      },
+      {
+        href: "/twitter",
+        text: "Share on Twitter",
+        icon: "twitter",
+        hidden_text: "",
+      },
+    ]
+    render_component(links: links_with_no_hidden_text)
+    assert_select ".gem-c-share-links .gem-c-share-links__link[href=\"/facebook\"] .govuk-visually-hidden", text: /\AShare on/, count: 0
+    assert_select ".gem-c-share-links .gem-c-share-links__link[href=\"/twitter\"] .govuk-visually-hidden", text: /\AShare on/, count: 0
+  end
+
   it "adds the correct classes when flexbox is true" do
     render_component(links:, flexbox: true)
     assert_select ".gem-c-share-links--flexbox"


### PR DESCRIPTION
## What

Do not render hidden "share" text elements if no hidden text is provided

## Why

If the hidden text is empty (for example, when the share text is set to "Share on"), there's no need to render empty hidden elements.

https://github.com/alphagov/frontend/pull/5371

## Visual changes

### Before

<img width="1728" height="1117" alt="Screenshot 2026-07-07 at 18 09 21" src="https://github.com/user-attachments/assets/2a089b83-508b-4f37-a91a-ff0c422616eb" />

### After

<img width="1728" height="1117" alt="Screenshot 2026-07-07 at 18 05 01" src="https://github.com/user-attachments/assets/d3b2f4d3-b514-4209-9c73-d5a9c33b3942" />

## Anything else (examples)

### Empty hidden text

```diff
links: [
  {
    href: "share",
    text: "Share on Facebook",
+   hidden_text: "",
    icon: "facebook"
  }
]
```

```html
<span class="gem-c-share-links__label"> Share on Facebook
  <span class="govuk-visually-hidden">
    (opens in new tab)
  </span>
</span>
```

### No hidden text

```diff
links: [
  {
    href: "share",
    text: "Share on Facebook",,
-   hidden_text:,
    icon: "facebook"
  }
]
```

```html
<span class="gem-c-share-links__label"> <span class="govuk-visually-hidden">
    Share on
  </span>
  Facebook
  <span class="govuk-visually-hidden">
    (opens in new tab)
  </span>
</span>
```

### Custom hidden text

```diff
links: [
  {
    href: "share",
    text: "Share on Facebook",
+   hidden_text: "Download from",
    icon: "facebook"
  }
]
```

```html
<span class="gem-c-share-links__label"> <span class="govuk-visually-hidden">
    Download from
  </span>
  Facebook
  <span class="govuk-visually-hidden">
    (opens in new tab)
  </span>
</span>
```