### PR TITLE
Release Version 66.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 66.7.0
 
 * Add option to change Service navigation toggle text ([PR #5549](https://github.com/alphagov/govuk_publishing_components/pull/5549))
 * Use multiple box shadows in attachment components in place of outline and box shadow ([PR #5503](https://github.com/alphagov/govuk_publishing_components/pull/5503))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (66.6.1)
+    govuk_publishing_components (66.7.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "66.6.1".freeze
+  VERSION = "66.7.0".freeze
 end


### PR DESCRIPTION
## 66.7.0

* Add option to change Service navigation toggle text ([PR #5549](https://github.com/alphagov/govuk_publishing_components/pull/5549))
* Use multiple box shadows in attachment components in place of outline and box shadow ([PR #5503](https://github.com/alphagov/govuk_publishing_components/pull/5503))
* Add X as an option to share_links component ([PR #5526](https://github.com/alphagov/govuk_publishing_components/pull/5526))
* Reintroduce chart component ([PR #5484](https://github.com/alphagov/govuk_publishing_components/pull/5484))