### PR TITLE
Revert 5516 govspeak cards styles

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
@@ -30,13 +30,6 @@
     }
   }
 
-  // restore styles for cards component inside govspeak
-  .gem-c-cards__list {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-  }
-
   // Block quotes
 
   blockquote {


### PR DESCRIPTION
## What
Reverts https://github.com/alphagov/govuk_publishing_components/pull/5516

## Why
Cards component has been removed from govspeak, so no need for these override styles anymore

## Visual Changes
None.
