### PR TITLE
Add chartkick to the gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add chartkick to the gemspec ([PR #5558](https://github.com/alphagov/govuk_publishing_components/pull/5558))
+
 ## 66.7.0
 
 * Add option to change Service navigation toggle text ([PR #5549](https://github.com/alphagov/govuk_publishing_components/pull/5549))

--- a/Gemfile
+++ b/Gemfile
@@ -16,5 +16,3 @@ gemspec
 
 # To use a debugger
 # gem 'byebug', group: [:development, :test]
-
-gem "chartkick", "~> 5.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     govuk_publishing_components (66.7.0)
+      chartkick
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -651,7 +652,6 @@ PLATFORMS
 
 DEPENDENCIES
   capybara
-  chartkick (~> 5.2)
   climate_control
   dartsass-rails
   erb_lint

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{node_modules/accessible-autocomplete,node_modules/govuk-frontend,node_modules/axe-core,node_modules/sortablejs,node_modules/choices.js,node_modules/chartkick,app,config,db,lib}/**/*", "LICENCE.md", "README.md"]
 
+  s.add_dependency "chartkick"
   s.add_dependency "govuk_app_config"
   s.add_dependency "govuk_personalisation", ">= 0.7.0"
   s.add_dependency "kramdown"


### PR DESCRIPTION
## What / Why
- Chartkick was added to the gem as a dev dependency, but it needs to be in the gemspec to work properly when used in other applications, so this adds it to the gemspec. Without this, rendering the component in a rendering app crashes.
- Related to https://github.com/alphagov/govuk_publishing_components/pull/5484
## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.