### PR TITLE
Remove default margin on metadata component DL element

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_metadata.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_metadata.scss
@@ -29,6 +29,10 @@
   }
 }
 
+.gem-c-metadata__list {
+  margin: 0;
+}
+
 .gem-c-metadata--inverse-padded {
   padding: govuk-spacing(2) govuk-spacing(4);
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_metadata.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_metadata.scss
@@ -44,7 +44,7 @@
     margin: govuk-spacing(2) 0;
 
     @include govuk-media-query($from: tablet) {
-      margin: govuk-spacing(3) 0;
+      margin: 0;
     }
   }
 }

--- a/app/views/govuk_publishing_components/components/_metadata.html.erb
+++ b/app/views/govuk_publishing_components/components/_metadata.html.erb
@@ -35,7 +35,7 @@
       text: sanitize(title),
       font_size: "m",
       inverse:,
-      margin_bottom: 0,
+      margin_bottom: 2,
     } %>
   <% end %>
   <dl class="gem-c-metadata__list">

--- a/app/views/govuk_publishing_components/components/docs/metadata.yml
+++ b/app/views/govuk_publishing_components/components/docs/metadata.yml
@@ -355,8 +355,30 @@ examples:
       title: Title
   on_a_dark_background:
     data:
+      inverse: true
+      margin_bottom: 0
+      from: [
+        "<a href='/government/organisations/ministry-of-defence'>Ministry of Defence</a>",
+        "<a href='/government/organisations/cabinet-office'>Cabinet Office</a>",
+        "<a href=\"/government/organisations/department-for-business-energy-and-industrial-strategy\">Department for Business, Energy &amp; Industrial Strategy</a>",
+        "<a href=\"/government/organisations/foreign-commonwealth-office\">Foreign &amp; Commonwealth Office</a>",
+        "<a href=\"/government/people/william-hague\">The Rt Hon William Hague</a>",
+        "<a href=\"/government/organisations/department-for-environment-food-rural-affairs\">Department for Environment, Food &amp; Rural Affairs</a>",
+        "<a href=\"/government/organisations/department-for-work-pensions\">Department for work and pensions</a>",
+        "<a href=\"/government/organisations/foreign-commonwealth-office\">Foreign and Commonwealth Office</a>"
+      ]
+      first_published: 14 June 2014
+      last_updated: 10 September 2015
+      see_updates_link: true
+      other:
+        Applies to: England, Scotland, and Wales (see detailed guidance for <a href="http://www.dardni.gov.uk/news-dard-pa022-a-13-new-procedure-for" rel="external">Northern Ireland</a>)
+    context:
+      dark_background: true
+  on_a_dark_background_with_a_title:
+    data:
       title: This is a title
       inverse: true
+      margin_bottom: 0
       from: [
         "<a href='/government/organisations/ministry-of-defence'>Ministry of Defence</a>",
         "<a href='/government/organisations/cabinet-office'>Cabinet Office</a>",
@@ -380,6 +402,7 @@ examples:
       title: This is a title
       inverse: true
       inverse_compress: true
+      margin_bottom: 0
       from: [
         "<a href='/government/organisations/ministry-of-defence'>Ministry of Defence</a>",
         "<a href='/government/organisations/cabinet-office'>Cabinet Office</a>",


### PR DESCRIPTION
## What / why
- metadata component uses a `DL` element, which browsers style by default with margin bottom and top
- the margin bottom is generally lost inside the margin bottom of the parent element (the component itself) but the margin top pushes out and makes the component move down
- we generally do margin bottom on components and this is causing an alignment issue in finders, so removing

## Visual Changes
All instances of the metadata component will move up by 15px. This should be fine though because everything above the metadata block already has margin bottom - there aren't any instances where we rely on this margin to space elements apart.