### PR TITLE
Set chart component's chartArea to auto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Set chart component's chartArea to auto ([PR #5561](https://github.com/alphagov/govuk_publishing_components/pull/5561))
 * Add chartkick to the gemspec ([PR #5558](https://github.com/alphagov/govuk_publishing_components/pull/5558))
 * Do not render hidden "share" text elements if no hidden text is provided ([PR #5554](https://github.com/alphagov/govuk_publishing_components/pull/5554))
 

--- a/lib/govuk_publishing_components/presenters/chart_helper.rb
+++ b/lib/govuk_publishing_components/presenters/chart_helper.rb
@@ -30,7 +30,7 @@ module GovukPublishingComponents
       # config options are here: https://developers.google.com/chart/interactive/docs/gallery/linechart
       def chart_options
         {
-          chartArea: { width: "80%", height: "60%" },
+          chartArea: { width: "auto", height: "auto" },
           crosshair: { orientation: "vertical", trigger: "both", color: "#ccc" },
           curveType: "none",
           enableInteractivity: @enable_interactivity,

--- a/spec/lib/govuk_publishing_components/presenters/chart_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/chart_helper_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe GovukPublishingComponents::Presenters::ChartHelper do
       }
 
       expected = {
-        chartArea: { width: "80%", height: "60%" },
+        chartArea: { width: "auto", height: "auto" },
         crosshair: { orientation: "vertical", trigger: "both", color: "#ccc" },
         curveType: "none",
         enableInteractivity: true,


### PR DESCRIPTION
## What/Why
<!-- What are the reasons behind this change being made? -->
- Google Charts has a `chartArea` value, which sets the size and positioning of the chart within its container
- Previously, all charts were hardcoded to take up 80% of the width of its container, and 60% of the height
- In practice this reduces the responsiveness of the charts, because the chart was always forced to take up 80% of the container width, even if that constrained the rendering of the labels. This was the case when I tried to use this component on real data on GOV.UK
- Therefore, we set the `width` and `height` to `auto` by default, allowing the chart to decide how it can render most optimally.

## Visual Changes (default rendering)
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

| Before | After |
|--------|--------|
| <img width="684" height="803" alt="image" src="https://github.com/user-attachments/assets/4977315b-09e5-408a-b4e1-4b4d7b357c13" /> | <img width="684" height="803" alt="image" src="https://github.com/user-attachments/assets/015b7106-7eb3-4627-ae7a-280f84819f77" /> |
