### PR TITLE
Add options to the service navigation component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add options to the service navigation component ([PR #5562](https://github.com/alphagov/govuk_publishing_components/pull/5562))
+
 ## 66.7.1
 
 * Set chart component's chartArea to auto ([PR #5561](https://github.com/alphagov/govuk_publishing_components/pull/5561))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_service-navigation.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_service-navigation.scss
@@ -3,3 +3,23 @@
 .gem-c-service-navigation--full-width {
   padding-left: govuk-spacing(3);
 }
+
+.gem-c-service-navigation--hide-service-name-on-mobile {
+  .govuk-service-navigation__service-name {
+    display: none;
+
+    @include govuk-media-query($from: tablet) {
+      display: block;
+    }
+  }
+
+  .govuk-service-navigation__item:first-child {
+    @include govuk-media-query($from: tablet) {
+      display: none;
+    }
+  }
+
+  .govuk-service-navigation__service-name + .govuk-service-navigation__wrapper .govuk-service-navigation__toggle {
+    margin-top: govuk-spacing(2);
+  }
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/_service-navigation.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_service-navigation.scss
@@ -23,3 +23,12 @@
     margin-top: govuk-spacing(2);
   }
 }
+
+.gem-c-service-navigation--columns-layout {
+  .govuk-service-navigation__container {
+    @include govuk-media-query($from: tablet) {
+      display: grid;
+      grid-template-columns: auto 1fr;
+    }
+  }
+}

--- a/app/views/govuk_publishing_components/components/_service_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_service_navigation.html.erb
@@ -7,11 +7,13 @@
   inverse ||= false
   hide_service_name_on_mobile ||= false
   collapse_navigation_on_mobile = local_assigns.fetch(:collapse_navigation_on_mobile, navigation_items.length > 1)
+  columns_layout ||= false
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-service-navigation govuk-service-navigation")
   component_helper.add_class("govuk-service-navigation--inverse") if inverse
   component_helper.add_class("gem-c-service-navigation--hide-service-name-on-mobile") if hide_service_name_on_mobile
+  component_helper.add_class("gem-c-service-navigation--columns-layout") if columns_layout
   component_helper.add_aria_attribute({ label: "Service information" }) if service_name.present?
   component_helper.add_data_attribute({ module: "govuk-service-navigation" })
 

--- a/app/views/govuk_publishing_components/components/_service_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_service_navigation.html.erb
@@ -5,11 +5,13 @@
   navigation_aria_label ||= t("components.layout_header.menu")
   toggle_text ||= t("components.service_navigation.menu_toggle")
   inverse ||= false
+  hide_service_name_on_mobile ||= false
   collapse_navigation_on_mobile = local_assigns.fetch(:collapse_navigation_on_mobile, navigation_items.length > 1)
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-service-navigation govuk-service-navigation")
   component_helper.add_class("govuk-service-navigation--inverse") if inverse
+  component_helper.add_class("gem-c-service-navigation--hide-service-name-on-mobile") if hide_service_name_on_mobile
   component_helper.add_aria_attribute({ label: "Service information" }) if service_name.present?
   component_helper.add_data_attribute({ module: "govuk-service-navigation" })
 

--- a/app/views/govuk_publishing_components/components/docs/service_navigation.yml
+++ b/app/views/govuk_publishing_components/components/docs/service_navigation.yml
@@ -70,6 +70,25 @@ examples:
         href: "#"
       - text: Navigation item 3
         href: "#"
+  columns_layout:
+    description: Separates the service name and the navigation items into two separate columns on desktop. Has no effect on mobile or when the service name is not present.
+    data:
+      service_name: My service home
+      service_name_url: "/home"
+      columns_layout: true
+      navigation_items:
+      - text: Introduction
+        href: "#"
+      - text: Help and guidance
+        href: "#"
+      - text: The application process
+        href: "#"
+      - text: Your first application
+        href: "#"
+      - text: Contact us
+        href: "#"
+      - text: Further reading
+        href: "#"
   with_data_attributes_on_items:
     data:
       navigation_items:

--- a/app/views/govuk_publishing_components/components/docs/service_navigation.yml
+++ b/app/views/govuk_publishing_components/components/docs/service_navigation.yml
@@ -52,6 +52,24 @@ examples:
         href: "#"
       - text: Navigation item 3
         href: "#"
+  hide_service_name_on_mobile:
+    description: |
+      On desktop, use the `service_name` link to show the name of the main page and allow users to navigate to it.
+
+      On mobile, use the `toggle_text` to show the name of the main page, but allow users to navigate to it with the first link in the `navigation_items`, which is hidden on desktop.
+    data:
+      service_name: My service home
+      service_name_url: "/home"
+      hide_service_name_on_mobile: true
+      navigation_items:
+      - text: My service home
+        href: "/home"
+      - text: Navigation item 1
+        href: "#"
+      - text: Navigation item 2
+        href: "#"
+      - text: Navigation item 3
+        href: "#"
   with_data_attributes_on_items:
     data:
       navigation_items:

--- a/spec/components/service_navigation_spec.rb
+++ b/spec/components/service_navigation_spec.rb
@@ -158,4 +158,18 @@ describe "Service navigation", type: :view do
     })
     assert_select(".gem-c-service-navigation--hide-service-name-on-mobile")
   end
+
+  it "renders the columns_layout option correctly" do
+    render_component({
+      navigation_items: [
+        {
+          text: "Navigation item 1",
+          href: "#",
+        },
+      ],
+      columns_layout: true,
+      service_name: "My service home",
+    })
+    assert_select(".gem-c-service-navigation--columns-layout")
+  end
 end

--- a/spec/components/service_navigation_spec.rb
+++ b/spec/components/service_navigation_spec.rb
@@ -142,4 +142,20 @@ describe "Service navigation", type: :view do
                        collapse_navigation_on_mobile: true })
     assert_select(".govuk-service-navigation__toggle", text: "Menu")
   end
+
+  it "renders the hide_service_name_on_mobile option correctly" do
+    render_component({
+      navigation_items: [
+        {
+          text: "Navigation item 1",
+          href: "#",
+        },
+      ],
+      hide_service_name_on_mobile: true,
+      service_name: "My service home",
+      service_name_url: "/home",
+      toggle_text: "My service",
+    })
+    assert_select(".gem-c-service-navigation--hide-service-name-on-mobile")
+  end
 end


### PR DESCRIPTION
## What
Adds two options to the service navigation component.

## Why
Trying out some options to allow us to fit the service navigation component to a possible design.

## Visual Changes
Columns layout is relatively easy to demonstrate. The links sit to one side of the service name. Appearance on mobile is unchanged.

<img width="927" height="160" alt="Screenshot 2026-07-08 at 12 16 23" src="https://github.com/user-attachments/assets/b2baa76c-26dc-4a37-b355-f4d39754daa3" />

The links on mobile option is a little more complicated. We want to keep the service name as distinct from the rest of the links on desktop, but avoid duplication of that text/link on mobile. So we add a duplicate link to the service name that is only shown on mobile, because the service name link is hidden on mobile.

Essentially, we're allowing the `My service home` link to be shown on desktop and mobile, but using different elements.

On desktop:

<img width="932" height="92" alt="Screenshot 2026-07-08 at 12 19 31" src="https://github.com/user-attachments/assets/a0a9e6cd-0da1-4fa5-b253-cabec52354b3" />

On mobile:

<img width="545" height="225" alt="Screenshot 2026-07-08 at 12 19 42" src="https://github.com/user-attachments/assets/c1ddf884-b961-4c33-aacd-fb9e8c92f7b1" />

