### PR TITLE
Release version 66.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 66.7.1
 
 * Set chart component's chartArea to auto ([PR #5561](https://github.com/alphagov/govuk_publishing_components/pull/5561))
 * Add chartkick to the gemspec ([PR #5558](https://github.com/alphagov/govuk_publishing_components/pull/5558))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (66.7.0)
+    govuk_publishing_components (66.7.1)
       chartkick
       govuk_app_config
       govuk_personalisation (>= 0.7.0)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "66.7.0".freeze
+  VERSION = "66.7.1".freeze
 end


### PR DESCRIPTION
## 66.7.1

* Set chart component's chartArea to auto ([PR #5561](https://github.com/alphagov/govuk_publishing_components/pull/5561))
* Add chartkick to the gemspec ([PR #5558](https://github.com/alphagov/govuk_publishing_components/pull/5558))
* Do not render hidden "share" text elements if no hidden text is provided ([PR #5554](https://github.com/alphagov/govuk_publishing_components/pull/5554))