### PR TITLE
Remove $govuk-new-typography-scale feature flag

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/settings/_index.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/settings/_index.scss
@@ -1,4 +1,3 @@
 @import "app-font-url";
 @import "app-image-url";
 @import "colours";
-@import "typography";

--- a/app/assets/stylesheets/govuk_publishing_components/settings/_typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/settings/_typography.scss
@@ -1,1 +1,0 @@
-$govuk-new-typography-scale: true;


### PR DESCRIPTION
## What
Remove `$govuk-new-typography-scale` feature flag as requested in [govuk-frontend v6.0.0 release notes](https://github.com/alphagov/govuk-frontend/releases/tag/v6.0.0#:~:text=Remove%20references%20to%20the%20%24govuk%2Dnew%2Dtypography%2Dscale%20feature%20flag).

Percy is reporting no visual differences even at the highest precision setting which I've enabled for this PR: 

<img width="425" height="254" alt="Screenshot 2026-07-08 at 16 18 50" src="https://github.com/user-attachments/assets/3154a235-2413-4238-b424-a1831c5c20a1" />


### Background
The feature flag was first made available in [v5.2.0](https://github.com/alphagov/govuk-frontend/blob/main/CHANGELOG.md#520-feature-release). We enabled the feature in https://github.com/alphagov/govuk_publishing_components/pull/4160/changes/f4e30994704da6ac030e2702d8a2b0fdb2eb34e6 and simultaneously made some minor adjustments for the new type scale (https://github.com/alphagov/govuk_publishing_components/pull/4160/changes/0b9904a647e91234b3d61fabbb8f8cf83df1d204 and https://github.com/alphagov/govuk_publishing_components/pull/4160/changes/8e63a0d096d749c738a58999910194857c5d15ae).

## Why
https://gov-uk.atlassian.net/browse/NAV-18916