### PR TITLE
Remove govuk-chat from auditing tools

### DIFF
--- a/app/controllers/govuk_publishing_components/applications_page_controller.rb
+++ b/app/controllers/govuk_publishing_components/applications_page_controller.rb
@@ -12,7 +12,7 @@ module GovukPublishingComponents
         },
         {
           type: "utility",
-          apps: %w[account-api signon govspeak govspeak-preview release govuk-developer-docs govuk-chat govuk_web_banners].sort,
+          apps: %w[account-api signon govspeak govspeak-preview release govuk-developer-docs govuk_web_banners].sort,
         },
       ]
 

--- a/app/controllers/govuk_publishing_components/audit_controller.rb
+++ b/app/controllers/govuk_publishing_components/audit_controller.rb
@@ -15,7 +15,6 @@ module GovukPublishingComponents
         frontend
         govspeak
         govspeak-preview
-        govuk-chat
         govuk-developer-docs
         govuk_web_banners
         local-links-manager


### PR DESCRIPTION
## What / why
- removing `govuk-chat` from the component and application auditing
- its not our application so even if the auditing raises some issues we're not going to fix them, so including it seems unnecessary

## Visual Changes
None.