### PR TITLE
Add header_three_quarters option to the chart component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add header_three_quarters option to the chart component ([PR #5567](https://github.com/alphagov/govuk_publishing_components/pull/5567))
 * Add options to the service navigation component ([PR #5562](https://github.com/alphagov/govuk_publishing_components/pull/5562))
 
 ## 66.7.1

--- a/app/assets/stylesheets/govuk_publishing_components/components/_chart.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_chart.scss
@@ -42,10 +42,17 @@
   margin-bottom: govuk-spacing(2);
 }
 
-.gem-c-chart__heading {
-  // Ensure heading content width is constrained to two thirds on desktop
+.gem-c-chart__header {
+  // Ensure header content width is constrained to two thirds on desktop
   @include govuk-media-query($from: "desktop") {
-    max-width: 66.6667%;
+    max-width: 630px;
+  }
+}
+
+.gem-c-chart__header--three-quarters {
+  // Ensure header content width is constrained to three quarters on desktop
+  @include govuk-media-query($from: "desktop") {
+    max-width: 742.5px;
   }
 }
 

--- a/app/views/govuk_publishing_components/components/_chart.html.erb
+++ b/app/views/govuk_publishing_components/components/_chart.html.erb
@@ -7,6 +7,9 @@
   download_link ||= false
   heading ||= nil
   description ||= nil
+  header_three_quarters ||= false
+  header_class = "gem-c-chart__header"
+  header_class << "--three-quarters" if header_three_quarters
   source ||= false
 
   if !heading || !description
@@ -33,7 +36,7 @@
     <% @include_script[:script_included] = true %>
   <% end %>
   <%= tag.div(**component_helper.all_attributes) do %>
-    <div class="gem-c-chart__heading">
+    <div class="<%= header_class %>">
         <%= render "govuk_publishing_components/components/heading", {
           text: heading,
           heading_level: heading_level,

--- a/app/views/govuk_publishing_components/components/docs/chart.yml
+++ b/app/views/govuk_publishing_components/components/docs/chart.yml
@@ -423,3 +423,42 @@ examples:
             - 118
             - 85
             - 80
+  with_a_different_header_max_width:
+    description: |
+      By default, the `max-width` of the header (heading and description) is set to `630px` which is the width of a standard GOV.UK two-thirds column. This prevents the header being too wide for legibility purposes if it is rendered in a full width container.
+
+      In some cases you might want the `max-width` to match the width of a three quarter column. Therefore you can set `header_three_quarters` to increase the max width to `742.5px`.
+    data:
+      header_three_quarters: true
+      heading: This heading is intentionally quite long to demonstrate the max width functionality of the component
+      h_axis_title: Day
+      v_axis_title: Views
+      description: Additionally, this is a description with quite a lot of words so that you can see how the description looks with a max width of three-quarters.
+      height: 200
+      keys:
+        - 1st
+        - 2nd
+        - 3rd
+        - 4th
+        - 5th
+        - 6th
+        - 7th
+      rows:
+        - label: January 2015
+          values:
+            - 5
+            - 119
+            - 74
+            - 117
+            - 33
+            - 89
+            - 79
+        - label: January 2016
+          values:
+            - 3
+            - 8
+            - 37
+            - 82
+            - 118
+            - 85
+            - 80

--- a/spec/components/chart_spec.rb
+++ b/spec/components/chart_spec.rb
@@ -144,4 +144,19 @@ describe "Chart", type: :view do
       render_component(data)
     }.to raise_error("A heading and description must be provided for accessibility purposes.")
   end
+
+  it "has the gem-c-chart__header class by default" do
+    render_component(data)
+
+    assert_select ".gem-c-chart__header"
+    assert_select ".gem-c-chart__header--three-quarters", false
+  end
+
+  it "can replace the gem-c-chart__header class with the gem-c-chart__header--three-quarters class" do
+    data[:header_three_quarters] = true
+    render_component(data)
+
+    assert_select ".gem-c-chart__header", false
+    assert_select ".gem-c-chart__header--three-quarters"
+  end
 end


### PR DESCRIPTION
## What / Why
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- The chart component had a `max-width: 66%` restriction on the heading and description
- Instead use `max-width: 630px` otherwise when the heading is in a two-thirds column, it will only take up 66% of the width of the column
- Also add a `header_max_width` option that allows the value to be changed to accommodate for different column widths

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

| Before | After |
|--------|--------|
| <img width="885" height="899" alt="image" src="https://github.com/user-attachments/assets/c7ab29b6-c0df-4cae-aeff-099602573a00" />  | <img width="885" height="899" alt="image" src="https://github.com/user-attachments/assets/d3978754-e20e-414e-9807-7f8e2fed1d93" /> |
