### PR TITLE
BREAKING: remove the aria_live option from the notice component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* **BREAKING:** remove the aria_live option from the notice component ([PR #5568](https://github.com/alphagov/govuk_publishing_components/pull/5568))
+
 ## 66.9.0
 
 * Improve the look of the metadata component ([PR #5552](https://github.com/alphagov/govuk_publishing_components/pull/5552))

--- a/app/views/govuk_publishing_components/components/_notice.html.erb
+++ b/app/views/govuk_publishing_components/components/_notice.html.erb
@@ -3,7 +3,6 @@
   description_text ||= false
   description_govspeak ||= false
   description ||= yield || false
-  aria_live ||= false
   lang = local_assigns[:lang].presence
   local_assigns[:margin_bottom] ||= 8
   local_assigns[:margin_bottom] = 8 if local_assigns[:margin_bottom] > 9
@@ -17,7 +16,6 @@
   component_helper.add_class("govuk-notification-banner gem-c-notice")
 
   component_helper.add_aria_attribute({ label: "Notice" })
-  component_helper.add_aria_attribute({ live: "polite" }) if aria_live
   component_helper.add_aria_attribute({ labelledby: banner_title_id }) if show_banner_title
 
   component_helper.set_lang(lang)

--- a/app/views/govuk_publishing_components/components/docs/notice.yml
+++ b/app/views/govuk_publishing_components/components/docs/notice.yml
@@ -37,12 +37,6 @@ examples:
   without_title:
     data:
       description_govspeak: '<p>Scheduled to publish at 8am on 25 April 2019</p><ul><li><a href="change-date">Change date</a></li><li><a href="stop-scheduled-publishing">Stop scheduled publishing</a></li></ul>'
-  with_aria_live:
-    description: Passing the aria live flag to the notice component will read the notice out to users if the notice changes, e.g on form submission the notice may go from hidden to visible.
-    data:
-      title: 'Your settings have been saved'
-      description_govspeak: <p>This is a confirmation message to tell you your settings have been saved</p>
-      aria_live: true
   with_locale:
     description: |
       Passing a lang value allows the content of the notice to be labelled as being a different language from surrounding content.

--- a/spec/components/notice_spec.rb
+++ b/spec/components/notice_spec.rb
@@ -72,8 +72,8 @@ describe "Notice", type: :view do
     assert_select ".gem-c-notice__title", text: 'Advisory Committee on Novel Foods and Processes has a <a href="http://www.food.gov.uk/acnfp">separate website</a>'
   end
 
-  it "adds an aria-live attribute when the aria-live flag is provided" do
-    render_component(title: "Your settings have been saved", aria_live: true)
+  it "adds an aria-live attribute when the aria value is provided" do
+    render_component(title: "Your settings have been saved", aria: { live: "polite" })
     assert_select ".gem-c-notice[aria-live=polite]"
   end
 


### PR DESCRIPTION
## What / Why

- The component wrapper has a built in aria option, so this isn't needed.
- I've looked on GitHub and I don't think any app is using this option either so it should be safe to remove, even though it's considered a breaking change.

## Visual Changes

None.
