### PR TITLE
Update emergency banner colours

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_emergency-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_emergency-banner.scss
@@ -52,14 +52,11 @@
 }
 
 .gem-c-emergency-banner--national-emergency {
-  // Not using govuk-colour("red") aka #d4351c as that's a slightly different red.
-  background-color: #b10e1e;
+  background-color: govuk-colour("red", $variant: "shade-25");
 }
 
 .gem-c-emergency-banner--local-emergency {
-  // Not using govuk-colour("turquoise") for background colour as
-  // the contrast was too low with white text
-  background-color: #00847d;
+  background-color: govuk-colour("teal", $variant: "shade-25");
 }
 
 @include govuk-media-query($media-type: print) {


### PR DESCRIPTION
## What

Update emergency banner colours

- https://gov-uk.atlassian.net/browse/NAV-18924
- https://gov-uk.atlassian.net/browse/NAV-18929

## Why

- Replace non-standard colours
- Improve colour contrast ratios to meet accessibility requirements.

## Visual Changes

### National emergency (before)

<img width="1920" height="320" alt="components publishing service gov uk_component-guide_emergency_banner_national_emergency_preview" src="https://github.com/user-attachments/assets/2e8e6eb3-0152-4beb-a35b-6cc16a593bc8" />

### National emergency (after)

<img width="1920" height="320" alt="components-gem-pr-5569 herokuapp com_component-guide_emergency_banner_national_emergency_preview" src="https://github.com/user-attachments/assets/7b4723ab-c2f3-4012-9dc3-14dba61ebca6" />

### Local emergency (before)

<img width="1920" height="320" alt="components publishing service gov uk_component-guide_emergency_banner_local_emergency_preview" src="https://github.com/user-attachments/assets/04938ae9-183a-48c2-8618-408a69aa480e" />

### Local emergency (after)

<img width="1920" height="320" alt="components-gem-pr-5569 herokuapp com_component-guide_emergency_banner_local_emergency_preview" src="https://github.com/user-attachments/assets/61899ea2-e997-4de0-9dd1-d282a917baf5" />