### PR TITLE
Update breadcrumb font size print styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add options to the details component ([PR #5594](https://github.com/alphagov/govuk_publishing_components/pull/5594))
 * **BREAKING:** remove the aria_live option from the notice component ([PR #5568](https://github.com/alphagov/govuk_publishing_components/pull/5568))
 * Tidy up organisation colours stylesheet ([PR #5578](https://github.com/alphagov/govuk_publishing_components/pull/5578))
+* Update breadcrumb font size print styles ([PR #5570](https://github.com/alphagov/govuk_publishing_components/pull/5570))
 
 ## 66.9.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_breadcrumbs.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_breadcrumbs.scss
@@ -28,10 +28,6 @@
 }
 
 @include govuk-media-query($media-type: print) {
-  .gem-c-breadcrumbs {
-    font-size: 12pt;
-  }
-
   .gem-c-breadcrumbs,
   .govuk-breadcrumbs {
     .govuk-breadcrumbs__list-item {


### PR DESCRIPTION
## What

Update print styles

## Why

## Visual Changes

### Breadcrumbs (changes font size from 12pt to 14pt)

<img width="1728" height="1117" alt="Screenshot 2026-07-10 at 15 22 00" src="https://github.com/user-attachments/assets/d4999cdf-7670-4f4f-93ad-b2081bb7cf44" />