### PR TITLE
Remove deprecated organisation colours flag and suppressed warnings for deprecated organisations

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/settings/_colours.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/settings/_colours.scss
@@ -1,5 +1,3 @@
-$govuk-new-organisation-colours: true;
-
 $govuk-suppressed-warnings: (
   organisation-colours
 );

--- a/app/assets/stylesheets/govuk_publishing_components/settings/_colours.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/settings/_colours.scss
@@ -1,3 +1,0 @@
-$govuk-suppressed-warnings: (
-  organisation-colours
-);

--- a/app/assets/stylesheets/govuk_publishing_components/settings/_index.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/settings/_index.scss
@@ -1,3 +1,2 @@
 @import "app-font-url";
 @import "app-image-url";
-@import "colours";


### PR DESCRIPTION
## What
Remove deprecated feature flag for the new organisation colour palette as requested in the [v6.0.0 release notes](https://gov-uk.atlassian.net/jira/software/c/projects/NAV/boards/1422?selectedIssue=NAV-18919#:~:text=Update%20to%20the%20latest%20organisation%20colour%20palette ). We had already opted into the feature in https://github.com/alphagov/govuk_publishing_components/pull/4160; we also simultaneously [changed `web-safe` to `contrast-safe` parameter](https://github.com/alphagov/govuk_publishing_components/pull/4160/changes/8580845d45f079bc860ba1661153c5e557e3803e) as requested in the release notes.

Also remove suppressed warnings for deprecated organisations. We originally suppressed the warnings about deprecated organisations in https://github.com/alphagov/govuk_publishing_components/pull/4185. The warnings were not coming from organisation names used in the gem but in `/node_modules/govuk-frontend/dist/govuk/settings/_colours-organisations.scss`. As v6.0.0 updates those names, we no longer need to suppress the warnings.

As this change removes the `settings/colours` file, I've also checked through the docs in the gem but couldn't see anything documenting this file which might need to be updated. 

## Why
https://gov-uk.atlassian.net/jira/software/c/projects/NAV/boards/1422?selectedIssue=NAV-18919


