### PR TITLE
Update frontend apps to ensure the new functional colour custom prope…

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/all-components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/all-components.scss
@@ -1,3 +1,5 @@
+$govuk-output-custom-properties: true;
+
 @import "base";
 
 @import "govuk/core/index";

--- a/app/assets/stylesheets/govuk_publishing_components/settings/_custom-properties.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/settings/_custom-properties.scss
@@ -1,0 +1,9 @@
+// Default the `govuk-output-custom-properties` flag to false to prevent custom properties
+// being output multiple times.
+// Entry points such as `all-components.scss` and `specific-components` override this
+// value when they need to include custom properties (for example, the component guide
+// or application stylesheets where there is only a single stylesheet).
+// Direct imports of base (e.g. secondary stylesheets) keep the default value of `false`,
+// rather than using the GOV.UK Frontend default of `true`.
+
+$govuk-output-custom-properties: false !default;

--- a/app/assets/stylesheets/govuk_publishing_components/settings/_index.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/settings/_index.scss
@@ -1,2 +1,3 @@
 @import "app-font-url";
 @import "app-image-url";
+@import "custom-properties";

--- a/app/assets/stylesheets/govuk_publishing_components/specific-components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/specific-components.scss
@@ -1,3 +1,5 @@
+$govuk-output-custom-properties: true;
+
 @import "base";
 
 @import "govuk/core/index";


### PR DESCRIPTION
## What

In preparation for the upgrade to the Design System v6, this PR centralises the configuration of the `$govuk-output-custom-properties` setting within the gem. This ensures that standalone and secondary stylesheets exclude duplicate custom properties automatically, while primary files such as `application.css` still load once as required.

## Why

In v6, importing the core base styles automatically outputs a block of functional colour custom properties. Because `base` is used as a foundational tool across many stylesheets, this causes redundant code duplication in compiled CSS production.

To solve this centrally in the gem without modifying many individual entry points across our frontend applications, we have introduced a new `_custom-properties.scss` settings file imported via `settings/_index.scss`. 

This follows the implementation pattern outlined in this [govuk-frontend PR](https://github.com/alphagov/govuk-frontend/pull/6606).

Jira card: https://gov-uk.atlassian.net/browse/NAV-18925

## Visual changes

There should be no visual changes. This is makes an improvement to the asset pipeline only. The functional colour custom properties are still loaded globally via the primary layout's `application.css`, so components rendered on these pages will inherit their functional colours as expected.

## Testing

This change was tested locally by pointing the application's Gemfile directly to the gem to simulate the upcoming production environment. Ran and checked local asset compilation to ensure the build completes without errors.

### Frontend
Before
<img width="1469" height="703" alt="Screenshot 2026-07-13 at 12 55 23" src="https://github.com/user-attachments/assets/36108f51-4245-4b4c-a831-d7d4a037e893" />
After
<img width="1473" height="708" alt="Screenshot 2026-07-13 at 12 56 00" src="https://github.com/user-attachments/assets/e1eaef53-76cc-4cef-8a6c-8bc6c84a2bad" />

### Collections
Before
<img width="1914" height="929" alt="Screenshot 2026-07-13 at 12 56 50" src="https://github.com/user-attachments/assets/390ad985-02f3-4ebb-a6a2-2447eb40d3ed" />
After
<img width="1911" height="927" alt="Screenshot 2026-07-13 at 12 59 31" src="https://github.com/user-attachments/assets/ef174c84-ca24-461b-8746-44cca63d614d" />

### !default flag
Tested with and without using the [!default property](https://sass-lang.com/documentation/variables/#:~:text=Default%20Values,-Normally%20when%20you&text=To%20make%20this%20possible%2C%20Sass,existing%20value%20will%20be%20used.). Found that we require !default so the false setting acts as a flexible fallback rather than a hard override. This allows the secondary stylesheets to automatically default to false since no variable was declared beforehand, while preventing the file from accidentally reverting the `$govuk-output-custom-properties: true;` intentionally set at the top of application.css. See attached image where removing the !default flag wipes the functional colour custom properties from the compiled `application.css`.

Without !default - Missing functional colour custom properties 
<img width="1909" height="929" alt="Screenshot 2026-07-13 at 13 31 29" src="https://github.com/user-attachments/assets/3f466db8-92c4-4166-b287-05cb8c0c0eef" />



