### PR TITLE
Release Version 66.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 66.8.0
 
 * Remove columns layout from service nav component ([PR #5576](https://github.com/alphagov/govuk_publishing_components/pull/5576))
 * Add header_three_quarters option to the chart component ([PR #5567](https://github.com/alphagov/govuk_publishing_components/pull/5567))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (66.7.1)
+    govuk_publishing_components (66.8.0)
       chartkick
       govuk_app_config
       govuk_personalisation (>= 0.7.0)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "66.7.1".freeze
+  VERSION = "66.8.0".freeze
 end


### PR DESCRIPTION
## 66.8.0

* Remove columns layout from service nav component ([PR #5576](https://github.com/alphagov/govuk_publishing_components/pull/5576))
* Add header_three_quarters option to the chart component ([PR #5567](https://github.com/alphagov/govuk_publishing_components/pull/5567))
* Add options to the service navigation component ([PR #5562](https://github.com/alphagov/govuk_publishing_components/pull/5562))
* Announce big number component as one element in JAWS and NVDA ([PR #5458](https://github.com/alphagov/govuk_publishing_components/pull/5458))