### PR TITLE
Remove columns layout from service nav component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@
 
 ## Unreleased
 
+* Remove columns layout from service nav component ([PR #5576](https://github.com/alphagov/govuk_publishing_components/pull/5576))
 * Add header_three_quarters option to the chart component ([PR #5567](https://github.com/alphagov/govuk_publishing_components/pull/5567))
 * Add options to the service navigation component ([PR #5562](https://github.com/alphagov/govuk_publishing_components/pull/5562))
 * Announce big number component as one element in JAWS and NVDA ([PR #5458](https://github.com/alphagov/govuk_publishing_components/pull/5458))
-
 
 ## 66.7.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_service-navigation.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_service-navigation.scss
@@ -23,12 +23,3 @@
     margin-top: govuk-spacing(2);
   }
 }
-
-.gem-c-service-navigation--columns-layout {
-  .govuk-service-navigation__container {
-    @include govuk-media-query($from: tablet) {
-      display: grid;
-      grid-template-columns: auto 1fr;
-    }
-  }
-}

--- a/app/views/govuk_publishing_components/components/_service_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_service_navigation.html.erb
@@ -7,13 +7,11 @@
   inverse ||= false
   hide_service_name_on_mobile ||= false
   collapse_navigation_on_mobile = local_assigns.fetch(:collapse_navigation_on_mobile, navigation_items.length > 1)
-  columns_layout ||= false
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-service-navigation govuk-service-navigation")
   component_helper.add_class("govuk-service-navigation--inverse") if inverse
   component_helper.add_class("gem-c-service-navigation--hide-service-name-on-mobile") if hide_service_name_on_mobile
-  component_helper.add_class("gem-c-service-navigation--columns-layout") if columns_layout
   component_helper.add_aria_attribute({ label: "Service information" }) if service_name.present?
   component_helper.add_data_attribute({ module: "govuk-service-navigation" })
 

--- a/app/views/govuk_publishing_components/components/docs/service_navigation.yml
+++ b/app/views/govuk_publishing_components/components/docs/service_navigation.yml
@@ -70,25 +70,6 @@ examples:
         href: "#"
       - text: Navigation item 3
         href: "#"
-  columns_layout:
-    description: Separates the service name and the navigation items into two separate columns on desktop. Has no effect on mobile or when the service name is not present.
-    data:
-      service_name: My service home
-      service_name_url: "/home"
-      columns_layout: true
-      navigation_items:
-      - text: Introduction
-        href: "#"
-      - text: Help and guidance
-        href: "#"
-      - text: The application process
-        href: "#"
-      - text: Your first application
-        href: "#"
-      - text: Contact us
-        href: "#"
-      - text: Further reading
-        href: "#"
   with_data_attributes_on_items:
     data:
       navigation_items:

--- a/spec/components/service_navigation_spec.rb
+++ b/spec/components/service_navigation_spec.rb
@@ -158,18 +158,4 @@ describe "Service navigation", type: :view do
     })
     assert_select(".gem-c-service-navigation--hide-service-name-on-mobile")
   end
-
-  it "renders the columns_layout option correctly" do
-    render_component({
-      navigation_items: [
-        {
-          text: "Navigation item 1",
-          href: "#",
-        },
-      ],
-      columns_layout: true,
-      service_name: "My service home",
-    })
-    assert_select(".gem-c-service-navigation--columns-layout")
-  end
 end


### PR DESCRIPTION
## What / why
- removes the columns_layout option from the service navigation component, as this isn't in use or needed anymore
- was used as part of some intended work, but the layout proved impractical with real content

## Visual Changes
Removes this layout option:

<img width="1027" height="170" alt="Screenshot 2026-07-13 at 15 12 47" src="https://github.com/user-attachments/assets/392bd029-fc6e-4835-9b51-51f86ef616b2" />
