### PR TITLE
Tidy up organisation colours stylesheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * **BREAKING:** remove the aria_live option from the notice component ([PR #5568](https://github.com/alphagov/govuk_publishing_components/pull/5568))
+* Tidy up organisation colours stylesheet ([PR #5578](https://github.com/alphagov/govuk_publishing_components/pull/5578))
 
 ## 66.9.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
@@ -13,40 +13,6 @@
 
 @include organisation-brand-colour;
 
-// in the past we used the-office-of-the-leader-of-the-house-of-commons before
-// the "the" prefix was dropped, this is maintained here for backwards
-// compatibility
-.brand--the-office-of-the-leader-of-the-house-of-commons {
-  &.brand__border-color,
-  .brand__border-color {
-    border-color: govuk-organisation-colour("office-of-the-leader-of-the-house-of-commons", $contrast-safe: false);
-  }
-}
-// colours for the prime ministers office are not included in the toolkit
-// so are written out here for our use
-
-.brand--prime-ministers-office-10-downing-street {
-  .brand__color {
-    color: govuk-colour("black");
-
-    &:link,
-    &:visited,
-    &:active {
-      color: govuk-colour("black");
-    }
-
-    &:hover,
-    &:focus {
-      color: $govuk-focus-text-colour;
-    }
-  }
-
-  &.brand__border-color,
-  .brand__border-color {
-    border-color: govuk-colour("black");
-  }
-}
-
 // in the toolkit, civil service has red for the text and borders
 // but the required border colour is black, ideally would fix this in
 // the toolkit but other things are using it
@@ -55,15 +21,6 @@
   &.brand__border-color,
   .brand__border-color {
     border-color: govuk-colour("black");
-  }
-}
-
-// Temp colour overrides
-
-.brand--department-for-science-innovation-and-technology {
-  &.brand__border-color,
-  .brand__border-color {
-    border-color: govuk-organisation-colour("department-for-science-innovation-technology", $contrast-safe: false);
   }
 }
 

--- a/app/views/govuk_publishing_components/components/docs/organisation_logo.yml
+++ b/app/views/govuk_publishing_components/components/docs/organisation_logo.yml
@@ -99,7 +99,7 @@ examples:
       organisation:
         name: 'Office of the <br>Leader of the <br>House of Commons'
         url: '/government/organisations/the-office-of-the-leader-of-the-house-of-commons'
-        brand: 'the-office-of-the-leader-of-the-house-of-commons'
+        brand: 'office-of-the-leader-of-the-house-of-commons'
         crest: 'portcullis'
   wales_office:
     data:


### PR DESCRIPTION
## What
This PR cleans up and refactors the custom brand colours stylesheet by removing hardcoded overrides and aligning various department pages with the Design System.

- DSIT, 10 Downing Street and Office of the Leader of the House of Commons styles are no longer required and have been removed
- Removed 'The' from Office of the Leader of the House of Commons brand in the component guide

## Why
Many of these overrides were introduced years ago to handle specific visual conflicts that have since been resolved. This PR removes hardcoded exceptions in the stylesheets, ensuring cleaner code and making organisation colours more maintainable. 

Jira card: https://gov-uk.atlassian.net/browse/NAV-19016

## Visual Changes

### DSIT Organisation Page (no change)
<img width="997" height="658" alt="Screenshot 2026-07-17 at 16 08 30" src="https://github.com/user-attachments/assets/bc74ad56-3e7b-46af-ae1c-5be103a3916c" />

### Prime Minister's Office 10 Downing Street Organisation Page (black override removed on borders and links)
| Before | After |
|--------|--------|
| <img width="1006" height="922" alt="Screenshot 2026-07-17 at 16 11 24" src="https://github.com/user-attachments/assets/b2e837f2-0d8a-48e4-8648-8d17999a88a0" /> | <img width="1009" height="925" alt="Screenshot 2026-07-17 at 16 11 20" src="https://github.com/user-attachments/assets/3fc7ef8a-c33d-4a87-9ce4-36c00a381b6b" /> |

### Office of the Leader of the House of Commons Organisation Page (no change)
<img width="1031" height="757" alt="Screenshot 2026-07-17 at 16 14 14" src="https://github.com/user-attachments/assets/bade459e-ac36-435c-8c71-49d22680c8b9" />