### PR TITLE
Remove the unused "app name" option from the phase banner component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Merge published dates component into metadata component ([PR #5572](https://github.com/alphagov/govuk_publishing_components/pull/5572))
+* Remove the unused "app name" option from the phase banner component ([PR #5579](https://github.com/alphagov/govuk_publishing_components/pull/5579))
 
 ## 66.8.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_phase-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_phase-banner.scss
@@ -1,19 +1,11 @@
 @import "govuk/components/phase-banner/phase-banner";
 
-.gem-c-phase-banner {
-  .govuk-phase-banner__content__app-name {
-    display: inline-block;
-    margin-right: govuk-spacing(2);
-  }
-}
-
 .gem-c-phase-banner--inverse {
   .govuk-phase-banner__content__tag {
     background: govuk-colour("white");
     color: $govuk-brand-colour;
   }
 
-  .govuk-phase-banner__content__app-name,
   .govuk-phase-banner__text,
   .govuk-link {
     color: govuk-colour("white");
@@ -36,11 +28,6 @@
     .govuk-tag {
       border: 1pt solid $govuk-print-text-colour;
     }
-  }
-
-  .govuk-phase-banner__content__app-name {
-    margin-bottom: 1mm;
-    font-size: 12pt;
   }
 }
 // stylelint-enable declaration-no-important

--- a/app/views/govuk_publishing_components/components/_phase_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_phase_banner.html.erb
@@ -1,5 +1,4 @@
 <%
-app_name ||= nil
 phase ||= nil
 message ||= nil
 inverse ||= false
@@ -33,7 +32,6 @@ end
 
 <%= tag.div(**component_helper.all_attributes) do %>
   <%= tag.p class: "govuk-phase-banner__content" do %>
-    <%= tag.strong app_name, class: "govuk-phase-banner__content__app-name" if app_name %>
     <%= tag.strong phase.titleize, class: "govuk-tag govuk-phase-banner__content__tag" if phase %>
     <%= tag.span message, class: "govuk-phase-banner__text" if message %>
   <% end %>

--- a/app/views/govuk_publishing_components/components/docs/phase_banner.yml
+++ b/app/views/govuk_publishing_components/components/docs/phase_banner.yml
@@ -20,19 +20,8 @@ examples:
       phase: beta
       message: This is an optional different message to explain what the state means in this
         context which can take <a class="govuk-link" href='https://www.gov.uk'>HTML</a>
-  with_app_name:
-    data:
-      app_name: Skittles Maker
-      phase: beta
   inverse_for_blue_background:
     data:
-      phase: beta
-      inverse: true
-    context:
-      dark_background: true
-  inverse_for_blue_background_with_app_name:
-    data:
-      app_name: Skittles Maker
       phase: beta
       inverse: true
     context:
@@ -41,6 +30,5 @@ examples:
     description: |
       Disables GA4 tracking on the banner. Tracking is enabled by default. This includes link tracking on the component itself, and allows pageviews to record the presence of the banner on page load.
     data:
-      app_name: Skittles Maker
       phase: beta
       disable_ga4: true

--- a/spec/components/phase_banner_spec.rb
+++ b/spec/components/phase_banner_spec.rb
@@ -29,13 +29,6 @@ describe "Phase banner", type: :view do
     assert_select ".govuk-phase-banner__content__tag", text: "Beta"
   end
 
-  it "shows the app name" do
-    render_component(app_name: "Skittles Maker", phase: "beta")
-
-    assert_select ".govuk-phase-banner__content__app-name", text: "Skittles Maker"
-    assert_select ".govuk-phase-banner__content__tag", text: "Beta"
-  end
-
   it "correctly uses inverse mode" do
     render_component(phase: "beta", inverse: true)
     assert_select ".gem-c-phase-banner--inverse"


### PR DESCRIPTION
## What

Remove the unused `app_name` option from the phase banner component.

## Why

The `app_name` option is no longer used anywhere.

The only remaining references I could find are two occurrences in archived repos:
https://github.com/search?q=org%3Aalphagov+components%2Fphase_banner+app_name+-repo%3Aalphagov%2Fgovuk_publishing_components&type=code.