### PR TITLE
Version 66.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 66.9.0
 
 * Improve the look of the metadata component ([PR #5552](https://github.com/alphagov/govuk_publishing_components/pull/5552))
 * Merge published dates component into metadata component ([PR #5572](https://github.com/alphagov/govuk_publishing_components/pull/5572))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (66.8.0)
+    govuk_publishing_components (66.9.0)
       chartkick
       govuk_app_config
       govuk_personalisation (>= 0.7.0)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "66.8.0".freeze
+  VERSION = "66.9.0".freeze
 end


### PR DESCRIPTION
## 66.9.0

* Improve the look of the metadata component ([PR #5552](https://github.com/alphagov/govuk_publishing_components/pull/5552))
* Merge published dates component into metadata component ([PR #5572](https://github.com/alphagov/govuk_publishing_components/pull/5572))
* Remove the unused "app name" option from the phase banner component ([PR #5579](https://github.com/alphagov/govuk_publishing_components/pull/5579))
