### PR TITLE
Move to using `govuk-functional-colour` for borders and secondary text

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_app-promo-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_app-promo-banner.scss
@@ -46,7 +46,7 @@
 .gem-c-app-promo-banner__close-button {
   border: 0;
   padding: 0;
-  color: govuk-colour("black", $variant: "tint-25");
+  color: govuk-functional-colour("secondary-text");
   background: none;
   flex: 0 0 24px;
   height: 24px;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
@@ -23,7 +23,7 @@ $thumbnail-border-width: 5px;
   max-width: calc($thumbnail-width / 1.5);
   height: calc($thumbnail-height / 1.5);
   background: govuk-colour("white");
-  box-shadow: 0 2px 2px govuk-colour("black", $variant: "tint-50"), 0 0 0 5px govuk-colour("black", $variant: "tint-80");
+  box-shadow: 0 2px 2px govuk-colour("black", $variant: "tint-50"), 0 0 0 5px govuk-functional-colour("border");
   fill: govuk-colour("black", $variant: "tint-50");
   stroke: govuk-colour("black", $variant: "tint-50");
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_checkboxes.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_checkboxes.scss
@@ -6,7 +6,7 @@
   box-sizing: border-box;
   border-left-style: solid;
   border-left-width: 4px;
-  border-color: govuk-colour("black", $variant: "tint-80");
+  border-color: govuk-functional-colour("border");
   margin-top: govuk-spacing(2);
   margin-bottom: govuk-spacing(2);
   padding: govuk-spacing(2) govuk-spacing(4);

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cross-service-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cross-service-header.scss
@@ -259,7 +259,7 @@ $toggle-border-height: 3px;
     padding: govuk-spacing(3) 0;
 
     &:not(:last-child) {
-      border-bottom: 1px solid govuk-colour("black", $variant: "tint-80");
+      border-bottom: 1px solid govuk-functional-colour("border");
     }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -94,7 +94,7 @@
 }
 
 .gem-c-document-list__item--highlight {
-  border: 1px solid govuk-colour("black", $variant: "tint-80");
+  border: 1px solid govuk-functional-colour("border");
   padding: govuk-spacing(6);
   margin-bottom: govuk-spacing(6);
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -50,7 +50,7 @@
 }
 
 .gem-c-document-list__item-context {
-  color: govuk-colour("black", $variant: "tint-25");
+  color: govuk-functional-colour("secondary-text");
 }
 
 .gem-c-document-list__item-description {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_govspeak-html-publication.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_govspeak-html-publication.scss
@@ -113,7 +113,7 @@
       // total and subtotal rows
       tr.subtotal > *,
       tr.total > * {
-        border-top: 3px solid govuk-colour("black", $variant: "tint-80");
+        border-top: 3px solid govuk-functional-colour("border");
       }
 
       tr.total > *,

--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -75,7 +75,7 @@
   font-size: 16px;
   font-size: govuk-px-to-rem(16px);
   margin: 0 0 calc(govuk-spacing(3) / 2);
-  color: govuk-colour("black", $variant: "tint-25");
+  color: govuk-functional-colour("secondary-text");
   @include govuk-font($size: false);
 
   @include govuk-media-query($from: tablet) {
@@ -102,7 +102,7 @@
   }
 
   .gem-c-image-card__list-item--text {
-    color: govuk-colour("black", $variant: "tint-25");
+    color: govuk-functional-colour("secondary-text");
   }
 
   .gem-c-image-card__list-item-link {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -607,7 +607,7 @@ $search-icon-height: 20px;
 // JS available - styling for the "services-and-information" group of links
 .gem-c-layout-super-navigation-header__navigation-second-items--services-and-information {
   @include govuk-media-query($until: "desktop") {
-    border-bottom: 1px solid govuk-colour("black", $variant: "tint-80");
+    border-bottom: 1px solid govuk-functional-colour("border");
   }
 
   @include govuk-media-query($from: "desktop") {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_related-navigation.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_related-navigation.scss
@@ -11,7 +11,7 @@
 }
 
 .gem-c-related-navigation__sub-heading {
-  border-top: 1px solid govuk-colour("black", $variant: "tint-80");
+  border-top: 1px solid govuk-functional-colour("border");
   margin: 0;
   padding-top: govuk-spacing(3);
   @include govuk-font(16);

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search-with-autocomplete.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search-with-autocomplete.scss
@@ -98,7 +98,7 @@ $large-input-size: 50px;
   align-items: center;
   margin: 0 govuk-spacing(3);
   padding: govuk-spacing(1) 0;
-  border-bottom: 1px solid govuk-colour("black", $variant: "tint-80");
+  border-bottom: 1px solid govuk-functional-colour("border");
 }
 
 .gem-c-search-with-autocomplete__option:last-child .gem-c-search-with-autocomplete__option-wrapper {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_select-with-search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_select-with-search.scss
@@ -46,8 +46,8 @@ $choices-button-dimension: 12px !default;
 
   .choices[data-type*="select-multiple"] .choices__button,
   .choices[data-type*="text"] .choices__button {
-    border-color: govuk-colour("black", $variant: "tint-80");
-    border-right: 1px solid govuk-colour("black", $variant: "tint-80");
+    border-color: govuk-functional-colour("border");
+    border-right: 1px solid govuk-functional-colour("border");
     padding: govuk-spacing(2) govuk-spacing(4) govuk-spacing(2) govuk-spacing(2);
     margin-right: 0;
 
@@ -125,7 +125,7 @@ $choices-button-dimension: 12px !default;
     padding: 0 0 0 govuk-spacing(2);
     margin: govuk-spacing(2) govuk-spacing(2) 0 0;
     background-color: govuk-colour("black", $variant: "tint-95");
-    box-shadow: 0 $govuk-border-width-form-element 0 govuk-colour("black", $variant: "tint-80");
+    box-shadow: 0 $govuk-border-width-form-element 0 govuk-functional-colour("border");
     line-height: 1;
     color: govuk-functional-colour(text);
 
@@ -149,7 +149,7 @@ $choices-button-dimension: 12px !default;
   .choices__list--dropdown .choices__item,
   .choices__list[aria-expanded] .choices__item {
     position: relative;
-    border-bottom: 1px solid govuk-colour("black", $variant: "tint-80");
+    border-bottom: 1px solid govuk-functional-colour("border");
 
     &:last-child {
       border-bottom: 0;
@@ -168,7 +168,7 @@ $choices-button-dimension: 12px !default;
     @include govuk-typography-weight-bold;
     color: govuk-colour("black"); // Choices.js doesn't use a variable for this color for some reason :(
     padding: govuk-spacing(6) govuk-spacing(2) govuk-spacing(2);
-    border-bottom: 1px solid govuk-colour("black", $variant: "tint-80");
+    border-bottom: 1px solid govuk-functional-colour("border");
     cursor: default;
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
@@ -530,7 +530,7 @@ $top-border: solid 1px govuk-functional-colour("border");
 .gem-c-step-nav__context {
   display: inline-block;
   font-weight: normal;
-  color: govuk-colour("black", $variant: "tint-25");
+  color: govuk-functional-colour("secondary-text");
 
   &::before {
     content: " \2013\00a0"; // dash followed by &nbsp;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
@@ -1,7 +1,7 @@
 $stroke-width: 1px;
 $number-circle-size: 30px;
 $number-circle-size-large: 35px;
-$top-border: solid 1px govuk-colour("black", $variant: "tint-80");
+$top-border: solid 1px govuk-functional-colour("border");
 
 @mixin step-nav-vertical-line($line-style: solid) {
   content: "";
@@ -9,7 +9,7 @@ $top-border: solid 1px govuk-colour("black", $variant: "tint-80");
   z-index: 2;
   width: 0;
   height: 100%;
-  border-left: $line-style $stroke-width govuk-colour("black", $variant: "tint-80");
+  border-left: $line-style $stroke-width govuk-functional-colour("border");
   background: govuk-colour("white");
 }
 
@@ -261,7 +261,7 @@ $top-border: solid 1px govuk-colour("black", $variant: "tint-80");
     margin-left: calc($number-circle-size / 4);
     width: calc($number-circle-size / 2);
     height: 0;
-    border-bottom: solid $stroke-width govuk-colour("black", $variant: "tint-80");
+    border-bottom: solid $stroke-width govuk-functional-colour("border");
   }
 
   &::after {
@@ -319,7 +319,7 @@ $top-border: solid 1px govuk-colour("black", $variant: "tint-80");
 }
 
 .gem-c-step-nav__circle--number {
-  border: solid $stroke-width govuk-colour("black", $variant: "tint-80");
+  border: solid $stroke-width govuk-functional-colour("border");
   @include step-nav-font(16, $weight: bold, $line-height: 29px);
 
   .gem-c-step-nav--large & {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_sub-navigation-menu.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_sub-navigation-menu.scss
@@ -5,7 +5,7 @@
 
 .gem-c-sub-navigation-menu__button-container {
   background-color: govuk-colour("black", $variant: "tint-95");
-  border-bottom: 1px solid govuk-colour("black", $variant: "tint-80");
+  border-bottom: 1px solid govuk-functional-colour("border");
 }
 
 .gem-c-sub-navigation-menu__button-container--collapsed {
@@ -59,7 +59,7 @@
 }
 
 .gem-c-sub-navigation-menu__button[aria-expanded="true"] {
-  border-color: govuk-colour("black", $variant: "tint-80");
+  border-color: govuk-functional-colour("border");
   background-color: govuk-colour("white");
 
   @include govuk-media-query($until: tablet) {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_table.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_table.scss
@@ -1,7 +1,7 @@
 @import "govuk/components/table/table";
 
 $table-border-width: 1px;
-$table-border-colour: govuk-colour("black", $variant: "tint-80");
+$table-border-colour: govuk-functional-colour("border");
 $table-header-border-width: 2px;
 $table-header-background-colour: govuk-colour("black", $variant: "tint-95");
 $sort-link-active-colour: govuk-colour("white");

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
@@ -39,7 +39,7 @@
         width: $thumbnail-width;
         height: 140px;
         background: govuk-colour("white");
-        box-shadow: 0 2px 2px govuk-colour("black", $variant: "tint-50"), 0 0 0 5px govuk-colour("black", $variant: "tint-80");
+        box-shadow: 0 2px 2px govuk-colour("black", $variant: "tint-50"), 0 0 0 5px govuk-functional-colour("border");
 
         @include high-contrast-outline;
       }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_contact.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_contact.scss
@@ -12,7 +12,7 @@
   // .address is used by the `$A` markdown pattern
   .address,
   .contact {
-    border-left: 1px solid govuk-colour("black", $variant: "tint-80");
+    border-left: 1px solid govuk-functional-colour("border");
     padding-left: govuk-spacing(3);
     margin: 0 0 govuk-spacing(6) 0;
   }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_example.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_example.scss
@@ -8,7 +8,7 @@
 .govspeak, // Legacy class name that's still used in some content items - needs to be kept until `.govspeak` is removed from the content items.
 .gem-c-govspeak {
   .example {
-    border-left: 10px solid govuk-colour("black", $variant: "tint-80");
+    border-left: 10px solid govuk-functional-colour("border");
     padding: govuk-spacing(4) 0 0.1234px govuk-spacing(4); // non-zero padding on bottom keeps margin of last element inside parent, simulating padding
     margin: 0 0 govuk-spacing(4) 0;
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_footnotes.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_footnotes.scss
@@ -14,7 +14,7 @@
 .govspeak, // Legacy class name that's still used in some content items - needs to be kept until `.govspeak` is removed from the content items.
 .gem-c-govspeak {
   .footnotes {
-    border-top: 1px solid govuk-colour("black", $variant: "tint-80");
+    border-top: 1px solid govuk-functional-colour("border");
     margin: 0 0 govuk-spacing(4) 0;
     padding-top: govuk-spacing(4);
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_information-callout.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_information-callout.scss
@@ -9,7 +9,7 @@
 .govspeak, // Legacy class name that's still used in some content items - needs to be kept until `.govspeak` is removed from the content items.
 .gem-c-govspeak {
   .info-notice {
-    border-left: 10px solid govuk-colour("black", $variant: "tint-80");
+    border-left: 10px solid govuk-functional-colour("border");
     padding: govuk-spacing(4) 0 0.1234px govuk-spacing(4); // non-zero padding on bottom keeps margin of last element inside parent, simulating padding
     margin: 0 0 govuk-spacing(4) 0;
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_place.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_place.scss
@@ -3,7 +3,7 @@
 .gem-c-govspeak {
   .place {
     margin: 0 0 govuk-spacing(4) 0;
-    border-bottom: solid 1px govuk-colour("black", $variant: "tint-80");
+    border-bottom: solid 1px govuk-functional-colour("border");
     padding-bottom: 1.5em;
 
     .address {

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_tables.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_tables.scss
@@ -25,7 +25,7 @@
     td {
       vertical-align: top;
       padding: govuk-spacing(2) govuk-spacing(4) govuk-spacing(2) 0;
-      border-bottom: 1px solid govuk-colour("black", $variant: "tint-80");
+      border-bottom: 1px solid govuk-functional-colour("border");
 
       &:last-child {
         padding: govuk-spacing(2) 0 govuk-spacing(2) 0;

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_colours.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_colours.scss
@@ -3,7 +3,7 @@ $gem-secondary-button-hover-colour: darken($gem-secondary-button-colour, 5%);
 $gem-secondary-button-background-colour: govuk-colour("white");
 $gem-secondary-button-hover-background-colour: govuk-colour("black", $variant: "tint-95");
 
-$gem-quiet-button-colour: govuk-colour("black", $variant: "tint-25");
+$gem-quiet-button-colour: govuk-functional-colour("secondary-text");
 $gem-quiet-button-hover-colour: govuk-colour("black");
 $gem-quiet-button-hover-background-colour: govuk-colour("black", $variant: "tint-80");
 


### PR DESCRIPTION
## What
Replace instances where`govuk-colour("black", $variant: "tint-80")` is being used as border colour with `govuk-functional-colour("border")`. Also replace some instances of it in `box-shadow` where it is clearly being used as a border; if usage is more ambigious, do not replace with `govuk-functional-colour("border")`.

Replace instances where `govuk-colour("black", $variant: "tint-25")` is being used as secondary text colour with `govuk-functional-colour("secondary-text")`.

## Why
https://gov-uk.atlassian.net/browse/NAV-18929