### PR TITLE
Use the details component for toggling element visibility in the metadata component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Use the details component for toggling element visibility in the metadata component ([PR #5592](https://github.com/alphagov/govuk_publishing_components/pull/5592))
+
 ## 67.0.0
 
 * Add options to the details component ([PR #5594](https://github.com/alphagov/govuk_publishing_components/pull/5594))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Adjust cards content elements widths ([PR #](https://github.com/alphagov/govuk_publishing_components/pull/5665))
+* Use the details component for toggling element visibility in the metadata component ([PR #5592](https://github.com/alphagov/govuk_publishing_components/pull/5592))
 
 ## 68.1.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_metadata.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_metadata.scss
@@ -90,7 +90,7 @@
   display: none;
 }
 
-.gem-c-metadata--history {
+.gem-c-metadata--border-top {
   padding-top: govuk-spacing(2);
   border-top: 1px solid $govuk-border-colour;
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_metadata.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_metadata.scss
@@ -110,20 +110,28 @@
 }
 
 .gem-c-metadata__change-history {
-  margin: govuk-spacing(4) 0 0 0;
+  margin: 0;
   padding: 0;
   list-style: none;
 }
 
-.gem-c-metadata__change-date {
-  display: block;
-  margin: govuk-spacing(3) 0;
-  @include govuk-font(16, $weight: bold);
+.gem-c-metadata__change-history-item {
+  margin-bottom: govuk-spacing(4);
+
+  &:last-child {
+    margin: 0;
+  }
+
+  .gem-c-metadata__change-note {
+    margin: 0;
+    white-space: pre-line;
+  }
 }
 
-.gem-c-metadata__change-note {
-  margin: 0;
-  white-space: pre-line;
+.gem-c-metadata__change-date {
+  display: block;
+  margin: 0 0 govuk-spacing(3) 0;
+  @include govuk-font(16, $weight: bold);
 }
 
 // stylelint-disable declaration-no-important

--- a/app/views/govuk_publishing_components/components/_metadata.html.erb
+++ b/app/views/govuk_publishing_components/components/_metadata.html.erb
@@ -69,7 +69,7 @@
     <% end %>
     <% if local_assigns.include?(:last_updated) && last_updated %>
       <dt class="gem-c-metadata__term"><%= t("components.metadata.last_updated") %>:</dt>
-      <dd class="gem-c-metadata__definition" data-module="gem-toggle">
+      <dd class="gem-c-metadata__definition">
         <%= last_updated %>
         <% if local_assigns.include?(:see_updates_link) %>
           &#8212; <a href="#full-publication-update-history"
@@ -78,27 +78,19 @@
           </a>
         <% end %>
         <% if page_history.any? %>
-          <span aria-hidden="true">&#8212; </span>
-          <% page_history_toggle_id = "page-history-#{SecureRandom.hex(4)}" %>
-          <a
-            href="#full-history"
-            class="gem-c-metadata__toggle govuk-link"
-            data-controls="<%= page_history_toggle_id %>"
-            data-expanded="false"
-            data-toggled-text='<%= t("components.metadata.hide_all_updates", locale: :en) %>'
-            data-module="ga4-event-tracker"
-            data-ga4-event='<%= { event_name: "select_content", type: "content history", section: "Footer" }.to_json %>'
-            data-ga4-expandable>
-            <%= t("components.metadata.show_all_updates", locale: :en) %>
-          </a>
-          <ol class="gem-c-metadata__change-history js-hidden" id="<%= page_history_toggle_id %>">
-            <% page_history.each do |change| %>
-              <li>
-                <time class="gem-c-metadata__change-date timestamp" datetime="<%= change[:timestamp] %>"><%= change[:display_time] %></time>
-                <p class="gem-c-metadata__change-note"><%= change[:note].strip %></p>
-              </li>
-            <% end %>
-          </ol>
+          <%= render "govuk_publishing_components/components/details", {
+            title: t("components.metadata.show_all_updates", locale: :en),
+            small: true,
+          } do %>
+            <ol class="gem-c-metadata__change-history">
+              <% page_history.each do |change| %>
+                <li class="gem-c-metadata__change-history-item">
+                  <time class="gem-c-metadata__change-date" datetime="<%= change[:timestamp] %>"><%= change[:display_time] %></time>
+                  <p class="gem-c-metadata__change-note"><%= change[:note].strip %></p>
+                </li>
+              <% end %>
+            </ol>
+          <% end %>
         <% end %>
       </dd>
     <% end %>
@@ -111,10 +103,8 @@
         <% if definition.any? %>
           <dt class="gem-c-metadata__term"><%= title %>:</dt>
           <dd class="gem-c-metadata__definition"
-            <% if disable_ga4 %>
-              data-module="gem-toggle"
-            <% else %>
-              data-module="gem-toggle ga4-link-tracker"
+            <% unless disable_ga4 %>
+              data-module="ga4-link-tracker"
               data-ga4-link="<%= ga4_object %>"
             <% end %>>
             <%= render "govuk_publishing_components/components/metadata/sentence", items: definition, toggle_id: "#{index}-#{SecureRandom.hex(4)}" %>

--- a/app/views/govuk_publishing_components/components/_metadata.html.erb
+++ b/app/views/govuk_publishing_components/components/_metadata.html.erb
@@ -13,12 +13,12 @@
   other ||= nil
   inverse ||= false
   inverse_compress ||= false
+  border_top ||= false
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class("gem-c-metadata")
   component_helper.add_class("direction-#{direction}") if local_assigns.include?(:direction)
-
-  component_helper.add_class("gem-c-metadata--history") if page_history.any?
+  component_helper.add_class("gem-c-metadata--border-top") if border_top
   component_helper.set_id("full-publication-update-history") if page_history.any?
 
   if inverse

--- a/app/views/govuk_publishing_components/components/_metadata.html.erb
+++ b/app/views/govuk_publishing_components/components/_metadata.html.erb
@@ -49,13 +49,13 @@
   <dl class="gem-c-metadata__list">
     <% if from.any? %>
       <dt class="gem-c-metadata__term"><%= t("components.metadata.from") %>:</dt>
-      <dd class="gem-c-metadata__definition" data-module="gem-toggle">
+      <dd class="gem-c-metadata__definition">
         <%= render "govuk_publishing_components/components/metadata/sentence", items: from, toggle_id: "from-#{SecureRandom.hex(4)}" %>
       </dd>
     <% end %>
     <% if part_of.any? %>
       <dt class="gem-c-metadata__term"><%= t("components.metadata.part_of") %>:</dt>
-      <dd class="gem-c-metadata__definition" data-module="gem-toggle">
+      <dd class="gem-c-metadata__definition">
         <%= render "govuk_publishing_components/components/metadata/sentence", items: part_of, toggle_id: "part-of-#{SecureRandom.hex(4)}" %>
       </dd>
     <% end %>

--- a/app/views/govuk_publishing_components/components/docs/metadata.yml
+++ b/app/views/govuk_publishing_components/components/docs/metadata.yml
@@ -22,6 +22,10 @@ examples:
   history_only:
     data:
       history: Updated 2 weeks ago
+  with_border_top:
+    data:
+      border_top: true
+      from: <a href='/government/organisations/ministry-of-defence'>Ministry of Defence</a>
   published_and_updated:
     data:
       first_published: 14 June 2014
@@ -33,6 +37,37 @@ examples:
     data:
       last_updated: 10 September 2015
       see_updates_link: true
+  display_page_history:
+    description: |
+      This will set up an expandable section on the page, with a top border, to let users toggle the display of the page history. It also includes a hidden H2 heading of 'Updates to this page'. This heading will not be included if one is passed to the component using the `title` option.
+
+      This example includes an expandable 'part of' section to show both toggling elements working together in one component instance.
+    data:
+      border_top: true
+      part_of:
+        - <a href="/government/world/afghanistan">Afghanistan</a>
+        - <a href="/government/world/albania">Albania</a>
+        - <a href="/government/world/algeria">Algeria</a>
+        - <a href="/government/world/angola">Angola</a>
+        - <a href="/government/world/anguilla">Anguilla</a>
+        - <a href="/government/world/argentina">Argentina</a>
+        - <a href="/government/world/armenia">Armenia</a>
+        - <a href="/government/world/australia">Australia</a>
+        - <a href="/government/world/austria">Austria</a>
+        - <a href="/government/world/azerbaijan">Azerbaijan</a>
+        - <a href="/government/world/bahrain">Bahrain</a>
+      first_published: 1st January 1990
+      last_updated: 20th October 2016
+      page_history:
+      - display_time: 1st January 1990
+        note: First published
+        timestamp: 1990-01-01T15:42:37.000+00:00
+      - display_time: 20th July 1995
+        note: Updated to include information for 1994
+        timestamp: 1995-07-20T15:42:37.000+00:00
+      - display_time: 14th October 2000
+        note: Updated information on pupil premium reviews and what information schools need to publish on their websites.
+        timestamp: 2000-10-14T15:42:37.000+00:00
   extensive:
     data:
       from:
@@ -348,41 +383,6 @@ examples:
       first_published: 14 June 2014
       other:
         Applies to: England, Scotland, and Wales (see detailed guidance for <a href="http://www.dardni.gov.uk/news-dard-pa022-a-13-new-procedure-for" rel="external">Northern Ireland</a>)
-  with_border_top:
-    data:
-      border_top: true
-      from: <a href='/government/organisations/ministry-of-defence'>Ministry of Defence</a>
-  display_page_history:
-    description: |
-      This will set up an expandable section on the page, with a top border, to let users toggle the display of the page history. It also includes a hidden H2 heading of 'Updates to this page'. This heading will not be included if one is passed to the component using the `title` option.
-
-      This example includes an expandable 'part of' section to show both toggling elements working together in one component instance.
-    data:
-      border_top: true
-      part_of:
-        - <a href="/government/world/afghanistan">Afghanistan</a>
-        - <a href="/government/world/albania">Albania</a>
-        - <a href="/government/world/algeria">Algeria</a>
-        - <a href="/government/world/angola">Angola</a>
-        - <a href="/government/world/anguilla">Anguilla</a>
-        - <a href="/government/world/argentina">Argentina</a>
-        - <a href="/government/world/armenia">Armenia</a>
-        - <a href="/government/world/australia">Australia</a>
-        - <a href="/government/world/austria">Austria</a>
-        - <a href="/government/world/azerbaijan">Azerbaijan</a>
-        - <a href="/government/world/bahrain">Bahrain</a>
-      first_published: 1st January 1990
-      last_updated: 20th October 2016
-      page_history:
-      - display_time: 1st January 1990
-        note: First published
-        timestamp: 1990-01-01T15:42:37.000+00:00
-      - display_time: 20th July 1995
-        note: Updated to include information for 1994
-        timestamp: 1995-07-20T15:42:37.000+00:00
-      - display_time: 14th October 2000
-        note: Updated information on pupil premium reviews and what information schools need to publish on their websites.
-        timestamp: 2000-10-14T15:42:37.000+00:00
   with_title:
     data:
       last_updated: 10 September 2015

--- a/app/views/govuk_publishing_components/components/docs/metadata.yml
+++ b/app/views/govuk_publishing_components/components/docs/metadata.yml
@@ -348,12 +348,17 @@ examples:
       first_published: 14 June 2014
       other:
         Applies to: England, Scotland, and Wales (see detailed guidance for <a href="http://www.dardni.gov.uk/news-dard-pa022-a-13-new-procedure-for" rel="external">Northern Ireland</a>)
+  with_border_top:
+    data:
+      border_top: true
+      from: <a href='/government/organisations/ministry-of-defence'>Ministry of Defence</a>
   display_page_history:
     description: |
       This will set up an expandable section on the page, with a top border, to let users toggle the display of the page history. It also includes a hidden H2 heading of 'Updates to this page'. This heading will not be included if one is passed to the component using the `title` option.
 
       This example includes an expandable 'part of' section to show both toggling elements working together in one component instance.
     data:
+      border_top: true
       part_of:
         - <a href="/government/world/afghanistan">Afghanistan</a>
         - <a href="/government/world/albania">Albania</a>

--- a/app/views/govuk_publishing_components/components/metadata/_sentence.html.erb
+++ b/app/views/govuk_publishing_components/components/metadata/_sentence.html.erb
@@ -9,16 +9,10 @@
 %>
 <%= items.to_sentence(two_words_connector: connector, last_word_connector: connector).html_safe %>
 <% if remaining.any? %>
-  <div class="gem-c-metadata__toggle-wrap govuk-!-display-none-print">
-    <a href="#"
-       class="gem-c-metadata__definition-link govuk-!-display-none-print"
-       data-controls="toggle-<%= toggle_id %>"
-       data-expanded="false"
-       data-toggled-text="<%= t("common.toggle_less") %>">
-        <%= t("common.toggle_more",
-          show: t("common.show"),
-          number: remaining.length) %>
-    </a>
-  </div>
-  <span id="toggle-<%= toggle_id %>" class="gem-c-metadata__toggle-items js-hidden"><%= remaining.to_sentence.html_safe %></span>
+  <%= render "govuk_publishing_components/components/details", {
+    title: t("common.toggle_more", show: t("common.show"), number: remaining.length),
+    small: true,
+  } do %>
+    <%= remaining.to_sentence.html_safe %>
+  <% end %>
 <% end %>

--- a/spec/components/metadata_spec.rb
+++ b/spec/components/metadata_spec.rb
@@ -300,8 +300,7 @@ describe "Metadata", type: :view do
       page_history: [{ display_time: "23 August 2013", note: "Updated with new data" }],
     )
     assert_select "#full-publication-update-history.gem-c-metadata"
-    assert_select ".gem-c-metadata__change-history"
-    assert_select ".gem-c-metadata--history .gem-c-metadata__change-date", text: "23 August 2013"
+    assert_select ".gem-c-metadata__change-history .gem-c-metadata__change-date", text: "23 August 2013"
   end
 
   it "includes a hidden title if there is page history" do
@@ -323,8 +322,7 @@ describe "Metadata", type: :view do
       last_updated: "15th July 2015",
       page_history: [{ display_time: "23 August 2013", note: "Updated with new data" }],
     )
-    assert_select ".gem-c-metadata__change-history"
-    assert_select ".gem-c-metadata--history .gem-c-metadata__change-note", text: /^\S/
+    assert_select ".gem-c-metadata__change-history .gem-c-metadata__change-note", text: /^\S/
   end
 
   it "only adds history id when passed page history" do
@@ -356,6 +354,11 @@ describe "Metadata", type: :view do
       page_history: [{ display_time: "23 August 2013", note: "Updated with new data" }],
     )
     assert_select ".gem-c-metadata .gem-c-details .govuk-details__summary-text"
+  end
+
+  it "renders with a top border" do
+    render_component({ border_top: true })
+    assert_select ".gem-c-metadata.gem-c-metadata--border-top"
   end
 
   def assert_truncation(length, limit)

--- a/spec/components/metadata_spec.rb
+++ b/spec/components/metadata_spec.rb
@@ -265,22 +265,6 @@ describe "Metadata", type: :view do
     assert_select '.gem-c-metadata.govuk-\!-margin-bottom-2'
   end
 
-  it "renders the component with 3 toggle sections for 'part of', 'from' and 'other'" do
-    render_component(
-      part_of: "<a href='/link'>Department</a>",
-      from: [
-        "<a href='/from-1'>From 1</a>",
-      ],
-      other: {
-        "Related topics": [
-          "<a href='/government/topics/topic-1'>Topic 1</a>",
-        ],
-      },
-    )
-
-    assert_select "[data-module*=\"gem-toggle\"]", count: 3
-  end
-
   it "adds GA4 tracking to the 'see all updates' link" do
     render_component(last_updated: "Hello World", see_updates_link: true, other: { "Updated" => "13 April 2023, <a href=\"/hmrc-internal-manuals/self-assessment-claims-manual/updates\">see all updates</a>" })
 
@@ -385,15 +369,15 @@ describe "Metadata", type: :view do
   end
 
   def assert_truncation(length, limit)
-    assert_select ".gem-c-metadata__toggle-items", count: 1
+    assert_select ".gem-c-details", count: 1
     assert_select ".gem-c-metadata__definition > a", count: limit
-    assert_select ".gem-c-metadata__definition .gem-c-metadata__toggle-items a", count: length - limit
-    assert_select "a[href=\"#\"]", text: t("common.toggle_more", show: t("common.show"), number: length - limit)
+    assert_select ".gem-c-details .govuk-details__text a", count: length - limit
+    assert_select ".govuk-details__summary-text", text: t("common.toggle_more", show: t("common.show"), number: length - limit)
   end
 
   def assert_no_truncation(length)
     assert_select ".gem-c-metadata__definition > a", count: length
-    assert_select ".gem-c-metadata__toggle-items", count: 0
+    assert_select ".gem-c-details", count: 0
   end
 
   def assert_definition(term, definition)

--- a/spec/components/metadata_spec.rb
+++ b/spec/components/metadata_spec.rb
@@ -275,7 +275,7 @@ describe "Metadata", type: :view do
     }.to_json
 
     assert_select ".gem-c-metadata__definition:nth-of-type(2)" do |alternate_see_all_updates_container|
-      expect(alternate_see_all_updates_container.attr("data-module").to_s).to eq "gem-toggle ga4-link-tracker"
+      expect(alternate_see_all_updates_container.attr("data-module").to_s).to eq "ga4-link-tracker"
       expect(alternate_see_all_updates_container.attr("data-ga4-link").to_s).to eq expected_ga4_json
     end
   end
@@ -300,7 +300,7 @@ describe "Metadata", type: :view do
       page_history: [{ display_time: "23 August 2013", note: "Updated with new data" }],
     )
     assert_select "#full-publication-update-history.gem-c-metadata"
-    assert_select ".gem-c-metadata__change-history#page-history-1234"
+    assert_select ".gem-c-metadata__change-history"
     assert_select ".gem-c-metadata--history .gem-c-metadata__change-date", text: "23 August 2013"
   end
 
@@ -323,7 +323,7 @@ describe "Metadata", type: :view do
       last_updated: "15th July 2015",
       page_history: [{ display_time: "23 August 2013", note: "Updated with new data" }],
     )
-    assert_select ".gem-c-metadata__change-history#page-history-1234"
+    assert_select ".gem-c-metadata__change-history"
     assert_select ".gem-c-metadata--history .gem-c-metadata__change-note", text: /^\S/
   end
 
@@ -345,27 +345,17 @@ describe "Metadata", type: :view do
       last_updated: "15th July 2015",
       page_history: [{ display_time: "23 August 2013", note: "Updated with new data" }],
     )
-    assert_select ".gem-c-metadata__change-history.js-hidden"
+    assert_select ".gem-c-details .gem-c-metadata__change-history"
+    assert_select ".gem-c-details[open] .gem-c-metadata__change-history", false
   end
 
-  it "renders link to full page history if history is provided" do
+  it "renders full page history in a details component if history is provided" do
     render_component(
       first_published: "1st November 2000",
       last_updated: "15th July 2015",
       page_history: [{ display_time: "23 August 2013", note: "Updated with new data" }],
     )
-    assert_select ".gem-c-metadata a[href=\"#full-history\"]"
-  end
-
-  it "includes data attributes for toggle behaviour" do
-    render_component(
-      first_published: "1st November 2000",
-      last_updated: "15th July 2015",
-      page_history: [{ display_time: "23 August 2013", note: "Updated with new data" }],
-    )
-    assert_select ".gem-c-metadata__definition[data-module=\"gem-toggle\"]"
-    assert_select ".gem-c-metadata--history a[href=\"#full-history\"][data-controls=\"page-history-1234\"]"
-    assert_select ".gem-c-metadata--history a[href=\"#full-history\"][data-expanded=\"false\"]"
+    assert_select ".gem-c-metadata .gem-c-details .govuk-details__summary-text"
   end
 
   def assert_truncation(length, limit)


### PR DESCRIPTION
## What
Change the metadata component so that show/hide of elements is handled by the details component instead of the `gem-toggle` script.

Depends upon changes in https://github.com/alphagov/govuk_publishing_components/pull/5594

## Why
Using a details element prevents cumulative layout shift, as the display of the contents of the details element (visible or hidden) is handled by the HTML, which is rendered without needing to wait for CSS or JS to load. 

Using native toggle functionality in the browser also feels better than writing a script to do the same, as it is accessible and [keyboard ready out of the box](https://github.com/alphagov/govuk_publishing_components/issues/5580).

The major difference (apart from visual, below) is that the text no longer changes when the visibility of elements is toggled, but my understanding is that this is acceptable from an accessibility standpoint.

Also, in theory this would reduce the JS, but the `gem-toggle` script is used in other places still.

## Visual Changes

Changes to the metadata component, desktop.

Before | After
------ | ------
<img width="543" height="172" alt="Screenshot 2026-07-17 at 11 56 12" src="https://github.com/user-attachments/assets/4081c0d0-54dc-4ab4-b952-65ece6fa561d" /> | <img width="531" height="213" alt="Screenshot 2026-07-17 at 11 56 21" src="https://github.com/user-attachments/assets/9790678e-e5d4-466d-92b3-f27af784f73a" />
<img width="624" height="423" alt="Screenshot 2026-07-17 at 11 56 31" src="https://github.com/user-attachments/assets/511112ef-95f3-4ba6-a590-07a29ebb0d9e" /> | <img width="654" height="529" alt="Screenshot 2026-07-17 at 11 56 40" src="https://github.com/user-attachments/assets/bc001ce2-a5d5-4e02-8b2b-511188e613ab" />

Changes to the metadata component, mobile.

Before | After
------ | ------
<img width="392" height="223" alt="Screenshot 2026-07-17 at 12 00 16" src="https://github.com/user-attachments/assets/be6a89e7-5d04-48b2-830e-abd37a420c89" /> | <img width="388" height="258" alt="Screenshot 2026-07-17 at 12 00 23" src="https://github.com/user-attachments/assets/53e2c078-2b96-4be4-93f3-a081c58cb2a8" />
<img width="467" height="486" alt="Screenshot 2026-07-17 at 12 00 32" src="https://github.com/user-attachments/assets/9c76effe-ef7a-45ee-a4f3-d6ab005844ce" /> | <img width="484" height="574" alt="Screenshot 2026-07-17 at 12 00 40" src="https://github.com/user-attachments/assets/4757d817-4a1c-4986-bdc3-d10e9de57d3d" />
