### PR TITLE
Add options to the details component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add options to the details component ([PR #5594](https://github.com/alphagov/govuk_publishing_components/pull/5594))
 * **BREAKING:** remove the aria_live option from the notice component ([PR #5568](https://github.com/alphagov/govuk_publishing_components/pull/5568))
 * Tidy up organisation colours stylesheet ([PR #5578](https://github.com/alphagov/govuk_publishing_components/pull/5578))
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_details.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_details.scss
@@ -1,5 +1,46 @@
 @import "govuk/components/details/details";
 
+[dir="rtl"] .gem-c-details,
+.direction-rtl .gem-c-details,
+.gem-c-details.direction-rtl {
+  direction: rtl;
+  text-align: start;
+
+  .govuk-details__summary {
+    padding-left: 0;
+    padding-right: govuk-spacing(5);
+
+    &::before {
+      left: auto;
+      right: 0;
+      transform: rotate(180deg);
+    }
+  }
+
+  &[open] {
+    .govuk-details__summary::before {
+      transform: none;
+    }
+  }
+
+  .govuk-details__text {
+    border: 0;
+    border-right: 5px solid $govuk-border-colour;
+    padding-left: 0;
+    padding-right: govuk-spacing(4);
+  }
+
+  &.gem-c-details--small {
+    .govuk-details__summary {
+      padding-right: govuk-spacing(4);
+    }
+
+    .govuk-details__text {
+      padding-right: govuk-spacing(3);
+    }
+  }
+}
+
 .gem-c-details--black {
   .govuk-details__summary {
     color: govuk-colour("black");

--- a/app/assets/stylesheets/govuk_publishing_components/components/_details.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_details.scss
@@ -34,6 +34,21 @@
   }
 }
 
+.gem-c-details--small {
+  .govuk-details__summary {
+    padding-left: govuk-spacing(4);
+  }
+
+  .govuk-details__summary-text,
+  .govuk-details__text {
+    @include govuk-font(16);
+  }
+
+  .govuk-details__text {
+    padding-left: govuk-spacing(3);
+  }
+}
+
 // fix for issue https://github.com/alphagov/govuk_publishing_components/issues/5436
 .govuk-details__summary {
   box-shadow: 0 4px transparent;

--- a/app/views/govuk_publishing_components/components/_details.html.erb
+++ b/app/views/govuk_publishing_components/components/_details.html.erb
@@ -7,6 +7,7 @@
   local_assigns[:margin_bottom] ||= 3
   theme ||= nil
   inverse ||= false
+  small ||= false
 
   unless disable_ga4
     ga4_event = {
@@ -25,6 +26,7 @@
   component_helper.add_class("gem-c-details govuk-details")
   component_helper.add_class("gem-c-details--black") if theme == "black"
   component_helper.add_class("gem-c-details--inverse") if inverse
+  component_helper.add_class("gem-c-details--small") if small
   component_helper.add_data_attribute({ module: "ga4-event-tracker" }) unless disable_ga4
   component_helper.add_data_attribute({ ga4_event: ga4_event }) unless disable_ga4
   component_helper.set_open(open)

--- a/app/views/govuk_publishing_components/components/_details.html.erb
+++ b/app/views/govuk_publishing_components/components/_details.html.erb
@@ -27,6 +27,7 @@
   component_helper.add_class("gem-c-details--black") if theme == "black"
   component_helper.add_class("gem-c-details--inverse") if inverse
   component_helper.add_class("gem-c-details--small") if small
+  component_helper.add_class("direction-#{direction}") if local_assigns.include?(:direction)
   component_helper.add_data_attribute({ module: "ga4-event-tracker" }) unless disable_ga4
   component_helper.add_data_attribute({ ga4_event: ga4_event }) unless disable_ga4
   component_helper.set_open(open)

--- a/app/views/govuk_publishing_components/components/docs/details.yml
+++ b/app/views/govuk_publishing_components/components/docs/details.yml
@@ -22,6 +22,12 @@ examples:
       title: Help with nationality
       block: |
         We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post.
+  basic_rtl:
+    data:
+      direction: rtl
+      title: Help with nationality
+      block: |
+        We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post.
   with_aria_attributes:
     description: |
       Aria attributes can be applied to the summary element of the component.

--- a/app/views/govuk_publishing_components/components/docs/details.yml
+++ b/app/views/govuk_publishing_components/components/docs/details.yml
@@ -82,3 +82,9 @@ examples:
       inverse: true
       block: |
         We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post. <a href="#" class="govuk-link">Example link</a>
+  small:
+    data:
+      small: true
+      title: Help with nationality
+      block: |
+        We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post.

--- a/spec/components/details_spec.rb
+++ b/spec/components/details_spec.rb
@@ -11,6 +11,8 @@ describe "Details", type: :view do
     end
 
     assert_select "details.gem-c-details[data-module='ga4-event-tracker']"
+    assert_select ".gem-c-details--black", false
+    assert_select ".gem-c-details--inverse", false
     assert_select ".gem-c-details--small", false
     assert_select ".govuk-details__summary-text[data-ga4-expandable]", text: "Some title"
     assert_select ".govuk-details__text", text: "This is more info"
@@ -88,6 +90,22 @@ describe "Details", type: :view do
     )
     assert_select ".govuk-details__summary[data-ga4-event]", false
     assert_select ".govuk-details__summary-text[data-ga4-expandable]", false
+  end
+
+  it "renders black theme" do
+    render_component(title: "Some title", theme: "black") do
+      "This is more info"
+    end
+
+    assert_select ".gem-c-details.gem-c-details--black"
+  end
+
+  it "renders inverse" do
+    render_component(title: "Some title", inverse: true) do
+      "This is more info"
+    end
+
+    assert_select ".gem-c-details.gem-c-details--inverse"
   end
 
   it "renders small" do

--- a/spec/components/details_spec.rb
+++ b/spec/components/details_spec.rb
@@ -97,4 +97,12 @@ describe "Details", type: :view do
 
     assert_select ".gem-c-details.gem-c-details--small"
   end
+
+  it "renders right to left" do
+    render_component(title: "Some title", direction: "rtl") do
+      "This is more info"
+    end
+
+    assert_select ".gem-c-details.direction-rtl"
+  end
 end

--- a/spec/components/details_spec.rb
+++ b/spec/components/details_spec.rb
@@ -11,6 +11,7 @@ describe "Details", type: :view do
     end
 
     assert_select "details.gem-c-details[data-module='ga4-event-tracker']"
+    assert_select ".gem-c-details--small", false
     assert_select ".govuk-details__summary-text[data-ga4-expandable]", text: "Some title"
     assert_select ".govuk-details__text", text: "This is more info"
   end
@@ -87,5 +88,13 @@ describe "Details", type: :view do
     )
     assert_select ".govuk-details__summary[data-ga4-event]", false
     assert_select ".govuk-details__summary-text[data-ga4-expandable]", false
+  end
+
+  it "renders small" do
+    render_component(title: "Some title", small: true) do
+      "This is more info"
+    end
+
+    assert_select ".gem-c-details.gem-c-details--small"
   end
 end


### PR DESCRIPTION
## What
Adds a `small` option and right to left support to the details component.

PR note: I had to write some slightly complex CSS to get the RTL option to play nicely with the `small` option. It's worth double checking that this works as expected, both when the `direction-rtl` class is applied to the component, as well as separately applied to a parent element.

## Why
Needed for this PR: https://github.com/alphagov/govuk_publishing_components/pull/5592 (was originally part of, but decided to split the relevant commits out).

## Visual Changes
New `small` option on the details component:

<img width="1071" height="524" alt="Screenshot 2026-07-17 at 11 55 36" src="https://github.com/user-attachments/assets/00648122-45e3-492b-ae02-c6a21209c5a3" />

New right to left option on the details component:

<img width="1078" height="548" alt="Screenshot 2026-07-17 at 12 55 29" src="https://github.com/user-attachments/assets/22e53a0f-f35f-4b28-b40f-be5aec443dcd" />
