### PR TITLE
Remove px values in font-size styles

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_big-number.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_big-number.scss
@@ -5,7 +5,6 @@
 
 .gem-c-big-number__value {
   line-height: 1;
-  font-size: 80px;
   font-size: govuk-px-to-rem(80px);
   @include govuk-font($size: false, $weight: bold);
   // Make the value an inline element, and the label a block level element to make them stack vertically but be announced as one element by JAWS and NVDA.

--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -72,7 +72,6 @@
 
 .gem-c-image-card__context,
 .gem-c-image-card__metadata {
-  font-size: 16px;
   font-size: govuk-px-to-rem(16px);
   margin: 0 0 calc(govuk-spacing(3) / 2);
   color: govuk-colour("dark-grey");

--- a/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
@@ -6,10 +6,8 @@ $search-icon-size: 40px;
   display: block;
   position: relative;
   z-index: 1;
-  margin-bottom: -$search-icon-size;
   margin-bottom: -(govuk-px-to-rem($search-icon-size));
   width: $search-icon-size;
-  height: $search-icon-size;
   height: govuk-px-to-rem($search-icon-size);
   background: url("govuk_publishing_components/icon-search.svg") no-repeat -3px center;
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -158,7 +158,6 @@ $search-icon-height: 20px;
 .gem-c-layout-super-navigation-header__search-item-link {
   color: govuk-colour("white");
   display: inline-block;
-  font-size: 19px;
   font-size: govuk-px-to-rem(19px);
   font-weight: bold;
   padding: govuk-spacing(4) 0;
@@ -182,7 +181,6 @@ $search-icon-height: 20px;
   &:link,
   &:visited {
     color: govuk-colour("white");
-    font-size: 16px;
     font-size: govuk-px-to-rem(16px);
     height: govuk-spacing(4);
     text-decoration: none;
@@ -238,7 +236,6 @@ $search-icon-height: 20px;
 
 // JS available - target the "Menu" toggle button
 .gem-c-layout-super-navigation-header__navigation-top-toggle-button {
-  font-size: 16px;
   font-size: govuk-px-to-rem(16px);
   font-weight: 700;
   background: none;
@@ -519,7 +516,7 @@ $search-icon-height: 20px;
 // JS available - styles the close icon, used when the search menu is in the open state
 .gem-c-layout-super-navigation-header__navigation-top-toggle-close-icon {
   display: none;
-  font-size: 36px;
+  font-size: govuk-px-to-rem(36px);
   font-weight: normal;
   left: 0;
   line-height: 22px;
@@ -616,7 +613,6 @@ $search-icon-height: 20px;
 }
 
 .gem-c-layout-super-navigation-header__navigation-second-item-link {
-  font-size: 16px;
   font-size: govuk-px-to-rem(16px);
   font-weight: bold;
 
@@ -634,7 +630,6 @@ $search-icon-height: 20px;
 }
 
 .gem-c-layout-super-navigation-header__navigation-second-item-link--with-description {
-  font-size: 16px;
   font-size: govuk-px-to-rem(16px);
   font-weight: bold;
 
@@ -645,7 +640,6 @@ $search-icon-height: 20px;
 }
 
 .gem-c-layout-super-navigation-header__navigation-second-item-description {
-  font-size: 16px;
   font-size: govuk-px-to-rem(16px);
   font-weight: normal;
   margin: govuk-spacing(1) 0 0 0;
@@ -661,7 +655,7 @@ $search-icon-height: 20px;
 }
 
 .gem-c-layout-super-navigation-header__column-header {
-  font-size: 24px;
+  font-size: govuk-px-to-rem(24px);
 }
 
 // Ensure the total space to the left of the logo for mobile screen sizes is 24px (margin is 15px)
@@ -677,7 +671,6 @@ $search-icon-height: 20px;
   // custom class to the label of the search component to turn off
   // the responsive font size
   .gem-c-layout-super-navigation-header__search-label--large-navbar {
-    font-size: 24px;
     font-size: govuk-px-to-rem(24px);
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_modal-dialogue.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_modal-dialogue.scss
@@ -117,12 +117,9 @@ $govuk-modal-wide-breakpoint: $govuk-page-width + $govuk-modal-margin * 2 + $gov
   color: govuk-colour("white");
   background: none;
   cursor: pointer;
-
-  @include govuk-font($size: 36, $weight: bold, $line-height: 1.3);
-  @include govuk-media-query($until: tablet) {
-    font-size: 36px;
-    line-height: 1.3;
-  }
+  font-size: govuk-px-to-rem(36px);
+  line-height: 1.3;
+  @include govuk-font($size: false, $weight: bold);
 
   &:focus,
   &:hover {

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_tables.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_tables.scss
@@ -39,7 +39,6 @@
     }
 
     td small {
-      font-size: 19px;
       font-size: govuk-px-to-rem(19);
     }
 


### PR DESCRIPTION
## What

* Remove `px` values used in font-size styles
* Small refactor to the close button font styles in the [modal-dialogue component](https://components.publishing.service.gov.uk/component-guide/modal_dialogue)

## Why

### Removal of CSS fallbacks
The font-size rules are duplicated to create a CSS fallback for older ([Grade X](https://frontend.design-system.service.gov.uk/browser-support/#grade-x)) browsers that do not support `rem` values, IE6-10 for example.

The CSS callback approach can safely be removed as `rem` values are now widely supported - https://caniuse.com/rem

### Modal dialogue component

The previous approached used the `govuk-font` mixin which scales the line-height based on the screen size. A media query was then used to ensure the same size font and line-height is used.

The new approach is consistent with the pattern used in other components, where the font-size and line-height are set, then the `govuk-font` mixin is used only to include the required font styles, with the exception of font-size and line-height.

Jira card: https://gov-uk.atlassian.net/browse/NAV-18930

## Visual Changes
No visual changes
