### PR TITLE
Update the Civil Service organisation page to use its official brand colour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * **BREAKING:** remove the aria_live option from the notice component ([PR #5568](https://github.com/alphagov/govuk_publishing_components/pull/5568))
 * Tidy up organisation colours stylesheet ([PR #5578](https://github.com/alphagov/govuk_publishing_components/pull/5578))
 * Update breadcrumb font size print styles ([PR #5570](https://github.com/alphagov/govuk_publishing_components/pull/5570))
+* Update the Civil Service organisation page to use its official brand colour ([PR #5610](https://github.com/alphagov/govuk_publishing_components/pull/5610))
 
 ## 66.9.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
@@ -13,17 +13,6 @@
 
 @include organisation-brand-colour;
 
-// in the toolkit, civil service has red for the text and borders
-// but the required border colour is black, ideally would fix this in
-// the toolkit but other things are using it
-
-.brand--civil-service {
-  &.brand__border-color,
-  .brand__border-color {
-    border-color: govuk-colour("black");
-  }
-}
-
 .brand--government-digital-service {
   &.brand__border-color,
   .brand__border-color {


### PR DESCRIPTION
## What
In this PR we're updating the [Civil Service organisation page](https://www.gov.uk/government/organisations/civil-service) to use its [official brand colour](https://www.brand.gov.uk/department/civil-service/) (#b2292e) for borders, removing any hardcoded overrides. This brings the page in line with the brand guidelines and the Design System.

## Why
Historically, an override was put in place to force Civil Service page borders to black because the anchor links on the page were also red, causing a visual clash.

Jira card: https://gov-uk.atlassian.net/browse/NAV-19016

## Visual Changes

| Before | After |
|--------|--------|
| <img width="1035" height="919" alt="Screenshot 2026-07-22 at 15 49 58" src="https://github.com/user-attachments/assets/1fd68de4-e8b4-499b-aaeb-c3eb90dc3b22" /> | <img width="1044" height="905" alt="Screenshot 2026-07-22 at 15 50 24" src="https://github.com/user-attachments/assets/3a3499ff-3ea3-4cc2-9fec-be0d11d673a4" /> | 
| <img width="1021" height="912" alt="Screenshot 2026-07-23 at 14 54 00" src="https://github.com/user-attachments/assets/09be2159-e1de-47c7-8c0d-da9ab4c84e8d" /> | <img width="1025" height="909" alt="Screenshot 2026-07-23 at 14 53 53" src="https://github.com/user-attachments/assets/9fc6bdcb-2bc2-49f1-afdb-445bcf22e703" /> |
