### PR TITLE
Hide breadcrumbs when printed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Update breadcrumb font size print styles ([PR #5570](https://github.com/alphagov/govuk_publishing_components/pull/5570))
 * Update the Civil Service organisation page to use its official brand colour ([PR #5610](https://github.com/alphagov/govuk_publishing_components/pull/5610))
 * Remove px values in font-size styles ([PR #5595](https://github.com/alphagov/govuk_publishing_components/pull/5595))
+* Hide breadcrumbs when printed ([PR #5617](https://github.com/alphagov/govuk_publishing_components/pull/5617))
 
 ## 66.9.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_breadcrumbs.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_breadcrumbs.scss
@@ -26,19 +26,3 @@
     }
   }
 }
-
-@include govuk-media-query($media-type: print) {
-  .gem-c-breadcrumbs,
-  .govuk-breadcrumbs {
-    .govuk-breadcrumbs__list-item {
-      .govuk-breadcrumbs__link:link,
-      .govuk-breadcrumbs__link:visited {
-        color: $govuk-print-text-colour;
-      }
-
-      &::before {
-        border-color: $govuk-print-text-colour;
-      }
-    }
-  }
-}

--- a/app/views/govuk_publishing_components/components/_breadcrumbs.html.erb
+++ b/app/views/govuk_publishing_components/components/_breadcrumbs.html.erb
@@ -8,7 +8,7 @@
 
   breadcrumb_presenter = GovukPublishingComponents::Presenters::Breadcrumbs.new(breadcrumbs)
 
-  classes = %w[gem-c-breadcrumbs govuk-breadcrumbs]
+  classes = %w[gem-c-breadcrumbs govuk-breadcrumbs govuk-!-display-none-print]
   classes << "govuk-breadcrumbs--collapse-on-mobile" if collapse_on_mobile
   classes << "govuk-breadcrumbs--inverse" if inverse
   classes << "gem-c-breadcrumbs--border-bottom" if border == "bottom"

--- a/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
@@ -13,11 +13,9 @@
   <% if breadcrumb_selector.step_by_step %>
     <%= render "govuk_publishing_components/components/step_by_step_nav_header", breadcrumb_selector.breadcrumbs %>
   <% elsif breadcrumb_selector.breadcrumbs %>
-    <div class="govuk-!-display-none-print">
-      <%= render "govuk_publishing_components/components/breadcrumbs",
-                 breadcrumbs: breadcrumb_selector.breadcrumbs,
-                 inverse: inverse,
-                 collapse_on_mobile: collapse_on_mobile %>
-    </div>
+    <%= render "govuk_publishing_components/components/breadcrumbs",
+                breadcrumbs: breadcrumb_selector.breadcrumbs,
+                inverse: inverse,
+                collapse_on_mobile: collapse_on_mobile %>
   <% end %>
 <% end %>


### PR DESCRIPTION
## What

Currently, contextual breadcrumbs are hidden when printed, whereas the breadcrumbs component is not. This change ensures both components are hidden when printing.

## Why

https://github.com/alphagov/govuk_publishing_components/issues/5601