### PR TITLE
Update the Action Link component's circle colour to improve colour co…

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
@@ -23,7 +23,11 @@
   width: 28px;
 
   .gem-c-action-link__icon__circle {
-    fill: #eeefef;
+    fill: $govuk-blue-tint-80;
+
+    .gem-c-action-link--inverse & {
+      fill: govuk-colour("white");
+    }
 
     @media (forced-colors: active) {
       fill: LinkText;


### PR DESCRIPTION
## What
Updated the action link icon circle fill to:
- Blue tint 80% (#D2E2F1) for the default variant.
- White (#FFFFFF) for the inverse variant.

## Why
This change ensures the icon maintains clear visual contrast against both light backgrounds and solid blue inverse backgrounds.

Jira card: https://gov-uk.atlassian.net/browse/NAV-19020

## Visual Changes

### Default 

Before
<img width="984" height="191" alt="Screenshot 2026-07-27 at 16 59 58" src="https://github.com/user-attachments/assets/73374ade-07f6-49f2-8a6b-cbf4aa6f4818" />

After
<img width="983" height="194" alt="Screenshot 2026-07-27 at 17 00 10" src="https://github.com/user-attachments/assets/05620043-1f41-4279-b14e-af8cc88c620d" />

### Inverse

Before
<img width="991" height="84" alt="Screenshot 2026-07-27 at 17 00 20" src="https://github.com/user-attachments/assets/64cfc75a-2df9-4c19-b1d8-093a7668d669" />

After
<img width="980" height="90" alt="Screenshot 2026-07-27 at 17 00 43" src="https://github.com/user-attachments/assets/47c4ad6f-9635-4d20-a17c-27924fe5646d" />



[NAV-19020]: https://gov-uk.atlassian.net/browse/NAV-19020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ