### PR TITLE
Add tabular number font style to tables

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_tables.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_tables.scss
@@ -15,6 +15,7 @@
     overflow-x: auto;
     width: 100%;
     @include govuk-font($size: 19);
+    @include govuk-font-tabular-numbers($important: false);
 
     caption {
       text-align: left;


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

Apply the tabular number font style to right aligned table cells using the Sass helper

## Why
<!-- What are the reasons behind this change being made? -->
When tabular data is right-aligned use tabular numbers to ensure the numbers line up, making them easier to scan and analyse.

Apply this only to right-aligned cells to scope the change to cell data that is likely to be numeric.

An alternative solution would be to add a new class that sets the tabular style explicitly. However, this would only apply to tables that have set that class, whereas this change will work retroactively to all tables that have right aligned data.

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

| Before | After |
|--------|--------|
| <img width="1368" height="1257" alt="Screenshot 2026-07-29 at 09-31-29 Examples of tables and charts to use on GOV UK - GOV UK" src="https://github.com/user-attachments/assets/ded29107-298d-4982-9254-02eaffc44b67" /> | <img width="1368" height="1257" alt="Screenshot 2026-07-29 at 09-31-06 Examples of tables and charts to use on GOV UK - GOV UK" src="https://github.com/user-attachments/assets/11e4d7c1-7d27-467c-8319-40ea80a58cef" /> |
