### PR TITLE
Release Version 67.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 67.0.0
 
 * Add options to the details component ([PR #5594](https://github.com/alphagov/govuk_publishing_components/pull/5594))
 * **BREAKING:** remove the aria_live option from the notice component ([PR #5568](https://github.com/alphagov/govuk_publishing_components/pull/5568))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (66.9.0)
+    govuk_publishing_components (67.0.0)
       chartkick
       govuk_app_config
       govuk_personalisation (>= 0.7.0)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "66.9.0".freeze
+  VERSION = "67.0.0".freeze
 end


### PR DESCRIPTION
## 67.0.0

* Add options to the details component ([PR #5594](https://github.com/alphagov/govuk_publishing_components/pull/5594))
* **BREAKING:** remove the aria_live option from the notice component ([PR #5568](https://github.com/alphagov/govuk_publishing_components/pull/5568))
* Tidy up organisation colours stylesheet ([PR #5578](https://github.com/alphagov/govuk_publishing_components/pull/5578))
* Update breadcrumb font size print styles ([PR #5570](https://github.com/alphagov/govuk_publishing_components/pull/5570))
* Update the Civil Service organisation page to use its official brand colour ([PR #5610](https://github.com/alphagov/govuk_publishing_components/pull/5610))
* Remove px values in font-size styles ([PR #5595](https://github.com/alphagov/govuk_publishing_components/pull/5595))
* Hide breadcrumbs when printed ([PR #5617](https://github.com/alphagov/govuk_publishing_components/pull/5617))