### PR TITLE
Separate the header element from the super navigation header component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Set attachment SVG sizes ([PR #5639](https://github.com/alphagov/govuk_publishing_components/pull/5639))
 * Add Cross service header to component guide ([PR #5640](https://github.com/alphagov/govuk_publishing_components/pull/5640))
+* Separate the header element from the super navigation header component ([PR #5627](https://github.com/alphagov/govuk_publishing_components/pull/5627))
 
 ## 67.0.1
 

--- a/app/views/govuk_publishing_components/components/_cross_service_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_cross_service_header.html.erb
@@ -4,7 +4,7 @@
   service_navigation_items ||= []
 %>
 
-<header class="gem-c-cross-service-header gem-c-rebranded-cross-service-header" data-module="cross-service-header">
+<div class="gem-c-cross-service-header gem-c-rebranded-cross-service-header" data-module="cross-service-header">
   <%= render "govuk_publishing_components/components/cross_service_header/one_login_header", {
     one_login_navigation_items: one_login_navigation_items,
   } %>
@@ -12,4 +12,4 @@
     service_name: service_name,
     navigation_items: service_navigation_items,
   } %>
-</header>
+</div>

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -81,27 +81,29 @@
       <% end %>
     <% end %>
     <% unless omit_header %>
-      <% if show_cross_service_header %>
-        <%= render "govuk_publishing_components/components/cross_service_header", {
-          one_login_navigation_items: one_login_navigation_items,
-          service_navigation_items: service_navigation_items,
-          service_name: service_name,
-        } %>
-      <% else %>
-        <% I18n.with_locale(:en) do %>
-          <%= render "govuk_publishing_components/components/layout_super_navigation_header", {
-            homepage:,
-            logo_link:,
-            phase_banner:,
+      <%= tag.header do %>
+        <% if show_cross_service_header %>
+          <%= render "govuk_publishing_components/components/cross_service_header", {
+            one_login_navigation_items: one_login_navigation_items,
+            service_navigation_items: service_navigation_items,
+            service_name: service_name,
           } %>
+        <% else %>
+          <% I18n.with_locale(:en) do %>
+            <%= render "govuk_publishing_components/components/layout_super_navigation_header", {
+              homepage:,
+              logo_link:,
+              phase_banner:,
+            } %>
+          <% end %>
+        <% end %>
+
+        <%= raw(emergency_banner) %>
+
+        <% if global_banner.present? %>
+          <%= raw(global_banner) %>
         <% end %>
       <% end %>
-    <% end %>
-
-    <%= raw(emergency_banner) %>
-
-    <% if global_banner.present? %>
-      <%= raw(global_banner) %>
     <% end %>
 
     <% if show_account_layout %>

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -38,7 +38,7 @@
   component_helper.add_class("gem-c-layout-super-navigation-header")
   component_helper.add_data_attribute({ module: "ga4-event-tracker ga4-link-tracker", ga4_expandable: "" })
 %>
-<%= tag.header(**component_helper.all_attributes) do %>
+<%= tag.div(**component_helper.all_attributes) do %>
 <div class="gem-c-layout-super-navigation-header__nav-wrapper">
   <div class="gem-c-layout-super-navigation-header__container govuk-width-container">
     <nav

--- a/app/views/govuk_publishing_components/components/docs/cross_service_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/cross_service_header.yml
@@ -25,7 +25,6 @@ accessibility_criteria:
 govuk_frontend_components:
   - service-navigation
 accessibility_excluded_rules:
-  - landmark-banner-is-top-level
   - duplicate-id-aria
   - landmark-no-duplicate-banner
   - landmark-unique

--- a/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
@@ -12,6 +12,7 @@ accessibility_criteria: |
     * have a `lang` attribute
     * contain a [skip link](/component-guide/skip_link)
     * have a sensible page `<title>`
+    * contain a `<header>` element
 examples:
   default:
     data:
@@ -47,11 +48,11 @@ examples:
         href: "item-3"
         show_only_in_collapsed_menu: true
   with_global_banner:
-    description: This allows the HTML for the global banner to be added to the page. This is only the slot for the global banner - the markup for the banner needs to be passed in.
+    description: This allows the HTML for the global banner to be added to the page within the header element. This is only the slot for the global banner - the markup for the banner needs to be passed in.
     data:
       global_banner: <div class="govuk-!-padding-top-5 govuk-!-padding-bottom-3">This is the global banner slot</div>
   with_emergency_banner:
-    description: This allows the HTML for the emergency banner to be added to the page in the correct place. This is only the slot for the emergency banner - the markup for the banner needs to be passed in.
+    description: This allows the HTML for the emergency banner to be added to the page within the header element. This is only the slot for the emergency banner - the markup for the banner needs to be passed in.
     data:
       emergency_banner: <div class="govuk-!-padding-top-3 govuk-!-padding-bottom-3">This is the emergency banner slot</div>
   with_phase_banner:
@@ -61,7 +62,7 @@ examples:
         phase: "beta"
         message: "This is a custom test message for the public layout phase banner."
   with_all_banners:
-    description: The phase banner, global banner and emergency banner should be usable together.
+    description: The phase banner, global banner and emergency banner should be usable together within the header element.
     data:
       phase_banner:
           phase: "beta"

--- a/app/views/govuk_publishing_components/components/docs/layout_super_navigation_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_super_navigation_header.yml
@@ -16,10 +16,8 @@ accessibility_criteria: |
 
   Landmarks and Roles in the super navigation header should:
 
-  * have a role of banner at the root of the component (<header>) (ARIA 1.1)
+  * sit within the primary header element (<header>) provided by the page layout
 accessibility_excluded_rules:
-   # The header element can not be top level in the examples.
-  - landmark-banner-is-top-level
   # Banners will be duplicated in component examples list.
   - duplicate-id
   - duplicate-id-active

--- a/spec/components/cross_service_header_spec.rb
+++ b/spec/components/cross_service_header_spec.rb
@@ -27,6 +27,15 @@ describe "Cross service header", type: :view do
     end
   end
 
+  it "renders the Cross service header as a div" do
+    render_component({ show_account_layout: true,
+                       one_login_navigation_items:,
+                       service_name: "GOV.UK email subscriptions" })
+
+    assert_select "div.gem-c-cross-service-header"
+    assert_select "header", count: 0
+  end
+
   it "renders the One Login service header" do
     render_component({ show_account_layout: true,
                        one_login_navigation_items:,

--- a/spec/components/layout_for_public_spec.rb
+++ b/spec/components/layout_for_public_spec.rb
@@ -87,30 +87,50 @@ describe "Layout for public", :capybara, type: :view do
     assert_select ".gem-c-app-promo-banner"
   end
 
-  it "can add a emergency banner" do
+  it "can add an emergency banner inside the header element" do
     render_component({
       emergency_banner: "<div id='test-emergency-banner'>This is an emergency banner test</div>",
     })
 
-    assert_select "#test-emergency-banner", text: "This is an emergency banner test"
+    assert_select "header #test-emergency-banner", text: "This is an emergency banner test"
   end
 
-  it "can add a global banner" do
+  it "can add a global banner inside the header element" do
     render_component({
       global_banner: "<div id='test-global-banner'>This is a global banner test</div>",
     })
 
-    assert_select "#test-global-banner", text: "This is a global banner test"
+    assert_select "header #test-global-banner", text: "This is a global banner test"
   end
 
-  it "can add both an emergency banner and a global banner" do
+  it "can add both an emergency banner and a global banner inside the header element" do
     render_component({
       emergency_banner: "<div id='test-emergency-banner'>This is an emergency banner test</div>",
       global_banner: "<div id='test-global-banner'>This is a global banner test</div>",
     })
 
-    assert_select "#test-emergency-banner", text: "This is an emergency banner test"
-    assert_select "#test-global-banner", text: "This is a global banner test"
+    assert_select "header #test-emergency-banner", text: "This is an emergency banner test"
+    assert_select "header #test-global-banner", text: "This is a global banner test"
+  end
+
+  it "renders the super navigation header inside a header element" do
+    render_component({})
+
+    assert_select "header div.gem-c-layout-super-navigation-header"
+    assert_select "header header", false
+  end
+
+  it "renders the cross-service header inside a header element" do
+    render_component({
+      show_cross_service_header: true,
+      one_login_navigation_items: {
+        one_login_home: { href: "/one-login-home" },
+        one_login_sign_out: { href: "/sign-out" },
+      },
+    })
+
+    assert_select "header div.gem-c-cross-service-header"
+    assert_select "header header", false
   end
 
   it "has the default logo link when no logo_link is specified" do
@@ -190,7 +210,7 @@ describe "Layout for public", :capybara, type: :view do
   it "does not render a phase banner by default" do
     render_component({})
 
-    assert_select "header.gem-c-layout-super-navigation-header .gem-c-phase-banner", false
+    assert_select ".gem-c-layout-super-navigation-header .gem-c-phase-banner", false
   end
 
   it "account layout renders with a phase banner by default" do
@@ -230,7 +250,7 @@ describe "Layout for public", :capybara, type: :view do
       },
     })
 
-    assert_select "header.gem-c-layout-super-navigation-header", false
+    assert_select ".gem-c-layout-super-navigation-header", false
     assert_select ".gem-c-phase-banner", false
   end
 
@@ -242,7 +262,7 @@ describe "Layout for public", :capybara, type: :view do
       },
     })
 
-    assert_select "header.gem-c-layout-super-navigation-header .gem-c-phase-banner"
+    assert_select ".gem-c-layout-super-navigation-header .gem-c-phase-banner"
   end
 
   it "correctly passes the phase and message through to the phase banner markup" do

--- a/spec/components/layout_super_navigation_header_spec.rb
+++ b/spec/components/layout_super_navigation_header_spec.rb
@@ -5,10 +5,11 @@ describe "Super navigation header", type: :view do
     "layout_super_navigation_header"
   end
 
-  it "renders the super navigation header" do
+  it "renders the super navigation header as a div" do
     render_component({})
 
-    assert_select ".gem-c-layout-super-navigation-header", count: 1
+    assert_select "div.gem-c-layout-super-navigation-header", count: 1
+    assert_select "header", count: 0
   end
 
   it "has a nav element that is labelled by a heading that exists" do
@@ -130,7 +131,7 @@ describe "Super navigation header", type: :view do
   it "adds GA4 tracking" do
     render_component({})
 
-    assert_select "header[data-module='ga4-event-tracker ga4-link-tracker']"
+    assert_select "div[data-module='ga4-event-tracker ga4-link-tracker']"
     assert_select "a[data-ga4-link]", count: 23
     assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","external":"false","text":"GOV.UK","section":"Logo","index_link":1,"index_section":0,"index_section_count":2,"index_total":1}\']'
     assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index_section":1,"index_link":1,"index_section_count":3,"index_total":16,"section":"Services and information"}\']'


### PR DESCRIPTION
## What

This PR separates the header element from header components and moves it into the public layout component, allowing a single header to wrap additional elements like emergency and global banners.

- Separated header element from header components 
- Replaced the header tag with a div in layout_super_navigation_header.html.erb and cross_service_header.html.erb.
- Moved header tag to public layout component level in layout_for_public.html.erb, wrapping navigation headers, emergency banner, and global banner inside a single top level header element.
- Updated test suites and component documentation

**Before**

```html
<!-- Header component rendered as a standalone <header> element -->
<header class="gem-c-layout-super-navigation-header">
  <section class="gem-c-service-navigation">...</section>
  <div class="gem-c-phase-banner">...</div>
</header>

<!-- Alert banners sat outside the header -->
<section class="gem-c-emergency-banner">...</section>
<div class="gem-c-global-banner">...</div>
```

**After**

```html
<!-- Added a top-level <header> provided by layout_for_public -->
<header>
  <div class="gem-c-layout-super-navigation-header">
    <section class="gem-c-service-navigation">...</section>
    <div class="gem-c-phase-banner">...</div>
  </div>

  <!-- Alert banners are now inside the header -->
  <section class="gem-c-emergency-banner">...</section>
  <div class="gem-c-global-banner">...</div>
</header>
```


## Why
This change allows site wide top elements like the Emergency Banner and Global Banner to sit within a single, semantic header container along with the Phase Banner and Service Navigation. This aligns with WCAG and ARIA landmark guidelines by ensuring screen reader users navigate a clean, unified header section at the top of public facing pages.

Jira card: https://gov-uk.atlassian.net/browse/NAV-18965

## Visual Changes

### Global Banner 

<img width="1020" height="139" alt="Screenshot 2026-08-03 at 14 06 19" src="https://github.com/user-attachments/assets/f77c3a20-7605-4307-9636-b18a946e391e" />

**Before**

| Page  | HTML |
| ------------- | ------------- |
| <img width="992" height="792" alt="Screenshot 2026-08-04 at 08 54 12" src="https://github.com/user-attachments/assets/a0513520-a40a-4cfb-b5a6-de11dfb816ce" /> | <img width="761" height="781" alt="Screenshot 2026-08-04 at 08 54 20" src="https://github.com/user-attachments/assets/a9b683d2-cb97-448d-8a37-a65314a29871" /> |

**After**

The global banner is now part of the header.

| Page  | HTML |
| ------------- | ------------- |
| <img width="1018" height="834" alt="Screenshot 2026-08-03 at 14 06 10" src="https://github.com/user-attachments/assets/e0e13ab8-7e58-4fb5-be86-962822234f28" /> | <img width="696" height="809" alt="Screenshot 2026-08-03 at 14 06 34" src="https://github.com/user-attachments/assets/e182d81c-8e2b-409f-b266-2959f91fea4d" /> |

### Emergency Banner 

<img width="1020" height="235" alt="Screenshot 2026-08-03 at 14 30 37" src="https://github.com/user-attachments/assets/c82ac06c-6518-45da-8c66-ef03e2a6fa5a" />

**Before**

| Page  | HTML |
| ------------- | ------------- |
| <img width="994" height="648" alt="Screenshot 2026-08-04 at 08 38 50" src="https://github.com/user-attachments/assets/b8436b20-88e0-4206-94cf-df15c302c91a" /> | <img width="763" height="780" alt="Screenshot 2026-08-04 at 08 39 06" src="https://github.com/user-attachments/assets/85d1f329-60df-4e6a-b221-e1c2fbe787ea" /> |

**After**

The emergency banner is now part of the header. 

| Page  | HTML |
| ------------- | ------------- |
| <img width="1020" height="834" alt="Screenshot 2026-08-03 at 14 28 05" src="https://github.com/user-attachments/assets/788b1d38-4f36-4a93-a372-6898fd38161e" /> | <img width="695" height="837" alt="Screenshot 2026-08-03 at 14 28 26" src="https://github.com/user-attachments/assets/cc28172e-9633-452b-94b4-93d351619b64" /> |

### Phase Banner

<img width="1055" height="142" alt="Screenshot 2026-08-10 at 12 04 31" src="https://github.com/user-attachments/assets/b7330216-30aa-4ec4-b3f0-81e2275fb398" />

**Before**

The phase banner was already within the header element rendered in layout_super_navigation_header. 

| Page  | HTML |
| ------------- | ------------- |
| <img width="1056" height="300" alt="Screenshot 2026-08-10 at 11 59 02" src="https://github.com/user-attachments/assets/f455323c-8bdc-48af-9ecf-53550988eb5b" /> | <img width="760" height="786" alt="Screenshot 2026-08-10 at 11 59 15" src="https://github.com/user-attachments/assets/1c56098f-56de-47ec-8376-1c9c4a470f50" /> |

**After**

| Page  | HTML |
| ------------- | ------------- |
| <img width="1054" height="430" alt="Screenshot 2026-08-10 at 12 01 11" src="https://github.com/user-attachments/assets/a9ddd258-0fb3-4cdc-b313-b9a93c8d917f" /> | <img width="760" height="786" alt="Screenshot 2026-08-10 at 11 59 15" src="https://github.com/user-attachments/assets/e1d9727d-3500-4793-8d06-5f36cb8d9c02" /> |

### Service Navigation

<img width="1036" height="164" alt="Screenshot 2026-08-03 at 15 55 41" src="https://github.com/user-attachments/assets/a3012b8a-6be3-41a7-b403-dee9b57dc45d" />

The service navigation was already within the header element rendered in cross_service_header. 

Note: Public layout -> Navigation is currently broken in the [component guide](https://components.publishing.service.gov.uk/component-guide/layout_for_public#navigation:~:text=true%0A%7D%20%25%3E-,Navigation%20(preview),-Passes%20the%20navigation) as the public layout passes the navigation to the cross service header. 

Cross service header was recently added to the the Public layout https://components.publishing.service.gov.uk/component-guide/layout_for_public/with_cross_service_header
PR: https://github.com/alphagov/govuk_publishing_components/pull/5640

**Before**

| Page  | HTML |
| ------------- | ------------- |
| <img width="1052" height="832" alt="Screenshot 2026-08-10 at 12 06 44" src="https://github.com/user-attachments/assets/9fac6a3c-c26a-4144-845d-d19f89992764" /> | <img width="759" height="786" alt="Screenshot 2026-08-10 at 12 06 56" src="https://github.com/user-attachments/assets/2ed7759f-50d7-4091-a755-2da986556584" /> |

**After**

| Page  | HTML |
| ------------- | ------------- |
| <img width="1035" height="830" alt="Screenshot 2026-08-03 at 15 59 26" src="https://github.com/user-attachments/assets/840adf7e-6a19-481f-b855-ecc76cd777dd" /> | <img width="719" height="788" alt="Screenshot 2026-08-03 at 15 57 29" src="https://github.com/user-attachments/assets/44526216-478d-409e-b5b6-0e590e109ba9" /> |