### PR TITLE
Remove govuk-govspeak class

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_notice.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_notice.scss
@@ -1,7 +1,7 @@
 @import "govuk/components/notification-banner/notification-banner";
 
 .gem-c-notice {
-  .govuk-govspeak {
+  .gem-c-govspeak {
     p:last-child {
       margin-bottom: 0;
     }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_tables.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_tables.scss
@@ -57,7 +57,6 @@
 }
 
 // Add rtl table styling when `direction: "rtl"` is set
-.govuk-govspeak.gem-c-govspeak--direction-rtl,
 .gem-c-govspeak.gem-c-govspeak--direction-rtl {
   table {
     caption {

--- a/app/views/govuk_publishing_components/components/_govspeak.html.erb
+++ b/app/views/govuk_publishing_components/components/_govspeak.html.erb
@@ -5,7 +5,7 @@
   disable_youtube_expansions = local_assigns.fetch(:disable_youtube_expansions) if local_assigns.include?(:disable_youtube_expansions)
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
-  component_helper.add_class("gem-c-govspeak govuk-govspeak")
+  component_helper.add_class("gem-c-govspeak")
   component_helper.add_class(direction_class) if direction_class
   component_helper.add_class("js-disable-youtube") if disable_youtube_expansions
   component_helper.add_class("gem-c-govspeak--inverse") if inverse

--- a/app/views/govuk_publishing_components/components/docs/contents_list_with_body.yml
+++ b/app/views/govuk_publishing_components/components/docs/contents_list_with_body.yml
@@ -29,7 +29,7 @@ examples:
         - href: "#launch-of-merger-inquiry"
           text: Launch of merger inquiry
       block: |
-        <div class="govuk-govspeak direction-ltr">
+        <div class="gem-c-govspeak direction-ltr">
             <h2 id="statutory-timetable">Statutory timetable</h2>
             <table>
               <thead>

--- a/spec/components/notice_spec.rb
+++ b/spec/components/notice_spec.rb
@@ -45,9 +45,9 @@ describe "Notice", type: :view do
     render_component(title: "Statistics release update", description_govspeak: "<p>The Oil &amp; Gas Authority launched a new website on 3 October 2016 to reflect its new status as a government company.</p><p>This formalises the transfer of the Secretary of State’s regulatory powers in respect of oil and gas to the OGA, and grants it new powers. This website will no longer be updated. Visitors should refer to <a rel=\"external\" href=\"https://www.ogauthority.co.uk/news-publications/announcements/2015/establishment-of-the-oil-and-gas-authority-1/\">www.ogauthority.co.uk</a></p>".html_safe)
 
     assert_select ".gem-c-notice__title", text: "Statistics release update"
-    assert_select ".govuk-govspeak p", text: "The Oil & Gas Authority launched a new website on 3 October 2016 to reflect its new status as a government company."
-    assert_select ".govuk-govspeak p", text: "This formalises the transfer of the Secretary of State’s regulatory powers in respect of oil and gas to the OGA, and grants it new powers. This website will no longer be updated. Visitors should refer to www.ogauthority.co.uk"
-    assert_select ".govuk-govspeak p a[href=\"https://www.ogauthority.co.uk/news-publications/announcements/2015/establishment-of-the-oil-and-gas-authority-1/\"][rel=\"external\"]", text: "www.ogauthority.co.uk"
+    assert_select ".gem-c-govspeak p", text: "The Oil & Gas Authority launched a new website on 3 October 2016 to reflect its new status as a government company."
+    assert_select ".gem-c-govspeak p", text: "This formalises the transfer of the Secretary of State’s regulatory powers in respect of oil and gas to the OGA, and grants it new powers. This website will no longer be updated. Visitors should refer to www.ogauthority.co.uk"
+    assert_select ".gem-c-govspeak p a[href=\"https://www.ogauthority.co.uk/news-publications/announcements/2015/establishment-of-the-oil-and-gas-authority-1/\"][rel=\"external\"]", text: "www.ogauthority.co.uk"
   end
 
   it "renders title as heading only if description present" do

--- a/spec/javascripts/components/govspeak-spec.js
+++ b/spec/javascripts/components/govspeak-spec.js
@@ -20,7 +20,7 @@ describe('Govspeak', function () {
     it('embeds youtube videos', function () {
       container = document.createElement('div')
       container.innerHTML =
-        '<div class="gem-c-govspeak govuk-govspeak" data-module="govspeak">' +
+        '<div class="gem-c-govspeak" data-module="govspeak">' +
           '<p><a href="https://www.youtube.com/watch?v=0XpAtr24uUQ">Agile at GDS</a></p>' +
         '<div>'
       document.body.appendChild(container)
@@ -34,7 +34,7 @@ describe('Govspeak', function () {
     it('allows disabling embeds of youtube videos', function () {
       container = document.createElement('div')
       container.innerHTML =
-        '<div class="gem-c-govspeak govuk-govspeak js-disable-youtube" data-module="govspeak">' +
+        '<div class="gem-c-govspeak js-disable-youtube" data-module="govspeak">' +
           '<p><a href="https://www.youtube.com/watch?v=0XpAtr24uUQ">Agile at GDS</a></p>' +
         '<div>'
       document.body.appendChild(container)
@@ -50,7 +50,7 @@ describe('Govspeak', function () {
     it('embeds barcharts', function () {
       container = document.createElement('div')
       container.innerHTML =
-        '<div id="govspeak-barchart" class="gem-c-govspeak govuk-govspeak" data-module="govspeak">' +
+        '<div id="govspeak-barchart" class="gem-c-govspeak" data-module="govspeak">' +
           '<table class="js-barchart-table mc-auto-outdent">' +
             '<tbody>' +
               '<tr>' +

--- a/spec/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement-spec.js
@@ -17,7 +17,7 @@ describe('Youtube link enhancement', function () {
 
     it('replaces a link and its container with a media-player embed', function () {
       container.innerHTML =
-        '<div class="gem-c-govspeak govuk-govspeak" data-module="govspeak">' +
+        '<div class="gem-c-govspeak" data-module="govspeak">' +
           '<p><a href="https://www.youtube.com/watch?v=0XpAtr24uUQ">Agile at GDS</a></p>' +
         '<div>'
       document.body.appendChild(container)
@@ -32,7 +32,7 @@ describe('Youtube link enhancement', function () {
 
     it('supports overriding the default class with a custom class', function () {
       container.innerHTML =
-        '<div class="gem-c-govspeak govuk-govspeak" data-module="govspeak">' +
+        '<div class="gem-c-govspeak" data-module="govspeak">' +
           '<p><a href="https://www.youtube.com/watch?v=0XpAtr24uUQ">Agile at GDS</a></p>' +
         '<div>'
       document.body.appendChild(container)
@@ -46,7 +46,7 @@ describe('Youtube link enhancement', function () {
 
     it('doesn\'t replace non Youtube links', function () {
       container.innerHTML =
-        '<div class="gem-c-govspeak govuk-govspeak" data-module="govspeak">' +
+        '<div class="gem-c-govspeak" data-module="govspeak">' +
           '<p><a href="https://www.gov.uk">GOV.UK</a></p>' +
         '<div>'
       document.body.appendChild(container)
@@ -355,7 +355,7 @@ describe('Youtube link enhancement', function () {
 
     it('replaces a livestream link and its container with a media-player embed', function () {
       container.innerHTML =
-        '<div class="gem-c-govspeak govuk-govspeak" data-module="govspeak">' +
+        '<div class="gem-c-govspeak" data-module="govspeak">' +
           '<p><a href="https://www.youtube.com/embed/live_stream?channel=UCoMdktPbSTixAyNGwb-UYkQ">Livestream</a></p>' +
         '<div>'
       document.body.appendChild(container)


### PR DESCRIPTION
## What
Removes the `govuk-govspeak` class from the govspeak component.

## Why
This class doesn't appear to be needed. 

I thought it was the original class for govspeak styling, and when that was turned into the govspeak component we added the `gem-c-govspeak` class to conform to component conventions. However on investigation that class turns out to be `govspeak` (which is still present [throughout the govspeak component styles](https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss#L11)), so I'm not sure why this class was here. There are no uses of it across alphagov apart from in prototypes, tests, archived repos and places where the govspeak component is being manually reproduced.

## Visual Changes
There's one visual change in the contents list with body component, because the YML file had the `govuk-govspeak` class in it (which didn't style the contents of the component) and I've replaced that with the correct `gem-c-govspeak` class (which does style the contents of the component). So this looks different, but technically better, as it's now being styled correctly.
