### PR TITLE
[PNP-10104] Improve Devolved Nations Component Welsh Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Improve Devolved Nations Component Welsh Support ([PR #5633](https://github.com/alphagov/govuk_publishing_components/pull/5633))
+
 ## 67.0.0
 
 * Add options to the details component ([PR #5594](https://github.com/alphagov/govuk_publishing_components/pull/5594))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Improve Devolved Nations Component Welsh Support ([PR #5633](https://github.com/alphagov/govuk_publishing_components/pull/5633))
 * Set attachment SVG sizes ([PR #5639](https://github.com/alphagov/govuk_publishing_components/pull/5639))
 * Add Cross service header to component guide ([PR #5640](https://github.com/alphagov/govuk_publishing_components/pull/5640))
 

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -80,15 +80,15 @@ cy:
       aria_label:
       england:
         end: " a Lloegr"
-        middle: ", Lloegr"
+        middle: "Lloegr"
         start: Loegr
       northern_ireland:
         end: " a Gogledd Iwerddon"
-        middle: ", Gogledd Iwerddon"
+        middle: "Gogledd Iwerddon"
         start: Ogledd Iwerddon
       scotland:
         end: " a'r Alban"
-        middle: ", yr Alban"
+        middle: "yr Alban"
         start: "'r Alban"
       type:
         consultation: Ymgynghoriad ar gyfer %{nation}
@@ -97,7 +97,7 @@ cy:
         publication: Cyhoeddiad ar gyfer %{nation}
       wales:
         end: " a Chymru"
-        middle: ", Cymru"
+        middle: "Cymru"
         start: Gymru
     feedback:
       close: Cau

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -75,15 +75,15 @@ en:
       aria_label: Nation
       england:
         end: " and England"
-        middle: ", England"
+        middle: "England"
         start: England
       northern_ireland:
         end: " and Northern Ireland"
-        middle: ", Northern Ireland"
+        middle: "Northern Ireland"
         start: Northern Ireland
       scotland:
         end: " and Scotland"
-        middle: ", Scotland"
+        middle: "Scotland"
         start: Scotland
       type:
         consultation: Consultation for %{nation}
@@ -92,7 +92,7 @@ en:
         publication: Publication for %{nation}
       wales:
         end: " and Wales"
-        middle: ", Wales"
+        middle: "Wales"
         start: Wales
     feedback:
       close: Cancel

--- a/lib/govuk_publishing_components/presenters/devolved_nations_helper.rb
+++ b/lib/govuk_publishing_components/presenters/devolved_nations_helper.rb
@@ -23,7 +23,8 @@ module GovukPublishingComponents
               else
                 :middle
               end
-        I18n.t("components.devolved_nations.#{nation}.#{key}", locale: use_english_translation ? :en : nil)
+        name = I18n.t("components.devolved_nations.#{nation}.#{key}", locale: use_english_translation ? :en : nil)
+        position.zero? || position == (total - 1) ? name : ", #{name}"
       end
 
       def ga4_applicable_nations_title_text(remove_connector_word = nil)
@@ -41,7 +42,7 @@ module GovukPublishingComponents
 
         url_to_nation_keys.transform_values do |nation_keys|
           nations_text = nation_keys.each_with_index.map { |key, index|
-            name_for_position(key, index, nation_keys.count, true)
+            name_for_position(key, index, nation_keys.count, false)
           }.join
 
           alternative_content_text(nations_text)

--- a/lib/govuk_publishing_components/presenters/devolved_nations_helper.rb
+++ b/lib/govuk_publishing_components/presenters/devolved_nations_helper.rb
@@ -15,9 +15,9 @@ module GovukPublishingComponents
         nation_keys.each_with_index.map { |k, i| name_for_position(k, i, nation_keys.count, use_english_translation) }.join
       end
 
-      def name_for_position(nation, position, total, use_english_translation)
+      def name_for_position(nation, position, total, use_english_translation, cy_initial_mutation: true)
         key = if position.zero?
-                :start
+                cy_initial_mutation ? :start : :middle
               elsif position == (total - 1)
                 :end
               else
@@ -42,7 +42,7 @@ module GovukPublishingComponents
 
         url_to_nation_keys.transform_values do |nation_keys|
           nations_text = nation_keys.each_with_index.map { |key, index|
-            name_for_position(key, index, nation_keys.count, false)
+            name_for_position(key, index, nation_keys.count, false, cy_initial_mutation: false)
           }.join
 
           alternative_content_text(nations_text)

--- a/spec/components/devolved_nations_spec.rb
+++ b/spec/components/devolved_nations_spec.rb
@@ -92,6 +92,52 @@ describe "Devolved Nations", type: :view do
       )
       assert_select ".gem-c-devolved-nations > h2", text: "Yn berthnasol i Loegr, Cymru a'r Alban"
     end
+
+    it "renders a devolved nations component, which applies to one nation, with individual publication available, correctly" do
+      render_component(
+        national_applicability: {
+          england: {
+            applicable: true,
+          },
+          northern_ireland: {
+            applicable: false,
+            alternative_url: "/publication-northern-ireland",
+          },
+          scotland: {
+            applicable: false,
+            alternative_url: "/publication-scotland",
+          },
+          wales: {
+            applicable: false,
+            alternative_url: "/publication-wales",
+          },
+        },
+      )
+      assert_select ".gem-c-devolved-nations > h2", text: "Yn berthnasol i Loegr"
+      assert_select ".gem-c-devolved-nations > ul > li:nth-child(1) > [href='/publication-northern-ireland']", text: "Cyhoeddiad ar gyfer Gogledd Iwerddon"
+      assert_select ".gem-c-devolved-nations > ul > li:nth-child(2) > [href='/publication-scotland']", text: "Cyhoeddiad ar gyfer yr Alban"
+      assert_select ".gem-c-devolved-nations > ul > li:nth-child(3) > [href='/publication-wales']", text: "Cyhoeddiad ar gyfer Cymru"
+    end
+
+    it "renders a devolved nations component, which applies to one nation, with single publication available for other nations, correctly" do
+      render_component(
+        national_applicability: {
+          england: {
+            applicable: false,
+            alternative_url: "/publication-en-ni",
+          },
+          northern_ireland: {
+            applicable: false,
+            alternative_url: "/publication-en-ni",
+          },
+          wales: {
+            applicable: true,
+          },
+        },
+      )
+      assert_select ".gem-c-devolved-nations > h2", text: "Yn berthnasol i Gymru"
+      assert_select ".gem-c-devolved-nations > ul > li:nth-child(1) > [href='/publication-en-ni']", text: "Cyhoeddiad ar gyfer Lloegr a Gogledd Iwerddon"
+    end
   end
 
   it "renders a devolved nations component, which applies to one nation, with individual publication available, correctly" do

--- a/spec/components/devolved_nations_spec.rb
+++ b/spec/components/devolved_nations_spec.rb
@@ -92,6 +92,76 @@ describe "Devolved Nations", type: :view do
       )
       assert_select ".gem-c-devolved-nations > h2", text: "Yn berthnasol i Loegr, Cymru a'r Alban"
     end
+
+    it "renders a devolved nations component, which applies to one nation, with individual publication available, correctly" do
+      render_component(
+        national_applicability: {
+          england: {
+            applicable: true,
+          },
+          northern_ireland: {
+            applicable: false,
+            alternative_url: "/publication-northern-ireland",
+          },
+          scotland: {
+            applicable: false,
+            alternative_url: "/publication-scotland",
+          },
+          wales: {
+            applicable: false,
+            alternative_url: "/publication-wales",
+          },
+        },
+      )
+      assert_select ".gem-c-devolved-nations > h2", text: "Yn berthnasol i Loegr"
+      assert_select ".gem-c-devolved-nations > ul > li:nth-child(1) > [href='/publication-northern-ireland']", text: "Cyhoeddiad ar gyfer Gogledd Iwerddon"
+      assert_select ".gem-c-devolved-nations > ul > li:nth-child(2) > [href='/publication-scotland']", text: "Cyhoeddiad ar gyfer yr Alban"
+      assert_select ".gem-c-devolved-nations > ul > li:nth-child(3) > [href='/publication-wales']", text: "Cyhoeddiad ar gyfer Cymru"
+    end
+
+    it "renders a devolved nations component, which applies to one nation, with single publication available for two other nations, correctly" do
+      render_component(
+        national_applicability: {
+          england: {
+            applicable: false,
+            alternative_url: "/publication-en-ni",
+          },
+          northern_ireland: {
+            applicable: false,
+            alternative_url: "/publication-en-ni",
+          },
+          wales: {
+            applicable: true,
+          },
+        },
+      )
+      assert_select ".gem-c-devolved-nations > h2", text: "Yn berthnasol i Gymru"
+      assert_select ".gem-c-devolved-nations > ul > li:nth-child(1) > [href='/publication-en-ni']", text: "Cyhoeddiad ar gyfer Lloegr a Gogledd Iwerddon"
+    end
+
+    it "renders a devolved nations component, which applies to one nation, with single publication available for three other nations, correctly" do
+      render_component(
+        national_applicability: {
+          england: {
+            applicable: false,
+            alternative_url: "/publication-not-wales",
+          },
+          northern_ireland: {
+            applicable: false,
+            alternative_url: "/publication-not-wales",
+          },
+          wales: {
+            applicable: true,
+          },
+          scotland: {
+            applicable: false,
+            alternative_url: "/publication-not-wales",
+          },
+        },
+      )
+      assert_select ".gem-c-devolved-nations > h2", text: "Yn berthnasol i Gymru"
+      assert_select ".gem-c-devolved-nations > ul > li:nth-child(1) > [href='/publication-not-wales']", text: "Cyhoeddiad ar gyfer Lloegr, Gogledd Iwerddon a'r Alban"
+    end
   end
 
   it "renders a devolved nations component, which applies to one nation, with individual publication available, correctly" do


### PR DESCRIPTION
Todo:

- [x] Wait for confirmation on Zendesk ticket.

## What

Adds support for Welsh in the alternative urls part of the component.

## Why
<!-- What are the reasons behind this change being made? -->
Currently if there are alternative urls provided to the component, the nation name is rendered in English.

Jira card: https://gov-uk.atlassian.net/browse/PNP-10104

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

| Before | After |
|--------|--------|
| <img width="646" height="120" alt="image" src="https://github.com/user-attachments/assets/c0642aa3-6b48-494a-8020-ab5d4eed5916" />| <img width="639" height="115" alt="image" src="https://github.com/user-attachments/assets/3a03b988-de76-4be7-b3c1-6a7cc06ec439" /> |
