### PR TITLE
Restore underline to subscription links feed link

### DIFF
--- a/app/views/govuk_publishing_components/components/_subscription_links.html.erb
+++ b/app/views/govuk_publishing_components/components/_subscription_links.html.erb
@@ -46,7 +46,7 @@
             lang: feed_link_text_locale,
           ) if sl_helper.feed_link_box_value %>
           <%= link_to(feed_link_text, sl_helper.feed_link,
-            class: "govuk-link govuk-link--no-underline gem-c-subscription-links__item #{brand_helper.color_class} gem-c-subscription-links__item--link",
+            class: "govuk-link gem-c-subscription-links__item #{brand_helper.color_class} gem-c-subscription-links__item--link",
             data: sl_helper.feed_link_data_attributes,
             lang: feed_link_text_locale
           ) unless sl_helper.feed_link_box_value %>


### PR DESCRIPTION
## What / why
- removes the no underline class from the 'subscribe to feed' link in the subscription links component
- there are two links in this component, both acting as links, yet this one was not underlined but the other is
- this seems to have been added deliberately five years ago without a clear explanation why: https://github.com/alphagov/govuk_publishing_components/pull/2099/changes/192639a5661948fa3047737f3c8f1219f7913014
- links should look consistent

## Visual Changes

Before | After
----- | ------
<img width="404" height="157" alt="Screenshot 2026-08-05 at 08 46 44" src="https://github.com/user-attachments/assets/7c236785-fdff-4e26-83a9-bf58551922dd" /> | <img width="412" height="158" alt="Screenshot 2026-08-05 at 08 48 10" src="https://github.com/user-attachments/assets/a121ea89-0d86-48b2-b636-b57d3249b410" />
<img width="723" height="359" alt="Screenshot 2026-08-05 at 08 48 35" src="https://github.com/user-attachments/assets/c840711c-816f-4ebd-a8de-f409cc8f0996" /> | <img width="722" height="354" alt="Screenshot 2026-08-05 at 08 48 47" src="https://github.com/user-attachments/assets/2391e4f3-1828-4fb4-8527-8b48ad983fe2" />

