### PR TITLE
Fix text wrapping in govspeak footnotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix text wrapping in govspeak footnotes ([PR #5637](https://github.com/alphagov/govuk_publishing_components/pull/5637))
+
 ## 67.0.0
 
 * Add options to the details component ([PR #5594](https://github.com/alphagov/govuk_publishing_components/pull/5594))

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_footnotes.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_footnotes.scss
@@ -17,10 +17,7 @@
     border-top: 1px solid govuk-colour("mid-grey");
     margin: 0 0 govuk-spacing(4) 0;
     padding-top: govuk-spacing(4);
-
-    a {
-      overflow-wrap: break-word;
-    }
+    overflow-wrap: break-word;
 
     ol li:nth-of-type(99) ~ li {
       margin-left: 11px;


### PR DESCRIPTION
## What / why
- move the text wrap property from being only applied to A tags within footnotes to anything within a footnote
- an example has occurred where a URL is in a footnote but not in link, and the text is failing to wrap on mobile and breaking the page layout
- considered a wider solution to this (put break-word on all of govspeak?) but I'm not sure of the consequences, and this seems like a sensible fix in the circumstances
- example problem found in footnote 27 on this page: https://www.gov.uk/government/publications/disability-foresight-research-future-trends-for-disabled-people/disability-foresight-research-uk-final-report#executive-summary

## Visual Changes
Before | After
----- | ------
<img width="477" height="117" alt="Screenshot 2026-08-05 at 15 23 22" src="https://github.com/user-attachments/assets/f1948447-2f79-4a7f-b644-239755cae33d" /> | <img width="494" height="160" alt="Screenshot 2026-08-05 at 15 23 48" src="https://github.com/user-attachments/assets/5c07c0f7-e68d-496d-9fc4-228d02fa7078" />
