### PR TITLE
Version 67.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 67.0.1
 
 * Fix text wrapping in govspeak footnotes ([PR #5637](https://github.com/alphagov/govuk_publishing_components/pull/5637))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (67.0.0)
+    govuk_publishing_components (67.0.1)
       chartkick
       govuk_app_config
       govuk_personalisation (>= 0.7.0)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "67.0.0".freeze
+  VERSION = "67.0.1".freeze
 end


### PR DESCRIPTION
## 67.0.1

* Fix text wrapping in govspeak footnotes ([PR #5637](https://github.com/alphagov/govuk_publishing_components/pull/5637))
