### PR TITLE
Add Cross service header to component guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Set attachment SVG sizes ([PR #5639](https://github.com/alphagov/govuk_publishing_components/pull/5639))
+* Add Cross service header to component guide ([PR #5640](https://github.com/alphagov/govuk_publishing_components/pull/5640))
 
 ## 67.0.1
 

--- a/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
@@ -68,6 +68,26 @@ examples:
           message: "This is the phase banner banner"
       emergency_banner: <div class="govuk-!-padding-top-3 govuk-!-padding-bottom-3">This is the emergency banner slot</div>
       global_banner: <div class="govuk-!-padding-top-5 govuk-!-padding-bottom-3">This is the global banner slot</div>
+  with_cross_service_header:
+    description: Passes the navigation through to the [cross service header](/component-guide/cross_service_header/).
+    data:
+      show_cross_service_header: true
+      service_name: "My Service Name"
+      one_login_navigation_items:
+        one_login_home:
+          href: "#"
+        one_login_sign_out:
+          href: "#"
+        navigation_items: []
+      service_navigation_items:
+        - text: Navigation item 1
+          href: "item-1"
+          active: true
+        - text: Navigation item 2
+          href: "item-2"
+        - text: Hidden on desktop
+          href: "item-3"
+          show_only_in_collapsed_menu: true
   with_account_layout_enabled:
     description: Adds account layout wrapper around the content passed in to the component
     data:


### PR DESCRIPTION
## What
- Added the Cross service header to the component guide.

## Why
The Cross service header renders the One Login header navigation and the service navigation in the public layout. This can now be previewed in the component guide.


## Visual Changes
<img width="1098" height="304" alt="Screenshot 2026-08-07 at 14 52 42" src="https://github.com/user-attachments/assets/f8dc57b2-4cab-479f-bfe8-a34b720acaf3" />

