### PR TITLE
Update form date input component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Prevent metadata component rendering when no data ([PR #5672](https://github.com/alphagov/govuk_publishing_components/pull/5672))
+* Update form date input component ([PR #5644](https://github.com/alphagov/govuk_publishing_components/pull/5644))
 
 ## 68.3.0
 

--- a/app/views/govuk_publishing_components/components/_date_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_date_input.html.erb
@@ -8,30 +8,34 @@
   ]
   autocomplete_date_of_birth ||= nil
   legend_text ||= nil
+  legend_heading_level ||= nil
+  legend_size ||= nil
   hint ||= nil
   error_message ||= nil
   error_items ||= []
-  describedby ||= nil
-  has_error ||= error_message || error_items.any?
+  error_id ||= nil
+  has_error ||= error_message || error_items.any? || error_id
 
   css_classes = %w(gem-c-date-input govuk-date-input)
   form_group_css_classes = %w(govuk-form-group)
   form_group_css_classes << "govuk-form-group--error" if has_error
 
   hint_id = "hint-#{SecureRandom.hex(4)}"
-  error_id = "error-#{SecureRandom.hex(4)}"
+  error_id = error_id || "error-#{SecureRandom.hex(4)}"
 
-  aria_described_by ||= nil
-  if hint || has_error || describedby
+  aria_described_by = nil
+  if hint || has_error
     aria_described_by = []
-    aria_described_by << hint_id if hint
+    aria_described_by << hint_id if hint && !has_error
     aria_described_by << error_id if has_error
-    aria_described_by << describedby if describedby
     aria_described_by = aria_described_by.join(" ")
   end
+
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class(form_group_css_classes.join(" "))
 %>
 
-<%= content_tag :div, class: form_group_css_classes do %>
+<%= tag.div(**component_helper.all_attributes) do %>
   <% fieldset_content = capture do %>
     <% if hint %>
       <%= render "govuk_publishing_components/components/hint", {
@@ -41,7 +45,7 @@
       } %>
     <% end %>
 
-    <% if has_error %>
+    <% if error_message || error_items.any? %>
       <%= render "govuk_publishing_components/components/error_message", {
         id:  error_id,
         text: error_message,
@@ -62,6 +66,7 @@
             value: item[:value],
             width: item[:width],
             id: item[:id],
+            describedby: aria_described_by,
             type: "number",
             data: item[:data],
             autocomplete: autocomplete_date_of_birth ? "bday-#{item[:name]}" : nil,
@@ -73,8 +78,9 @@
 
   <% if legend_text %>
     <%= render "govuk_publishing_components/components/fieldset", {
-      describedby: aria_described_by,
       legend_text: legend_text,
+      heading_level: legend_heading_level,
+      heading_size: legend_size,
       text: fieldset_content,
       role: "group",
     } %>

--- a/app/views/govuk_publishing_components/components/docs/date_input.yml
+++ b/app/views/govuk_publishing_components/components/docs/date_input.yml
@@ -1,5 +1,6 @@
 name: Form date input
 description: Use the date input component to help users enter a memorable date or one they can easily look up.
+uses_component_wrapper_helper: true
 accessibility_criteria: |
   Inputs in the component must:
 
@@ -36,22 +37,44 @@ examples:
   with_legend:
     data:
       legend_text: "What is your date of birth?"
+  with_legend_level_and_size:
+    description: Valid options for level are 1 to 6. Valid options for size are s, m, l and xl.
+    data:
+      legend_text: "What is your date of birth?"
+      legend_heading_level: 2
+      legend_size: "l"
   with_hint:
+    description: When hint text is rendered each input field takes the value of `hint_id` as a value for the `aria-describedby` attribute
     data:
       legend_text: "What is your date of birth?"
       hint: "For example, 31 3 1980"
   with_error:
+    description: When an error message is rendered each input field takes the value of `error_id` as a value for the `aria-describedby` attribute. Note that error_id is optional, if it is not passed one will be generated automatically.
     data:
       legend_text: "What is your date of birth?"
       hint: "For example, 31 3 1980"
+      error_id: error_item_id
       error_message: "Error message goes here"
   with_error_items:
+    description: When error messages are rendered each input field takes the value of `error_id` as a value for the `aria-describedby` attribute. Note that error_id is optional, if it is not passed one will be generated automatically.
     data:
       legend_text: "What is your date of birth?"
       hint: "For example, 31 3 1980"
+      error_id: error_id
       error_items:
         - text: "Error 1"
         - text: "Error 2"
+  with_error_id_but_no_message:
+    description: For some instances of this component the error message should be rendered separately but an error state is still required. In this scenario an `error_id` can be passed without an `error_message` to highlight the component and set `aria-describedby` correctly.
+    data:
+      legend_text: "What is your date of birth?"
+      hint: "For example, 31 3 1980"
+      error_id: error_id
+  with_data_attributes:
+    data:
+      data_attributes:
+        module: "some-module"
+        other_attribute: "something-else"
   with_custom_items:
     data:
       legend_text: "Beth yw eich dyddiad geni?"

--- a/spec/components/date_input_spec.rb
+++ b/spec/components/date_input_spec.rb
@@ -5,6 +5,10 @@ describe "Date input", type: :view do
     "date_input"
   end
 
+  before do
+    allow(SecureRandom).to receive(:hex).and_return("1234")
+  end
+
   it "renders with default fields when no data is given" do
     render_component({})
 
@@ -42,8 +46,17 @@ describe "Date input", type: :view do
     )
 
     assert_select ".govuk-fieldset[role=group] .govuk-fieldset__legend", text: "What is your date of birth?"
-    assert_select ".govuk-fieldset[role=group] .govuk-date-input", 1
-    assert_select ".govuk-fieldset[role=group] .govuk-date-input__item", 3
+  end
+
+  it "renders with custom legend heading level and size" do
+    render_component(
+      legend_text: "What is your date of birth?",
+      legend_heading_level: 1,
+      legend_size: "l",
+    )
+
+    assert_select ".govuk-fieldset[role=group] .govuk-fieldset__legend.govuk-fieldset__legend--l"
+    assert_select ".govuk-fieldset[role=group] .govuk-fieldset__legend h1", text: "What is your date of birth?"
   end
 
   it "renders with hint" do
@@ -53,6 +66,9 @@ describe "Date input", type: :view do
     )
 
     assert_select ".govuk-fieldset[role=group] .govuk-hint", text: "For example, 31 3 1980"
+    assert_select "input[name='day'][aria-describedby='hint-1234']"
+    assert_select "input[name='month'][aria-describedby='hint-1234']"
+    assert_select "input[name='year'][aria-describedby='hint-1234']"
   end
 
   it "renders with error message" do
@@ -63,6 +79,51 @@ describe "Date input", type: :view do
 
     assert_select ".govuk-form-group--error .govuk-fieldset[role=group] .govuk-error-message", text: "Error: Error message goes here"
     assert_select ".govuk-form-group--error .govuk-fieldset[role=group] .govuk-date-input__item .govuk-input--error", 3
+    assert_select "input[name='day'][aria-describedby='error-1234']"
+    assert_select "input[name='month'][aria-describedby='error-1234']"
+    assert_select "input[name='year'][aria-describedby='error-1234']"
+  end
+
+  it "renders with hint and error message" do
+    render_component(
+      legend_text: "What is your date of birth?",
+      hint: "For example, 31 3 1980",
+      error_message: "Error message goes here",
+    )
+
+    assert_select ".govuk-fieldset[role=group] .govuk-hint", text: "For example, 31 3 1980"
+    assert_select ".govuk-form-group--error .govuk-fieldset[role=group] .govuk-error-message", text: "Error: Error message goes here"
+    assert_select ".govuk-form-group--error .govuk-fieldset[role=group] .govuk-date-input__item .govuk-input--error", 3
+    assert_select "input[name='day'][aria-describedby='error-1234']"
+    assert_select "input[name='month'][aria-describedby='error-1234']"
+    assert_select "input[name='year'][aria-describedby='error-1234']"
+  end
+
+  it "renders with an error id but no message" do
+    error_id = "error-id"
+
+    render_component(
+      legend_text: "What is your date of birth?",
+      hint: "For example, 31 3 1980",
+      error_id: error_id,
+    )
+
+    assert_select ".govuk-fieldset[role=group] .govuk-hint", text: "For example, 31 3 1980"
+    assert_select ".govuk-form-group--error .govuk-fieldset[role=group] .govuk-date-input__item .govuk-input--error", 3
+    assert_select "input[name='day'][aria-describedby='#{error_id}']"
+    assert_select "input[name='month'][aria-describedby='#{error_id}']"
+    assert_select "input[name='year'][aria-describedby='#{error_id}']"
+  end
+
+  it "renders with data attributes" do
+    render_component(
+      data_attributes: {
+        module: "not-a-real-module",
+        something_else: "i-just-thought-of",
+      },
+    )
+
+    assert_select ".govuk-form-group[data-module='not-a-real-module'][data-something-else='i-just-thought-of']"
   end
 
   it "renders with custom items" do


### PR DESCRIPTION
## What
Makes updates to the "Form date input" component: 
- Add new option "With legend level and size"
- Add new option "With data attributes"
- Add new option "With error id but no message"
  - similar to the option in the [Select](https://components.publishing.service.gov.uk/component-guide/select#with_error_id_but_no_message) component
- Update how "aria-describedby" attributes are applied: 
  - By default there is no such attribute
  - If hint text is present `input` elements take the `hint-id` as the value for `aria-describedby`
    - similar to the option in the [Select](https://components.publishing.service.gov.uk/component-guide/select#with_hint) component
  - If error messages are present `input` elements take the `error-id` as the value for `aria-describedby`
    - similar to the option in the [Select](https://components.publishing.service.gov.uk/component-guide/select#with_error) component
  - If both hint and error text are present `input` elements take the `error-id` as the value for `aria-describedby
<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
<!-- What are the reasons behind this change being made? -->
Jira card: https://gov-uk.atlassian.net/browse/MAIN-1311

This is part of the bigger task to introduce a new "Datetime fields" component. The work to do this is partially done and exists in [another PR](https://github.com/alphagov/govuk_publishing_components/pull/5492). The "Datetime fields" component uses the "Form date input" component to render date input fields but requires some changes for it to function correctly so I am splitting out the required changes to that component in this PR to avoid that becoming overly complicated. These include:
- making the legend level and text size configurable
- allowing data-attributes to be passed through to the component
- allowing the component to display the input fields styled as errors without also displaying error messages and for these to have an aria-describedby attribute that matches the error id
- updating how the aria-describedby attributes are applied, which is incorrect in the component as it currently exists. 

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

| Option | Screenshot | Markup (partial) generated by component |
|--------|--------|--------|
|With legend level and size|<img width="959" height="417" alt="Screenshot 2026-08-11 at 14 36 29" src="https://github.com/user-attachments/assets/1bd70d8f-bb42-4d41-9288-7184f59345f8" />|\<legend class="govuk-fieldset__legend govuk-fieldset__legend--l"\>\<h2 class="govuk-fieldset__heading">What is your date of birth?\</h2>\</legend>|
|With data attributes|<img width="959" height="385" alt="Screenshot 2026-08-11 at 14 38 30" src="https://github.com/user-attachments/assets/9c8bd203-401c-455c-8f30-077a29042ef2" />|\<div class="govuk-form-group" data-module="some-module" data-other-attribute="something-else"\> ... \</div\>|
|With error id but no message|<img width="959" height="440" alt="Screenshot 2026-08-11 at 14 40 17" src="https://github.com/user-attachments/assets/7d3b7b18-d21e-4fb6-8cfb-fbcdf96531aa" />|\<div class="govuk-form-group--error"\> ... \<input aria-describedby="error_id"\> ... \<input aria-describedby="error_id"\> ... \<input aria-describedby="error_id"\> ... \</div\>|
|If hint text is present `input` elements take the `hint-id` as the value for `aria-describedby`|<img width="959" height="402" alt="Screenshot 2026-08-11 at 14 42 48" src="https://github.com/user-attachments/assets/e3fe7b37-4b29-4ef1-bc27-ddf0ebeaa859" />|\<div id="hint-0342f3e9"\>For example, 31 3 1980\</div\> ... \<input aria-describedby="hint-0342f3e9"\> ... \<input aria-describedby="hint-0342f3e9"\> ... \<input aria-describedby="hint-0342f3e9"\>|
|If error messages are present `input` elements take the `error-id` as the value for `aria-describedby`|<img width="959" height="476" alt="Screenshot 2026-08-11 at 14 44 45" src="https://github.com/user-attachments/assets/15d39081-0b5d-4e5e-a53f-9a8a262b49a4" />|\<div id="hint-6fded4c1"\>For example, 31 3 1980\</div\> ... \<p id="error-cd5fedb6"\>Error message goes here\</p\> ... \<input aria-describedby="error-cd5fedb6"\> ... \<input aria-describedby="error-cd5fedb6"\> ... \<input aria-describedby="error-cd5fedb6"\>|
