### PR TITLE
Version 67.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 67.1.0
 
 * Improve Devolved Nations Component Welsh Support ([PR #5633](https://github.com/alphagov/govuk_publishing_components/pull/5633))
 * Set attachment SVG sizes ([PR #5639](https://github.com/alphagov/govuk_publishing_components/pull/5639))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (67.0.1)
+    govuk_publishing_components (67.1.0)
       chartkick
       govuk_app_config
       govuk_personalisation (>= 0.7.0)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "67.0.1".freeze
+  VERSION = "67.1.0".freeze
 end


### PR DESCRIPTION
## Version 67.1.0

* Improve Devolved Nations Component Welsh Support ([PR #5633](https://github.com/alphagov/govuk_publishing_components/pull/5633))
* Set attachment SVG sizes ([PR #5639](https://github.com/alphagov/govuk_publishing_components/pull/5639))
* Add Cross service header to component guide ([PR #5640](https://github.com/alphagov/govuk_publishing_components/pull/5640))
* Separate the header element from the super navigation header component ([PR #5627](https://github.com/alphagov/govuk_publishing_components/pull/5627))

