### PR TITLE
Improve filter Javascript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Improve filter Javascript ([PR #5646](https://github.com/alphagov/govuk_publishing_components/pull/5646))
 * Add new brand colour for BIST ([PR #5652](https://github.com/alphagov/govuk_publishing_components/pull/5652))
 
 ## 68.0.0

--- a/app/assets/javascripts/govuk_publishing_components/lib/filter-list.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/filter-list.js
@@ -5,11 +5,15 @@
     this.module = module
     this.items = this.module.querySelectorAll('[data-filter-item]')
     this.labelText = this.module.getAttribute('data-filter-label') || 'Filter list'
+    this.resultsFound = this.items.length
+    this.resultsId = 'filter-results-count'
   }
 
   FilterList.prototype.init = function () {
-    if (this.items.length) {
+    if (this.resultsFound) {
       this.appendFilterInput()
+      this.resultsElement = document.getElementById(this.resultsId)
+      this.updateResultsCount()
     }
   }
 
@@ -23,13 +27,17 @@
     formLabel.textContent = this.labelText
 
     const formInput = document.createElement('input')
-    formInput.classList.add('gem-c-input', 'govuk-input')
+    formInput.classList.add('gem-c-input', 'govuk-input', 'govuk-!-margin-bottom-1')
     formInput.id = 'filterInput'
     formInput.name = 'name'
     formInput.spellcheck = false
     formInput.type = 'text'
 
-    form.append(formLabel, formInput)
+    const results = document.createElement('div')
+    results.classList.add('govuk-hint')
+    results.id = this.resultsId
+
+    form.append(formLabel, formInput, results)
 
     this.module.prepend(form)
     const input = form.querySelector('.govuk-input')
@@ -50,6 +58,12 @@
         item.classList.add('govuk-!-display-none')
       }
     }
+    this.updateResultsCount()
+  }
+
+  FilterList.prototype.updateResultsCount = function () {
+    const count = Array.from(this.items).filter((item) => !item.classList.contains('govuk-!-display-none')).length
+    this.resultsElement.innerHTML = count === 1 ? `${count} result found` : `${count === 0 ? 'No' : count} results found`
   }
 
   Modules.FilterList = FilterList

--- a/app/assets/javascripts/govuk_publishing_components/lib/filter-list.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/filter-list.js
@@ -7,13 +7,20 @@
     this.labelText = this.module.getAttribute('data-filter-label') || 'Filter list'
     this.resultsFound = this.items.length
     this.resultsId = 'filter-results-count'
+
+    window.GOVUK.vars = window.GOVUK.vars || {}
   }
 
   FilterList.prototype.init = function () {
+    if (window.GOVUK.vars.filterStarted) {
+      return
+    }
+
     if (this.resultsFound) {
       this.appendFilterInput()
       this.resultsElement = document.getElementById(this.resultsId)
       this.updateResultsCount()
+      window.GOVUK.vars.filterStarted = true
     }
   }
 

--- a/app/assets/javascripts/govuk_publishing_components/lib/filter-list.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/filter-list.js
@@ -3,7 +3,7 @@
 
   function FilterList (module) {
     this.module = module
-    this.items = this.module.querySelectorAll('[data-filter-item]')
+    this.items = document.querySelectorAll('[data-filter-item]')
     this.labelText = this.module.getAttribute('data-filter-label') || 'Filter list'
     this.resultsFound = this.items.length
     this.resultsId = 'filter-results-count'

--- a/app/assets/javascripts/govuk_publishing_components/lib/filter-list.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/filter-list.js
@@ -32,10 +32,12 @@
     formInput.name = 'name'
     formInput.spellcheck = false
     formInput.type = 'text'
+    formInput.setAttribute('aria-describedby', this.resultsId)
 
     const results = document.createElement('div')
     results.classList.add('govuk-hint')
     results.id = this.resultsId
+    results.setAttribute('aria-live', 'polite')
 
     form.append(formLabel, formInput, results)
 
@@ -63,7 +65,9 @@
 
   FilterList.prototype.updateResultsCount = function () {
     const count = Array.from(this.items).filter((item) => !item.classList.contains('govuk-!-display-none')).length
-    this.resultsElement.innerHTML = count === 1 ? `${count} result found` : `${count === 0 ? 'No' : count} results found`
+    const text = count === 1 ? `${count} result found` : `${count === 0 ? 'No' : count} results found`
+
+    this.resultsElement.innerHTML = count !== this.resultsFound ? text : ''
   }
 
   Modules.FilterList = FilterList

--- a/spec/javascripts/govuk_publishing_components/lib/filter-list-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/filter-list-spec.js
@@ -33,6 +33,8 @@ describe('The filter list code', function () {
     it('creates an input if there is something to filter', function () {
       expect(el.querySelectorAll('label.gem-c-label')).toHaveSize(1)
       expect(el.querySelectorAll('input.gem-c-input')).toHaveSize(1)
+      expect(el.querySelectorAll('.govuk-hint')).toHaveSize(1)
+      expect(el.querySelector('.govuk-hint').textContent).toBe('3 results found')
     })
 
     it('shows one element based on user input', function () {
@@ -41,6 +43,7 @@ describe('The filter list code', function () {
       expect(el.querySelector('[data-filter-item="a"]')).toHaveClass('govuk-!-display-none')
       expect(el.querySelector('[data-filter-item="b"]')).not.toHaveClass('govuk-!-display-none')
       expect(el.querySelector('[data-filter-item="c"]')).toHaveClass('govuk-!-display-none')
+      expect(el.querySelector('.govuk-hint').textContent).toBe('1 result found')
     })
 
     it('shows multiple elements based on user input', function () {
@@ -49,6 +52,16 @@ describe('The filter list code', function () {
       expect(el.querySelector('[data-filter-item="a"]')).not.toHaveClass('govuk-!-display-none')
       expect(el.querySelector('[data-filter-item="b"]')).toHaveClass('govuk-!-display-none')
       expect(el.querySelector('[data-filter-item="c"]')).not.toHaveClass('govuk-!-display-none')
+      expect(el.querySelector('.govuk-hint').textContent).toBe('2 results found')
+    })
+
+    it('shows no results if the input does not match', function () {
+      input.value = 'france'
+      window.GOVUK.triggerEvent(input, 'input')
+      expect(el.querySelector('[data-filter-item="a"]')).toHaveClass('govuk-!-display-none')
+      expect(el.querySelector('[data-filter-item="b"]')).toHaveClass('govuk-!-display-none')
+      expect(el.querySelector('[data-filter-item="c"]')).toHaveClass('govuk-!-display-none')
+      expect(el.querySelector('.govuk-hint').textContent).toBe('No results found')
     })
 
     it('resets if the input is cleared', function () {
@@ -57,6 +70,7 @@ describe('The filter list code', function () {
       expect(el.querySelector('[data-filter-item="a"]')).not.toHaveClass('govuk-!-display-none')
       expect(el.querySelector('[data-filter-item="b"]')).not.toHaveClass('govuk-!-display-none')
       expect(el.querySelector('[data-filter-item="c"]')).not.toHaveClass('govuk-!-display-none')
+      expect(el.querySelector('.govuk-hint').textContent).toBe('3 results found')
     })
   })
 

--- a/spec/javascripts/govuk_publishing_components/lib/filter-list-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/filter-list-spec.js
@@ -4,9 +4,12 @@ describe('The filter list code', function () {
   const el = document.createElement('div')
   let input
   const markup = `
-    <p data-filter-item="a">United Kingdom</p>
-    <p data-filter-item="b">United States</p>
-    <p data-filter-item="c">United Kingdom of Smaller Countries</p>
+    <div id="separate"></div>
+    <div>
+      <p data-filter-item="a">United Kingdom</p>
+      <p data-filter-item="b">United States</p>
+      <p data-filter-item="c">United Kingdom of Smaller Countries</p>
+    </div>
   `
 
   beforeEach(function () {
@@ -27,7 +30,7 @@ describe('The filter list code', function () {
   describe('filtering', function () {
     beforeEach(function () {
       el.innerHTML = markup
-      new window.GOVUK.Modules.FilterList(el).init()
+      new window.GOVUK.Modules.FilterList(document.getElementById('separate')).init()
       input = el.querySelector('input')
     })
 

--- a/spec/javascripts/govuk_publishing_components/lib/filter-list-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/filter-list-spec.js
@@ -33,8 +33,10 @@ describe('The filter list code', function () {
     it('creates an input if there is something to filter', function () {
       expect(el.querySelectorAll('label.gem-c-label')).toHaveSize(1)
       expect(el.querySelectorAll('input.gem-c-input')).toHaveSize(1)
+      expect(el.querySelector('input.gem-c-input').getAttribute('aria-describedby')).toBe('filter-results-count')
       expect(el.querySelectorAll('.govuk-hint')).toHaveSize(1)
-      expect(el.querySelector('.govuk-hint').textContent).toBe('3 results found')
+      expect(el.querySelector('.govuk-hint').textContent).toBe('')
+      expect(el.querySelector('.govuk-hint').getAttribute('aria-live')).toBe('polite')
     })
 
     it('shows one element based on user input', function () {
@@ -70,7 +72,7 @@ describe('The filter list code', function () {
       expect(el.querySelector('[data-filter-item="a"]')).not.toHaveClass('govuk-!-display-none')
       expect(el.querySelector('[data-filter-item="b"]')).not.toHaveClass('govuk-!-display-none')
       expect(el.querySelector('[data-filter-item="c"]')).not.toHaveClass('govuk-!-display-none')
-      expect(el.querySelector('.govuk-hint').textContent).toBe('3 results found')
+      expect(el.querySelector('.govuk-hint').textContent).toBe('')
     })
   })
 

--- a/spec/javascripts/govuk_publishing_components/lib/filter-list-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/filter-list-spec.js
@@ -14,6 +14,7 @@ describe('The filter list code', function () {
   })
 
   afterEach(function () {
+    delete window.GOVUK.vars.filterStarted
     document.body.removeChild(el)
   })
 
@@ -28,6 +29,19 @@ describe('The filter list code', function () {
       el.innerHTML = markup
       new window.GOVUK.Modules.FilterList(el).init()
       input = el.querySelector('input')
+    })
+
+    it('only creates one instance of itself', function () {
+      const markup2 = `
+        <p data-filter-item="a">United Kingdom</p>
+        <p data-filter-item="b">United States</p>
+      `
+      const el2 = document.createElement('div')
+      el2.innerHTML = markup2
+      document.body.appendChild(el2)
+      new window.GOVUK.Modules.FilterList(el2).init()
+      expect(document.querySelectorAll('input.gem-c-input')).toHaveSize(1)
+      document.body.removeChild(el2)
     })
 
     it('creates an input if there is something to filter', function () {


### PR DESCRIPTION
## What
Improve the generic filter JavaScript. This is currently used in the component guide main page and on the component guide applications page.

- adds a result count
- announces the result count for screen reader users
- prevents itself from initialising more than once on a page
- allow the script to be used anywhere on a page, not tied to the element containing the things that need filtering

## Why
These improvements will make this a more viable option for public use.

## Visual Changes
Example from its use on the component guide main page:

<img width="1094" height="305" alt="Screenshot 2026-08-11 at 17 02 01" src="https://github.com/user-attachments/assets/cfeeeb9b-b8d5-4fbb-8378-6c8a77668fb2" />
