### PR TITLE
Fix failing accordion test

### DIFF
--- a/spec/features/accordion_spec.rb
+++ b/spec/features/accordion_spec.rb
@@ -17,7 +17,9 @@ describe "Accordion", :capybara, :js do
   def then_the_accordion_loads
     expect(page).to have_css(".gem-c-accordion", visible: :visible)
     expect(page).to have_css(".govuk-accordion__show-all", visible: :visible)
-    expect(page).to have_css(".govuk-accordion__section-content[hidden='until-found']", text: "This is the content for Writing well for the web.")
+    # rubocop:disable Capybara/VisibilityMatcher
+    expect(page).to have_css(".govuk-accordion__section-content[hidden='until-found']", text: "This is the content for Writing well for the web.", visible: false)
+    # rubocop:enable Capybara/VisibilityMatcher
   end
 
   def when_i_click_the_first_accordion_section
@@ -26,8 +28,10 @@ describe "Accordion", :capybara, :js do
 
   def then_the_accordion_opens
     expect(page).to have_selector(".govuk-accordion__section.govuk-accordion__section--expanded", visible: :visible)
-    expect(page).to have_css(".govuk-accordion__section-content", text: "This is the content for Writing well for the web.")
-    expect(page).not_to have_css(".govuk-accordion__section-content[hidden='until-found']", text: "This is the content for Writing well for the web.")
+    expect(page).to have_css(".govuk-accordion__section-content", text: "This is the content for Writing well for the web.", visible: :visible)
+    # rubocop:disable Capybara/VisibilityMatcher
+    expect(page).not_to have_css(".govuk-accordion__section-content[hidden='until-found']", text: "This is the content for Writing well for the web.", visible: false)
+    # rubocop:enable Capybara/VisibilityMatcher
   end
 
   def then_the_accordion_has_data_attributes


### PR DESCRIPTION
## What
- test was failing locally (but apparently not on github)
- needed to add visible: false as the accordion section in question is invisible (collapsed)
- what isn't clear is how this test was passing previously, or what changed that made it fail

For some reason Rubocop doesn't like `visible: false` and insists on `visible: :hidden` instead, but this causes the test to fail again, so I've added the disable/enable lines to make it pass.

## Why
Failure was as follows:

```
  1) Accordion There is a page with the accordion rendered
     Failure/Error: expect(page).to have_css(".govuk-accordion__section-content[hidden='until-found']", text: "This is the content for Writing well for the web.")
       expected `#<Capybara::Session>.has_css?(".govuk-accordion__section-content[hidden='until-found']", {:text=>"This is the content for Writing well for the web."})` to be truthy, got false
     # ./spec/features/accordion_spec.rb:20:in `then_the_accordion_loads'
     # ./spec/features/accordion_spec.rb:6:in `block (2 levels) in <top (required)>'

Finished in 4.29 seconds (files took 1.82 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/features/accordion_spec.rb:4 # Accordion There is a page with the accordion rendered
```

The test is doing the following steps:

- create an accordion, by default with all sections closed (hidden)
- check that the first section (which contains the text `This is the content for Writing well for the web.`) is closed as it should be, by matching the CSS of the element, along with the text it contains and the `hidden='until-found'` attribute (this attribute is toggled off when an accordion section is opened) **<- this is the bit that was failing**
- click to expand the first section
- then check that the first section is opened, by doing two checks...
- first check that there's a section with the text above
- then also check that there isn't a section with the text above that still has the `hidden='until-found'` attribute. This second check seems a little unnecessary but the first check would pass even if the section was still hidden


## Visual Changes
None.