### PR TITLE
Version 68.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## 68.0.0
 
-* **BREAKING:** Bump govuk frontend to 6 ([PR #5550](https://github.com/alphagov/govuk_publishing_components/pull/5550))
+* **BREAKING:** Bump govuk frontend to v6 ([PR #5550](https://github.com/alphagov/govuk_publishing_components/pull/5550))
 
 ## 67.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 68.0.0
 
 * **BREAKING:** Bump govuk frontend to 6 ([PR #5550](https://github.com/alphagov/govuk_publishing_components/pull/5550))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (67.1.0)
+    govuk_publishing_components (68.0.0)
       chartkick
       govuk_app_config
       govuk_personalisation (>= 0.7.0)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "67.1.0".freeze
+  VERSION = "68.0.0".freeze
 end


### PR DESCRIPTION
## Version 68.0.0

* **BREAKING:** Bump govuk frontend to v6 ([PR #5550](https://github.com/alphagov/govuk_publishing_components/pull/5550))

