### PR TITLE
Remove Grade X browser support from the super navigation header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Prevent metadata component rendering when no data ([PR #5672](https://github.com/alphagov/govuk_publishing_components/pull/5672))
 * Update form date input component ([PR #5644](https://github.com/alphagov/govuk_publishing_components/pull/5644))
+* Remove Grade X browser support from the super navigation header ([PR #5649](https://github.com/alphagov/govuk_publishing_components/pull/5649))
 
 ## 68.3.0
 

--- a/app/assets/javascripts/govuk_publishing_components/components/layout-super-navigation-header.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/layout-super-navigation-header.js
@@ -1,89 +1,51 @@
 (function (Modules) {
-  var SETTINGS = {
+  const SETTINGS = {
     label: {
       hide: 'data-text-for-hide',
       show: 'data-text-for-show'
     }
   }
 
-  // Small helpers that update the label when the state of the button has
-  // changed:
-  var setLabel = function ($button, showOrHide) {
-    var newLabel = $button.getAttribute(SETTINGS.label[showOrHide])
+  // Small helpers that update the label when the state of the button has changed:
+  const setLabel = function (button, showOrHide) {
+    const newLabel = button.getAttribute(SETTINGS.label[showOrHide])
 
     if (newLabel) {
-      $button.setAttribute('aria-label', newLabel)
+      button.setAttribute('aria-label', newLabel)
     }
   }
 
   // Wrapper functions to contain all of the mechanisms needed for hiding and
   // toggling the menus.
-  var hide = function ($button, $menu) {
-    $button.setAttribute('aria-expanded', false)
-    $button.classList.remove('gem-c-layout-super-navigation-header__open-button')
-    $menu.setAttribute('hidden', 'hidden')
-    setLabel($button, 'show')
-  }
-  var show = function ($button, $menu) {
-    $button.setAttribute('aria-expanded', true)
-    $button.classList.add('gem-c-layout-super-navigation-header__open-button')
-    $menu.removeAttribute('hidden')
-    setLabel($button, 'hide')
+  const hide = function (button, menu) {
+    button.setAttribute('aria-expanded', false)
+    button.classList.remove('gem-c-layout-super-navigation-header__open-button')
+    menu.setAttribute('hidden', 'hidden')
+    setLabel(button, 'show')
   }
 
-  var toggle = function ($button, $menu) {
-    var isOpen = $button.getAttribute('aria-expanded') === 'true'
+  const show = function (button, menu) {
+    button.setAttribute('aria-expanded', true)
+    button.classList.add('gem-c-layout-super-navigation-header__open-button')
+    menu.removeAttribute('hidden')
+    setLabel(button, 'hide')
+  }
+
+  const toggle = function (button, menu) {
+    const isOpen = button.getAttribute('aria-expanded') === 'true'
     if (isOpen) {
-      hide($button, $menu)
+      hide(button, menu)
     } else {
-      show($button, $menu)
+      show(button, menu)
     }
   }
 
-  // Clicking an element inside a `button` element causes the `event.target` to
-  // be the inside element, not the button. This can be taken care of by setting
-  // the CSS pointer-events to be none, but that doesn't work for older
-  // browsers, won't work for people with CSS turned off, or for people who are
-  // using CSS overrides.
-  //    This checks if the $element is the `elementType`; if it is, it gets
-  // returned; if not it recursively checks to see if the parent element is a
-  // `elementType`. This means that it can be used with `pointer-events: none`.
-  var closestParentIncluding = function ($element, elementType) {
-    if ($element.tagName.toLowerCase() === elementType.toLowerCase()) {
-      return $element
-    }
-    return closestParentIncluding($element.parentNode, elementType)
-  }
-
-  // Searched the previous elements to find one with the same tag as set in
-  // `elementType` . If it's found the element is returned; if not, it returns
-  // null.
-  var closestPrevious = function ($element, elementType) {
-    if ($element === null) {
-      return null
-    }
-
-    // Using `previousSibling` means that there is a possibility that the
-    // $element could be a text node or a comment node - checking the `nodeType`
-    // of the element will ensure that it's a real element.
-    if ($element.nodeType === 1 && $element.tagName.toLowerCase() === elementType.toLowerCase()) {
-      return $element
-    }
-
-    // If `previousElementSibling` can be used then let's use it as it'll be
-    // slightly faster since it skips things that aren't elements. If not,
-    // `previousSibling` can still be used as there's a `nodeType` check.
-    var previousElement = $element.previousElementSibling || $element.previousSibling
-
-    return closestPrevious(previousElement, elementType)
-  }
-
-  function SuperNavigationMegaMenu ($module) {
-    this.$module = $module
-    this.$searchToggle = this.$module.querySelector('#super-search-menu-toggle')
-    this.$searchMenu = this.$module.querySelector('#super-search-menu')
-    this.$navToggle = this.$module.querySelector('#super-navigation-menu-toggle')
-    this.$navMenu = this.$module.querySelector('#super-navigation-menu')
+  function SuperNavigationMegaMenu (module) {
+    this.module = module
+    this.searchToggle = this.module.querySelector('#super-search-menu-toggle')
+    this.searchMenu = this.module.querySelector('#super-search-menu')
+    this.navToggle = this.module.querySelector('#super-navigation-menu-toggle')
+    this.navMenu = this.module.querySelector('#super-navigation-menu')
 
     // The menu toggler buttons need three attributes for this to work:
     //  - `aria-controls` contains the id of the menu to be toggled
@@ -91,132 +53,129 @@
     //    smaller screens
     //  - `data-toggle-desktop-group` is the group that the menu belongs to on
     //    larger screens
-    this.$buttons = this.$module.querySelectorAll(
+    this.buttons = this.module.querySelectorAll(
       'button[aria-controls][data-toggle-mobile-group][data-toggle-desktop-group]'
     )
 
-    this.hiddenButtons = this.$module.querySelectorAll('button[hidden]')
+    this.hiddenButtons = this.module.querySelectorAll('button[hidden]')
   }
 
   SuperNavigationMegaMenu.prototype.buttonHandler = function (event) {
-    var $target = closestParentIncluding(event.target, 'button')
-    var $targetMenu = this.$module.querySelector('#' + $target.getAttribute('aria-controls'))
+    const target = event.target.closest('button')
+    const targetMenu = this.module.querySelector('#' + target.getAttribute('aria-controls'))
 
-    var toggleGroupAttribute = 'data-toggle-desktop-group'
-    var toggleGroupName = $target.getAttribute(toggleGroupAttribute)
-    var toggleGroupList = this.$module.querySelectorAll('[' + toggleGroupAttribute + '="' + toggleGroupName + '"]')
+    const toggleGroupAttribute = 'data-toggle-desktop-group'
+    const toggleGroupName = target.getAttribute(toggleGroupAttribute)
+    const toggleGroupList = this.module.querySelectorAll('[' + toggleGroupAttribute + '="' + toggleGroupName + '"]')
 
-    for (var k = 0; k < toggleGroupList.length; k++) {
-      var $element = toggleGroupList[k]
-      if ($element !== $target) {
-        var $menu = this.$module.querySelector('#' + $element.getAttribute('aria-controls'))
-        hide($element, $menu)
+    for (const element of toggleGroupList) {
+      if (element !== target) {
+        const menu = this.module.querySelector('#' + element.getAttribute('aria-controls'))
+        hide(element, menu)
       }
     }
 
-    toggle($target, $targetMenu)
+    toggle(target, targetMenu)
   }
 
   SuperNavigationMegaMenu.prototype.handleKeyDown = function (event) {
-    var KEY_TAB = 9
-    var KEY_ESC = 27
-    var $navMenuLinks = this.$navMenu.querySelectorAll('li a')
-    var $firstNavLink = $navMenuLinks[0]
-    var $lastNavLink = $navMenuLinks[$navMenuLinks.length - 1]
-    var $searchMenuTabbable = this.$searchMenu.querySelectorAll('li a, input, button')
-    var $lastSearchMenuTabbable = $searchMenuTabbable[$searchMenuTabbable.length - 1]
+    if (event.key !== 'Tab' && event.key !== 'Escape') {
+      return
+    }
 
-    if (event.keyCode === KEY_TAB) {
-      if (!this.$navMenu.hasAttribute('hidden')) {
+    const navMenuLinks = this.navMenu.querySelectorAll('li a')
+    const firstNavLink = navMenuLinks[0]
+    const lastNavLink = navMenuLinks[navMenuLinks.length - 1]
+    const searchMenuTabbable = this.searchMenu.querySelectorAll('li a, input, button')
+    const lastSearchMenuTabbable = searchMenuTabbable[searchMenuTabbable.length - 1]
+
+    if (event.key === 'Tab') {
+      if (!this.navMenu.hasAttribute('hidden')) {
         switch (document.activeElement) {
-          case this.$navToggle:
+          case this.navToggle:
             if (!event.shiftKey) {
               event.preventDefault()
-              $firstNavLink.focus()
+              firstNavLink.focus()
             }
             break
-          case $lastNavLink:
+          case lastNavLink:
             if (!event.shiftKey) {
               event.preventDefault()
-              this.$searchToggle.focus()
-              hide(this.$navToggle, this.$navMenu)
+              this.searchToggle.focus()
+              hide(this.navToggle, this.navMenu)
             }
             break
-          case $firstNavLink:
+          case firstNavLink:
             if (event.shiftKey) {
               event.preventDefault()
-              this.$navToggle.focus()
+              this.navToggle.focus()
             }
             break
-          case this.$searchToggle:
+          case this.searchToggle:
             if (event.shiftKey) {
               event.preventDefault()
-              $lastNavLink.focus()
+              lastNavLink.focus()
             }
             break
           default:
             break
         }
-      } else if (!this.$searchMenu.hasAttribute('hidden')) {
-        if (document.activeElement === $lastSearchMenuTabbable) {
+      } else if (!this.searchMenu.hasAttribute('hidden')) {
+        if (document.activeElement === lastSearchMenuTabbable) {
           if (!event.shiftKey) {
-            hide(this.$searchToggle, this.$searchMenu)
+            hide(this.searchToggle, this.searchMenu)
           }
         }
       }
-    } else if (event.keyCode === KEY_ESC) {
-      if (!this.$navMenu.hasAttribute('hidden')) {
-        hide(this.$navToggle, this.$navMenu)
-        this.$navToggle.focus()
-      } else if (!this.$searchMenu.hasAttribute('hidden')) {
-        hide(this.$searchToggle, this.$searchMenu)
-        this.$searchToggle.focus()
+    } else if (event.key === 'Escape') {
+      if (!this.navMenu.hasAttribute('hidden')) {
+        hide(this.navToggle, this.navMenu)
+        this.navToggle.focus()
+      } else if (!this.searchMenu.hasAttribute('hidden')) {
+        hide(this.searchToggle, this.searchMenu)
+        this.searchToggle.focus()
       }
     }
   }
 
   SuperNavigationMegaMenu.prototype.init = function () {
     // Handle key events for tab and escape keys
-    this.$module.addEventListener('keydown', this.handleKeyDown.bind(this))
+    this.module.addEventListener('keydown', this.handleKeyDown.bind(this))
 
-    for (var j = 0; j < this.$buttons.length; j++) {
-      var $button = this.$buttons[j]
-      $button.addEventListener('click', this.buttonHandler.bind(this), true)
+    for (const button of this.buttons) {
+      button.addEventListener('click', this.buttonHandler.bind(this), true)
     }
 
-    // The toggle buttons are hardcoded to be hidden in the markup - this means
-    // that people without JavaScript turned on won't have buttons present that
-    // don't do anything.
-    //     Since JavaScript is enabled we can remove the hidden attribute from
-    // the buttons so that they're perceivable by users.
-    //     As the toggle buttons are now selectable, we should prevent the links
-    // from being selectable to avoid confusion.
-    for (var i = 0; i < this.hiddenButtons.length; i++) {
-      var $element = this.hiddenButtons[i]
-      $element.removeAttribute('hidden')
+    // Reveal toggle buttons hidden by default in HTML for non-JavaScript users
+    // and hide the fallback links now that JavaScript is available.
+    for (const element of this.hiddenButtons) {
+      element.removeAttribute('hidden')
 
-      var closestSiblingLink = closestPrevious($element, 'a')
+      let sibling = element.previousElementSibling
 
-      if (closestSiblingLink) {
-        closestSiblingLink.setAttribute('hidden', 'hidden')
+      // Find and hide the preceding no JavaScript fallback links
+      while (sibling) {
+        if (sibling.matches('a')) {
+          sibling.setAttribute('hidden', 'hidden')
+          break
+        }
+        sibling = sibling.previousElementSibling
       }
     }
 
-    this.$module.querySelector('.gem-c-layout-super-navigation-header__search-item-link')
+    this.module.querySelector('.gem-c-layout-super-navigation-header__search-item-link')
       .setAttribute('hidden', 'hidden')
 
     // Navigation menu and search menu are hardcoded to be open in the markup -
-    // this means that the menu still makes sense with CSS and JavaScript turned
-    // off.
-    //     The menus now need to be hidden as part of the JavaScript
-    // initialisation.
-    //   - On both mobile and desktop, this means hiding the search menu
-    //   - On mobile, this means hiding the navigation
-    //   - On desktop, this means hiding the navigation button, showing the
-    //     second level navigation menu
-    hide(this.$searchToggle, this.$searchMenu)
+    // this means that the menu still makes sense with CSS and JavaScript turned off.
+    // The menus now need to be hidden as part of the JavaScript initialisation:
+    //  - On both mobile and desktop, this means hiding the search menu
+    //  - On mobile, this means hiding the navigation
+    //  - On desktop, this means hiding the navigation button, showing the
+    //    second level navigation menu
+    hide(this.searchToggle, this.searchMenu)
 
-    this.$module.classList.add('js-module-initialised')
+    this.module.classList.add('js-module-initialised')
   }
 
   Modules.SuperNavigationMegaMenu = SuperNavigationMegaMenu

--- a/app/assets/javascripts/govuk_publishing_components/lib/trigger-event.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/trigger-event.js
@@ -1,11 +1,13 @@
 // see https://github.com/alphagov/govuk_publishing_components/blob/main/docs/lib/trigger_event.md
-(function (root) {
+(function () {
   'use strict'
 
+  window.GOVUK = window.GOVUK || {}
+
   window.GOVUK.triggerEvent = function (element, eventName, parameters) {
-    var params = parameters || {}
-    var event
-    var keyCode = params.keyCode
+    const params = parameters || {}
+    const keyCode = params.keyCode
+    const key = params.key
 
     if (!Object.prototype.hasOwnProperty.call(params, 'bubbles')) {
       params.bubbles = true
@@ -15,11 +17,10 @@
       params.cancelable = true
     }
 
-    if (typeof window.CustomEvent === 'function') {
-      event = new window.CustomEvent(eventName, params)
-    } else {
-      event = document.createEvent('CustomEvent')
-      event.initCustomEvent(eventName, params.bubbles, params.cancelable, params.detail)
+    const event = new window.CustomEvent(eventName, params)
+
+    if (key) {
+      event.key = key
     }
 
     if (keyCode) {
@@ -30,6 +31,8 @@
       event.shiftKey = true
     }
 
-    element.dispatchEvent(event)
+    if (element && typeof element.dispatchEvent === 'function') {
+      element.dispatchEvent(event)
+    }
   }
-}(window))
+}())

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -26,13 +26,13 @@ $search-icon-height: 20px;
     border-bottom-color: $colour;
     border-right-color: $colour;
   } @else {
-    @include prefixed-transform($rotate: 45deg, $translateY: -35%);
     border-bottom: 2px solid $colour;
     border-right: 2px solid $colour;
     content: "";
     display: inline-block;
     height: 8px;
     margin: 0 10px 0 2px;
+    transform: translateY(-35%) rotate(45deg) scale(1);
     vertical-align: middle;
     width: 8px;
   }
@@ -373,7 +373,7 @@ $search-icon-height: 20px;
 
       &::before {
         @include chevron(govuk-colour("black"), true);
-        @include prefixed-transform($rotate: 225deg, $translateY: 1px);
+        transform: translateY(1px) rotate(225deg) scale(1);
       }
     }
   }
@@ -392,7 +392,7 @@ $search-icon-height: 20px;
       @include govuk-media-query($from: $chevron-breakpoint) {
         &::before {
           @include chevron(govuk-functional-colour(link), true);
-          @include prefixed-transform($rotate: 225deg, $translateY: 1px);
+          transform: translateY(1px) rotate(225deg) scale(1);
         }
       }
     }
@@ -609,7 +609,10 @@ $search-icon-height: 20px;
   }
 
   @include govuk-media-query($from: "desktop") {
-    @include columns($items: 16, $columns: 2, $selector: "li", $flow: column);
+    display: grid;
+    grid-auto-flow: column;
+    grid-template-columns: repeat(2, 1fr);
+    grid-template-rows: repeat(8, auto);
   }
 }
 

--- a/spec/javascripts/components/layout-super-navigation-header-spec.js
+++ b/spec/javascripts/components/layout-super-navigation-header-spec.js
@@ -4,8 +4,8 @@
 describe('The super header navigation', function () {
   'use strict'
 
-  var container
-  var thisModule
+  let container
+  let thisModule
 
   beforeEach(function () {
     container = document.createElement('div')
@@ -282,7 +282,7 @@ describe('The super header navigation', function () {
 
     document.body.appendChild(container)
 
-    var $element = document.querySelector('[data-module="super-navigation-mega-menu"]')
+    const $element = document.querySelector('[data-module="super-navigation-mega-menu"]')
     thisModule = new GOVUK.Modules.SuperNavigationMegaMenu($element)
   })
 
@@ -296,14 +296,14 @@ describe('The super header navigation', function () {
     })
 
     it('has the initialised class once the JavaScript has run', function () {
-      var $module = document.querySelector('[data-module="super-navigation-mega-menu"]')
+      const $module = document.querySelector('[data-module="super-navigation-mega-menu"]')
 
       expect($module).toHaveClass('js-module-initialised')
     })
   })
 
   describe('navigation toggle button', function () {
-    var $button
+    let $button
 
     beforeEach(function () {
       thisModule.init()
@@ -329,8 +329,8 @@ describe('The super header navigation', function () {
     })
 
     describe('updates correctly when clicked once', function () {
-      var $button
-      var $menu
+      let $button
+      let $menu
 
       beforeEach(function () {
         $button = document.querySelector('#super-navigation-menu-toggle')
@@ -348,14 +348,14 @@ describe('The super header navigation', function () {
       })
 
       it('updates the button’s `aria-label`', function () {
-        var hideLabel = $button.getAttribute('data-text-for-hide')
+        const hideLabel = $button.getAttribute('data-text-for-hide')
         expect($button.getAttribute('aria-label')).toBe(hideLabel)
       })
     })
 
     describe('updates correctly when clicked twice', function () {
-      var $button
-      var $menu
+      let $button
+      let $menu
 
       beforeEach(function () {
         $button = document.querySelector('#super-navigation-menu-toggle')
@@ -384,8 +384,8 @@ describe('The super header navigation', function () {
     })
 
     it('toggles the other menus in its group', function () {
-      var $searchButton = document.querySelector('#super-search-menu-toggle')
-      var $searchMenu = document.querySelector('#super-search-menu')
+      const $searchButton = document.querySelector('#super-search-menu-toggle')
+      const $searchMenu = document.querySelector('#super-search-menu')
 
       $button.click()
 
@@ -408,15 +408,15 @@ describe('The super header navigation', function () {
   })
 
   describe('tab key', function () {
-    var $navMenuButton
-    var $searchMenuButton
-    var $navMenu
-    var $navLinks
-    var $firstNavLink
-    var $lastNavLink
-    var $searchMenu
-    var $searchMenuTabbable
-    var $lastSearchMenuTabbable
+    let $navMenuButton
+    let $searchMenuButton
+    let $navMenu
+    let $navLinks
+    let $firstNavLink
+    let $lastNavLink
+    let $searchMenu
+    let $searchMenuTabbable
+    let $lastSearchMenuTabbable
 
     beforeEach(function () {
       thisModule.init()
@@ -434,7 +434,7 @@ describe('The super header navigation', function () {
     it('when the Menu button is focussed, the nav menu is open and the tab key is pressed focus moves to the first nav menu link', function () {
       $navMenu.removeAttribute('hidden')
       $navMenuButton.focus()
-      window.GOVUK.triggerEvent($navMenuButton, 'keydown', { keyCode: 9, cancelable: true })
+      window.GOVUK.triggerEvent($navMenuButton, 'keydown', { key: 'Tab', cancelable: true })
 
       expect(document.activeElement).toEqual($navLinks[0])
     })
@@ -442,7 +442,7 @@ describe('The super header navigation', function () {
     it('when the last nav menu link is focussed and the tab key is pressed focus moves to the search button and the nav menu is closed', function () {
       $navMenu.removeAttribute('hidden')
       $lastNavLink.focus()
-      window.GOVUK.triggerEvent($lastNavLink, 'keydown', { keyCode: 9, cancelable: true })
+      window.GOVUK.triggerEvent($lastNavLink, 'keydown', { key: 'Tab', cancelable: true })
 
       expect(document.activeElement).toEqual($searchMenuButton)
       expect($navMenu.hasAttribute('hidden')).toEqual(true)
@@ -454,7 +454,7 @@ describe('The super header navigation', function () {
     it('when the first nav menu link is focussed, the nav menu is open and the shift and tab keys are pressed focus moves to the Menu button', function () {
       $navMenu.removeAttribute('hidden')
       $firstNavLink.focus()
-      window.GOVUK.triggerEvent($firstNavLink, 'keydown', { keyCode: 9, cancelable: true, shiftKey: true })
+      window.GOVUK.triggerEvent($firstNavLink, 'keydown', { key: 'Tab', shiftKey: true, cancelable: true })
 
       expect(document.activeElement).toEqual($navMenuButton)
     })
@@ -462,7 +462,7 @@ describe('The super header navigation', function () {
     it('when the search button is focussed, the nav menu is open and the shift and tab keys are pressed focus moves to the last nav menu link', function () {
       $navMenu.removeAttribute('hidden')
       $searchMenuButton.focus()
-      window.GOVUK.triggerEvent($searchMenuButton, 'keydown', { keyCode: 9, cancelable: true, shiftKey: true })
+      window.GOVUK.triggerEvent($searchMenuButton, 'keydown', { key: 'Tab', shiftKey: true, cancelable: true })
 
       expect(document.activeElement).toEqual($lastNavLink)
     })
@@ -470,7 +470,7 @@ describe('The super header navigation', function () {
     it('when the last tabbable element in the search menu is focussed and the tab key is pressed the search menu is closed', function () {
       $searchMenu.removeAttribute('hidden')
       $lastSearchMenuTabbable.focus()
-      window.GOVUK.triggerEvent($lastSearchMenuTabbable, 'keydown', { keyCode: 9, cancelable: true })
+      window.GOVUK.triggerEvent($lastSearchMenuTabbable, 'keydown', { key: 'Tab', cancelable: true })
 
       expect($searchMenu.hasAttribute('hidden')).toEqual(true)
       expect($searchMenuButton.getAttribute('aria-expanded')).toEqual('false')
@@ -480,10 +480,10 @@ describe('The super header navigation', function () {
   })
 
   describe('escape key', function () {
-    var $navMenu
-    var $navMenuButton
-    var $searchMenu
-    var $searchMenuButton
+    let $navMenu
+    let $navMenuButton
+    let $searchMenu
+    let $searchMenuButton
 
     beforeEach(function () {
       thisModule.init()
@@ -496,7 +496,7 @@ describe('The super header navigation', function () {
     it('when the user presses the escape key and the nav menu is open the menu is closed and focus moves back to the Menu button', function () {
       $navMenu.removeAttribute('hidden')
       $navMenuButton.setAttribute('aria-expanded', 'true')
-      window.GOVUK.triggerEvent($navMenu, 'keydown', { keyCode: 27, cancelable: true })
+      window.GOVUK.triggerEvent($navMenu, 'keydown', { key: 'Escape', cancelable: true })
 
       expect($navMenu.hasAttribute('hidden')).toEqual(true)
       expect(document.activeElement).toEqual($navMenuButton)
@@ -509,7 +509,7 @@ describe('The super header navigation', function () {
       $searchMenu.removeAttribute('hidden')
       $searchMenuButton.setAttribute('aria-expanded', 'true')
       $searchMenuButton.classList.add('gem-c-layout-super-navigation-header__open-button')
-      window.GOVUK.triggerEvent($searchMenu, 'keydown', { keyCode: 27, cancelable: true })
+      window.GOVUK.triggerEvent($searchMenu, 'keydown', { key: 'Escape', cancelable: true })
 
       expect($searchMenu.hasAttribute('hidden')).toEqual(true)
       expect(document.activeElement).toEqual($searchMenuButton)
@@ -520,7 +520,7 @@ describe('The super header navigation', function () {
   })
 
   describe('search toggle button', function () {
-    var $button
+    let $button
 
     beforeEach(function () {
       thisModule.init()
@@ -546,8 +546,8 @@ describe('The super header navigation', function () {
     })
 
     describe('updates correctly when clicked once', function () {
-      var $button
-      var $menu
+      let $button
+      let $menu
 
       beforeEach(function () {
         $button = document.querySelector('#super-search-menu-toggle')
@@ -565,14 +565,14 @@ describe('The super header navigation', function () {
       })
 
       it('updates the button’s `aria-label`', function () {
-        var hideLabel = $button.getAttribute('data-text-for-hide')
+        const hideLabel = $button.getAttribute('data-text-for-hide')
         expect($button.getAttribute('aria-label')).toBe(hideLabel)
       })
     })
 
     describe('updates correctly when clicked twice', function () {
-      var $button
-      var $menu
+      let $button
+      let $menu
 
       beforeEach(function () {
         $button = document.querySelector('#super-search-menu-toggle')
@@ -601,8 +601,8 @@ describe('The super header navigation', function () {
     })
 
     it('toggles the other menus in its group', function () {
-      var $navigationButton = document.querySelector('#super-navigation-menu-toggle')
-      var $navigationMenu = document.querySelector('#super-navigation-menu')
+      const $navigationButton = document.querySelector('#super-navigation-menu-toggle')
+      const $navigationMenu = document.querySelector('#super-navigation-menu')
 
       $button.click()
 

--- a/spec/javascripts/govuk_publishing_components/lib/trigger-event-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/trigger-event-spec.js
@@ -1,9 +1,9 @@
 /* eslint-env jasmine */
 
 describe('The trigger event code', function () {
-  var element
+  let element
 
-  var obj = {
+  const obj = {
     calledFunction: function (event) {
       if (typeof event.cancelable !== 'boolean' || event.cancelable === true) {
         event.preventDefault()
@@ -15,6 +15,9 @@ describe('The trigger event code', function () {
         obj.secondCalledFunction()
       }
       if (event.keyCode === 13) {
+        obj.secondCalledFunction()
+      }
+      if (event.key === 'Enter') {
         obj.secondCalledFunction()
       }
     },
@@ -45,6 +48,13 @@ describe('The trigger event code', function () {
     expect(obj.secondCalledFunction).toHaveBeenCalled()
   })
 
+  it('creates and triggers a custom event with a key', function () {
+    element.addEventListener('keyup', obj.calledFunction)
+    window.GOVUK.triggerEvent(element, 'keyup', { key: 'Enter' })
+    expect(obj.calledFunction).toHaveBeenCalled()
+    expect(obj.secondCalledFunction).toHaveBeenCalled()
+  })
+
   it('creates and triggers a custom event with a keyCode', function () {
     element.addEventListener('keyup', obj.calledFunction)
     window.GOVUK.triggerEvent(element, 'keyup', { keyCode: 13 })
@@ -54,7 +64,7 @@ describe('The trigger event code', function () {
 
   it('creates a custom event that bubbles by default', function () {
     element = document.createElement('div')
-    var child = document.createElement('div')
+    const child = document.createElement('div')
     element.appendChild(child)
     document.body.appendChild(element)
     element.addEventListener('click', obj.calledFunction)
@@ -64,7 +74,7 @@ describe('The trigger event code', function () {
 
   it('creates a custom event that does not bubble', function () {
     element = document.createElement('div')
-    var child = document.createElement('div')
+    const child = document.createElement('div')
     element.appendChild(child)
     document.body.appendChild(element)
     element.addEventListener('click', obj.calledFunction)


### PR DESCRIPTION
## What
- ES6 update: Converted var to const/let and for/index loops to for/of loops
- Removed jQuery style $ prefixes
- Keyboard Events: Removed KEY_TAB = 9 or { keyCode: 27 } constants and event.keyCode checks in favour of standard event.key === 'Tab' and event.key === 'Escape'

### layout-super-navigation-header.js
- Replaced custom DOM traversal using closestParentIncluding() to native event.target.closest('button')
- Simplified closestPrevious() to traverse using native previousElementSibling directly

### trigger-event.js
- Added event.key support
- Events now pass standard string keys to event listeners during test runs
- Removed legacy document.createEvent('CustomEvent') and initCustomEvent fallback
- Removed the unused root parameter

### layout-super-navigation-header.scss
- Removed prefixed transforms to use native CSS transform
- Replaced grid mixin to use standard CSS grid (used only with layout-super-navigation-header and cards (cards updated in https://github.com/alphagov/govuk_publishing_components/pull/5658) 

## Why
Grade X (legacy) browsers do not receive JavaScript functionality, meaning the interactive super navigation dropdowns are never initialised on them. Removing the legacy grid mixin and transform fallbacks for these dropdowns eliminates dead styling and aligns our CSS directly with our JavaScript browser support.
This is also an opportunity to adopting native modern standards like Element.closest(), previousElementSibling, and event.key.

GOV.UK Browser Support: https://frontend.design-system.service.gov.uk/browser-support/

Jira card: https://gov-uk.atlassian.net/browse/NAV-18209

## Visual Changes
Code improvements only. No visual changes. 

## Automated Testing
- Confirmed automated tests are all passing without issues

## Manual Testing
- Keyboard navigation performing as expected with manual testing. Checked tabbing directions, focus states and tracking, and escape close functions.
-  Mouse toggling on the menu and search works as expected
- Verified aria-expanded toggles between "true" / "false" and aria-label between "Show navigation menu" / "Hide navigation menu"
- Links perform as expected when JS does not initialise 
- Links receive hidden="hidden" when JS initialises
- Spot checked on various browsers and browser versions