### PR TITLE
Add new brand colour for BIST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add new brand colour for BIST ([PR #5652](https://github.com/alphagov/govuk_publishing_components/pull/5652))
+
 ## 68.0.0
 
 * **BREAKING:** Bump govuk frontend to v6 ([PR #5550](https://github.com/alphagov/govuk_publishing_components/pull/5550))

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
@@ -19,3 +19,11 @@
     border-color: #16eeee;
   }
 }
+
+// This can be removed once the organisation is added to govuk-frontend
+.brand--department-for-business-innovation-science-trade {
+  &.brand__border-color,
+  .brand__border-color {
+    border-color: #ff4328;
+  }
+}


### PR DESCRIPTION
## What
Add new brand colour for BIST

## Why
The new brand colour will be available in a future release of govuk-frontend, see https://github.com/alphagov/govuk-frontend/pull/7354

This change allows us to get the change out in advance of the release of govuk-frontend that includes the brand colour for Department for Business, Innovation, Science and Trade

Jira card: https://gov-uk.atlassian.net/browse/NAV-19063

## Visual Changes

| Before | After |
|--------|--------|
| <img width="422" height="250" alt="after" src="https://github.com/user-attachments/assets/1f27d3df-4b45-4b88-a2d4-666a1a82108f" /> | <img width="425" height="257" alt="before" src="https://github.com/user-attachments/assets/2a43cb8f-e924-43dd-9b42-9564801a825e" /> |

Page example: https://www.gov.uk/government/organisations/department-for-business-innovation-science-and-trade
