### PR TITLE
Fix step by step navigation JS security warning

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
@@ -168,7 +168,7 @@
       var thisel = this.$module.steps[i]
       var title = thisel.querySelectorAll('.js-step-title')[0]
       var contentId = thisel.querySelectorAll('.js-panel')[0].getAttribute('id')
-      var titleText = title.textContent || title.innerText // IE8 fallback
+      var titleText = title.textContent
 
       title.outerHTML =
         `<span class="js-step-title">

--- a/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
@@ -171,16 +171,15 @@
       var titleText = title.textContent || title.innerText // IE8 fallback
 
       title.outerHTML =
-        '<span class="js-step-title">' +
-          '<button ' +
-            'class="gem-c-step-nav__button gem-c-step-nav__button--title js-step-title-button" ' +
-            'aria-expanded="false" aria-controls="' + contentId + '"' + '>' +
-              '<span class="gem-c-step-nav____title-text-focus">' +
-                  '<span class="gem-c-step-nav__title-text js-step-title-text"></span>' +
-                  '<span class="govuk-visually-hidden gem-c-step-nav__section-heading-divider">, </span>' +
-              '</span>' +
-          '</button>' +
-        '</span>'
+        `<span class="js-step-title">
+          <button class="gem-c-step-nav__button gem-c-step-nav__button--title js-step-title-button"
+            aria-expanded="false" aria-controls="${contentId}">
+              <span class="gem-c-step-nav____title-text-focus">
+                <span class="gem-c-step-nav__title-text js-step-title-text"></span>
+                <span class="govuk-visually-hidden gem-c-step-nav__section-heading-divider">, </span>
+              </span>
+          </button>
+        </span>`
 
       thisel.querySelector('.gem-c-step-nav__title-text').textContent = titleText
 

--- a/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
@@ -176,11 +176,13 @@
             'class="gem-c-step-nav__button gem-c-step-nav__button--title js-step-title-button" ' +
             'aria-expanded="false" aria-controls="' + contentId + '"' + '>' +
               '<span class="gem-c-step-nav____title-text-focus">' +
-                  '<span class="gem-c-step-nav__title-text js-step-title-text">' + titleText + '</span>' +
+                  '<span class="gem-c-step-nav__title-text js-step-title-text"></span>' +
                   '<span class="govuk-visually-hidden gem-c-step-nav__section-heading-divider">, </span>' +
               '</span>' +
           '</button>' +
         '</span>'
+
+      thisel.querySelector('.gem-c-step-nav__title-text').textContent = titleText
 
       if (this.$module.isGa4Enabled) {
         var ga4JSON = {


### PR DESCRIPTION
## What
Slightly refactor the JS for the step by step navigation component to remove a potential security risk.

## Why
See https://github.com/alphagov/govuk_publishing_components/security/code-scanning/47

However... I'm starting to wonder if this security warning is a false positive. The thing it seems to be worried about is `titleText` being inserted into a chunk of markup, which we get around here by creating the chunk of markup then inserting `titleText` afterwards using `textContent`, which sanitises it. But `titleText` is itself initially created by using `textContent`, so surely it's already been sanitised? Regardless, if this change silences a security warning, that still seems worth doing.

## Visual Changes
None.
