### PR TITLE
Address youtube script vulnerability

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
@@ -45,9 +45,11 @@
         <span class="govuk-heading-s">How to watch this YouTube video</span>
         <span class="gem-c-govspeak__youtube-placeholder-text">There's a YouTube video on this page. You can't access it because of your cookie settings.</span>
         <span class="gem-c-govspeak__youtube-placeholder-text">You can <a href="/help/cookies" class="govuk-link">change your cookie settings</a> or watch the video on YouTube instead:</span>
-        <a href="${href}" class="govuk-link">${text}</a>
+        <a href="${href}" class="govuk-link js-youtube-link"></a>
       `
       placeholder.innerHTML = markup
+      const link = placeholder.querySelector('.js-youtube-link')
+      link.textContent = text
       $linkParent.after(placeholder)
       $linkParent.classList.add('gem-c-govspeak__youtube-placeholder-link')
     }


### PR DESCRIPTION
## What
Address a potential security vulnerability in the Youtube link enhancement script

- replace direct insertion of variables with calls to `setAttribute` and `textContent`
- both methods escape characters, so HTML tags are not rendered and script injection becomes impossible


## Why
See https://github.com/alphagov/govuk_publishing_components/security/code-scanning/46

## Visual Changes
None.
