### PR TITLE
Remove grid helper and update Cards to native CSS Grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Review and fix image card spacing ([PR #5661](https://github.com/alphagov/govuk_publishing_components/pull/5661))  
 * Upgrade Stylelint to v17 ([PR #5654](https://github.com/alphagov/govuk_publishing_components/pull/5654))
+* Remove grid helper and update Cards to native CSS Grid ([PR #5658](https://github.com/alphagov/govuk_publishing_components/pull/5658))
 
 ## 68.2.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
@@ -49,15 +49,15 @@
 
 .gem-c-cards__list--two-column-desktop {
   @include govuk-media-query($from: "tablet") {
-    grid-auto-rows: fractions(1); // Set all rows to same fractional height of the complete grid
-    grid-template-columns: fractions(2); // Note that browsers that don't support CSS grid display the component as one column on all breakpoints
+    grid-auto-rows: 1fr;
+    grid-template-columns: repeat(2, 1fr);
   }
 }
 
 .gem-c-cards__list--three-column-desktop {
   @include govuk-media-query($from: "desktop") {
-    grid-auto-rows: fractions(1); // Set all rows to same fractional height of the complete grid
-    grid-template-columns: fractions(3); // Note that browsers that don't support CSS grid display the component as one column on all breakpoints
+    grid-auto-rows: 1fr;
+    grid-template-columns: repeat(3, 1fr);
   }
 }
 


### PR DESCRIPTION
## What
- The cards component was using grid-helper.scss to manage multiple card columns. It used the fractions() function, however, browsers without CSS grid support still displayed a single column. 
- The same can be achieved simply with using standard CSS Grid syntax.
- The graceful fallback will still be a single card layout. 

## Why

With modern browsers natively supporting standard CSS grid and legacy browsers automatically falling back to a single block layout, the use of grid-helper.scss in cards.scss is no longer necessary. This change helps remove technical debt while bringing the component in line with current design system standards.

Jira card: https://gov-uk.atlassian.net/browse/NAV-19065

## Visual Changes
There should be no visual changes. This is an update to the approach in the codebase only. 

Live three column cards can be seen in use on the the service manual page https://www.gov.uk/service-manual

<img width="1023" height="663" alt="Screenshot 2026-08-20 at 08 36 08" src="https://github.com/user-attachments/assets/729a62ab-4007-41d2-b25b-6596e0fe0635" />

## Testing
- Verified the 1 column, 2 column, 3 column, and Auto layout examples render properly aligned grids without issues
- Spot checked the cards component across modern browsers
