### PR TITLE
Review and fix image card spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Review and fix image card spacing ([PR #5661](https://github.com/alphagov/govuk_publishing_components/pull/5661))  
+
 ## 68.2.0
 
 * Adjust cards content elements widths ([PR #5665](https://github.com/alphagov/govuk_publishing_components/pull/5665))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -11,7 +11,6 @@
   @include govuk-text-colour;
 
   @include govuk-media-query($until: tablet) {
-    flex-direction: column-reverse;
     gap: govuk-spacing(3);
   }
 }
@@ -36,7 +35,7 @@
   height: auto;
   width: 100%;
   border: 0;
-  border-top: 1px solid govuk-functional-colour(border);
+  border-top: 1px solid govuk-functional-colour("border");
 }
 
 .gem-c-image-card__title {
@@ -73,7 +72,7 @@
 .gem-c-image-card__context,
 .gem-c-image-card__metadata {
   font-size: govuk-px-to-rem(16px);
-  margin: 0 0 calc(govuk-spacing(3) / 2);
+  margin: 0 0 govuk-spacing(2);
   color: govuk-functional-colour("secondary-text");
   @include govuk-font($size: false);
 
@@ -83,7 +82,7 @@
 }
 
 .gem-c-image-card__description {
-  padding-top: calc(govuk-spacing(3) / 2);
+  padding-top: govuk-spacing(2);
   word-wrap: break-word;
   @include govuk-font($size: 19);
 }
@@ -91,7 +90,7 @@
 .gem-c-image-card__list {
   position: relative;
   z-index: 2;
-  padding: calc(govuk-spacing(3) / 2) 0 0 0;
+  padding: govuk-spacing(2) 0 0 0;
   margin: 0;
   list-style: none;
   @include govuk-font($size: 19);


### PR DESCRIPTION
## What
- Replaced custom calc(govuk-spacing(3) / 2) (7.5px) spacing with standard govuk-spacing(2) (10px) on the context, metadata, description, and list on the card component
- Removed a redundant flex-direction: column-reverse declaration
- Added missing quotes around the "border" key in govuk-functional-colour("border")

## Why
Using calc(govuk-spacing(3) / 2) produced a 7.5px pixel value, which falls outside the Design System spacing scale. Updating these elements to use govuk-spacing(2) brings the image card component into alignment with the Design System standards and ensures consistent vertical spacing across mobile and desktop views.

Metadata spacing introduced here: https://github.com/alphagov/govuk_publishing_components/pull/390

Jira card: https://gov-uk.atlassian.net/browse/NAV-19026

## Visual Changes

### Card context (mobile only) 7.5px -> 10px
| Before | After |
|--------|--------|
| <img width="1610" height="929" alt="Screenshot 2026-08-18 at 12 22 06" src="https://github.com/user-attachments/assets/d504bc13-d2b6-40d4-9e64-61f30935cbf2" /> | <img width="1623" height="928" alt="Screenshot 2026-08-18 at 12 22 42" src="https://github.com/user-attachments/assets/48bc676d-e06a-4546-921e-dc49cd918e70" /> |

### Card metadata (mobile only) 7.5px -> 10px
| Before | After |
|--------|--------|
| <img width="1647" height="925" alt="Screenshot 2026-08-18 at 12 24 54" src="https://github.com/user-attachments/assets/f86b5f47-903d-4ecb-9721-576e99d76be7" /> | <img width="1678" height="924" alt="Screenshot 2026-08-18 at 12 25 00" src="https://github.com/user-attachments/assets/62c1d5d2-5422-4ad9-a08a-7399f225106f" /> |

### Card description (all breakpoints) 7.5px -> 10px
| Before | After |
|--------|--------|
| <img width="1905" height="924" alt="Screenshot 2026-08-18 at 12 27 00" src="https://github.com/user-attachments/assets/a7c3e3a1-43d1-4479-998e-8a6f0054d15c" /> | <img width="1916" height="926" alt="Screenshot 2026-08-18 at 12 27 15" src="https://github.com/user-attachments/assets/dedd5151-bd38-44bd-9ae6-825c22862bd3" /> |

### Card list (all breakpoints) 7.5px -> 10px
| Before | After |
|--------|--------|
| <img width="1897" height="922" alt="Screenshot 2026-08-18 at 12 34 40" src="https://github.com/user-attachments/assets/9990f8ae-2a5a-4429-9975-45097ae09851" /> | <img width="1907" height="923" alt="Screenshot 2026-08-18 at 12 32 57" src="https://github.com/user-attachments/assets/0221b890-f8da-4e5d-947a-4a103c481988" /> |
