### PR TITLE
Adjust cards content elements widths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Adjust cards content elements widths ([PR #](https://github.com/alphagov/govuk_publishing_components/pull/5665))
+
 ## 68.1.0
 
 * Improve filter Javascript ([PR #5646](https://github.com/alphagov/govuk_publishing_components/pull/5646))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
@@ -158,10 +158,11 @@
 
 .gem-c-cards__sub-heading {
   margin: 0 govuk-spacing(6) govuk-spacing(2) 0;
+  text-wrap: pretty;
 
   // Ensure card content width is constrained to two thirds on desktop
   @include govuk-media-query($from: "desktop") {
-    max-width: 66.6667%;
+    max-width: 640px;
   }
 }
 
@@ -208,10 +209,11 @@
 
 .gem-c-cards__description {
   margin: 0 govuk-spacing(6) 0 0;
+  text-wrap: pretty;
 
   // Ensure card content width is constrained to two thirds on desktop
   @include govuk-media-query($from: "desktop") {
-    max-width: 66.6667%;
+    max-width: 640px;
   }
 }
 


### PR DESCRIPTION
## What
- change the cards component heading and description elements to use a fixed pixel max-width instead of a percentage
- percentage works correctly when the component is used in a full width column, but when it is constrained to a 2/3rds column (as on the homepage) this means these text elements were reduced in width further, necessitating a component override in `frontend` (which breaks component isolation)
- instead, use a pixel value for the max-width, which does the same job but means this problem doesn't occur, is equivalent to the percentage at full width and means the width isn't unnecessarily reduced when the component is in a 2/3rds column
- switching to a pixel value doesn't mean the element can overlap its container, it's still constrained by the normal behaviour of a block level element
- this means we can remove the override in `frontend`
- also add text-wrap: pretty, to prevent single words from dangling onto a second line by themselves (as was occurring in some of the guide examples), note that this will cause a small visual diff

## Why
This change will allow us to remove this [component style override in frontend](https://github.com/alphagov/frontend/blob/main/app/assets/stylesheets/views/_homepage.scss#L294-L300).

## Visual Changes
The width change doesn't make any visual change, but the text-wrap change ensures any second lines won't be a single word. Before:

<img width="1086" height="171" alt="Screenshot 2026-08-18 at 08 23 33" src="https://github.com/user-attachments/assets/b8fd3e6e-be41-4f31-b04e-569c74adf1b5" />

After:

<img width="1097" height="172" alt="Screenshot 2026-08-18 at 08 23 13" src="https://github.com/user-attachments/assets/24742ddf-0902-4f0b-9d79-42f0b081e3f3" />
