### PR TITLE
Version 68.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 68.2.0
 
-* Adjust cards content elements widths ([PR #](https://github.com/alphagov/govuk_publishing_components/pull/5665))
+* Adjust cards content elements widths ([PR #5665](https://github.com/alphagov/govuk_publishing_components/pull/5665))
 * Use the details component for toggling element visibility in the metadata component ([PR #5592](https://github.com/alphagov/govuk_publishing_components/pull/5592))
 
 ## 68.1.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (68.1.0)
+    govuk_publishing_components (68.2.0)
       chartkick
       govuk_app_config
       govuk_personalisation (>= 0.7.0)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "68.1.0".freeze
+  VERSION = "68.2.0".freeze
 end


### PR DESCRIPTION
## 68.2.0

* Adjust cards content elements widths ([PR #5665](https://github.com/alphagov/govuk_publishing_components/pull/5665))
* Use the details component for toggling element visibility in the metadata component ([PR #5592](https://github.com/alphagov/govuk_publishing_components/pull/5592))
