### PR TITLE
Review and fix organisation logo typography

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_organisation-logo.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_organisation-logo.scss
@@ -6,12 +6,6 @@
   margin: 0;
   @include govuk-typography-common;
   @include govuk-font-size(19);
-
-  @include govuk-media-query($until: tablet) {
-    // only override line-height on small screens otherwise use govuk-font-size
-    // line-height
-    line-height: 1.35;
-  }
 }
 
 .gem-c-organisation-logo__container {


### PR DESCRIPTION
## What
Removes the custom mobile block containing line-height: 1.35 from the organisation logo component. This lets the component rely entirely on the Design System's default govuk-font-size(19) mixin across all viewport sizes.

[Line-height introduced here](https://github.com/alphagov/govuk_publishing_components/commit/22e7ea41fd1ab616e0dede5159b2c94ba39eb0de)

## Why
Deferring to govuk-font-size(19) restores the correct mobile line-height and ensures it automatically inherits future accessibility, typography changes, or vertical grid updates made to govuk frontend.

Jira card: https://gov-uk.atlassian.net/browse/NAV-19027

## Visual Changes
| Before | After |
|--------|--------|
| <img width="883" height="835" alt="Screenshot 2026-08-18 at 15 46 41" src="https://github.com/user-attachments/assets/61870070-02cb-42ce-872d-18a6e7ae1887" /> | <img width="1021" height="832" alt="Screenshot 2026-08-18 at 15 51 47" src="https://github.com/user-attachments/assets/660e0398-f2f6-4bea-b289-6c5154e25426" /> |
