### PR TITLE
Allow exemptions from `data-ga4-form-use-*-count` [WHIT-3832]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Review and fix image card spacing ([PR #5661](https://github.com/alphagov/govuk_publishing_components/pull/5661))  
 * Upgrade Stylelint to v17 ([PR #5654](https://github.com/alphagov/govuk_publishing_components/pull/5654))
 * Remove grid helper and update Cards to native CSS Grid ([PR #5658](https://github.com/alphagov/govuk_publishing_components/pull/5658))
+* Allow individual fields to report their values to GA4 even when `data-ga4-use-[select|text]-count` attr is present on the form ([PR #5669](https://github.com/alphagov/govuk_publishing_components/pull/5669))
 
 ## 68.2.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
@@ -151,7 +151,7 @@
           input.answer = this.getInputAnswerFromSelect(selectedOptions, forceReportValue)
         }
       } else if (isTextField && elem.value) {
-        input.answer = this.getInputAnswerFromText(elem, isDateField)
+        input.answer = this.getInputAnswerFromText(elem, isDateField, forceReportValue)
       } else if (inputType === 'file') {
         input.answer = elem.files.length + ' files chosen'
       } else {
@@ -202,22 +202,29 @@
     return joinedSelections
   }
 
-  Ga4FormTracker.prototype.getInputAnswerFromText = function (inputElement, isDateField) {
-    if (this.includeTextInputValues || inputElement.hasAttribute('data-ga4-form-include-input')) {
-      if (this.useTextCount && !isDateField) {
+  Ga4FormTracker.prototype.getInputAnswerFromText = function (inputElement, isDateField, forceReportValue) {
+    var willRecordInputValue = this.includeTextInputValues || inputElement.hasAttribute('data-ga4-form-include-input')
+    var willReplaceInputValueWithLength = this.useTextCount && !isDateField
+
+    if (forceReportValue) {
+      willReplaceInputValueWithLength = false
+    }
+
+    if (willRecordInputValue) {
+      if (willReplaceInputValueWithLength) {
         return inputElement.value.length
-      } else {
-        var PIIRemover = new window.GOVUK.analyticsGa4.PIIRemover()
-        return PIIRemover.stripPIIWithOverride(inputElement.value, true, true)
       }
+
+      var PIIRemover = new window.GOVUK.analyticsGa4.PIIRemover()
+      return PIIRemover.stripPIIWithOverride(inputElement.value, true, true)
+    }
+
+    // if recording JSON when recording text input not allowed
+    // set the specific answer to '[REDACTED]'
+    if (this.recordJson) {
+      return '[REDACTED]'
     } else {
-      // if recording JSON when text input not allowed
-      // set the specific answer to '[REDACTED]'
-      if (this.recordJson) {
-        return '[REDACTED]'
-      } else {
-        this.redacted = true
-      }
+      this.redacted = true
     }
   }
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
@@ -11,6 +11,7 @@
     this.useSelectCount = this.module.hasAttribute('data-ga4-form-use-select-count')
     this.redacted = false
     this.useFallbackValue = this.module.hasAttribute('data-ga4-form-no-answer-undefined') ? undefined : 'No answer given'
+    this.piiRemover = new window.GOVUK.analyticsGa4.PIIRemover()
   }
 
   Ga4FormTracker.prototype.init = function () {
@@ -215,8 +216,7 @@
         return inputElement.value.length
       }
 
-      var PIIRemover = new window.GOVUK.analyticsGa4.PIIRemover()
-      return PIIRemover.stripPIIWithOverride(inputElement.value, true, true)
+      return this.piiRemover.stripPIIWithOverride(inputElement.value, true, true)
     }
 
     // if recording JSON when recording text input not allowed

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
@@ -117,6 +117,8 @@
 
       var isDateField = elem.closest('.govuk-date-input')
 
+      var forceReportValue = elem.hasAttribute('data-ga4-force-report-value-in-form-tracker')
+
       if (conditionalCheckbox && !conditionalCheckboxChecked) {
         // don't include conditional field if condition not checked
         inputs.splice(i, 1)
@@ -146,7 +148,7 @@
           // if placeholder value in select, do not include as not filled in
           inputs.splice(i, 1)
         } else {
-          input.answer = this.useSelectCount && selectedOptions.length > 1 ? selectedOptions.length : selectedOptions.join(',')
+          input.answer = this.getInputAnswerFromSelect(selectedOptions, forceReportValue)
         }
       } else if (isTextField && elem.value) {
         if (this.includeTextInputValues || elem.hasAttribute('data-ga4-form-include-input')) {
@@ -199,6 +201,20 @@
       }
     }
     return inputs
+  }
+
+  Ga4FormTracker.prototype.getInputAnswerFromSelect = function (selectedOptions, forceReportValue) {
+    var joinedSelections = selectedOptions.join(',')
+
+    if (forceReportValue) {
+      return joinedSelections
+    }
+
+    if (this.useSelectCount && selectedOptions.length > 1) {
+      return selectedOptions.length
+    }
+
+    return joinedSelections
   }
 
   Ga4FormTracker.prototype.combineGivenAnswers = function (data) {

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
@@ -151,22 +151,7 @@
           input.answer = this.getInputAnswerFromSelect(selectedOptions, forceReportValue)
         }
       } else if (isTextField && elem.value) {
-        if (this.includeTextInputValues || elem.hasAttribute('data-ga4-form-include-input')) {
-          if (this.useTextCount && !isDateField) {
-            input.answer = elem.value.length
-          } else {
-            var PIIRemover = new window.GOVUK.analyticsGa4.PIIRemover()
-            input.answer = PIIRemover.stripPIIWithOverride(elem.value, true, true)
-          }
-        } else {
-          // if recording JSON and text input not allowed
-          // set the specific answer to '[REDACTED]'
-          if (this.recordJson) {
-            input.answer = '[REDACTED]'
-          } else {
-            this.redacted = true
-          }
-        }
+        input.answer = this.getInputAnswerFromText(elem, isDateField)
       } else if (inputType === 'file') {
         input.answer = elem.files.length + ' files chosen'
       } else {
@@ -215,6 +200,25 @@
     }
 
     return joinedSelections
+  }
+
+  Ga4FormTracker.prototype.getInputAnswerFromText = function (inputElement, isDateField) {
+    if (this.includeTextInputValues || inputElement.hasAttribute('data-ga4-form-include-input')) {
+      if (this.useTextCount && !isDateField) {
+        return inputElement.value.length
+      } else {
+        var PIIRemover = new window.GOVUK.analyticsGa4.PIIRemover()
+        return PIIRemover.stripPIIWithOverride(inputElement.value, true, true)
+      }
+    } else {
+      // if recording JSON when text input not allowed
+      // set the specific answer to '[REDACTED]'
+      if (this.recordJson) {
+        return '[REDACTED]'
+      } else {
+        this.redacted = true
+      }
+    }
   }
 
   Ga4FormTracker.prototype.combineGivenAnswers = function (data) {

--- a/docs/analytics-ga4/trackers/ga4-form-tracker.md
+++ b/docs/analytics-ga4/trackers/ga4-form-tracker.md
@@ -42,14 +42,16 @@ The script will automatically collect the answer submitted in the `text` field. 
 There are several optional data attributes, which will enable different output for the `text` field.
 
 
-| Data attribute | Element apply to | Description | Before | After |
-| -------- | ------- | -------- | ------- | ------- |
-| `data-ga4-form-include-text`  | `form` | Prevents redaction of text inputs  | `[REDACTED],[REDACTED]` | `Text input value,Another text input value` |
-| `data-ga4-form-include-input`  | `input[type=text]` | Prevents redaction of specific text input  | `[REDACTED],[REDACTED]` | `[REDACTED],Specific text input value` |
-| `data-ga4-form-use-text-count`  | `form` | Uses character count instead of text input value | `[REDACTED]` | `24` |
-| `data-ga4-form-use-select-count`  | `form` | Uses number of selected options instead of selected options values  | `yoghurt,pie,trifle` | `3` |
-| `data-ga4-form-record-json`  | `form` | Uses JSON format with label of input as key | `yoghurt,ice cream,trifle` | `{ "What are your favourite cold puddings?": "yoghurt,ice cream,trifle" }` |
-| `data-ga4-form-no-answer-undefined` | `form` | Use `undefined` instead of `No answer given` for empty inputs | `"No answer given"` | `undefined` |
+| Data attribute                                | Element apply to   | Description                                                                                                                                      | Before                     | After                                                                      |
+|-----------------------------------------------|--------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------|----------------------------------------------------------------------------|
+| `data-ga4-form-include-text`                  | `form`             | Prevents redaction of text inputs                                                                                                                | `[REDACTED],[REDACTED]`    | `Text input value,Another text input value`                                |
+| `data-ga4-form-include-input`                 | `input[type=text]` | Prevents redaction of specific text input                                                                                                        | `[REDACTED],[REDACTED]`    | `[REDACTED],Specific text input value`                                     |
+| `data-ga4-form-use-text-count`                | `form`             | Uses character count instead of text input value                                                                                                 | `[REDACTED]`               | `24`                                                                       |
+| `data-ga4-form-use-select-count`              | `form`             | Uses number of selected options instead of selected options values                                                                               | `yoghurt,pie,trifle`       | `3`                                                                        |
+| `data-ga4-form-record-json`                   | `form`             | Uses JSON format with label of input as key                                                                                                      | `yoghurt,ice cream,trifle` | `{ "What are your favourite cold puddings?": "yoghurt,ice cream,trifle" }` |
+| `data-ga4-form-no-answer-undefined`           | `form`             | Use `undefined` instead of `No answer given` for empty inputs                                                                                    | `"No answer given"`        | `undefined`                                                                |
+| `data-ga4-force-report-value-in-form-tracker` | `select`, `input`  | Ignore the presence of `data-ga4-form-use-select-count` and/or `data-ga4-form-use-text-count` when determining the reported value for this field | `2` / `18`                 | `Option 1, Option2` / `Example text input`                                 |
+
 
 These can be used in combination as well as separately.
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
@@ -676,6 +676,28 @@ describe('Google Analytics form tracking', function () {
       window.GOVUK.triggerEvent(element, 'submit')
       expect(window.dataLayer[0]).toEqual(expected)
     })
+
+    it('collects text value when force-report-value attr is present', function () {
+      element.innerHTML =
+          '<label for="text">Text label</label>' +
+          '<input type="text" id="text" name="test-text" value="Some text" data-ga4-force-report-value-in-form-tracker/>'
+
+      expected.event_data.text = 'Some text'
+
+      window.GOVUK.triggerEvent(element, 'submit')
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+
+    it('collects text value and redacts PII when force-report-value attr is present', function () {
+      element.innerHTML =
+          '<label for="text">Text label</label>' +
+          '<input type="text" id="text" name="test-text" value="this is an email: my-email-address@example.com" data-ga4-force-report-value-in-form-tracker/>'
+
+      expected.event_data.text = 'this is an email: [email]'
+
+      window.GOVUK.triggerEvent(element, 'submit')
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
   })
 
   describe('when tracking a form with undefined instead of no answer given', function () {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
@@ -854,5 +854,20 @@ describe('Google Analytics form tracking', function () {
       window.GOVUK.triggerEvent(element, 'submit')
       expect(window.dataLayer[0]).toEqual(expected)
     })
+
+    it('collects all selected options when force-report-value attr is present', function () {
+      element.innerHTML =
+          '<label for="s1">Label</label>' +
+          '<select multiple name="select" id="s1" data-ga4-force-report-value-in-form-tracker>' +
+          '<option selected value="option1">Option 1</option>' +
+          '<option selected value="option2">Option 2</option>' +
+          '<option value="option3">Option 3</option>' +
+          '</select>'
+
+      expected.event_data.text = 'Option 1,Option 2'
+
+      window.GOVUK.triggerEvent(element, 'submit')
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
   })
 })


### PR DESCRIPTION
## What
Creates a new `data` attribute for the `Ga4FormTracker` module that allows consumers to exempt `select` and `input` fields from the `data-ga4-form-use-select-count` and `data-ga4-form-use-text-count` attributes added to a form.

This means we can add `data-ga4-force-report-value-in-form-tracker` to a field and get report the values submitted for those fields to GA, whilst still only submitting text and/or selected option counts for other fields in the same form.

Also make a small refactor to how `PIIRemover` is used in the form tracker module, since we only need one per form and not one per field.  I can pull this out into a separate PR is people would prefer.

## Why

In Whitehall, we need to maintain the text character counts and select counts for most fields, but we do need to know the actual values submitted by other fields.  This is due to access limiting work, where we don't want to report the contents of an edition's body, but do want some information about how it is access limited from other fields.

Addresses some of the points in https://gov-uk.atlassian.net/browse/WHIT-3832

## Visual Changes
No visual changes.
