### PR TITLE
Pin untrusted GitHub Actions to a commit SHA

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -6,7 +6,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           show-progress: false
       - uses: alphagov/govuk-infrastructure/.github/actions/actionlint@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,21 +39,21 @@ jobs:
         ruby: [3.3, 3.4]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7.0.1
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         ref: ${{ inputs.ref || github.ref }}
     # Clone the publishing-api repo, a dependency of the govuk_schemas gem, for content schemas
-    - uses: actions/checkout@v7.0.1
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         repository: alphagov/publishing-api
         ref: main
         path: tmp/publishing-api
-    - uses: ruby/setup-ruby@v1.321.0
+    - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
         cache-version: 1
-    - uses: actions/setup-node@v7.0.0
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: lts/* # use the latest LTS release
         cache: yarn
@@ -78,11 +78,11 @@ jobs:
     permissions:
       contents: write
     steps:
-    - uses: actions/checkout@v7.0.1
-    - uses: ruby/setup-ruby@v1.321.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
       with:
         rubygems: latest
-    - uses: actions/setup-node@v7.0.0
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: lts/* # use the latest LTS release
     - run: yarn install

--- a/.github/workflows/visual-regression-tests.yml
+++ b/.github/workflows/visual-regression-tests.yml
@@ -38,13 +38,13 @@ jobs:
   visual-regression-test-components:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.ref || github.ref }}
-      - uses: ruby/setup-ruby@v1.321.0
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           bundler-cache: true # Also runs `bundle install`
-      - uses: actions/setup-node@v7.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: lts/* # use the latest LTS release
           cache: yarn


### PR DESCRIPTION
Pin untrusted non-alphagov/non-github actions

To reduce security risks such as supply chain attacks and unexpectedly breaking changes.

As per policy: https://docs.publishing.service.gov.uk/manual/test-and-build-a-project-with-github-actions.html#pin-untrusted-github-actions-to-a-commit-sha
