### PR TITLE
Prevent metadata component rendering when no data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Prevent metadata component rendering when no data ([PR #5672](https://github.com/alphagov/govuk_publishing_components/pull/5672))
+
 ## 68.3.0
 
-* Review and fix image card spacing ([PR #5661](https://github.com/alphagov/govuk_publishing_components/pull/5661))  
+* Review and fix image card spacing ([PR #5661](https://github.com/alphagov/govuk_publishing_components/pull/5661))
 * Upgrade Stylelint to v17 ([PR #5654](https://github.com/alphagov/govuk_publishing_components/pull/5654))
 * Remove grid helper and update Cards to native CSS Grid ([PR #5658](https://github.com/alphagov/govuk_publishing_components/pull/5658))
 * Allow individual fields to report their values to GA4 even when `data-ga4-use-[select|text]-count` attr is present on the form ([PR #5669](https://github.com/alphagov/govuk_publishing_components/pull/5669))

--- a/app/views/govuk_publishing_components/components/_metadata.html.erb
+++ b/app/views/govuk_publishing_components/components/_metadata.html.erb
@@ -10,6 +10,9 @@
   page_history ||= []
   page_history = Array(page_history)
 
+  history ||= nil
+  first_published ||= nil
+  last_updated ||= nil
   other ||= nil
   inverse ||= false
   inverse_compress ||= false
@@ -34,83 +37,87 @@
     type: "content history",
     section: "Top",
   }.to_json unless disable_ga4
+
+  render_component = true if from.any? || part_of.any? || history || first_published || last_updated || page_history.any? || other
 %>
-<%= tag.div(**component_helper.all_attributes) do %>
-  <% if title.present? %>
-    <%= render "govuk_publishing_components/components/heading", {
-      text: sanitize(title),
-      font_size: "m",
-      inverse:,
-      margin_bottom: 2,
-    } %>
-  <% elsif page_history.any? %>
-    <h2 class="govuk-visually-hidden"><%= t("components.metadata.hidden_heading") %></h2>
-  <% end %>
-  <dl class="gem-c-metadata__list">
-    <% if from.any? %>
-      <dt class="gem-c-metadata__term"><%= t("components.metadata.from") %>:</dt>
-      <dd class="gem-c-metadata__definition">
-        <%= render "govuk_publishing_components/components/metadata/sentence", items: from, toggle_id: "from-#{SecureRandom.hex(4)}" %>
-      </dd>
+<% if render_component %>
+  <%= tag.div(**component_helper.all_attributes) do %>
+    <% if title.present? %>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: sanitize(title),
+        font_size: "m",
+        inverse:,
+        margin_bottom: 2,
+      } %>
+    <% elsif page_history.any? %>
+      <h2 class="govuk-visually-hidden"><%= t("components.metadata.hidden_heading") %></h2>
     <% end %>
-    <% if part_of.any? %>
-      <dt class="gem-c-metadata__term"><%= t("components.metadata.part_of") %>:</dt>
-      <dd class="gem-c-metadata__definition">
-        <%= render "govuk_publishing_components/components/metadata/sentence", items: part_of, toggle_id: "part-of-#{SecureRandom.hex(4)}" %>
-      </dd>
-    <% end %>
-    <% if local_assigns.include?(:history) %>
-      <dt class="gem-c-metadata__term"><%= t("components.metadata.history") %>:</dt>
-      <dd class="gem-c-metadata__definition"><%= history %></dd>
-    <% end %>
-    <% if local_assigns.include?(:first_published) && first_published %>
-      <dt class="gem-c-metadata__term"><%= t("components.metadata.published") %>:</dt>
-      <dd class="gem-c-metadata__definition"><%= first_published %></dd>
-    <% end %>
-    <% if local_assigns.include?(:last_updated) && last_updated %>
-      <dt class="gem-c-metadata__term"><%= t("components.metadata.last_updated") %>:</dt>
-      <dd class="gem-c-metadata__definition">
-        <%= last_updated %>
-        <% if local_assigns.include?(:see_updates_link) %>
-          &#8212; <a href="#full-publication-update-history"
-                    class="gem-c-metadata__definition-link govuk-!-display-none-print js-see-all-updates-link">
-            <%= t("components.metadata.see_all_updates") %>
-          </a>
-        <% end %>
-        <% if page_history.any? %>
-          <%= render "govuk_publishing_components/components/details", {
-            title: t("components.metadata.show_all_updates", locale: :en),
-            small: true,
-          } do %>
-            <ol class="gem-c-metadata__change-history">
-              <% page_history.each do |change| %>
-                <li class="gem-c-metadata__change-history-item">
-                  <time class="gem-c-metadata__change-date" datetime="<%= change[:timestamp] %>"><%= change[:display_time] %></time>
-                  <p class="gem-c-metadata__change-note"><%= change[:note].strip %></p>
-                </li>
-              <% end %>
-            </ol>
+    <dl class="gem-c-metadata__list">
+      <% if from.any? %>
+        <dt class="gem-c-metadata__term"><%= t("components.metadata.from") %>:</dt>
+        <dd class="gem-c-metadata__definition">
+          <%= render "govuk_publishing_components/components/metadata/sentence", items: from, toggle_id: "from-#{SecureRandom.hex(4)}" %>
+        </dd>
+      <% end %>
+      <% if part_of.any? %>
+        <dt class="gem-c-metadata__term"><%= t("components.metadata.part_of") %>:</dt>
+        <dd class="gem-c-metadata__definition">
+          <%= render "govuk_publishing_components/components/metadata/sentence", items: part_of, toggle_id: "part-of-#{SecureRandom.hex(4)}" %>
+        </dd>
+      <% end %>
+      <% if local_assigns.include?(:history) %>
+        <dt class="gem-c-metadata__term"><%= t("components.metadata.history") %>:</dt>
+        <dd class="gem-c-metadata__definition"><%= history %></dd>
+      <% end %>
+      <% if local_assigns.include?(:first_published) && first_published %>
+        <dt class="gem-c-metadata__term"><%= t("components.metadata.published") %>:</dt>
+        <dd class="gem-c-metadata__definition"><%= first_published %></dd>
+      <% end %>
+      <% if local_assigns.include?(:last_updated) && last_updated %>
+        <dt class="gem-c-metadata__term"><%= t("components.metadata.last_updated") %>:</dt>
+        <dd class="gem-c-metadata__definition">
+          <%= last_updated %>
+          <% if local_assigns.include?(:see_updates_link) %>
+            &#8212; <a href="#full-publication-update-history"
+                      class="gem-c-metadata__definition-link govuk-!-display-none-print js-see-all-updates-link">
+              <%= t("components.metadata.see_all_updates") %>
+            </a>
+          <% end %>
+          <% if page_history.any? %>
+            <%= render "govuk_publishing_components/components/details", {
+              title: t("components.metadata.show_all_updates", locale: :en),
+              small: true,
+            } do %>
+              <ol class="gem-c-metadata__change-history">
+                <% page_history.each do |change| %>
+                  <li class="gem-c-metadata__change-history-item">
+                    <time class="gem-c-metadata__change-date" datetime="<%= change[:timestamp] %>"><%= change[:display_time] %></time>
+                    <p class="gem-c-metadata__change-note"><%= change[:note].strip %></p>
+                  </li>
+                <% end %>
+              </ol>
+            <% end %>
+          <% end %>
+        </dd>
+      <% end %>
+      <% if other.present? %>
+        <% other.each_with_index do |(title, definition), index| %>
+          <%
+            definition ||= []
+            definition = Array(definition)
+          %>
+          <% if definition.any? %>
+            <dt class="gem-c-metadata__term"><%= title %>:</dt>
+            <dd class="gem-c-metadata__definition"
+              <% unless disable_ga4 %>
+                data-module="ga4-link-tracker"
+                data-ga4-link="<%= ga4_object %>"
+              <% end %>>
+              <%= render "govuk_publishing_components/components/metadata/sentence", items: definition, toggle_id: "#{index}-#{SecureRandom.hex(4)}" %>
+            </dd>
           <% end %>
         <% end %>
-      </dd>
-    <% end %>
-    <% if other.present? %>
-      <% other.each_with_index do |(title, definition), index| %>
-        <%
-          definition ||= []
-          definition = Array(definition)
-        %>
-        <% if definition.any? %>
-          <dt class="gem-c-metadata__term"><%= title %>:</dt>
-          <dd class="gem-c-metadata__definition"
-            <% unless disable_ga4 %>
-              data-module="ga4-link-tracker"
-              data-ga4-link="<%= ga4_object %>"
-            <% end %>>
-            <%= render "govuk_publishing_components/components/metadata/sentence", items: definition, toggle_id: "#{index}-#{SecureRandom.hex(4)}" %>
-          </dd>
-        <% end %>
       <% end %>
-    <% end %>
-  </dl>
+    </dl>
+  <% end %>
 <% end %>

--- a/spec/components/metadata_spec.rb
+++ b/spec/components/metadata_spec.rb
@@ -9,12 +9,16 @@ describe "Metadata", type: :view do
     allow(SecureRandom).to receive(:hex).and_return("1234")
   end
 
+  it "renders nothing when no data is given" do
+    assert_empty render_component({})
+  end
+
   it "renders metadata in a definition list" do
-    render_component({})
+    render_component(from: "<a href='/link'>Department</a>")
     assert_select ".gem-c-metadata dl"
 
-    assert_select "dd", false
-    assert_select "dt", false
+    assert_select "dd", true
+    assert_select "dt", true
   end
 
   it "renders from metadata" do
@@ -35,6 +39,18 @@ describe "Metadata", type: :view do
     render_component(history: "Updated 2 weeks ago")
 
     assert_definition("History:", "Updated 2 weeks ago")
+  end
+
+  it "renders first_published metadata" do
+    render_component(first_published: "Updated 2 weeks ago")
+
+    assert_definition("Published:", "Updated 2 weeks ago")
+  end
+
+  it "renders last_updated metadata" do
+    render_component(last_updated: "Updated 2 weeks ago")
+
+    assert_definition("Last updated:", "Updated 2 weeks ago")
   end
 
   it "renders custom metadata" do
@@ -357,7 +373,7 @@ describe "Metadata", type: :view do
   end
 
   it "renders with a top border" do
-    render_component({ border_top: true })
+    render_component({ first_published: "1st November 2000", border_top: true })
     assert_select ".gem-c-metadata.gem-c-metadata--border-top"
   end
 


### PR DESCRIPTION
## What
- stops anything from being rendered when nothing is passed to the metadata component
- previously would render an empty wrapping element, crucially with a margin bottom, which can disrupt layouts
- add explicit variables that could be passed to the component but not defined i.e. history and first_published

## Why
We're using it in a few places in `frontend` where it can have a variety of things passed to it, and it would be easier if it just didn't render if nothing was passed to it, than having to wrap it in multiple `if` statements.

## Visual Changes
Shouldn't be any.