### PR TITLE
Bump govuk-frontend to v6.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Update form date input component ([PR #5644](https://github.com/alphagov/govuk_publishing_components/pull/5644))
 * Remove Grade X browser support from the super navigation header ([PR #5649](https://github.com/alphagov/govuk_publishing_components/pull/5649))
 * Update chart colours to align with the brand update ([PR #5685](https://github.com/alphagov/govuk_publishing_components/pull/5685))
+* Bump govuk-frontend to v6.1.0 ([PR #5674](https://github.com/alphagov/govuk_publishing_components/pull/5674))
 
 ## 68.3.0
 

--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -15,7 +15,7 @@ $gem-guide-border-width: 1px;
   border: 3px solid govuk-functional-colour(error);
   margin: 0 0 govuk-spacing(6);
   padding: govuk-spacing(6);
-  @include govuk-text-colour;
+  color: govuk-functional-colour(text);
 
   .component-violation__title {
     margin: 0;
@@ -115,8 +115,8 @@ $gem-guide-border-width: 1px;
 .component-guide-preview--violation,
 .component-guide-preview--warning {
   margin-top: -$gem-guide-border-width;
-
-  @include govuk-text-colour;
+  
+  color: govuk-functional-colour(text);
   @include govuk-font($size: 19);
 
   &:empty {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_accordion.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_accordion.scss
@@ -1,4 +1,4 @@
-@import "govuk/components/accordion/accordion";
+@import "govuk/components/accordion";
 
 // Prevent elements inside the button from receiving click events
 .gem-c-accordion__show-all > * {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_add-another.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_add-another.scss
@@ -1,5 +1,5 @@
-@import "govuk/components/button/button";
-@import "govuk/components/fieldset/fieldset";
+@import "govuk/components/button";
+@import "govuk/components/fieldset";
 
 .gem-c-add-another {
   .gem-c-add-another__remove-button {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_app-promo-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_app-promo-banner.scss
@@ -3,7 +3,7 @@
   padding: govuk-spacing(5) 0;
   border-top: 4px solid govuk-functional-colour(brand);
   background-color: $govuk-blue-tint-95;
-  @include govuk-text-colour;
+  color: govuk-functional-colour(text);
 }
 
 .gem-c-app-promo-banner--visible {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_back-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_back-link.scss
@@ -1,1 +1,1 @@
-@import "govuk/components/back-link/back-link";
+@import "govuk/components/back-link";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_big-number.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_big-number.scss
@@ -1,6 +1,6 @@
 .gem-c-big-number {
   margin-bottom: govuk-spacing(3);
-  @include govuk-text-colour;
+  color: govuk-functional-colour(text);
 }
 
 .gem-c-big-number__value {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_breadcrumbs.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_breadcrumbs.scss
@@ -1,4 +1,4 @@
-@import "govuk/components/breadcrumbs/breadcrumbs";
+@import "govuk/components/breadcrumbs";
 
 .gem-c-breadcrumbs--border-bottom {
   border-bottom: 1px solid govuk-functional-colour(border);

--- a/app/assets/stylesheets/govuk_publishing_components/components/_button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_button.scss
@@ -1,4 +1,4 @@
-@import "govuk/components/button/button";
+@import "govuk/components/button";
 
 // Because govuk-frontend adds a responsive bottom margin by default for each component
 // we reset it to zero so we can set it separately using `gem-c-button--bottom-margin`

--- a/app/assets/stylesheets/govuk_publishing_components/components/_button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_button.scss
@@ -33,7 +33,7 @@
   display: block;
   max-width: 14em;
   margin-top: .5em;
-  @include govuk-text-colour;
+  color: govuk-functional-colour(text);
   @include govuk-font($size: 16);
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_character-count.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_character-count.scss
@@ -1,1 +1,1 @@
-@import "govuk/components/character-count/character-count";
+@import "govuk/components/character-count";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_checkboxes.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_checkboxes.scss
@@ -1,4 +1,4 @@
-@import "govuk/components/checkboxes/checkboxes";
+@import "govuk/components/checkboxes";
 
 .govuk-checkboxes--nested {
   width: 100%;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_contents-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_contents-list.scss
@@ -9,7 +9,7 @@
 
 .gem-c-contents-list__title {
   margin: 0;
-  @include govuk-text-colour;
+  color: govuk-functional-colour(text);
   @include govuk-font($size: 16, $weight: regular, $line-height: 1.5);
 }
 
@@ -18,7 +18,7 @@
   margin: 0;
   padding: 0;
   list-style-type: none;
-  @include govuk-text-colour;
+  color: govuk-functional-colour(text);
   @include govuk-font($size: 16);
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
@@ -1,4 +1,4 @@
-@import "govuk/components/cookie-banner/cookie-banner";
+@import "govuk/components/cookie-banner";
 
 .gem-c-cookie-banner {
   [hidden],

--- a/app/assets/stylesheets/govuk_publishing_components/components/_date-input.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_date-input.scss
@@ -1,4 +1,4 @@
-@import "govuk/components/date-input/date-input";
+@import "govuk/components/date-input";
 
 // Add spacing between input items on narrow containers when they collapse under each other
 .govuk-date-input {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_details.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_details.scss
@@ -1,4 +1,4 @@
-@import "govuk/components/details/details";
+@import "govuk/components/details";
 
 [dir="rtl"] .gem-c-details,
 .direction-rtl .gem-c-details,

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -1,7 +1,7 @@
 .gem-c-document-list {
   margin: 0;
   padding: 0;
-  @include govuk-text-colour;
+  color: govuk-functional-colour(text);
   @include govuk-font(19);
 }
 
@@ -55,7 +55,7 @@
 
 .gem-c-document-list__item-description {
   margin: govuk-spacing(1) 0;
-  @include govuk-text-colour;
+  color: govuk-functional-colour(text);
 }
 
 .gem-c-document-list__subtext {
@@ -79,7 +79,7 @@
   display: inline-block;
   list-style: none;
   padding-right: govuk-spacing(4);
-  @include govuk-text-colour;
+  color: govuk-functional-colour(text);
   @include govuk-font(16);
 
   & { // stylelint-disable-line no-duplicate-selectors, block-no-redundant-nested-style-rules
@@ -160,7 +160,7 @@
 .gem-c-document-list-child__description {
   margin-top: govuk-spacing(1);
   margin-bottom: govuk-spacing(1);
-  @include govuk-text-colour;
+  color: govuk-functional-colour(text);
 
   @include govuk-media-query($until: tablet) {
     display: none;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_error-message.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_error-message.scss
@@ -1,1 +1,1 @@
-@import "govuk/components/error-message/error-message";
+@import "govuk/components/error-message";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_error-summary.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_error-summary.scss
@@ -1,4 +1,4 @@
-@import "govuk/components/error-summary/error-summary";
+@import "govuk/components/error-summary";
 
 .gem-c-error-summary__list-item {
   color: govuk-functional-colour(error);

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -176,13 +176,13 @@ $feedback-prompt-border-top-colour: $govuk-blue-tint-50;
   // this comes from the backend so we can't put a class on it
   h2 {
     margin: 0 0 govuk-spacing(3);
-    @include govuk-text-colour;
+    color: govuk-functional-colour(text);
     @include govuk-font($size: 24, $weight: bold);
   }
 
   p {
     margin: 0 0 govuk-spacing(3);
-    @include govuk-text-colour;
+    color: govuk-functional-colour(text);
     @include govuk-font($size: 19);
   }
 
@@ -211,13 +211,13 @@ $feedback-prompt-border-top-colour: $govuk-blue-tint-50;
 
 .gem-c-feedback__form-heading {
   margin: 0 0 govuk-spacing(3);
-  @include govuk-text-colour;
+  color: govuk-functional-colour(text);
   @include govuk-font(24, $weight: bold);
 }
 
 .gem-c-feedback__form-paragraph {
   margin: 0 0 govuk-spacing(6);
-  @include govuk-text-colour;
+  color: govuk-functional-colour(text);
   @include govuk-font(19);
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_fieldset.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_fieldset.scss
@@ -1,1 +1,1 @@
-@import "govuk/components/fieldset/fieldset";
+@import "govuk/components/fieldset";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_file-upload.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_file-upload.scss
@@ -1,1 +1,1 @@
-@import "govuk/components/file-upload/file-upload";
+@import "govuk/components/file-upload";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_hint.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_hint.scss
@@ -1,1 +1,1 @@
-@import "govuk/components/hint/hint";
+@import "govuk/components/hint";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -8,7 +8,7 @@
   gap: govuk-spacing(2);
   justify-content: space-between;
   align-items: stretch;
-  @include govuk-text-colour;
+  color: govuk-functional-colour(text);
 
   @include govuk-media-query($until: tablet) {
     gap: govuk-spacing(3);

--- a/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
@@ -1,4 +1,4 @@
-@import "govuk/components/input/input";
+@import "govuk/components/input";
 
 $search-icon-size: 40px;
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_inset-text.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_inset-text.scss
@@ -1,4 +1,4 @@
-@import "govuk/components/inset-text/inset-text";
+@import "govuk/components/inset-text";
 
 @include govuk-media-query($media-type: print) {
   .gem-c-inset-text {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_intervention.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_intervention.scss
@@ -1,7 +1,7 @@
 .gem-c-intervention {
   background-color: govuk-colour("black", $variant: "tint-95");
   border-left: 10px solid govuk-functional-colour(success);
-  @include govuk-text-colour;
+  color: govuk-functional-colour(text);
   @include govuk-responsive-padding(3);
   @include govuk-responsive-margin(6, "bottom");
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_label.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_label.scss
@@ -1,1 +1,1 @@
-@import "govuk/components/label/label";
+@import "govuk/components/label";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-footer.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-footer.scss
@@ -1,4 +1,4 @@
-@import "govuk/components/footer/footer";
+@import "govuk/components/footer";
 
 .govuk-footer__list-item {
   display: inline-block;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
@@ -1,4 +1,4 @@
-@import "govuk/components/header/header";
+@import "govuk/components/header";
 
 .gem-c-layout-header.gem-c-layout-header--no-bottom-border,
 .gem-c-layout-header.gem-c-layout-header--no-bottom-border .govuk-header__container {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -1,4 +1,4 @@
-@import "govuk/components/header/header";
+@import "govuk/components/header";
 
 $chevron-breakpoint: 360px;
 $chevron-indent-spacing: 7px;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_lead-paragraph.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_lead-paragraph.scss
@@ -2,7 +2,7 @@
   margin-top: 0;
   // Ensure the text has a line-length of around 60 characters
   max-width: 30em;
-  @include govuk-text-colour;
+  color: govuk-functional-colour(text);
   @include responsive-bottom-margin;
   @include govuk-font(24);
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_metadata.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_metadata.scss
@@ -1,5 +1,5 @@
 .gem-c-metadata {
-  @include govuk-text-colour;
+  color: govuk-functional-colour(text);
   @include govuk-font(16);
   @include responsive-bottom-margin;
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_modal-dialogue.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_modal-dialogue.scss
@@ -36,7 +36,7 @@ $govuk-modal-wide-breakpoint: $govuk-page-width + $govuk-modal-margin * 2 + $gov
   }
 
   @include govuk-font($size: 19);
-  @include govuk-text-colour;
+  color: govuk-functional-colour(text);
   @include govuk-media-query($from: tablet) {
     position: relative;
     top: inherit;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_notice.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_notice.scss
@@ -1,4 +1,4 @@
-@import "govuk/components/notification-banner/notification-banner";
+@import "govuk/components/notification-banner";
 
 .gem-c-notice {
   .gem-c-govspeak {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_pagination.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_pagination.scss
@@ -1,4 +1,4 @@
-@import "govuk/components/pagination/pagination";
+@import "govuk/components/pagination";
 
 // stylelint-disable declaration-no-important
 @include govuk-media-query($media-type: print) {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_panel.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_panel.scss
@@ -1,4 +1,4 @@
-@import "govuk/components/panel/panel";
+@import "govuk/components/panel";
 
 .gem-c-panel__prepend {
   margin-bottom: govuk-spacing(3);

--- a/app/assets/stylesheets/govuk_publishing_components/components/_password-input.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_password-input.scss
@@ -1,1 +1,1 @@
-@import "govuk/components/password-input/password-input";
+@import "govuk/components/password-input";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_phase-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_phase-banner.scss
@@ -1,4 +1,4 @@
-@import "govuk/components/phase-banner/phase-banner";
+@import "govuk/components/phase-banner";
 
 .gem-c-phase-banner--inverse {
   .govuk-phase-banner__content__tag {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_radio.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_radio.scss
@@ -1,4 +1,4 @@
-@import "govuk/components/radios/radios";
+@import "govuk/components/radios";
 
 .gem-c-radio__heading-text {
   margin: 0 0 govuk-spacing(4);

--- a/app/assets/stylesheets/govuk_publishing_components/components/_related-navigation.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_related-navigation.scss
@@ -1,7 +1,7 @@
 .gem-c-related-navigation {
   border-top: 2px solid govuk-colour("blue");
   margin-bottom: govuk-spacing(9);
-  @include govuk-text-colour;
+  color: govuk-functional-colour(text);
 }
 
 .gem-c-related-navigation__main-heading {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_select-with-search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_select-with-search.scss
@@ -14,7 +14,7 @@ $choices-border-radius-item: 0 !default;
 $choices-z-index: 2 !default;
 $choices-button-dimension: 12px !default;
 
-@import "govuk/components/label/label";
+@import "govuk/components/label";
 @import "choices.js/src/styles/choices";
 
 .gem-c-select-with-search {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_select.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_select.scss
@@ -1,4 +1,4 @@
-@import "govuk/components/select/select";
+@import "govuk/components/select";
 
 // Increase height of selects that have a `multiple`
 // attribute otherwise they are too small to be useful.

--- a/app/assets/stylesheets/govuk_publishing_components/components/_service-navigation.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_service-navigation.scss
@@ -1,4 +1,4 @@
-@import "govuk/components/service-navigation/service-navigation";
+@import "govuk/components/service-navigation";
 
 .gem-c-service-navigation--full-width {
   padding-left: govuk-spacing(3);

--- a/app/assets/stylesheets/govuk_publishing_components/components/_skip-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_skip-link.scss
@@ -1,1 +1,1 @@
-@import "govuk/components/skip-link/skip-link";
+@import "govuk/components/skip-link";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-header.scss
@@ -5,7 +5,7 @@
   border-bottom: solid 1px govuk-colour("blue");
   margin-top: govuk-spacing(3);
   @include govuk-font(24, $weight: bold);
-  @include govuk-text-colour;
+  color: govuk-functional-colour(text);
 
   @include govuk-media-query($from: tablet) {
     padding: govuk-spacing(5);

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-related.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-related.scss
@@ -1,7 +1,7 @@
 .gem-c-step-nav-related {
   border-top: 2px solid govuk-colour("blue");
   margin-bottom: govuk-spacing(6);
-  @include govuk-text-colour;
+  color: govuk-functional-colour(text);
 }
 
 .gem-c-step-nav-related__heading {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
@@ -395,7 +395,7 @@ $top-border: solid 1px govuk-functional-colour("border");
 .gem-c-step-nav__title {
   margin: 0;
   @include step-nav-font(19, $weight: bold, $line-height: 1.4);
-  @include govuk-text-colour;
+  color: govuk-functional-colour(text);
 
   .gem-c-step-nav--large & {
     @include step-nav-font(19, $tablet-size: 24, $weight: bold, $line-height: 1.4);
@@ -417,7 +417,7 @@ $top-border: solid 1px govuk-functional-colour("border");
 .gem-c-step-nav__panel {
   padding-bottom: govuk-spacing(5);
   @include step-nav-font(16);
-  @include govuk-text-colour;
+  color: govuk-functional-colour(text);
 
   .gem-c-step-nav--large & {
     @include step-nav-font(16, $tablet-size: 19);

--- a/app/assets/stylesheets/govuk_publishing_components/components/_subscription-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_subscription-links.scss
@@ -1,5 +1,5 @@
 .gem-c-subscription-links {
-  @include govuk-text-colour;
+  color: govuk-functional-colour(text);
   @include govuk-font(19, $weight: bold);
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_success-alert.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_success-alert.scss
@@ -1,4 +1,4 @@
-@import "govuk/components/notification-banner/notification-banner";
+@import "govuk/components/notification-banner";
 
 // stylelint-disable declaration-no-important
 @include govuk-media-query($media-type: print) {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_summary-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_summary-card.scss
@@ -1,4 +1,4 @@
-@import "govuk/components/summary-list/summary-list";
+@import "govuk/components/summary-list";
 
 .gem-c-summary-card {
   .govuk-summary-list__key {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_summary-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_summary-list.scss
@@ -1,4 +1,4 @@
-@import "govuk/components/summary-list/summary-list";
+@import "govuk/components/summary-list";
 
 .gem-c-summary-list {
   margin-bottom: govuk-spacing(6);

--- a/app/assets/stylesheets/govuk_publishing_components/components/_table.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_table.scss
@@ -1,4 +1,4 @@
-@import "govuk/components/table/table";
+@import "govuk/components/table";
 
 $table-border-width: 1px;
 $table-border-colour: govuk-functional-colour("border");

--- a/app/assets/stylesheets/govuk_publishing_components/components/_tabs.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_tabs.scss
@@ -1,4 +1,4 @@
-@import "govuk/components/tabs/tabs";
+@import "govuk/components/tabs";
 
 .govuk-frontend-supported {
   .gem-c-tabs__panel--no-border {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_tag.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_tag.scss
@@ -1,4 +1,4 @@
-@import "govuk/components/tag/tag";
+@import "govuk/components/tag";
 
 .gem-c-tag {
   max-width: none;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_textarea.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_textarea.scss
@@ -1,4 +1,4 @@
-@import "govuk/components/textarea/textarea";
+@import "govuk/components/textarea";
 
 .gem-c-textarea {
   .govuk-textarea {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_translation-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_translation-nav.scss
@@ -1,7 +1,7 @@
 .gem-c-translation-nav {
   margin-bottom: govuk-spacing(6);
   border-bottom: 1px solid govuk-functional-colour(border);
-  @include govuk-text-colour;
+  color: govuk-functional-colour(text);
   @include govuk-font(16);
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_warning-text.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_warning-text.scss
@@ -1,4 +1,4 @@
-@import "govuk/components/warning-text/warning-text";
+@import "govuk/components/warning-text";
 
 .gem-c-warning-text .govuk-warning-text__text {
   margin: 0;

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_button.scss
@@ -1,4 +1,4 @@
-@import "govuk/components/button/button";
+@import "govuk/components/button";
 
 .govspeak, // Legacy class name that's still used in some content items - needs to be kept until `.govspeak` is removed from the content items.
 .gem-c-govspeak {

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_warning-callout.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_warning-callout.scss
@@ -6,7 +6,7 @@
 // - alphagov/whitehall: ✔︎
 // - alphagov/govspeak: ✔︎
 
-@import "govuk/components/warning-text/warning-text";
+@import "govuk/components/warning-text";
 
 // stylelint-disable max-nesting-depth
 .govspeak, // Legacy class name that's still used in some content items - needs to be kept until `.govspeak` is removed from the content items.

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_markdown-typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_markdown-typography.scss
@@ -1,5 +1,5 @@
 @mixin markdown-typography {
-  @include govuk-text-colour;
+  color: govuk-functional-colour(text);
   @include govuk-font($size: 16);
 
   ol,

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "axe-core": "^4.13.0",
     "chartkick": "^5.0.1",
     "choices.js": "^11.2.4",
-    "govuk-frontend": "6.0.0",
+    "govuk-frontend": "6.1.0",
     "sortablejs": "^1.15.7"
   },
   "devDependencies": {

--- a/spec/dummy_gem/app/assets/stylesheets/govuk_publishing_components/components/_test-component.scss
+++ b/spec/dummy_gem/app/assets/stylesheets/govuk_publishing_components/components/_test-component.scss
@@ -1,5 +1,5 @@
 // this file is needed to test the component auditing
-@import "govuk/components/accordion/accordion";
+@import "govuk/components/accordion";
 
 @include govuk-media-query($media-type: print) {
   .test {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1970,10 +1970,10 @@ got@^11.7.0:
     p-cancelable "^2.0.0"
     responselike "^2.0.0"
 
-govuk-frontend@6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-6.0.0.tgz#5906601cc9249027796c233f537eca00a0add0db"
-  integrity sha512-n1DUbQD6coHL3UkQS0yTbd4ziIxLBzkWBODVCjXMclSY7FvOGeHcTg3c72z6u7DQECQb0tfZofhPjGxPUOIizA==
+govuk-frontend@6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-6.1.0.tgz#7022bede1d72f6c63f6bf43f16f3d207c6f1214e"
+  integrity sha512-sqivexZFa82LiDIDVMItsUlqEXE/wEUWWBqzEoxHvUFLBH7bY0C8lVrj1qsDThSnj5JEUMS7isBAbKnfQ5Qp6g==
 
 graceful-fs@^4.1.15, graceful-fs@^4.1.2:
   version "4.2.11"


### PR DESCRIPTION
## What
This bumps govuk-frontend to v6.1.0 following the instructions in the [release notes](https://github.com/alphagov/govuk-frontend/releases#release-v6.1.0). 

Specifically, this PR:
- Updates govuk-frontend component import paths to the new format
- Moves to using `govuk-functional-colour(text)` to set the text colour

We'll revisit the "Use Sass functions to configure asset URLs" change in the release notes when upgrading to v6.2.0 which enables using @use to include GOV.UK Frontend styles in Sass.

## Why
https://gov-uk.atlassian.net/jira/software/c/projects/NAV/boards/1422?selectedIssue=NAV-190

## Further detail
We also have a PR to update frontend once this has been merged: https://github.com/alphagov/frontend/pull/5756 The other frontend apps didn't require updating. 