### PR TITLE
Update chart colours to align with the brand update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Prevent metadata component rendering when no data ([PR #5672](https://github.com/alphagov/govuk_publishing_components/pull/5672))
 * Update form date input component ([PR #5644](https://github.com/alphagov/govuk_publishing_components/pull/5644))
 * Remove Grade X browser support from the super navigation header ([PR #5649](https://github.com/alphagov/govuk_publishing_components/pull/5649))
+* Update chart colours to align with the brand update ([PR #5685](https://github.com/alphagov/govuk_publishing_components/pull/5685))
 
 ## 68.3.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_charts.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_charts.scss
@@ -30,18 +30,18 @@
   // For charts, the palette should be used instead of the GOV.UK colour palette - https://design-system.service.gov.uk/styles/colour/
   // https://gss.civilservice.gov.uk/policy-store/data-visualisation-colours-in-charts/#section-5
 
-  $gss-colour-dark-blue: #12436d;
-  $gss-colour-turquoise: #1bbbaf;
-  $gss-colour-dark-pink: #801650;
-  $gss-colour-orange: #f46a25;
-  $gss-colour-dark-grey: #3d3d3d;
-  $gss-colour-plum: #a285d1;
+  $chart-blue-shade-50: govuk-colour("blue", $variant: "shade-50");
+  $chart-teal-tint-25: govuk-colour("teal", $variant: "tint-25");
+  $chart-magenta-shade-25: govuk-colour("magenta", $variant: "shade-25");
+  $chart-primary-orange: govuk-colour("orange");
+  $chart-green-shade-50: govuk-colour("green", $variant: "shade-50");
+  $chart-accent-purple: #ba4aff; // There is currently no equivalent colour in the GOV.UK palette, but this can be updated in future if one is added.
 
   // CHART COLOUR SCHEME
 
   $chart-border: govuk-colour("white"); // Chart border colour
   $key-border: govuk-colour("white"); // Key border colour
-  $bar-colours: $gss-colour-dark-blue, $gss-colour-turquoise, $gss-colour-dark-pink, $gss-colour-orange, $gss-colour-dark-grey, $gss-colour-plum;
+  $bar-colours: $chart-blue-shade-50, $chart-teal-tint-25, $chart-magenta-shade-25, $chart-primary-orange, $chart-green-shade-50, $chart-accent-purple;
   $bar-text-colours: govuk-colour("white"), govuk-colour("black"), govuk-colour("white"), govuk-colour("black"), govuk-colour("white"), govuk-colour("black");
   $bar-cell-colour: govuk-colour("black");
   $bar-outdented-colour: govuk-colour("black");
@@ -148,6 +148,7 @@
           margin-bottom: 1px;
           color: govuk-colour("white");
           text-indent: $bar-padding;
+          font-weight: $govuk-font-weight-bold;
         }
 
         // Bar colours
@@ -175,6 +176,7 @@
           text-align: $label-align;
           display: table-cell;
           vertical-align: middle;
+          font-weight: $govuk-font-weight-bold;
         }
       }
     }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_charts.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_charts.scss
@@ -24,7 +24,6 @@
   $bar-spacing: 5px; // The spacing around the bars
   $stack-spacing: 1px; // For stacked bars, the spacing between each stack in a bar
   $caption-side: top; // Caption alignment. Top or bottom.
-  $key-width: 160px; // Only used by IE. Other browsers get smallest width that fits content
 
   // The following accessible colour palette has been developed to meet the colour contrast requirements for adjacent colours (as set out in WCAG 2.1)
   // For charts, the palette should be used instead of the GOV.UK colour palette - https://design-system.service.gov.uk/styles/colour/


### PR DESCRIPTION
## What

Update chart colours to align with the brand update, based on the new colours added in https://gov-uk.atlassian.net/browse/NAV-18942?focusedCommentId=204506.

## Why

https://gov-uk.atlassian.net/browse/NAV-18938

## Visual Changes

<img width="1728" height="1117" alt="Screenshot 2026-09-03 at 11 29 57" src="https://github.com/user-attachments/assets/96c68276-d70e-4743-a728-f35e3d07bc40" />

<img width="1728" height="1117" alt="Screenshot 2026-09-03 at 11 31 18" src="https://github.com/user-attachments/assets/0628a26d-3d10-4178-9a4b-e15c3bfc457f" />

<img width="1728" height="1117" alt="Screenshot 2026-09-03 at 11 32 01" src="https://github.com/user-attachments/assets/176d860a-a733-46dc-b2f2-09d585a87514" />

<img width="1728" height="1117" alt="Screenshot 2026-09-03 at 11 32 43" src="https://github.com/user-attachments/assets/e2e0f68e-15aa-46e4-aa95-7b31b9382cfe" />