### PR TITLE
Make 'No data' more logical on bar charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Make 'No data' more logical on bar charts ([PR #5686](https://github.com/alphagov/govuk_publishing_components/pull/5686))
+
 ## 69.0.0
 
 * Prevent metadata component rendering when no data ([PR #5672](https://github.com/alphagov/govuk_publishing_components/pull/5672))

--- a/app/assets/javascripts/govuk_publishing_components/lib/govspeak/magna-charta.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/govspeak/magna-charta.js
@@ -389,6 +389,17 @@
       for (var j = 0; j < cells.length; j++) {
         var $cell = cells[j]
         var parsedCellVal = parseFloat(this.utils.stripValue($cell.innerText), 10)
+
+        if (isNaN(parsedCellVal)) {
+          parsedCellVal = 0
+
+          if (this.options.stacked) {
+            $cell.classList.add('govuk-visually-hidden')
+          } else {
+            $cell.classList.add('mc-no-data')
+          }
+        }
+
         var parsedVal = parsedCellVal * this.dimensions.single
         var absParsedCellVal = Math.abs(parsedCellVal)
         var absParsedVal = Math.abs(parsedVal)

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_charts.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_charts.scss
@@ -21,7 +21,7 @@
   $base-unit: 16px; // For font sizes and related spacing
   $compact-font-size: 12px; // For the 'compact' bar style
   $bar-padding: 8px; // The padding between the bar values and the edge of the bar
-  $bar-spacing: 5px; // The spacing around the bars
+  $bar-spacing: 10px; // The spacing around the bars
   $stack-spacing: 1px; // For stacked bars, the spacing between each stack in a bar
   $caption-side: top; // Caption alignment. Top or bottom.
 
@@ -52,7 +52,6 @@
     width: 100%;
     border-spacing: 0 $bar-spacing;
     border: 1px solid $chart-border;
-    padding: $base-unit 0;
     position: relative;
     margin-bottom: $base-unit;
 
@@ -156,6 +155,18 @@
             background-color: list.nth($bar-colours, $i + 1);
             color: list.nth($bar-text-colours, $i + 1);
           }
+
+          .mc-bar-#{$i + 1}.mc-no-data {
+              color: govuk-colour("black");
+              border-width: 2px;
+              border-style: solid;
+              border-color: list.nth($bar-colours, $i + 1);
+          }
+        }
+
+        .mc-no-data span {
+          display: inline-block;
+          min-width: 75px;
         }
 
         // Negative bars

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -634,7 +634,7 @@ examples:
               <td>row 3</td><td>2</td>
             </tr>
             <tr>
-              <td>row 4</td><td>48</td>
+              <td>row 4</td><td>No data</td>
             </tr>
           </tbody>
         </table>
@@ -686,9 +686,9 @@ examples:
             <tr><th>Some Data</th><th>YES</th><th>NO</th><th>MAYBE</th></tr>
           </thead>
           <tbody>
-            <tr><th>Testing One</th><td>5</td><td>6</td><td>11</td></tr>
-            <tr><th>Testing Two</th><td>6</td><td>2</td><td>8</td></tr>
-            <tr><th>Testing Three</th><td>3</td><td>9</td><td>12</td></tr>
+            <tr><th>Testing One</th><td>No data</td><td>7</td><td>6</td></tr>
+            <tr><th>Testing Two</th><td>6</td><td>2</td><td>No data</td></tr>
+            <tr><th>Testing Three</th><td>3</td><td>No data</td><td>9</td></tr>
           </tbody>
         </table>
   chart_stacked:
@@ -700,6 +700,7 @@ examples:
               <th scope="col">Colours</th>
               <th scope="col">Fruits</th>
               <th scope="col">Vegetables</th>
+              <th scope="col">Chocolates</th>
               <th scope="col">Beans</th>
               <th scope="col">Nuts</th>
               <th scope="col">Total</th>
@@ -709,6 +710,7 @@ examples:
             <tr>
               <td>Red</td>
               <td>23</td>
+              <td> No data</td>
               <td>9</td>
               <td>2</td>
               <td>1</td>
@@ -717,6 +719,7 @@ examples:
             <tr>
               <td>Green</td>
               <td>5</td>
+              <td>No data</td>
               <td>33</td>
               <td>8</td>
               <td>0</td>
@@ -727,6 +730,7 @@ examples:
               <td>2</td>
               <td>10</td>
               <td>0</td>
+              <td>No data</td>
               <td>15</td>
               <td>27</td>
             </tr>

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -638,6 +638,31 @@ examples:
             </tr>
           </tbody>
         </table>
+  negative_charts:
+    description: |
+      Charts can contain positive and negative values if the 'mc-negative' class is added to the table.
+    data:
+      block: |
+        <table class='js-barchart-table mc-auto-outdent mc-negative'>
+          <caption>Calorie Gain/Loss by Superhero</caption>
+          <tbody>
+            <tr>
+              <td>Hulk</td><td>6000</td>
+            </tr>
+            <tr>
+              <td>Thor</td><td>5000</td>
+            </tr>
+            <tr>
+              <td>Spiderman</td><td>-2000</td>
+            </tr>
+            <tr>
+              <td>Iron Man</td><td>No data</td>
+            </tr>
+            <tr>
+              <td>Black Widow</td><td>-1500</td>
+            </tr>
+          </tbody>
+        </table>
   chart_with_colours:
     data:
       block: |

--- a/spec/javascripts/govuk_publishing_components/lib/govspeak/magna-charta-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/govspeak/magna-charta-spec.js
@@ -28,6 +28,7 @@ describe('Magna charta', function () {
         '<tr><td>Testing One</td><td>5</td></tr>' +
         '<tr><td>Testing Two</td><td>4</td></tr>' +
         '<tr><td>Testing Three</td><td>3</td></tr>' +
+        '<tr><td>Testing Four</td><td>Not A Number</td></tr>' +
       '</tbody>' +
     '</table>'
 
@@ -39,8 +40,9 @@ describe('Magna charta', function () {
       '</thead>' +
       '<tbody>' +
         '<tr><td>Testing One</td><td>5</td><td>6</td><td>11</td></tr>' +
-        '<tr><td>Testing Two</td><td>6</td><td>2</td><td>8</td></tr>' +
+        '<tr><td>Testing Two</td><td>6</td><td>No Data</td><td>8</td></tr>' +
         '<tr><td>Testing Three</td><td>3</td><td>9</td><td>12</td></tr>' +
+        '<tr><td>Testing Four</td><td>3</td><td>No Data</td><td>12</td></tr>' +
       '</tbody>' +
     '</table>'
 
@@ -52,7 +54,7 @@ describe('Magna charta', function () {
       '</thead>' +
       '<tbody>' +
         '<tr><td>Testing One</td><td>5</td><td>6</td><td>11</td></tr>' +
-        '<tr><td>Testing Two</td><td>6</td><td>2</td><td>8</td></tr>' +
+        '<tr><td>Testing Two</td><td>6</td><td>No Data</td><td>8</td></tr>' +
         '<tr><td>Testing Three</td><td>3</td><td>9</td><td>12</td></tr>' +
       '</tbody>' +
     '</table>'
@@ -64,7 +66,7 @@ describe('Magna charta', function () {
         '<tr><th>Some Data</th><th>YES</th><th>NO</th><th>MAYBE</th></tr>' +
       '</thead>' +
       '<tbody>' +
-        '<tr><th>Testing One</th><td>5</td><td>6</td><td>11</td></tr>' +
+        '<tr><th>Testing One</th><td>5</td><td>No Data</td><td>11</td></tr>' +
         '<tr><th>Testing Two</th><td>6</td><td>2</td><td>8</td></tr>' +
         '<tr><th>Testing Three</th><td>3</td><td>9</td><td>12</td></tr>' +
       '</tbody>' +
@@ -80,6 +82,7 @@ describe('Magna charta', function () {
         '<tr><td>Something Positive</td><td>10</td></tr>' +
         '<tr><td>Something More Negative</td><td>-10</td></tr>' +
         '<tr><td>Something Less Positive</td><td>5</td></tr>' +
+        '<tr><td>Not A Number</td><td>No Data</td></tr>' +
       '</tbody>' +
     '</table>'
 
@@ -93,6 +96,7 @@ describe('Magna charta', function () {
         '<tr><td>Something Positive</td><td>10</td></tr>' +
         '<tr><td>Something More Negative</td><td>-10</td></tr>' +
         '<tr><td>Something Less Positive</td><td>5</td></tr>' +
+        '<tr><td>Not A Number</td><td>No Data</td></tr>' +
       '</tbody>' +
     '</table>'
 
@@ -106,6 +110,7 @@ describe('Magna charta', function () {
         '<tr><td>Something Positive</td><td>10</td></tr>' +
         '<tr><td>Something More Negative</td><td>-10</td></tr>' +
         '<tr><td>Something Less Positive</td><td>5</td></tr>' +
+        '<tr><td>Not A Number</td><td>No Data</td></tr>' +
       '</tbody>' +
     '</table>'
 
@@ -116,6 +121,7 @@ describe('Magna charta', function () {
         '<tr><td>Testing One</td><td>5</td><td>6</td><td>11</td></tr>' +
         '<tr><td>Testing Two</td><td>6</td><td>2</td><td>8</td></tr>' +
         '<tr><td>Testing Three</td><td>3</td><td>9</td><td>12</td></tr>' +
+        '<tr><td>Not A Number</td><td>No Data</td></tr>' +
       '</tbody>' +
     '</table>'
 
@@ -159,9 +165,9 @@ describe('Magna charta', function () {
 
     it('new chart div contains all table bits as divs', function () {
       expect(graph.querySelectorAll('.mc-thead').length).toBe(1)
-      expect(graph.querySelectorAll('.mc-tr').length).toBe(4)
+      expect(graph.querySelectorAll('.mc-tr').length).toBe(5)
       expect(graph.querySelectorAll('.mc-th').length).toBe(2)
-      expect(graph.querySelectorAll('.mc-td').length).toBe(6)
+      expect(graph.querySelectorAll('.mc-td').length).toBe(8)
     })
 
     it('new chart divs contain the right values', function () {
@@ -178,12 +184,12 @@ describe('Magna charta', function () {
     })
 
     it('divs that are bars or keys are given correct classes', function () {
-      expect(graph.querySelectorAll('.mc-key-cell').length).toBe(3)
-      expect(graph.querySelectorAll('.mc-bar-cell').length).toBe(3)
+      expect(graph.querySelectorAll('.mc-key-cell').length).toBe(4)
+      expect(graph.querySelectorAll('.mc-bar-cell').length).toBe(4)
     })
 
     it('bar cells have their values wrapped in a span tag', function () {
-      expect(graph.querySelectorAll('.mc-bar-cell span').length).toBe(3)
+      expect(graph.querySelectorAll('.mc-bar-cell span').length).toBe(4)
     })
 
     it('bars are given the correct width', function () {
@@ -191,6 +197,8 @@ describe('Magna charta', function () {
       expect(bars[0].style.width).toBe(cW(5, 5))
       expect(bars[1].style.width).toBe(cW(5, 4))
       expect(bars[2].style.width).toBe(cW(5, 3))
+      expect(bars[3].classList.contains('mc-no-data')).toBe(true)
+      expect(bars[3].offsetWidth).toBe(0)
     })
 
     it('new chart is inserted into DOM after table', function () {
@@ -274,9 +282,9 @@ describe('Magna charta', function () {
     })
 
     it('the cells that become bars are given the right classes', function () {
-      expect(graph.querySelectorAll('.mc-bar-cell').length).toBe(6) // bar cells
-      expect(graph.querySelectorAll('.mc-key-cell').length).toBe(3) // key cells
-      expect(graph.querySelectorAll('.mc-stacked-total').length).toBe(3) // total cells
+      expect(graph.querySelectorAll('.mc-bar-cell').length).toBe(8) // bar cells
+      expect(graph.querySelectorAll('.mc-key-cell').length).toBe(4) // key cells
+      expect(graph.querySelectorAll('.mc-stacked-total').length).toBe(4) // total cells
     })
 
     it('header cells get the right values', function () {
@@ -286,8 +294,9 @@ describe('Magna charta', function () {
       expect(head.querySelectorAll('.mc-key-header').length).toBe(2)
     })
 
-    it('the bar cells are given the right widths', function () {
-      var cells = graph.querySelectorAll('.mc-bar-cell')
+    it('the bar cells are given the right widths when they have data', function () {
+      var cells = graph.querySelectorAll('.mc-bar-cell:not(.govuk-visually-hidden)')
+
       for (var cell of cells) {
         var cellText = cell.textContent
         var cellWidth = cell.style.width
@@ -295,6 +304,14 @@ describe('Magna charta', function () {
 
         expect(cellWidth).toContain('%')
         expect(parseFloat(cellWidth)).toBeCloseTo(calculatedWidth, 4)
+      }
+    })
+
+    it('the bar cells are given the right widths when they have no data', function () {
+      var cells = graph.querySelectorAll('.mc-bar-cell.govuk-visually-hidden')
+
+      for (var cell of cells) {
+        expect(cell.clientWidth).toBe(1)
       }
     })
 
@@ -380,6 +397,8 @@ describe('Magna charta', function () {
       expect(cells[1].style.width).toEqual(cW(10, 10))
       expect(cells[2].style.width).toEqual(cW(10, 10))
       expect(cells[3].style.width).toEqual(cW(10, 5))
+      expect(cells[4].classList.contains('mc-no-data')).toBe(true)
+      expect(cells[4].offsetWidth).toBe(0)
     })
 
     it('positive cells are given a left margin to align them with negative cells', function () {


### PR DESCRIPTION
## What / Why

- A user reported that we recommend adding "No data" to charts when they have some missing data for a given key. However "No data" (or anything that isn't a number) renders as a full width bar on our govspeak bar charts.
- This is an attempt to fix that by showing them with a 2px coloured border instead. The coloured border matches the key's colour.  
  - The only downside to this is the 2px border can end up being the same width as a small value on a chart (e.g. if a chart had a bar that was 500 and a bar that was 1,  500 would be full width, and 1 would appear as 2px wide, similar to "No data".) Though I'd argue that you would still able to understand the difference between 1 and "No data" in this case.
- I prevented "No data" from rendering on [stacked bar charts](https://components-gem-pr-5686.herokuapp.com/component-guide/govspeak/chart_stacked/preview) too. Rendering "No data" here would make a chart not make sense. For example, a bar could be wider than another due to it having a 'No data' on it, despite it having a lower total than other bars, which would mean the width of the stacked bar no longer conveyed its size relative to other bars.  (Very crude unstyled example in the screenshot)
  - <img width="578" height="334" alt="image" src="https://github.com/user-attachments/assets/865c89c7-4a5f-49e3-846c-5df9ab9eaded" />

  - Maybe we shouldn't promote the ability to add "No data" to a stacked chart anyway as it breaks the 3:1 adjacent colour contrast ratio. Each bar's colour is only meant to sit next to the specific ones next to it in our code, but a "No data" value here means a colour is skipped over, so bars end up next to colours they are not meant to be. 
- This PR also adjusts the spacing of the chart slightly, as requested by our designer.
- The design has been approved by our designer.
- Component link: https://components-gem-pr-5686.herokuapp.com/component-guide/govspeak
- Jira card: https://gov-uk.atlassian.net/browse/PNP-10137

## Visual Changes

<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

| Before | After |
|--------|--------|
| <img width="717" height="363" alt="image" src="https://github.com/user-attachments/assets/534e8c2f-7f30-4e81-a086-28c7c2c02cdd" /> | <img width="717" height="363" alt="image" src="https://github.com/user-attachments/assets/aa5809b5-a8db-4f34-be16-3b54eab0d90f" /> |
| <img width="821" height="545" alt="image" src="https://github.com/user-attachments/assets/74adc63a-ebb8-464a-be7e-48283a520de1" /> | <img width="821" height="545" alt="image" src="https://github.com/user-attachments/assets/ed2b433f-066e-476b-aafe-e0347b07812c" /> |
| <img width="578" height="334" alt="image" src="https://github.com/user-attachments/assets/7ee1a75f-883a-49ad-97c3-e3ff8677939f" /> | <img width="578" height="334" alt="image" src="https://github.com/user-attachments/assets/7ba4aea0-7352-4378-94c3-b594590c38f1" /> |
|<img width="717" height="864" alt="image" src="https://github.com/user-attachments/assets/a312d0ae-4058-4fd3-b2ed-2e4d4244ce7e" /> | <img width="717" height="864" alt="image" src="https://github.com/user-attachments/assets/0f71e920-fdf7-4cbf-934d-be9c9682bdd9" /> |