### PR TITLE
Increase metadata border spacing

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_metadata.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_metadata.scss
@@ -91,7 +91,7 @@
 }
 
 .gem-c-metadata--border-top {
-  padding-top: govuk-spacing(2);
+  padding-top: govuk-spacing(3);
   border-top: 1px solid $govuk-border-colour;
 }
 


### PR DESCRIPTION
## What / why
- adds a little bit of extra space between the content of the metadata component and the border top, when the border top option is applied
- space increases from 10px to 15px
- makes the metadata component with border more visually consistent with existing pages where the border is done with a separate element

## Visual Changes
Before | After
----- | -----
<img width="247" height="79" alt="Screenshot 2026-09-07 at 10 55 31" src="https://github.com/user-attachments/assets/d1c4fca3-0cb8-44ad-a8f3-0ab340edb5ae" /> | <img width="255" height="75" alt="Screenshot 2026-09-07 at 10 55 36" src="https://github.com/user-attachments/assets/7c9ef41e-8c4b-4e9c-8adb-f2c4bb72f00d" />
