### PR TITLE
Release Version 69.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 69.0.0
 
 * Prevent metadata component rendering when no data ([PR #5672](https://github.com/alphagov/govuk_publishing_components/pull/5672))
 * Update form date input component ([PR #5644](https://github.com/alphagov/govuk_publishing_components/pull/5644))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (68.3.0)
+    govuk_publishing_components (69.0.0)
       chartkick
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
@@ -246,7 +246,7 @@ GEM
       net-protocol
     net-pop (0.1.2)
       net-protocol
-    net-protocol (0.2.2)
+    net-protocol (0.3.0)
       timeout
     net-smtp (0.5.1)
       net-protocol

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "68.3.0".freeze
+  VERSION = "69.0.0".freeze
 end


### PR DESCRIPTION
## 69.0.0

* Prevent metadata component rendering when no data ([PR #5672](https://github.com/alphagov/govuk_publishing_components/pull/5672))
* Update form date input component ([PR #5644](https://github.com/alphagov/govuk_publishing_components/pull/5644))
* Remove Grade X browser support from the super navigation header ([PR #5649](https://github.com/alphagov/govuk_publishing_components/pull/5649))
* Update chart colours to align with the brand update ([PR #5685](https://github.com/alphagov/govuk_publishing_components/pull/5685))
* Bump govuk-frontend to v6.1.0 ([PR #5674](https://github.com/alphagov/govuk_publishing_components/pull/5674))
* **BREAKING:** Replace grid-helper usages and remove file ([PR #5688](https://github.com/alphagov/govuk_publishing_components/pull/5688)) - as discussed with @luke-booker, no syncing with any frontend app changes required, we already made the necessary changes in https://github.com/alphagov/frontend/pull/5768
