### PR TITLE
Release Version 69.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 69.0.1
 
 * Make 'No data' more logical on bar charts ([PR #5686](https://github.com/alphagov/govuk_publishing_components/pull/5686))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (69.0.0)
+    govuk_publishing_components (69.0.1)
       chartkick
       govuk_app_config
       govuk_personalisation (>= 0.7.0)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "69.0.0".freeze
+  VERSION = "69.0.1".freeze
 end


### PR DESCRIPTION
## 69.0.1

* Make 'No data' more logical on bar charts ([PR #5686](https://github.com/alphagov/govuk_publishing_components/pull/5686))