### PR TITLE
BREAKING: Replace prefixed-transform usages with standard CSS transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* **BREAKING:** Replace prefixed-transform usages with standard CSS transform ([PR #5686](https://github.com/alphagov/govuk_publishing_components/pull/5704))  
+
 ## 69.0.1
 
 * Make 'No data' more logical on bar charts ([PR #5686](https://github.com/alphagov/govuk_publishing_components/pull/5686))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
@@ -191,7 +191,7 @@
     right: govuk-spacing(1);
     top: 50%;
     margin-top: 5px;
-    @include prefixed-transform($rotate: 45deg);
+    transform: rotate(45deg);
     width: $dimension;
   }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_select-with-search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_select-with-search.scss
@@ -34,14 +34,14 @@ $choices-button-dimension: 12px !default;
 
   .choices[data-type*="select-one"]::after {
     @include govuk-shape-arrow($direction: down, $base: 10px, $display: inline-block);
-    @include prefixed-transform($translateY: -50%);
+    transform: translateY(-50%);
     margin: 0;
   }
 
   .choices.is-open[data-type*="select-one"]::after {
     margin: 0;
     bottom: govuk-em(1px, $font-size);
-    @include prefixed-transform($translateY: -50%, $rotate: 180deg);
+    transform: translateY(-50%) rotate(180deg);
   }
 
   .choices[data-type*="select-multiple"] .choices__button,

--- a/app/assets/stylesheets/govuk_publishing_components/components/mixins/_index.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/mixins/_index.scss
@@ -1,4 +1,3 @@
 @import "high-contrast-outline";
 @import "margins";
-@import "prefixed-transform";
 @import "scale";

--- a/app/assets/stylesheets/govuk_publishing_components/components/mixins/_prefixed-transform.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/mixins/_prefixed-transform.scss
@@ -1,5 +1,0 @@
-@mixin prefixed-transform($translateY: 0, $rotate: 0, $scale: 1) {
-  -webkit-transform: translateY($translateY) rotate($rotate) scale($scale);
-  -ms-transform: translateY($translateY) rotate($rotate) scale($scale);
-  transform: translateY($translateY) rotate($rotate) scale($scale);
-}


### PR DESCRIPTION
## What
- Removes the uses of prefixed-transform.
- Refactors cards and select with search to use standard native CSS transform.
- Removed prefixed-transform mixin itself and any imports 

### Cards

<img width="984" height="191" alt="Screenshot 2026-09-10 at 15 35 58" src="https://github.com/user-attachments/assets/3e44caee-3ac0-413f-a6fe-a6e0c365273a" />

### Select with search

<img width="1002" height="170" alt="Screenshot 2026-09-11 at 08 44 08" src="https://github.com/user-attachments/assets/a973a3d4-873f-489f-8140-5c902e1bdc15" />

## Why
- Replaces redundant prefixed-transform uses with native CSS transform supported by all Grade C+ browsers.
- Retains the exact transform behaviour while allowing unsupported legacy browsers to still present a functional page.
- The prefixed-transform mixin itself can then safely be removed. Applications elsewhere relying on this have been checked and refactored where required. 

Jira card: https://gov-uk.atlassian.net/browse/NAV-19071

## Visual changes

No visual differences

Device and browser testing in BrowserStack

### Cards

Device / browser | Outcome
-- | --
macOS Tahoe - Chrome 152 | No change, as expected
macOS Golden Gate - Safari 27 | No change, as expected
macOS Sonoma - Firefox 154 | No change, as expected
macOS Catalina - Edge 128 | No change, as expected
macOS Sierra - Safari 10.1 | No change, as expected
macOS Sierra - Firefox 60 | No change, as expected
macOS Catalina - Safari 13.1 | No change, as expected
Android 16 - Samsung Galaxy S23 (Chrome) | No change, as expected
Android 16 - Samsung Galaxy Tab S8 (Chrome) | No change, as expected
Android 14 - Samsung Galaxy A17 (Samsung Internet) | No change, as expected
iOS 11 - Safari | No change, as expected
iOS 15 - Chrome | No change, as expected
iOS SE 2022 - Safari | No change, as expected
Windows 10 - Edge 15 | No change, as expected
Windows 10 - Edge 100 | No change, as expected
Windows 10 - IE11 | No chevron, links work as expected

### Select with search (not used on public-facing pages)

Device / browser | Outcome
-- | --
macOS Tahoe - Chrome 152 | No change, as expected
macOS Sequoia - Safari 18.4 | No change, as expected
macOS Ventura - Firefox 154 | No change, as expected
macOS Big Sur - Edge 138 | No change, as expected
macOS Sierra - Safari 10.1 | Uses native select, same as live
macOS Sierra - Firefox 60 |  Select options not displaying, same as live
macOS Catalina - Safari 13.1 | Select options not displaying. 'Search in list' lost some styling'. Same as live
Android 16 - Samsung Galaxy A17 (Chrome) | No change, as expected
Android 11 - Samsung Galaxy Tab S7 (Chrome) | No change, as expected
Android 16 - Samsung Galaxy A17 (Samsung Internet) | No change, as expected
iOS 11 - Safari | Select options not displaying, same as live
iOS 15 - Chrome | No change, as expected
iOS SE 2022 - Safari | No change, as expected
Windows 10 - Edge 15 | No search, dropdown works, a few display issues. Same as live. 
Windows 10 - Edge 100 | No change, as expected
Windows 10 - IE11 | No search, dropdown works, a few display issues. Same as live. 