### PR TITLE
Remove conditional check in the action-link view template

### DIFF
--- a/app/views/govuk_publishing_components/components/_action_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_action_link.html.erb
@@ -27,7 +27,7 @@
           </g>
         </svg>
       </span>
-    <% elsif %>
+    <% else %>
       <span class="gem-c-action-link__icon" hidden>
         <svg xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true" viewBox="0 0 27 27" class="gem-c-action-link__svg">
           <circle class="gem-c-action-link__icon__circle" cx="13.5" cy="13.5" r="13.5" />


### PR DESCRIPTION
## What
Remove conditional check in the action-link view template

## Why
Replaced `elsif` with `else` as there are no other conditions to check, we simply want to output the default arrow SVG
