### PR TITLE
Add Ruby 4.0 to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [3.3, 3.4]
+        ruby: [3.3, 3.4, 4.0]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,7 +125,7 @@ GEM
       bigdecimal
       rexml
     crass (1.0.7)
-    csv (3.3.2)
+    csv (3.3.6)
     dartsass-rails (0.5.1)
       railties (>= 6.0.0)
       sass-embedded (~> 1.63)
@@ -191,15 +191,17 @@ GEM
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     i18n-coverage (0.2.0)
-    i18n-tasks (1.0.14)
+    i18n-tasks (1.1.2)
       activesupport (>= 4.0.2)
       ast (>= 2.1.0)
       erubi
-      highline (>= 2.0.0)
+      highline (>= 3.0.0)
       i18n
       parser (>= 3.2.2.1)
+      prism
       rails-i18n
       rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.8, >= 1.8.1)
       terminal-table (>= 1.5.1)
     io-console (0.9.2)
     irb (1.18.0)
@@ -433,7 +435,7 @@ GEM
       opentelemetry-api (~> 1.0)
     ostruct (0.6.3)
     parallel (1.28.0)
-    parser (3.3.11.1)
+    parser (3.3.12.0)
       ast (~> 2.4.1)
       racc
     percy-capybara (5.0.1)
@@ -487,7 +489,7 @@ GEM
     rails-html-sanitizer (1.7.1)
       loofah (~> 2.25, >= 2.25.2)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
-    rails-i18n (8.0.1)
+    rails-i18n (8.1.0)
       i18n (>= 0.7, < 2)
       railties (>= 8.0.0, < 9)
     rails_translation_manager (1.8.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -672,4 +672,4 @@ RUBY VERSION
    ruby 3.3.11p205
 
 BUNDLED WITH
-   2.3.14
+   2.5.22


### PR DESCRIPTION
## What
Add Ruby 4.0 to the test matrix

## Why
The govuk_publishing_components gem supports Ruby 4.0, this change ensures that we test against this version in our CI workflow, further info - https://docs.publishing.service.gov.uk/manual/test-and-build-a-project-with-github-actions.html#ci-workflow-for-ruby-gems

Fixes: https://github.com/alphagov/govuk_publishing_components/issues/5701
