### PR TITLE
Remove prioritise_taxon_breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@
 
 ## Unreleased
 
-* **BREAKING:** Replace prefixed-transform usages with standard CSS transform ([PR #5686](https://github.com/alphagov/govuk_publishing_components/pull/5704))  
-* Replace and remove scale mixin ([PR #5686](https://github.com/alphagov/govuk_publishing_components/pull/5709))  
+* **BREAKING:** Replace prefixed-transform usages with standard CSS transform ([PR #5686](https://github.com/alphagov/govuk_publishing_components/pull/5704))
+* Replace and remove scale mixin ([PR #5686](https://github.com/alphagov/govuk_publishing_components/pull/5709))
+* Remove prioritise_taxon_breadcrumbs ([PR #5708](https://github.com/alphagov/govuk_publishing_components/pull/5708))
 
 ## 69.0.1
 

--- a/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
@@ -1,7 +1,6 @@
 <%
   disable_ga4 ||= false
-  prioritise_taxon_breadcrumbs ||= false
-  breadcrumb_selector = GovukPublishingComponents::Presenters::BreadcrumbSelector.new(content_item, request, prioritise_taxon_breadcrumbs, disable_ga4)
+  breadcrumb_selector = GovukPublishingComponents::Presenters::BreadcrumbSelector.new(content_item, request, disable_ga4)
   inverse ||= false
   collapse_on_mobile ||= true unless local_assigns[:collapse_on_mobile].eql?(false)
 

--- a/lib/govuk_publishing_components/presenters/breadcrumb_selector.rb
+++ b/lib/govuk_publishing_components/presenters/breadcrumb_selector.rb
@@ -1,12 +1,11 @@
 module GovukPublishingComponents
   module Presenters
     class BreadcrumbSelector
-      attr_reader :content_item, :request, :prioritise_taxon_breadcrumbs
+      attr_reader :content_item, :request
 
-      def initialize(content_item, request, prioritise_taxon_breadcrumbs, disable_ga4)
+      def initialize(content_item, request, disable_ga4)
         @content_item = content_item
         @request = request
-        @prioritise_taxon_breadcrumbs = prioritise_taxon_breadcrumbs
         @disable_ga4 = disable_ga4
       end
 
@@ -39,11 +38,6 @@ module GovukPublishingComponents
           {
             step_by_step: true,
             breadcrumbs: navigation.step_nav_helper.header(@disable_ga4),
-          }
-        elsif navigation.content_is_tagged_to_a_live_taxon? && prioritise_taxon_breadcrumbs
-          {
-            step_by_step: false,
-            breadcrumbs: navigation.taxon_breadcrumbs,
           }
         elsif navigation.content_parent_is_mainstream_browse?
           {

--- a/spec/components/contextual_breadcrumbs_spec.rb
+++ b/spec/components/contextual_breadcrumbs_spec.rb
@@ -158,17 +158,9 @@ describe "ContextualBreadcrumbs", type: :view do
     assert_select "a", text: "EU Withdrawal Act 2018 statutory instruments"
   end
 
-  it "renders parent finder breadcrumb if content has a finder linked and taxon is prioritised" do
-    content_item = example_document_for("guide", "guide-with-facet-groups")
-    render_component(content_item:, prioritise_taxon_breadcrumbs: true)
-
-    assert_select "a", text: "Home"
-    assert_select "a", text: "EU Withdrawal Act 2018 statutory instruments"
-  end
-
   it "renders inverse parent finder breadcrumb" do
     content_item = example_document_for("guide", "guide-with-facet-groups")
-    render_component(content_item:, prioritise_taxon_breadcrumbs: true, inverse: true)
+    render_component(content_item:, inverse: true)
     assert_select ".gem-c-breadcrumbs.govuk-breadcrumbs--inverse"
   end
 
@@ -181,38 +173,14 @@ describe "ContextualBreadcrumbs", type: :view do
     assert_select(".gem-c-breadcrumbs", false)
   end
 
-  it "renders taxon breadcrumbs even if there are mainstream browse pages if prioritise_taxon_breadcrumbs is true" do
-    content_item = example_document_for("guide", "guide")
-    content_item = set_parent_titles_to_businesses(content_item)
-    content_item = set_live_taxons(content_item)
-    render_component(content_item:, prioritise_taxon_breadcrumbs: true)
-    assert_select "a", text: "Home"
-    assert_select "a", text: "Business and self-employed", count: 0
-    assert_select "a", text: "Licences and licence applications", count: 0
-    assert_select "a", text: "School curriculum"
-    assert_select "a", text: "Education, training and skills"
-  end
-
-  it "renders mainstream browse pages if prioritise_taxon_breadcrumbs is false and there are live taxons" do
-    content_item = example_document_for("guide", "guide")
-    content_item = set_parent_titles_to_businesses(content_item)
-    content_item = set_live_taxons(content_item)
-    render_component(content_item:, prioritise_taxon_breadcrumbs: false)
-    assert_select "a", text: "Home"
-    assert_select "a", text: "Business and self-employed"
-    assert_select "a", text: "Licences and licence applications"
-    assert_select "a", text: "School curriculum", count: 0
-    assert_select "a", text: "Education, training and skills", count: 0
-  end
-
-  it "renders mainstream browse pages if prioritise_taxon_breadcrumbs is not passed and are live taxons" do
+  it "doesn't render taxon breadcrumbs even if there are live taxons" do
     content_item = example_document_for("guide", "guide")
     content_item = set_parent_titles_to_businesses(content_item)
     content_item = set_live_taxons(content_item)
     render_component(content_item:)
     assert_select "a", text: "Home"
-    assert_select "a", text: "Business and self-employed"
-    assert_select "a", text: "Licences and licence applications"
+    assert_select "a", text: "Business and self-employed", count: 1
+    assert_select "a", text: "Licences and licence applications", count: 1
     assert_select "a", text: "School curriculum", count: 0
     assert_select "a", text: "Education, training and skills", count: 0
   end

--- a/spec/lib/govuk_publishing_components/presenters/breadcrumb_selector_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/breadcrumb_selector_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe GovukPublishingComponents::Presenters::BreadcrumbSelector do
     described_class.new(
       content_item,
       request,
-      prioritise_taxon_breadcrumbs,
       disable_ga4,
     )
   end
@@ -15,7 +14,6 @@ RSpec.describe GovukPublishingComponents::Presenters::BreadcrumbSelector do
   let(:path) { content_item["base_path"] }
   let(:query_parameters) { {} }
   let(:request) { instance_double(ActionDispatch::Request, path:, query_parameters:) }
-  let(:prioritise_taxon_breadcrumbs) { false }
   let(:disable_ga4) { false }
 
   def example_document_for(schema_name, example_name)


### PR DESCRIPTION
## What/ Why
- Remove `prioritise_taxon_breadcrumbs` from the gem as it isn't used anywhere anywhere across `alphagov`
- It was added in 2018 https://github.com/alphagov/govuk_publishing_components/pull/457 with the description "Rendering taxonomy breadcrumbs because the page is tagged to live taxons and we want to prioritise them over all other breadcrumbs"
- I locally checked out January 31st 2019 versions of `frontend`, `publishing-api`, `finder-frontend`, `collections`, `smart-answers`, `feedback`, `static`, `govuk_publishing_components`, and `government-frontend`, but I couldn't see any references to it at that date either, so I'm not sure it was ever used (i.e. No reference to the word `prioritise` in any of these codebases).
- Closes https://github.com/alphagov/govuk_publishing_components/issues/5698


## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None