### PR TITLE
Replace and remove scale mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * **BREAKING:** Replace prefixed-transform usages with standard CSS transform ([PR #5686](https://github.com/alphagov/govuk_publishing_components/pull/5704))  
+* Replace and remove scale mixin ([PR #5686](https://github.com/alphagov/govuk_publishing_components/pull/5709))  
 
 ## 69.0.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_subscription-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_subscription-links.scss
@@ -113,7 +113,7 @@
 }
 
 .gem-c-subscription-links__list-item--small .gem-c-subscription-links__icon {
-  @include scale(.9);
+  transform: scale(.9);
   transform-origin: bottom left;
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/mixins/_index.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/mixins/_index.scss
@@ -1,3 +1,2 @@
 @import "high-contrast-outline";
 @import "margins";
-@import "scale";

--- a/app/assets/stylesheets/govuk_publishing_components/components/mixins/_scale.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/mixins/_scale.scss
@@ -1,5 +1,0 @@
-@mixin scale($size) {
-  -webkit-transform: scale($size);  // Chrome, Opera 15+, Safari 3.1+
-  -ms-transform: scale($size);  // IE 9
-  transform: scale($size);  // Firefox 16+, IE 10+, Opera
-}


### PR DESCRIPTION
## What
- Removes the uses of scale.
- Refactors subscription links to use standard native CSS scale.
- Removed scale mixin itself and any imports.

### Subscription links (small variant)

<img width="330" height="102" alt="Screenshot 2026-09-11 at 12 21 21" src="https://github.com/user-attachments/assets/7d4474e8-5f0d-4513-9a2b-ede0e13aab77" />

## Why
- Replaces redundant scale uses with native CSS scale supported by all Grade C+ browsers and already widely used across the codebase.
- Retains the exact scale behaviour while allowing unsupported legacy browsers to still present a functional page.
- The scale mixin itself can then safely be removed. Varified no downstream apps are using the scale mixin. 

Jira card: https://gov-uk.atlassian.net/browse/NAV-19095

## Visual changes

No visual differences

Device and browser testing subscription links in BrowserStack

Device / browser | Outcome
-- | --
macOS Tahoe - Chrome 152 | No change, as expected
macOS Tahoe - Safari 26.4 | No change, as expected
macOS Sonoma - Firefox 155 | No change, as expected
macOS Catalina - Edge 128 | No change, as expected
Android 13 - Samsung Galaxy S23 (Chrome) | No change, as expected
Android 12 - Samsung Galaxy Tab S8 (Chrome) | No change, as expected
Android 11 - Samsung Galaxy S21 (Samsung Internet) | No change, as expected
iOS 11 - Safari | No change, as expected
iOS 15 - Chrome | No change, as expected
iOS 13 Pro - Safari | No change, as expected
Windows 10 - Edge 15 | No change, as expected
Windows 10 - Edge 100 | No change, as expected
Windows 10 - IE11 | No change, as expected